### PR TITLE
update the design

### DIFF
--- a/blazebot/memory/CMS-179.md
+++ b/blazebot/memory/CMS-179.md
@@ -13,6 +13,8 @@
 - Session 3: Prettier formatting applied to button.tsx after edit
 - Session 3: Code review passed with no critical or important issues
 - Session 3: Committed fix (798e045)
+- Session 4: Verified all three PR review comments are resolved — no new code changes needed
+- Session 4: Formatting check passes, all review feedback addressed
 
 ## Decisions Made
 
@@ -32,11 +34,13 @@
 
 ## Files Touched
 
-- Session 3: packages/studio/src/lib/runtime-ui/components/ui/badge.tsx (removed accent variant)
-- Session 3: packages/studio/src/lib/runtime-ui/components/ui/button.tsx (fixed secondary dark-mode contrast)
-- Session 3: packages/studio/README.md (added font loading documentation)
+- Session 1: 19 files across packages/studio/src/lib/runtime-ui/ (styles.css, components, pages, layout)
+- Session 2: 12 files reformatted with Prettier
+- Session 3: badge.tsx, button.tsx, README.md
+- Session 4: No code changes — verification only
 
 ## Prior Sessions
 
 - Session 1: Full design system implementation — 19 files updated with new color palette, typography, spacing, components per CMS_OSS v1.0.4 spec
 - Session 2: CI formatting fix — Prettier on 12 files
+- Session 3: Three CodeRabbit review comments addressed (accent badge removal, button contrast fix, font loading docs)

--- a/blazebot/memory/CMS-179.md
+++ b/blazebot/memory/CMS-179.md
@@ -1,0 +1,45 @@
+# Session Memory — CMS-179
+
+## Progress
+- Analyzed full design system reference (v1.0.4) and mapped all tokens to existing CSS custom properties
+- Updated styles.css with complete new color palette (blue primary, olive accent, updated neutrals), font families (Space Grotesk, Inter, Geist Mono), radius scale, and shadows
+- Updated button.tsx with new variants (primary blue with shadow, secondary dark, ghost with border)
+- Updated badge.tsx with pill-shaped tags using design tokens (rounded-pill, rounded-sm)
+- Updated card.tsx to use rounded-lg and border-border without shadow
+- Updated all 18 files to remove old orange accent overrides and use new design tokens
+- Code review completed; fixed all Critical and Important issues (empty className props, whitespace corruption, hardcoded radius values)
+
+## Decisions Made
+- Mapped `--accent` to Blue 500 (#2F49E5) since it's the primary action color throughout the UI
+- Kept `--accent-hover` as Blue 500 display (#4D65FF) for hover states
+- Used `--vibrant-green` (#CAF240) for logo dot instead of accent blue
+- Created `--border-solid` (#C5C5D8) alongside `--border` (rgba version) for contexts needing solid border color
+- Dark mode tokens were inferred from the light mode spec (spec only describes light mode)
+- Font loading for Space Grotesk and Geist Mono must be handled at the app level (not in studio CSS)
+- Base layer applies font-heading to all h1-h6 elements globally
+
+## Blockers
+- None
+
+## Files Touched
+- `packages/studio/src/lib/runtime-ui/styles.css` — Complete token overhaul
+- `packages/studio/src/lib/runtime-ui/components/ui/button.tsx` — New variants
+- `packages/studio/src/lib/runtime-ui/components/ui/badge.tsx` — Pill tags
+- `packages/studio/src/lib/runtime-ui/components/ui/card.tsx` — Border/radius update
+- `packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx` — Green dot
+- `packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx` — bg-card sidebar
+- `packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx` — bg-card header, font-heading
+- `packages/studio/src/lib/runtime-ui/app/admin/page.tsx` — Dashboard token updates
+- `packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/pages/content-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx` — Token updates
+- `packages/studio/src/lib/runtime-ui/components/coming-soon.tsx` — Font heading
+- `packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx` — Token update
+
+## Prior Sessions
+- No prior session

--- a/blazebot/memory/CMS-179.md
+++ b/blazebot/memory/CMS-179.md
@@ -5,8 +5,14 @@
 - Session 1: Applied CMS_OSS visual design system v1.0.4 across 19 studio files (colors, typography, spacing, components, radius, shadows)
 - Session 1: Code review completed; fixed Critical and Important issues (empty className props, whitespace corruption, hardcoded radius values)
 - Session 2: Fixed CI quality check failure — ran Prettier on 12 files that had formatting issues (line wrapping, hex case normalization)
-- Session 2: Code review confirmed all changes are formatting-only, no logic changes
 - Session 2: Committed formatting fix (d966cd2)
+- Session 3: Addressed three PR review comments from CodeRabbit:
+  1. Removed unused `accent` badge variant from badge.tsx (confirmed zero usages in codebase)
+  2. Fixed dark-mode contrast on secondary button — changed `text-primary-foreground` to `text-background` in button.tsx
+  3. Added font loading documentation section to packages/studio/README.md
+- Session 3: Prettier formatting applied to button.tsx after edit
+- Session 3: Code review passed with no critical or important issues
+- Session 3: Committed fix (798e045)
 
 ## Decisions Made
 
@@ -15,8 +21,10 @@
 - Used `--vibrant-green` (#CAF240) for logo dot instead of accent blue
 - Created `--border-solid` (#C5C5D8) alongside `--border` (rgba version) for contexts needing solid border color
 - Dark mode tokens were inferred from the light mode spec (spec only describes light mode)
-- Font loading for Space Grotesk and Geist Mono must be handled at the app level (not in studio CSS)
+- Font loading for Space Grotesk and Geist Mono must be handled at the app level (not in studio CSS) — documented in README
 - Base layer applies font-heading to all h1-h6 elements globally
+- Removed accent badge variant rather than documenting intent — it was dead code with zero references
+- Used `text-background` for secondary button dark-mode fix, matching existing `tooltip.tsx` pattern
 
 ## Blockers
 
@@ -24,9 +32,11 @@
 
 ## Files Touched
 
-- All 19 files from session 1 (see prior sessions)
-- Session 2 formatting fix applied to 12 of those files (no new files added)
+- Session 3: packages/studio/src/lib/runtime-ui/components/ui/badge.tsx (removed accent variant)
+- Session 3: packages/studio/src/lib/runtime-ui/components/ui/button.tsx (fixed secondary dark-mode contrast)
+- Session 3: packages/studio/README.md (added font loading documentation)
 
 ## Prior Sessions
 
 - Session 1: Full design system implementation — 19 files updated with new color palette, typography, spacing, components per CMS_OSS v1.0.4 spec
+- Session 2: CI formatting fix — Prettier on 12 files

--- a/blazebot/memory/CMS-179.md
+++ b/blazebot/memory/CMS-179.md
@@ -1,6 +1,7 @@
 # Session Memory — CMS-179
 
 ## Progress
+
 - Analyzed full design system reference (v1.0.4) and mapped all tokens to existing CSS custom properties
 - Updated styles.css with complete new color palette (blue primary, olive accent, updated neutrals), font families (Space Grotesk, Inter, Geist Mono), radius scale, and shadows
 - Updated button.tsx with new variants (primary blue with shadow, secondary dark, ghost with border)
@@ -10,6 +11,7 @@
 - Code review completed; fixed all Critical and Important issues (empty className props, whitespace corruption, hardcoded radius values)
 
 ## Decisions Made
+
 - Mapped `--accent` to Blue 500 (#2F49E5) since it's the primary action color throughout the UI
 - Kept `--accent-hover` as Blue 500 display (#4D65FF) for hover states
 - Used `--vibrant-green` (#CAF240) for logo dot instead of accent blue
@@ -19,9 +21,11 @@
 - Base layer applies font-heading to all h1-h6 elements globally
 
 ## Blockers
+
 - None
 
 ## Files Touched
+
 - `packages/studio/src/lib/runtime-ui/styles.css` — Complete token overhaul
 - `packages/studio/src/lib/runtime-ui/components/ui/button.tsx` — New variants
 - `packages/studio/src/lib/runtime-ui/components/ui/badge.tsx` — Pill tags
@@ -42,4 +46,5 @@
 - `packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx` — Token update
 
 ## Prior Sessions
+
 - No prior session

--- a/blazebot/memory/CMS-179.md
+++ b/blazebot/memory/CMS-179.md
@@ -2,13 +2,11 @@
 
 ## Progress
 
-- Analyzed full design system reference (v1.0.4) and mapped all tokens to existing CSS custom properties
-- Updated styles.css with complete new color palette (blue primary, olive accent, updated neutrals), font families (Space Grotesk, Inter, Geist Mono), radius scale, and shadows
-- Updated button.tsx with new variants (primary blue with shadow, secondary dark, ghost with border)
-- Updated badge.tsx with pill-shaped tags using design tokens (rounded-pill, rounded-sm)
-- Updated card.tsx to use rounded-lg and border-border without shadow
-- Updated all 18 files to remove old orange accent overrides and use new design tokens
-- Code review completed; fixed all Critical and Important issues (empty className props, whitespace corruption, hardcoded radius values)
+- Session 1: Applied CMS_OSS visual design system v1.0.4 across 19 studio files (colors, typography, spacing, components, radius, shadows)
+- Session 1: Code review completed; fixed Critical and Important issues (empty className props, whitespace corruption, hardcoded radius values)
+- Session 2: Fixed CI quality check failure — ran Prettier on 12 files that had formatting issues (line wrapping, hex case normalization)
+- Session 2: Code review confirmed all changes are formatting-only, no logic changes
+- Session 2: Committed formatting fix (d966cd2)
 
 ## Decisions Made
 
@@ -26,25 +24,9 @@
 
 ## Files Touched
 
-- `packages/studio/src/lib/runtime-ui/styles.css` — Complete token overhaul
-- `packages/studio/src/lib/runtime-ui/components/ui/button.tsx` — New variants
-- `packages/studio/src/lib/runtime-ui/components/ui/badge.tsx` — Pill tags
-- `packages/studio/src/lib/runtime-ui/components/ui/card.tsx` — Border/radius update
-- `packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx` — Green dot
-- `packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx` — bg-card sidebar
-- `packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx` — bg-card header, font-heading
-- `packages/studio/src/lib/runtime-ui/app/admin/page.tsx` — Dashboard token updates
-- `packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/pages/content-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx` — Token updates
-- `packages/studio/src/lib/runtime-ui/components/coming-soon.tsx` — Font heading
-- `packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx` — Token update
+- All 19 files from session 1 (see prior sessions)
+- Session 2 formatting fix applied to 12 of those files (no new files added)
 
 ## Prior Sessions
 
-- No prior session
+- Session 1: Full design system implementation — 19 files updated with new color palette, typography, spacing, components per CMS_OSS v1.0.4 spec

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -319,6 +319,44 @@ export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
   remain available as explicit runtime helpers without widening the client root
   entry.
 
+## Font Loading
+
+The Studio UI references three font families via CSS custom properties with
+system font fallbacks:
+
+- **Space Grotesk** (`--font-heading`) — headings
+- **Inter** (default sans-serif) — body text, button labels
+- **Geist Mono** (`--font-mono`) — code blocks, tags, technical text
+
+Font loading must be handled by the host application. The studio package does
+not bundle font files or `@font-face` declarations.
+
+### Next.js (recommended)
+
+```ts
+// app/layout.tsx
+import { Space_Grotesk, Inter } from "next/font/google";
+import localFont from "next/font/local";
+
+const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-heading" });
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+const geistMono = localFont({ src: "./fonts/GeistMono-Variable.woff2", variable: "--font-mono" });
+
+export default function RootLayout({ children }) {
+  return (
+    <html className={`${spaceGrotesk.variable} ${inter.variable} ${geistMono.variable}`}>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+### Google Fonts / self-hosted
+
+Add `<link>` tags or `@font-face` declarations that load the three families.
+The CSS variables will pick them up automatically; without explicit loading the
+fonts fall back to system equivalents.
+
 ## Build
 
 - `bun nx build studio`

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -185,8 +185,8 @@ export default function ContentTypePage() {
       <div className="p-6 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">{contentType.name}</h1>
-          <Button className="bg-accent hover:bg-accent-hover text-white">
+          <h1 className="text-2xl font-bold font-heading tracking-tight">{contentType.name}</h1>
+          <Button>
             <Plus className="mr-2 h-4 w-4" />
             New Document
           </Button>
@@ -502,7 +502,7 @@ export default function ContentTypePage() {
             <p className="mb-4 text-sm text-foreground-muted">
               Create your first {contentType.name} document to get started.
             </p>
-            <Button className="bg-accent hover:bg-accent-hover text-white">
+            <Button>
               <Plus className="mr-2 h-4 w-4" />
               New Document
             </Button>

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -185,7 +185,9 @@ export default function ContentTypePage() {
       <div className="p-6 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold font-heading tracking-tight">{contentType.name}</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            {contentType.name}
+          </h1>
           <Button>
             <Plus className="mr-2 h-4 w-4" />
             New Document

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -32,7 +32,7 @@ export default function ContentPage() {
       <div className="p-6 space-y-6">
         {/* Page Title */}
         <div>
-          <h1 className="text-2xl font-semibold">Content</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">Content</h1>
           <p className="text-sm text-foreground-muted">
             Browse and manage your content by type
           </p>
@@ -47,7 +47,7 @@ export default function ContentPage() {
                 <Card className="border-border h-full transition-all hover:border-accent/50 hover:shadow-sm">
                   <CardContent className="p-5">
                     <div className="flex items-start gap-4">
-                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent-subtle">
                         <IconComponent className="h-6 w-6 text-accent" />
                       </div>
                       <div className="flex-1 min-w-0 space-y-1">

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -32,7 +32,9 @@ export default function ContentPage() {
       <div className="p-6 space-y-6">
         {/* Page Title */}
         <div>
-          <h1 className="text-2xl font-bold font-heading tracking-tight">Content</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            Content
+          </h1>
           <p className="text-sm text-foreground-muted">
             Browse and manage your content by type
           </p>

--- a/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
@@ -65,7 +65,9 @@ export default function MediaPage() {
           </div>
 
           <div className="flex items-center justify-center gap-3 mb-4">
-            <h1 className="text-2xl font-bold font-heading tracking-tight">Media Library</h1>
+            <h1 className="text-2xl font-bold font-heading tracking-tight">
+              Media Library
+            </h1>
             <Badge variant="outline" className="border-accent text-accent">
               Coming Soon
             </Badge>

--- a/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
@@ -59,13 +59,13 @@ export default function MediaPage() {
         {/* Coming Soon Content */}
         <div className="text-center max-w-lg mx-auto mb-12">
           <div className="mb-6 flex justify-center">
-            <div className="rounded-full bg-accent/10 p-4">
+            <div className="rounded-full bg-accent-subtle p-4">
               <Image className="h-16 w-16 text-foreground-muted" />
             </div>
           </div>
 
           <div className="flex items-center justify-center gap-3 mb-4">
-            <h1 className="text-2xl font-semibold">Media Library</h1>
+            <h1 className="text-2xl font-bold font-heading tracking-tight">Media Library</h1>
             <Badge variant="outline" className="border-accent text-accent">
               Coming Soon
             </Badge>

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -80,7 +80,7 @@ export default function DashboardPage() {
       <div className="p-6 space-y-6">
         {/* Page Title */}
         <div>
-          <h1 className="text-2xl font-semibold">Dashboard</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">Dashboard</h1>
           <p className="text-sm text-foreground-muted">
             Welcome back, {currentUser.name}
           </p>
@@ -119,7 +119,7 @@ export default function DashboardPage() {
                       </p>
                     )}
                   </div>
-                  <div className="rounded-md bg-accent/10 p-2">
+                  <div className="rounded-md bg-accent-subtle p-2">
                     <stat.icon className="h-5 w-5 text-accent" />
                   </div>
                 </div>
@@ -135,11 +135,6 @@ export default function DashboardPage() {
               key={action.label}
               variant={action.variant}
               asChild
-              className={
-                action.variant === "default"
-                  ? "bg-accent hover:bg-accent-hover text-white"
-                  : ""
-              }
             >
               <Link href={action.href}>
                 <action.icon className="mr-2 h-4 w-4" />
@@ -159,7 +154,7 @@ export default function DashboardPage() {
               </CardTitle>
               <Link
                 href="/admin/content"
-                className="text-sm text-foreground-muted hover:text-accent flex items-center gap-1"
+                className="text-sm text-foreground-muted hover:text-foreground flex items-center gap-1"
               >
                 View all <ChevronRight className="h-4 w-4" />
               </Link>
@@ -174,7 +169,7 @@ export default function DashboardPage() {
                     href={`/admin/content/${type.id}`}
                     className="flex items-center gap-4 rounded-lg p-3 transition-colors hover:bg-background-subtle"
                   >
-                    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-accent/10">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-accent-subtle">
                       <FileText className="h-5 w-5 text-accent" />
                     </div>
                     <div className="flex-1 min-w-0">
@@ -220,7 +215,7 @@ export default function DashboardPage() {
               </CardTitle>
               <Link
                 href="#"
-                className="text-sm text-foreground-muted hover:text-accent flex items-center gap-1"
+                className="text-sm text-foreground-muted hover:text-foreground flex items-center gap-1"
               >
                 View all <ChevronRight className="h-4 w-4" />
               </Link>

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -80,7 +80,9 @@ export default function DashboardPage() {
       <div className="p-6 space-y-6">
         {/* Page Title */}
         <div>
-          <h1 className="text-2xl font-bold font-heading tracking-tight">Dashboard</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            Dashboard
+          </h1>
           <p className="text-sm text-foreground-muted">
             Welcome back, {currentUser.name}
           </p>
@@ -131,11 +133,7 @@ export default function DashboardPage() {
         {/* Quick Actions */}
         <div className="flex flex-wrap gap-3">
           {quickActions.map((action) => (
-            <Button
-              key={action.label}
-              variant={action.variant}
-              asChild
-            >
+            <Button key={action.label} variant={action.variant} asChild>
               <Link href={action.href}>
                 <action.icon className="mr-2 h-4 w-4" />
                 {action.label}

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
@@ -202,7 +202,7 @@ export default function SettingsPage({
                   </Select>
                 </div>
 
-                <Button className="bg-accent hover:bg-accent-hover text-white">
+                <Button>
                   Save changes
                 </Button>
               </div>
@@ -219,7 +219,7 @@ export default function SettingsPage({
                     Manage API keys for external integrations
                   </p>
                 </div>
-                <Button className="bg-accent hover:bg-accent-hover text-white">
+                <Button>
                   <Plus className="mr-2 h-4 w-4" />
                   Create API Key
                 </Button>
@@ -325,7 +325,7 @@ export default function SettingsPage({
                     Configure webhook endpoints for content events
                   </p>
                 </div>
-                <Button className="bg-accent hover:bg-accent-hover text-white">
+                <Button>
                   <Plus className="mr-2 h-4 w-4" />
                   Create Webhook
                 </Button>
@@ -443,7 +443,7 @@ export default function SettingsPage({
                   image/* MIME types.
                 </p>
 
-                <Button className="bg-accent hover:bg-accent-hover text-white">
+                <Button>
                   Save
                 </Button>
               </div>
@@ -478,7 +478,6 @@ export default function SettingsPage({
 
                   <Button
                     asChild
-                    className="bg-accent text-white hover:bg-accent-hover"
                   >
                     <Link href={schemaBrowserHref}>
                       Open schema browser

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
@@ -202,9 +202,7 @@ export default function SettingsPage({
                   </Select>
                 </div>
 
-                <Button>
-                  Save changes
-                </Button>
+                <Button>Save changes</Button>
               </div>
             </div>
           )}
@@ -443,9 +441,7 @@ export default function SettingsPage({
                   image/* MIME types.
                 </p>
 
-                <Button>
-                  Save
-                </Button>
+                <Button>Save</Button>
               </div>
             </div>
           )}
@@ -476,9 +472,7 @@ export default function SettingsPage({
                     </p>
                   </div>
 
-                  <Button
-                    asChild
-                  >
+                  <Button asChild>
                     <Link href={schemaBrowserHref}>
                       Open schema browser
                       <ArrowRight className="ml-2 h-4 w-4" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -86,7 +86,9 @@ export default function UsersPage() {
       <div className="p-6 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold font-heading tracking-tight">Users</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            Users
+          </h1>
           <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
             <DialogTrigger asChild>
               <Button>
@@ -163,9 +165,7 @@ export default function UsersPage() {
                 >
                   Cancel
                 </Button>
-                <Button
-                  onClick={() => setInviteDialogOpen(false)}
-                >
+                <Button onClick={() => setInviteDialogOpen(false)}>
                   Send Invitation
                 </Button>
               </DialogFooter>

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -55,7 +55,7 @@ import { cn } from "../../lib/utils";
 const roleConfig = {
   owner: {
     label: "Owner",
-    className: "bg-accent/10 text-accent border-accent/20",
+    className: "bg-accent-subtle text-accent border-accent/20",
   },
   admin: {
     label: "Admin",
@@ -86,10 +86,10 @@ export default function UsersPage() {
       <div className="p-6 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">Users</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">Users</h1>
           <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
             <DialogTrigger asChild>
-              <Button className="bg-accent hover:bg-accent-hover text-white">
+              <Button>
                 <Plus className="mr-2 h-4 w-4" />
                 Invite User
               </Button>
@@ -164,7 +164,6 @@ export default function UsersPage() {
                   Cancel
                 </Button>
                 <Button
-                  className="bg-accent hover:bg-accent-hover text-white"
                   onClick={() => setInviteDialogOpen(false)}
                 >
                   Send Invitation

--- a/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
@@ -29,7 +29,7 @@ export function ComingSoon({
           <Badge variant="secondary" className="mb-4">
             Coming Soon
           </Badge>
-          <h2 className="mb-2 text-2xl font-semibold tracking-tight">
+          <h2 className="mb-2 text-2xl font-bold font-heading tracking-tight">
             {title}
           </h2>
           <p className="mb-6 max-w-sm text-muted-foreground">{description}</p>

--- a/packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx
@@ -449,7 +449,7 @@ export function EditorSidebar({ document, mdxPropsPanel }: EditorSidebarProps) {
           {/* SEO Tab (Coming Soon) */}
           <TabsContent value="seo" className="flex-1 mt-0">
             <div className="flex flex-col items-center justify-center h-full p-6 text-center">
-              <div className="mb-4 rounded-full bg-accent/10 p-3">
+              <div className="mb-4 rounded-full bg-accent-subtle p-3">
                 <Sparkles className="h-6 w-6 text-accent" />
               </div>
               <h3 className="mb-2 font-semibold">SEO Analysis</h3>

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -86,7 +86,7 @@ export function AppSidebar({
     <TooltipProvider delayDuration={0}>
       <aside
         className={cn(
-          "fixed left-0 top-0 z-40 flex h-screen flex-col border-r border-border bg-background transition-all duration-300",
+          "fixed left-0 top-0 z-40 flex h-screen flex-col border-r border-border bg-card transition-all duration-300",
           collapsed ? "w-16" : "w-60",
         )}
       >

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -81,7 +81,10 @@ export function PageHeaderHeading({
 }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h1
-      className={cn("text-2xl font-bold font-heading tracking-tight", className)}
+      className={cn(
+        "text-2xl font-bold font-heading tracking-tight",
+        className,
+      )}
       {...props}
     >
       {children}

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -81,7 +81,7 @@ export function PageHeaderHeading({
 }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h1
-      className={cn("text-2xl font-semibold tracking-tight", className)}
+      className={cn("text-2xl font-bold font-heading tracking-tight", className)}
       {...props}
     >
       {children}
@@ -168,7 +168,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
 
   return (
     <TooltipProvider>
-      <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-background px-6">
+      <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-card px-6">
         {/* Left side - Breadcrumbs */}
         <BreadcrumbTrail breadcrumbs={breadcrumbs} />
 

--- a/packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx
@@ -14,7 +14,7 @@ export function MDCMSLogo({ collapsed = false, className }: MDCMSLogoProps) {
       <span className="text-xl font-bold tracking-tight text-foreground">
         {collapsed ? "m" : "mdcms"}
       </span>
-      <span className="h-2 w-2 rounded-full bg-accent" />
+      <span className="h-2 w-2 rounded-full bg-vibrant-green" />
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
@@ -10,18 +10,14 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-background-subtle text-foreground",
-        secondary:
-          "bg-neutral-grey text-foreground",
+        default: "bg-background-subtle text-foreground",
+        secondary: "bg-neutral-grey text-foreground",
         destructive:
           "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border-border-solid text-foreground [a&]:hover:bg-background-subtle",
-        accent:
-          "bg-vibrant-green text-foreground rounded-sm px-4 py-2 text-xs",
-        "light-blue":
-          "bg-light-blue text-accent",
+        accent: "bg-vibrant-green text-foreground rounded-sm px-4 py-2 text-xs",
+        "light-blue": "bg-light-blue text-accent",
       },
     },
     defaultVariants: {

--- a/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
@@ -6,18 +6,22 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-pill border border-transparent px-3 py-0.5 text-[10px] font-bold uppercase tracking-wide font-mono w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-2 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+          "bg-background-subtle text-foreground",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          "bg-neutral-grey text-foreground",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          "border-border-solid text-foreground [a&]:hover:bg-background-subtle",
+        accent:
+          "bg-vibrant-green text-foreground rounded-sm px-4 py-2 text-xs",
+        "light-blue":
+          "bg-light-blue text-accent",
       },
     },
     defaultVariants: {

--- a/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
@@ -16,7 +16,6 @@ const badgeVariants = cva(
           "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border-border-solid text-foreground [a&]:hover:bg-background-subtle",
-        accent: "bg-vibrant-green text-foreground rounded-sm px-4 py-2 text-xs",
         "light-blue": "bg-light-blue text-accent",
       },
     },

--- a/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
@@ -16,8 +16,7 @@ const buttonVariants = cva(
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border border-border-solid bg-transparent text-foreground hover:bg-background-subtle dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-foreground text-primary-foreground hover:bg-foreground/90",
+        secondary: "bg-foreground text-background hover:bg-foreground/90",
         ghost:
           "hover:bg-background-subtle hover:text-foreground dark:hover:bg-accent/50",
         link: "text-accent underline-offset-4 hover:underline",

--- a/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
@@ -6,20 +6,21 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-accent text-primary-foreground shadow-[var(--shadow-primary-button)] hover:bg-accent-hover",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-border-solid bg-transparent text-foreground hover:bg-background-subtle dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-foreground text-primary-foreground hover:bg-foreground/90",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "hover:bg-background-subtle hover:text-foreground dark:hover:bg-accent/50",
+        link: "text-accent underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
@@ -8,7 +8,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-lg border border-border py-6",
         className,
       )}
       {...props}

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1547,7 +1547,6 @@ export function ContentDocumentPageView({
 
             {state.status === "ready" ? (
               <Button
-                className="bg-accent text-white hover:bg-accent-hover"
                 disabled={!canPublish}
                 onClick={() => onPublishDialogOpenChange?.(true)}
               >
@@ -1686,7 +1685,6 @@ export function ContentDocumentPageView({
                   Cancel
                 </Button>
                 <Button
-                  className="bg-accent text-white hover:bg-accent-hover"
                   disabled={state.publishState === "publishing"}
                   onClick={onPublishSubmit}
                 >

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -33,7 +33,7 @@ export default function ContentPage() {
 
       <div className="space-y-6 p-6">
         <div>
-          <h1 className="text-2xl font-semibold">Content</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">Content</h1>
           <p className="text-sm text-foreground-muted">
             Browse and manage your content by type
           </p>
@@ -48,7 +48,7 @@ export default function ContentPage() {
                 <Card className="h-full border-border transition-all hover:border-accent/50 hover:shadow-sm">
                   <CardContent className="p-5">
                     <div className="flex items-start gap-4">
-                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent-subtle">
                         <IconComponent className="h-6 w-6 text-accent" />
                       </div>
                       <div className="min-w-0 flex-1 space-y-1">

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -33,7 +33,9 @@ export default function ContentPage() {
 
       <div className="space-y-6 p-6">
         <div>
-          <h1 className="text-2xl font-bold font-heading tracking-tight">Content</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            Content
+          </h1>
           <p className="text-sm text-foreground-muted">
             Browse and manage your content by type
           </p>

--- a/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
@@ -187,8 +187,8 @@ export default function ContentTypePage() {
 
       <div className="space-y-6 p-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">{contentType.name}</h1>
-          <Button className="bg-accent text-white hover:bg-accent-hover">
+          <h1 className="text-2xl font-bold font-heading tracking-tight">{contentType.name}</h1>
+          <Button>
             <Plus className="mr-2 h-4 w-4" />
             New Document
           </Button>
@@ -496,7 +496,7 @@ export default function ContentTypePage() {
             <p className="mb-4 text-sm text-foreground-muted">
               Create your first {contentType.name} document to get started.
             </p>
-            <Button className="bg-accent text-white hover:bg-accent-hover">
+            <Button>
               <Plus className="mr-2 h-4 w-4" />
               New Document
             </Button>

--- a/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
@@ -187,7 +187,9 @@ export default function ContentTypePage() {
 
       <div className="space-y-6 p-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold font-heading tracking-tight">{contentType.name}</h1>
+          <h1 className="text-2xl font-bold font-heading tracking-tight">
+            {contentType.name}
+          </h1>
           <Button>
             <Plus className="mr-2 h-4 w-4" />
             New Document

--- a/packages/studio/src/lib/runtime-ui/styles.css
+++ b/packages/studio/src/lib/runtime-ui/styles.css
@@ -7,16 +7,16 @@
 
 :root {
   /* Primary & Accent */
-  --background: #FCF9F8;
-  --background-subtle: #F6F3F2;
-  --foreground: #1C1B1B;
+  --background: #fcf9f8;
+  --background-subtle: #f6f3f2;
+  --foreground: #1c1b1b;
   --foreground-muted: #444655;
-  --accent: #2F49E5;
-  --accent-hover: #4D65FF;
-  --accent-subtle: #EAEDFF;
+  --accent: #2f49e5;
+  --accent-hover: #4d65ff;
+  --accent-subtle: #eaedff;
   --border: rgba(197, 197, 216, 0.3);
-  --border-solid: #C5C5D8;
-  --border-focus: #2F49E5;
+  --border-solid: #c5c5d8;
+  --border-focus: #2f49e5;
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
   --success: #22c55e;
@@ -25,9 +25,9 @@
   --warning-subtle: #fffbeb;
 
   /* Semantic aliases */
-  --card: #FFFFFF;
+  --card: #ffffff;
   --card-foreground: var(--foreground);
-  --popover: #FFFFFF;
+  --popover: #ffffff;
   --popover-foreground: var(--foreground);
   --primary: var(--accent);
   --primary-foreground: #ffffff;
@@ -40,15 +40,15 @@
   --ring: var(--accent);
 
   /* Extended palette */
-  --olive: #D6FF4D;
+  --olive: #d6ff4d;
   --olive-dark: #516600;
-  --vibrant-green: #CAF240;
-  --light-blue: #E2E2F1;
-  --neutral-grey: #E5E2E1;
-  --code-bg: #F0EDEC;
+  --vibrant-green: #caf240;
+  --light-blue: #e2e2f1;
+  --neutral-grey: #e5e2e1;
+  --code-bg: #f0edec;
 
   /* Chart colors */
-  --chart-1: #2F49E5;
+  --chart-1: #2f49e5;
   --chart-2: #22c55e;
   --chart-3: #f59e0b;
   --chart-4: #6366f1;
@@ -61,7 +61,7 @@
   --shadow-primary-button: 0px 25px 50px -12px rgba(47, 73, 229, 0.3);
 
   /* Sidebar */
-  --sidebar: #FFFFFF;
+  --sidebar: #ffffff;
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--accent);
   --sidebar-primary-foreground: #ffffff;
@@ -76,12 +76,12 @@
   --background-subtle: #1e2028;
   --foreground: #f9fafb;
   --foreground-muted: #9ca3af;
-  --accent: #4D65FF;
-  --accent-hover: #6B7FFF;
+  --accent: #4d65ff;
+  --accent-hover: #6b7fff;
   --accent-subtle: #1a1f3a;
   --border: rgba(197, 197, 216, 0.15);
   --border-solid: #3d3f52;
-  --border-focus: #4D65FF;
+  --border-focus: #4d65ff;
   --destructive: #f87171;
   --destructive-foreground: #191b20;
   --success: #4ade80;
@@ -101,9 +101,9 @@
   --accent-foreground: var(--foreground);
   --input: var(--border-solid);
   --ring: var(--accent);
-  --olive: #D6FF4D;
-  --olive-dark: #8FA800;
-  --vibrant-green: #CAF240;
+  --olive: #d6ff4d;
+  --olive-dark: #8fa800;
+  --vibrant-green: #caf240;
   --light-blue: #2a2a3d;
   --neutral-grey: #2d3039;
   --code-bg: #252730;
@@ -119,7 +119,8 @@
 
 @theme inline {
   --font-sans: "Inter", "Inter Fallback", system-ui, sans-serif;
-  --font-heading: "Space Grotesk", "Space Grotesk Fallback", system-ui, sans-serif;
+  --font-heading:
+    "Space Grotesk", "Space Grotesk Fallback", system-ui, sans-serif;
   --font-mono: "Geist Mono", "Geist Mono Fallback", monospace;
   --color-background: var(--background);
   --color-background-subtle: var(--background-subtle);

--- a/packages/studio/src/lib/runtime-ui/styles.css
+++ b/packages/studio/src/lib/runtime-ui/styles.css
@@ -6,41 +6,62 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #ffffff;
-  --background-subtle: #f9fafb;
-  --foreground: #191b20;
-  --foreground-muted: #6b7280;
-  --accent: #fd6127;
-  --accent-hover: #e5571f;
-  --accent-subtle: #fff3ee;
-  --border: #e5e7eb;
-  --border-focus: #fd6127;
+  /* Primary & Accent */
+  --background: #FCF9F8;
+  --background-subtle: #F6F3F2;
+  --foreground: #1C1B1B;
+  --foreground-muted: #444655;
+  --accent: #2F49E5;
+  --accent-hover: #4D65FF;
+  --accent-subtle: #EAEDFF;
+  --border: rgba(197, 197, 216, 0.3);
+  --border-solid: #C5C5D8;
+  --border-focus: #2F49E5;
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
   --success: #22c55e;
   --success-subtle: #f0fdf4;
   --warning: #f59e0b;
   --warning-subtle: #fffbeb;
-  --card: var(--background);
+
+  /* Semantic aliases */
+  --card: #FFFFFF;
   --card-foreground: var(--foreground);
-  --popover: var(--background);
+  --popover: #FFFFFF;
   --popover-foreground: var(--foreground);
   --primary: var(--accent);
   --primary-foreground: #ffffff;
-  --secondary: var(--background-subtle);
-  --secondary-foreground: var(--foreground);
+  --secondary: var(--foreground);
+  --secondary-foreground: #ffffff;
   --muted: var(--background-subtle);
   --muted-foreground: var(--foreground-muted);
   --accent-foreground: var(--foreground);
-  --input: var(--border);
+  --input: var(--border-solid);
   --ring: var(--accent);
-  --chart-1: #fd6127;
+
+  /* Extended palette */
+  --olive: #D6FF4D;
+  --olive-dark: #516600;
+  --vibrant-green: #CAF240;
+  --light-blue: #E2E2F1;
+  --neutral-grey: #E5E2E1;
+  --code-bg: #F0EDEC;
+
+  /* Chart colors */
+  --chart-1: #2F49E5;
   --chart-2: #22c55e;
   --chart-3: #f59e0b;
   --chart-4: #6366f1;
   --chart-5: #ec4899;
+
+  /* Radius */
   --radius: 0.5rem;
-  --sidebar: var(--background);
+
+  /* Shadows */
+  --shadow-primary-button: 0px 25px 50px -12px rgba(47, 73, 229, 0.3);
+
+  /* Sidebar */
+  --sidebar: #FFFFFF;
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--accent);
   --sidebar-primary-foreground: #ffffff;
@@ -55,31 +76,38 @@
   --background-subtle: #1e2028;
   --foreground: #f9fafb;
   --foreground-muted: #9ca3af;
-  --accent: #fd6127;
-  --accent-hover: #ff7a45;
-  --accent-subtle: #2a1f1a;
-  --border: #2d3039;
-  --border-focus: #fd6127;
+  --accent: #4D65FF;
+  --accent-hover: #6B7FFF;
+  --accent-subtle: #1a1f3a;
+  --border: rgba(197, 197, 216, 0.15);
+  --border-solid: #3d3f52;
+  --border-focus: #4D65FF;
   --destructive: #f87171;
   --destructive-foreground: #191b20;
   --success: #4ade80;
   --success-subtle: #14532d;
   --warning: #fbbf24;
   --warning-subtle: #422006;
-  --card: var(--background);
+  --card: #1e2028;
   --card-foreground: var(--foreground);
-  --popover: var(--background);
+  --popover: #1e2028;
   --popover-foreground: var(--foreground);
   --primary: var(--accent);
   --primary-foreground: #ffffff;
-  --secondary: var(--background-subtle);
-  --secondary-foreground: var(--foreground);
+  --secondary: var(--foreground);
+  --secondary-foreground: #191b20;
   --muted: var(--background-subtle);
   --muted-foreground: var(--foreground-muted);
   --accent-foreground: var(--foreground);
-  --input: var(--border);
+  --input: var(--border-solid);
   --ring: var(--accent);
-  --sidebar: var(--background);
+  --olive: #D6FF4D;
+  --olive-dark: #8FA800;
+  --vibrant-green: #CAF240;
+  --light-blue: #2a2a3d;
+  --neutral-grey: #2d3039;
+  --code-bg: #252730;
+  --sidebar: #191b20;
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--accent);
   --sidebar-primary-foreground: #ffffff;
@@ -91,7 +119,8 @@
 
 @theme inline {
   --font-sans: "Inter", "Inter Fallback", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --font-heading: "Space Grotesk", "Space Grotesk Fallback", system-ui, sans-serif;
+  --font-mono: "Geist Mono", "Geist Mono Fallback", monospace;
   --color-background: var(--background);
   --color-background-subtle: var(--background-subtle);
   --color-foreground: var(--foreground);
@@ -117,18 +146,26 @@
   --color-warning: var(--warning);
   --color-warning-subtle: var(--warning-subtle);
   --color-border: var(--border);
+  --color-border-solid: var(--border-solid);
   --color-border-focus: var(--border-focus);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-olive: var(--olive);
+  --color-olive-dark: var(--olive-dark);
+  --color-vibrant-green: var(--vibrant-green);
+  --color-light-blue: var(--light-blue);
+  --color-neutral-grey: var(--neutral-grey);
+  --color-code-bg: var(--code-bg);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 8px;
+  --radius-xl: 16px;
+  --radius-pill: 12px;
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
@@ -152,13 +189,11 @@
     overflow-x: hidden;
     @apply bg-background text-foreground;
     font-family: var(--font-sans);
-    background:
-      radial-gradient(
-        circle at top left,
-        rgba(253, 97, 39, 0.08),
-        transparent 24rem
-      ),
-      linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    background: var(--background);
+  }
+
+  .mdcms-studio-runtime :is(.dark) {
+    background: var(--background);
   }
 
   .mdcms-studio-runtime a {
@@ -168,6 +203,15 @@
 
   .mdcms-studio-runtime :is(button, input, textarea, select) {
     font: inherit;
+  }
+
+  .mdcms-studio-runtime h1,
+  .mdcms-studio-runtime h2,
+  .mdcms-studio-runtime h3,
+  .mdcms-studio-runtime h4,
+  .mdcms-studio-runtime h5,
+  .mdcms-studio-runtime h6 {
+    font-family: var(--font-heading);
   }
 }
 
@@ -181,7 +225,7 @@
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--border-solid);
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Applied CMS_OSS Visual Design System v1.0.4 to the studio UI across 18 source files.

**Core changes:**
- **styles.css**: Complete token overhaul — blue primary (#2F49E5/#4D65FF), olive accent (#D6FF4D), offwhite background (#FCF9F8), purple-grey borders (#C5C5D8), plus new font families (Space Grotesk for headings, Geist Mono for mono), updated radius scale (2px/4px/8px/12px/16px), and primary button shadow
- **button.tsx**: New variants — primary (blue + shadow), secondary (dark bg), ghost (transparent + border), outline (border-solid)
- **badge.tsx**: Pill-shaped tags with `rounded-pill` token, mono uppercase text, new color variants (default, secondary, accent/vibrant-green, light-blue)
- **card.tsx**: `rounded-lg` with `border-border`, no shadow
- **All pages**: Removed hardcoded orange accent overrides, updated headings to `font-heading font-bold`, replaced `bg-accent/10` with `bg-accent-subtle`

**Note**: Font loading for Space Grotesk and Geist Mono must be configured at the host app level (e.g., via Next.js font imports or `<link>` tags). The studio CSS declares the font families but does not bundle the font files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new badge variant (light-blue) and refined button variants (typography, shadows, border/hover behaviors).

* **UI/Style Updates**
  * Theme refreshed: accent shifted to blue, new palette tokens (olive, vibrant-green, light-blue, neutral), adjusted radii, scrollbar, cards, sidebar and global heading typography.
  * Logo dot color updated; many headings made bolder with heading font; several buttons reverted to component-default styling (including Publish actions).

* **Documentation**
  * Added session notes and a “Font Loading” guide for heading/sans/mono usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->