### PR TITLE
[E2E] Add GET /ping endpoint

### DIFF
--- a/blazebot/memory/AWT-83.md
+++ b/blazebot/memory/AWT-83.md
@@ -1,0 +1,23 @@
+# Session Memory — AWT-83
+
+## Progress
+- Analyzed ticket: add GET /api/ping returning { ping: 'pong' } with status 200
+- Identified studio-example as the Next.js app with app/ directory
+- Wrote test first (TDD) using project conventions (node:test + node:assert/strict)
+- Implemented route using Response.json() (Web API, no NextResponse import needed)
+- Test passes; code review passed with no issues
+
+## Decisions Made
+- Used `Response.json()` instead of `NextResponse.json()` — simpler, no import needed, works natively in Next.js App Router
+- Co-located test file at `app/api/ping/route.test.ts` matching project pattern from `app/page.test.tsx`
+- No bun available in sandbox environment; used npx tsx for running tests
+
+## Blockers
+- None
+
+## Files Touched
+- `apps/studio-example/app/api/ping/route.ts` — created, GET handler
+- `apps/studio-example/app/api/ping/route.test.ts` — created, test for GET handler
+
+## Prior Sessions
+- No prior sessions


### PR DESCRIPTION
Added GET /api/ping endpoint at `apps/studio-example/app/api/ping/route.ts` returning `{ ping: "pong" }` with status 200. Uses `Response.json()` (Web API). Includes co-located test at `route.test.ts` using project conventions (node:test + node:assert/strict). Test passes, code review clean, committed as 29722e6.