### PR TITLE
feat(cms-129): wire Studio shell session, env context, and role-aware nav

### DIFF
--- a/packages/shared/src/lib/contracts/extensibility.test.ts
+++ b/packages/shared/src/lib/contracts/extensibility.test.ts
@@ -750,6 +750,26 @@ test("assertStudioMountContext rejects invalid extracted mdx prop shapes", () =>
   );
 });
 
+test("assertHostBridgeV1 accepts a bridge with onNavigate callback", () => {
+  assert.doesNotThrow(() =>
+    assertHostBridgeV1({
+      ...validHostBridge,
+      onNavigate: () => {},
+    }),
+  );
+});
+
+test("assertHostBridgeV1 rejects a bridge with non-function onNavigate", () => {
+  assert.throws(
+    () =>
+      assertHostBridgeV1({
+        ...validHostBridge,
+        onNavigate: "not-a-function",
+      }),
+    /onNavigate/,
+  );
+});
+
 test("isModuleManifest and isStudioBootstrapManifest return booleans without throwing", () => {
   assert.equal(isModuleManifest(validModuleManifest), true);
   assert.equal(isModuleManifest({}), false);

--- a/packages/shared/src/lib/contracts/extensibility.ts
+++ b/packages/shared/src/lib/contracts/extensibility.ts
@@ -128,6 +128,7 @@ export type HostBridgeV1 = {
     props: Record<string, unknown>;
     key: string;
   }) => () => void;
+  onNavigate?: (target: { environment: string }) => void;
 };
 
 export type StudioDocumentRouteWriteContext =
@@ -370,6 +371,7 @@ const hostBridgeV1Schema = z
     ),
     resolveComponent: functionSchema,
     renderMdxPreview: functionSchema,
+    onNavigate: functionSchema.optional(),
   })
   .strict();
 

--- a/packages/studio/src/lib/environment-api.test.ts
+++ b/packages/studio/src/lib/environment-api.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  createStudioEnvironmentApi,
+  type StudioEnvironmentApiOptions,
+} from "./environment-api.js";
+
+function readHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | null {
+  const headers = init?.headers;
+
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+
+  if (headers && !Array.isArray(headers)) {
+    const value = (headers as Record<string, string>)[name];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function createApi(options: StudioEnvironmentApiOptions = {}) {
+  return createStudioEnvironmentApi(
+    {
+      project: "marketing-site",
+      environment: "production",
+      serverUrl: "http://localhost:4000",
+    },
+    options,
+  );
+}
+
+const validEnvSummary = {
+  id: "env-production",
+  project: "marketing-site",
+  name: "production",
+  extends: null,
+  isDefault: true,
+  createdAt: "2026-03-19T10:00:00.000Z",
+};
+
+test("list fetches environments with project header", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify({ data: [validEnvSummary] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  const result = await api.list();
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/environments",
+  );
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-project"), "marketing-site");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-environment"), "production");
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.name, "production");
+});
+
+test("list returns empty array for empty response", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  });
+
+  const result = await api.list();
+
+  assert.deepEqual(result, []);
+});
+
+test("list throws on 401 response", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({ code: "UNAUTHORIZED", message: "Unauthorized" }),
+        { status: 401 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.list(),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.statusCode === 401,
+  );
+});

--- a/packages/studio/src/lib/environment-api.ts
+++ b/packages/studio/src/lib/environment-api.ts
@@ -1,0 +1,82 @@
+import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
+
+import {
+  applyStudioAuthToRequestInit,
+  type StudioRuntimeAuth,
+} from "./request-auth.js";
+
+export type StudioEnvironmentApiConfig = {
+  project: string;
+  environment: string;
+  serverUrl: string;
+};
+
+export type StudioEnvironmentApiOptions = {
+  auth?: StudioRuntimeAuth;
+  fetcher?: typeof fetch;
+};
+
+export type StudioEnvironmentApi = {
+  list: () => Promise<EnvironmentSummary[]>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function readResponsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createStudioEnvironmentApi(
+  config: StudioEnvironmentApiConfig,
+  options: StudioEnvironmentApiOptions = {},
+): StudioEnvironmentApi {
+  const fetcher = options.fetcher ?? fetch;
+
+  return {
+    async list() {
+      const url = new URL("/api/v1/environments", config.serverUrl);
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "GET",
+          headers: {
+            "x-mdcms-project": config.project,
+            "x-mdcms-environment": config.environment,
+          },
+        }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        const parsed = isRecord(payload) ? payload : {};
+        const code =
+          typeof parsed.code === "string" && parsed.code.trim().length > 0
+            ? parsed.code
+            : "ENVIRONMENT_REQUEST_FAILED";
+        const message =
+          typeof parsed.message === "string" && parsed.message.trim().length > 0
+            ? parsed.message
+            : "Environment list request failed.";
+
+        throw new RuntimeError({
+          code,
+          message,
+          statusCode: response.status,
+          details: { status: response.status, payload },
+        });
+      }
+
+      if (!isRecord(payload) || !Array.isArray(payload.data)) {
+        return [];
+      }
+
+      return payload.data as EnvironmentSummary[];
+    },
+  };
+}

--- a/packages/studio/src/lib/remote-studio-app.test.ts
+++ b/packages/studio/src/lib/remote-studio-app.test.ts
@@ -366,6 +366,8 @@ test("SettingsPage links the schema tab to the live schema browser instead of re
           {
             value: {
               canReadSchema: true,
+              canManageUsers: false,
+              canManageSettings: false,
             },
           },
           createElement(SettingsPage, {

--- a/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
@@ -4,10 +4,14 @@ import { createContext, useContext, type PropsWithChildren } from "react";
 
 export type AdminCapabilitiesValue = {
   canReadSchema: boolean;
+  canManageUsers: boolean;
+  canManageSettings: boolean;
 };
 
 const DEFAULT_ADMIN_CAPABILITIES: AdminCapabilitiesValue = {
   canReadSchema: false,
+  canManageUsers: false,
+  canManageSettings: false,
 };
 
 const AdminCapabilitiesContext = createContext<AdminCapabilitiesValue>(
@@ -33,4 +37,12 @@ export function useAdminCapabilities(): AdminCapabilitiesValue {
 
 export function useCanReadSchema(): boolean {
   return useAdminCapabilities().canReadSchema;
+}
+
+export function useCanManageUsers(): boolean {
+  return useAdminCapabilities().canManageUsers;
+}
+
+export function useCanManageSettings(): boolean {
+  return useAdminCapabilities().canManageSettings;
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -44,8 +44,8 @@ export default function ContentPage() {
             const IconComponent = iconMap[type.icon] || FileText;
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
-                <Card className="border-border h-full transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-5">
+                <Card className="border-border h-full py-0 transition-all hover:border-accent/50 hover:shadow-sm">
+                  <CardContent className="p-4">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
@@ -3,7 +3,10 @@ import { test } from "bun:test";
 
 import type { StudioMountContext } from "@mdcms/shared";
 
-import { createAdminLayoutCapabilitiesLoadInput } from "./layout.js";
+import {
+  createAdminLayoutCapabilitiesLoadInput,
+  createAdminLayoutSessionLoadInput,
+} from "./layout.js";
 
 function createContext(): StudioMountContext {
   return {
@@ -42,4 +45,11 @@ test("createAdminLayoutCapabilitiesLoadInput returns null without an active docu
   delete context.documentRoute;
 
   assert.equal(createAdminLayoutCapabilitiesLoadInput(context), null);
+});
+
+test("createAdminLayoutSessionLoadInput maps the server URL and auth", () => {
+  assert.deepEqual(createAdminLayoutSessionLoadInput(createContext()), {
+    config: { serverUrl: "http://localhost:4000" },
+    auth: { mode: "cookie" },
+  });
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -2,10 +2,17 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import type { StudioMountContext } from "@mdcms/shared";
+import type { StudioMountContext, EnvironmentSummary } from "@mdcms/shared";
 
 import { createStudioCurrentPrincipalCapabilitiesApi } from "../../../current-principal-capabilities-api.js";
+import { createStudioSessionApi } from "../../../session-api.js";
+import { createStudioEnvironmentApi } from "../../../environment-api.js";
 import { AdminCapabilitiesProvider } from "./capabilities-context.js";
+import {
+  StudioSessionProvider,
+  type StudioSessionState,
+} from "./session-context.js";
+import { StudioMountInfoProvider } from "./mount-info-context.js";
 import { AppSidebar } from "../../components/layout/app-sidebar";
 import { cn } from "../../lib/utils";
 
@@ -15,6 +22,11 @@ type AdminLayoutCapabilitiesLoadInput = {
     environment: string;
     serverUrl: string;
   };
+  auth: StudioMountContext["auth"];
+};
+
+type AdminLayoutSessionLoadInput = {
+  config: { serverUrl: string };
   auth: StudioMountContext["auth"];
 };
 
@@ -37,6 +49,15 @@ export function createAdminLayoutCapabilitiesLoadInput(
   };
 }
 
+export function createAdminLayoutSessionLoadInput(
+  context: StudioMountContext,
+): AdminLayoutSessionLoadInput {
+  return {
+    config: { serverUrl: context.apiBaseUrl },
+    auth: context.auth,
+  };
+}
+
 export default function AdminLayout({
   children,
   context,
@@ -46,6 +67,12 @@ export default function AdminLayout({
 }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [canReadSchema, setCanReadSchema] = useState(false);
+  const [canManageUsers, setCanManageUsers] = useState(false);
+  const [canManageSettings, setCanManageSettings] = useState(false);
+  const [sessionState, setSessionState] = useState<StudioSessionState>({
+    status: "loading",
+  });
+  const [environments, setEnvironments] = useState<EnvironmentSummary[]>([]);
 
   // Persist sidebar state
   useEffect(() => {
@@ -55,20 +82,21 @@ export default function AdminLayout({
     }
   }, []);
 
+  // Fetch capabilities
   useEffect(() => {
     const loadInput = createAdminLayoutCapabilitiesLoadInput(context);
 
     if (!loadInput) {
       setCanReadSchema(false);
+      setCanManageUsers(false);
+      setCanManageSettings(false);
       return;
     }
 
     let cancelled = false;
     const capabilitiesApi = createStudioCurrentPrincipalCapabilitiesApi(
       loadInput.config,
-      {
-        auth: loadInput.auth,
-      },
+      { auth: loadInput.auth },
     );
 
     void capabilitiesApi
@@ -76,11 +104,99 @@ export default function AdminLayout({
       .then((response) => {
         if (!cancelled) {
           setCanReadSchema(response.capabilities.schema.read);
+          setCanManageUsers(response.capabilities.users.manage);
+          setCanManageSettings(response.capabilities.settings.manage);
         }
       })
       .catch(() => {
         if (!cancelled) {
           setCanReadSchema(false);
+          setCanManageUsers(false);
+          setCanManageSettings(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    context.apiBaseUrl,
+    context.auth.mode,
+    context.auth.token,
+    context.documentRoute?.environment,
+    context.documentRoute?.project,
+  ]);
+
+  // Fetch session
+  useEffect(() => {
+    const loadInput = createAdminLayoutSessionLoadInput(context);
+    let cancelled = false;
+
+    const sessionApi = createStudioSessionApi(loadInput.config, {
+      auth: loadInput.auth,
+    });
+
+    void sessionApi
+      .get()
+      .then((response) => {
+        if (!cancelled) {
+          setSessionState({
+            status: "authenticated",
+            session: response.session,
+            csrfToken: response.csrfToken,
+          });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          const isUnauthorized =
+            error &&
+            typeof error === "object" &&
+            "statusCode" in error &&
+            error.statusCode === 401;
+          setSessionState(
+            isUnauthorized
+              ? { status: "unauthenticated" }
+              : {
+                  status: "error",
+                  message:
+                    error instanceof Error
+                      ? error.message
+                      : "Session fetch failed.",
+                },
+          );
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [context.apiBaseUrl, context.auth.mode, context.auth.token]);
+
+  // Fetch environments
+  useEffect(() => {
+    const capLoadInput = createAdminLayoutCapabilitiesLoadInput(context);
+
+    if (!capLoadInput) {
+      setEnvironments([]);
+      return;
+    }
+
+    let cancelled = false;
+    const envApi = createStudioEnvironmentApi(capLoadInput.config, {
+      auth: capLoadInput.auth,
+    });
+
+    void envApi
+      .list()
+      .then((list) => {
+        if (!cancelled) {
+          setEnvironments(list);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEnvironments([]);
         }
       });
 
@@ -101,22 +217,38 @@ export default function AdminLayout({
     localStorage.setItem("sidebar-collapsed", String(newState));
   };
 
+  const mountInfo = {
+    project: context.documentRoute?.project ?? null,
+    environment: context.documentRoute?.environment ?? null,
+    apiBaseUrl: context.apiBaseUrl,
+    environments,
+    hostBridge: context.hostBridge,
+  };
+
   return (
     <div className="min-h-screen overflow-x-hidden bg-background">
-      <AdminCapabilitiesProvider value={{ canReadSchema }}>
-        <AppSidebar
-          canReadSchema={canReadSchema}
-          collapsed={sidebarCollapsed}
-          onToggle={handleToggle}
-        />
-        <main
-          className={cn(
-            "min-h-screen min-w-0 overflow-x-hidden transition-all duration-300",
-            sidebarCollapsed ? "ml-16" : "ml-60",
-          )}
-        >
-          {children}
-        </main>
+      <AdminCapabilitiesProvider
+        value={{ canReadSchema, canManageUsers, canManageSettings }}
+      >
+        <StudioSessionProvider value={sessionState}>
+          <StudioMountInfoProvider value={mountInfo}>
+            <AppSidebar
+              canReadSchema={canReadSchema}
+              canManageUsers={canManageUsers}
+              canManageSettings={canManageSettings}
+              collapsed={sidebarCollapsed}
+              onToggle={handleToggle}
+            />
+            <main
+              className={cn(
+                "min-h-screen min-w-0 overflow-x-hidden transition-all duration-300",
+                sidebarCollapsed ? "ml-16" : "ml-60",
+              )}
+            >
+              {children}
+            </main>
+          </StudioMountInfoProvider>
+        </StudioSessionProvider>
       </AdminCapabilitiesProvider>
     </div>
   );

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  type PropsWithChildren,
-} from "react";
+import { createContext, useContext, type PropsWithChildren } from "react";
 
 import type { EnvironmentSummary, HostBridgeV1 } from "@mdcms/shared";
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  type PropsWithChildren,
+} from "react";
+
+import type { EnvironmentSummary, HostBridgeV1 } from "@mdcms/shared";
+
+export type StudioMountInfo = {
+  project: string | null;
+  environment: string | null;
+  apiBaseUrl: string;
+  environments: EnvironmentSummary[];
+  hostBridge: HostBridgeV1 | null;
+};
+
+const DEFAULT_MOUNT_INFO: StudioMountInfo = {
+  project: null,
+  environment: null,
+  apiBaseUrl: "",
+  environments: [],
+  hostBridge: null,
+};
+
+const StudioMountInfoContext =
+  createContext<StudioMountInfo>(DEFAULT_MOUNT_INFO);
+
+export function StudioMountInfoProvider({
+  value,
+  children,
+}: PropsWithChildren<{ value: StudioMountInfo }>) {
+  return (
+    <StudioMountInfoContext.Provider value={value}>
+      {children}
+    </StudioMountInfoContext.Provider>
+  );
+}
+
+export function useStudioMountInfo(): StudioMountInfo {
+  return useContext(StudioMountInfoContext);
+}

--- a/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
@@ -12,8 +12,9 @@ export type StudioSessionState =
 
 const DEFAULT_SESSION_STATE: StudioSessionState = { status: "loading" };
 
-const StudioSessionContext =
-  createContext<StudioSessionState>(DEFAULT_SESSION_STATE);
+const StudioSessionContext = createContext<StudioSessionState>(
+  DEFAULT_SESSION_STATE,
+);
 
 export function StudioSessionProvider({
   value,

--- a/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext, type PropsWithChildren } from "react";
+
+import type { StudioSessionInfo } from "../../../session-api.js";
+
+export type StudioSessionState =
+  | { status: "loading" }
+  | { status: "authenticated"; session: StudioSessionInfo; csrfToken: string }
+  | { status: "unauthenticated" }
+  | { status: "error"; message: string };
+
+const DEFAULT_SESSION_STATE: StudioSessionState = { status: "loading" };
+
+const StudioSessionContext =
+  createContext<StudioSessionState>(DEFAULT_SESSION_STATE);
+
+export function StudioSessionProvider({
+  value,
+  children,
+}: PropsWithChildren<{ value: StudioSessionState }>) {
+  return (
+    <StudioSessionContext.Provider value={value}>
+      {children}
+    </StudioSessionContext.Provider>
+  );
+}
+
+export function useStudioSession(): StudioSessionState {
+  return useContext(StudioSessionContext);
+}

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
@@ -37,6 +37,8 @@ function renderSettingsPage(input: {
           {
             value: {
               canReadSchema: true,
+              canManageUsers: false,
+              canManageSettings: false,
               ...input.capabilities,
             },
           },

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
@@ -60,3 +60,79 @@ test("AppSidebar keeps review deployment links scoped to the active scenario bas
   assert.doesNotMatch(markup, /href="\/admin\/schema"/);
   assert.match(markup, /bg-accent-subtle/);
 });
+
+function renderSidebarWithCapabilities(caps: {
+  canReadSchema: boolean;
+  canManageUsers: boolean;
+  canManageSettings: boolean;
+}): string {
+  return renderToStaticMarkup(
+    createElement(
+      StudioNavigationProvider,
+      {
+        value: {
+          pathname: "/admin",
+          params: {},
+          push: () => {},
+          replace: () => {},
+          back: () => {},
+        },
+      },
+      createElement(AppSidebar, {
+        ...caps,
+        collapsed: false,
+        onToggle: () => {},
+      }),
+    ),
+  );
+}
+
+test("AppSidebar shows Users route when users.manage is allowed", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: true,
+    canManageSettings: true,
+  });
+
+  assert.match(markup, /href="\/admin\/users"/);
+});
+
+test("AppSidebar hides Users route when users.manage is not allowed", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: false,
+    canManageSettings: true,
+  });
+
+  assert.doesNotMatch(markup, /href="\/admin\/users"/);
+});
+
+test("AppSidebar shows Settings route when settings.manage is allowed", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: true,
+    canManageSettings: true,
+  });
+
+  assert.match(markup, /href="\/admin\/settings"/);
+});
+
+test("AppSidebar hides Settings route when settings.manage is not allowed", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: true,
+    canManageSettings: false,
+  });
+
+  assert.doesNotMatch(markup, /href="\/admin\/settings"/);
+});
+
+test("AppSidebar does not render online presence section", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: true,
+    canManageSettings: true,
+  });
+
+  assert.doesNotMatch(markup, /Online now/i);
+});

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -28,7 +28,6 @@ import {
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
-import { Avatar, AvatarFallback } from "../ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -41,11 +40,12 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { MDCMSLogo } from "../mdcms-logo";
-import { mockUsers } from "../../lib/mock-data";
 import { useState } from "react";
 
 interface AppSidebarProps {
   canReadSchema?: boolean;
+  canManageUsers?: boolean;
+  canManageSettings?: boolean;
   collapsed: boolean;
   onToggle: () => void;
 }
@@ -63,10 +63,17 @@ const mainNavItems = [
   { icon: Trash2, label: "Trash", href: "/admin/trash" },
 ];
 
-function getMainNavItems(canReadSchema: boolean) {
-  return canReadSchema
-    ? mainNavItems
-    : mainNavItems.filter((item) => item.href !== "/admin/schema");
+function getMainNavItems(filters: {
+  canReadSchema: boolean;
+  canManageUsers: boolean;
+  canManageSettings: boolean;
+}) {
+  return mainNavItems.filter((item) => {
+    if (item.href === "/admin/schema") return filters.canReadSchema;
+    if (item.href === "/admin/users") return filters.canManageUsers;
+    if (item.href === "/admin/settings") return filters.canManageSettings;
+    return true;
+  });
 }
 
 const comingSoonItems = [
@@ -77,6 +84,8 @@ const comingSoonItems = [
 
 export function AppSidebar({
   canReadSchema,
+  canManageUsers,
+  canManageSettings,
   collapsed,
   onToggle,
 }: AppSidebarProps) {
@@ -84,8 +93,9 @@ export function AppSidebar({
   const basePath = useBasePath();
   const contextCanReadSchema = useCanReadSchema();
   const effectiveCanReadSchema = canReadSchema ?? contextCanReadSchema;
+  const effectiveCanManageUsers = canManageUsers ?? false;
+  const effectiveCanManageSettings = canManageSettings ?? false;
   const [comingSoonOpen, setComingSoonOpen] = useState(false);
-  const onlineUsers = mockUsers.filter((u) => u.isOnline).slice(0, 5);
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -110,7 +120,11 @@ export function AppSidebar({
         {/* Main Navigation */}
         <nav className="flex-1 overflow-y-auto p-2">
           <ul className="space-y-1">
-            {getMainNavItems(effectiveCanReadSchema).map((item) => {
+            {getMainNavItems({
+              canReadSchema: effectiveCanReadSchema,
+              canManageUsers: effectiveCanManageUsers,
+              canManageSettings: effectiveCanManageSettings,
+            }).map((item) => {
               const resolvedHref = resolveStudioHref(basePath, item.href);
               const isActive =
                 pathname === resolvedHref ||
@@ -214,35 +228,6 @@ export function AppSidebar({
 
         {/* Bottom Section */}
         <div className="border-t border-border p-2">
-          {/* Online Users */}
-          {!collapsed && onlineUsers.length > 0 && (
-            <div className="mb-2 px-3 py-2">
-              <div className="mb-2 text-xs font-medium text-foreground-muted">
-                Online now
-              </div>
-              <div className="flex -space-x-2">
-                {onlineUsers.map((user) => (
-                  <Tooltip key={user.id}>
-                    <TooltipTrigger asChild>
-                      <div className="relative">
-                        <Avatar className="h-7 w-7 border-2 border-background">
-                          <AvatarFallback className="text-xs">
-                            {user.name
-                              .split(" ")
-                              .map((n) => n[0])
-                              .join("")}
-                          </AvatarFallback>
-                        </Avatar>
-                        <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-success ring-2 ring-background" />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>{user.name}</TooltipContent>
-                  </Tooltip>
-                ))}
-              </div>
-            </div>
-          )}
-
           {/* Collapse Toggle */}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -4,14 +4,7 @@
 import * as React from "react";
 import { useTheme } from "../../adapters/next-themes";
 import Link from "../../adapters/next-link";
-import {
-  Sun,
-  Moon,
-  ChevronRight,
-  LogOut,
-  User,
-  Settings,
-} from "lucide-react";
+import { Sun, Moon, ChevronRight, LogOut, User, Settings } from "lucide-react";
 import { Button } from "../ui/button";
 import { Avatar, AvatarFallback } from "../ui/avatar";
 import {

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -7,12 +7,10 @@ import Link from "../../adapters/next-link";
 import {
   Sun,
   Moon,
-  Bell,
   ChevronRight,
   LogOut,
   User,
   Settings,
-  Search,
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { Avatar, AvatarFallback } from "../ui/avatar";
@@ -38,13 +36,9 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 import { cn } from "../../lib/utils";
-import {
-  currentUser,
-  mockEnvironments,
-  mockProjects,
-  currentProject,
-} from "../../lib/mock-data";
-import { useState } from "react";
+import { useStudioSession } from "../../app/admin/session-context";
+import { useStudioMountInfo } from "../../app/admin/mount-info-context";
+import { createStudioSessionApi } from "../../../session-api.js";
 
 export type BreadcrumbItem = { label: string; href?: string };
 
@@ -151,19 +145,36 @@ export function BreadcrumbTrail({
   );
 }
 
+function deriveInitials(email: string): string {
+  const local = email.split("@")[0] ?? "";
+  const parts = local.split(/[._-]/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+  }
+  return local.slice(0, 2).toUpperCase();
+}
+
 export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
   const { theme, setTheme } = useTheme();
-  const [currentEnv, setCurrentEnv] = useState(mockEnvironments[0]);
-  const [hasNotifications] = useState(true);
+  const sessionState = useStudioSession();
+  const mountInfo = useStudioMountInfo();
 
-  const getEnvDotColor = (color: string) => {
-    const colors: Record<string, string> = {
-      green: "bg-success",
-      yellow: "bg-warning",
-      blue: "bg-blue-500",
-      gray: "bg-foreground-muted",
-    };
-    return colors[color] || colors.gray;
+  const handleSignOut = async () => {
+    if (sessionState.status !== "authenticated") return;
+
+    try {
+      const api = createStudioSessionApi(
+        { serverUrl: mountInfo.apiBaseUrl },
+        { auth: { mode: "cookie" } },
+      );
+      await api.signOut(sessionState.csrfToken);
+    } finally {
+      window.location.reload();
+    }
+  };
+
+  const handleEnvironmentChange = (environmentName: string) => {
+    mountInfo.hostBridge?.onNavigate?.({ environment: environmentName });
   };
 
   return (
@@ -174,69 +185,35 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
 
         {/* Right side - Controls */}
         <div className="flex items-center gap-3">
-          {/* Search trigger */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-foreground-muted"
-              >
-                <Search className="h-5 w-5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Search (Cmd+K)</TooltipContent>
-          </Tooltip>
-
           {/* Environment selector */}
-          <Select
-            value={currentEnv.id}
-            onValueChange={(value) => {
-              const env = mockEnvironments.find((e) => e.id === value);
-              if (env) setCurrentEnv(env);
-            }}
-          >
-            <SelectTrigger className="w-36 h-9">
-              <div className="flex items-center gap-2">
-                <span
-                  className={cn(
-                    "h-2 w-2 rounded-full",
-                    getEnvDotColor(currentEnv.color),
-                  )}
-                />
+          {mountInfo.environments.length > 0 ? (
+            <Select
+              value={mountInfo.environment ?? undefined}
+              onValueChange={handleEnvironmentChange}
+            >
+              <SelectTrigger className="w-36 h-9">
                 <SelectValue />
-              </div>
-            </SelectTrigger>
-            <SelectContent>
-              {mockEnvironments.map((env) => (
-                <SelectItem key={env.id} value={env.id}>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={cn(
-                        "h-2 w-2 rounded-full",
-                        getEnvDotColor(env.color),
-                      )}
-                    />
-                    <span>{env.name}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+              </SelectTrigger>
+              <SelectContent>
+                {mountInfo.environments.map((env) => (
+                  <SelectItem key={env.id} value={env.name}>
+                    {env.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : mountInfo.environment ? (
+            <div className="flex items-center gap-2 h-9 px-3 rounded-md border border-border text-sm text-foreground-muted">
+              {mountInfo.environment}
+            </div>
+          ) : null}
 
-          {/* Project switcher */}
-          <Select defaultValue={currentProject.id}>
-            <SelectTrigger className="w-40 h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {mockProjects.map((project) => (
-                <SelectItem key={project.id} value={project.id}>
-                  {project.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          {/* Project badge (read-only) */}
+          {mountInfo.project && (
+            <div className="flex items-center h-9 px-3 rounded-md border border-border text-sm text-foreground-muted">
+              {mountInfo.project}
+            </div>
+          )}
 
           {/* Dark mode toggle */}
           <Tooltip>
@@ -255,62 +232,50 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
             <TooltipContent>Toggle theme</TooltipContent>
           </Tooltip>
 
-          {/* Notifications */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="relative text-foreground-muted"
-              >
-                <Bell className="h-5 w-5" />
-                {hasNotifications && (
-                  <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-accent" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Notifications</TooltipContent>
-          </Tooltip>
-
           {/* User menu */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="rounded-full">
-                <Avatar className="h-8 w-8">
-                  <AvatarFallback className="text-sm">
-                    {currentUser.name
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")}
-                  </AvatarFallback>
-                </Avatar>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuLabel className="font-normal">
-                <div className="flex flex-col space-y-1">
-                  <p className="text-sm font-medium">{currentUser.name}</p>
-                  <p className="text-xs text-foreground-muted">
-                    {currentUser.email}
-                  </p>
-                </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem>
-                <User className="mr-2 h-4 w-4" />
-                Profile
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Settings className="mr-2 h-4 w-4" />
-                Preferences
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem className="text-destructive focus:text-destructive">
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {sessionState.status === "authenticated" ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="rounded-full">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback className="text-sm">
+                      {deriveInitials(sessionState.session.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel className="font-normal">
+                  <div className="flex flex-col space-y-1">
+                    <p className="text-sm font-medium">
+                      {sessionState.session.email}
+                    </p>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                  <User className="mr-2 h-4 w-4" />
+                  Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Settings className="mr-2 h-4 w-4" />
+                  Preferences
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={handleSignOut}
+                >
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Avatar className="h-8 w-8">
+              <AvatarFallback className="text-sm">?</AvatarFallback>
+            </Avatar>
+          )}
         </div>
       </header>
     </TooltipProvider>

--- a/packages/studio/src/lib/session-api.test.ts
+++ b/packages/studio/src/lib/session-api.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  createStudioSessionApi,
+  type StudioSessionApiOptions,
+} from "./session-api.js";
+
+function readHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | null {
+  const headers = init?.headers;
+
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+
+  if (headers && !Array.isArray(headers)) {
+    const value = (headers as Record<string, string>)[name];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function createSessionApi(options: StudioSessionApiOptions = {}) {
+  return createStudioSessionApi(
+    { serverUrl: "http://localhost:4000" },
+    options,
+  );
+}
+
+function createSessionResponse(
+  overrides: Record<string, unknown> = {},
+): Response {
+  return new Response(
+    JSON.stringify({
+      data: {
+        csrfToken: "csrf-test-token",
+        session: {
+          id: "session-1",
+          userId: "user-1",
+          email: "alice@company.com",
+          issuedAt: "2026-04-02T10:00:00.000Z",
+          expiresAt: "2026-04-02T22:00:00.000Z",
+          ...overrides,
+        },
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+test("get fetches session with cookie auth", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createSessionApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return createSessionResponse();
+    },
+  });
+
+  const result = await api.get();
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/auth/session",
+  );
+  assert.equal(calls[0]?.init?.credentials, "include");
+  assert.equal(readHeader(calls[0]?.init, "authorization"), null);
+  assert.equal(result.session.email, "alice@company.com");
+  assert.equal(result.session.userId, "user-1");
+  assert.equal(result.csrfToken, "csrf-test-token");
+});
+
+test("get attaches bearer token in token auth mode", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createSessionApi({
+    auth: { mode: "token", token: "mdcms_key_test" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return createSessionResponse();
+    },
+  });
+
+  const result = await api.get();
+
+  assert.equal(
+    readHeader(calls[0]?.init, "authorization"),
+    "Bearer mdcms_key_test",
+  );
+  assert.equal(calls[0]?.init?.credentials, undefined);
+  assert.equal(result.session.email, "alice@company.com");
+});
+
+test("get throws UNAUTHORIZED on 401 response", async () => {
+  const api = createSessionApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({
+          status: "error",
+          code: "UNAUTHORIZED",
+          message: "A valid Studio session is required.",
+        }),
+        { status: 401 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.get(),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.code === "UNAUTHORIZED" &&
+      error.statusCode === 401,
+  );
+});
+
+test("get throws on invalid response shape", async () => {
+  const api = createSessionApi({
+    fetcher: async () =>
+      new Response(JSON.stringify({ data: { csrfToken: "token" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  });
+
+  await assert.rejects(
+    () => api.get(),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.code === "SESSION_RESPONSE_INVALID",
+  );
+});
+
+test("signOut posts to logout with CSRF token", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createSessionApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify({ data: { revoked: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  await api.signOut("csrf-test-token");
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/auth/logout",
+  );
+  assert.equal(calls[0]?.init?.method, "POST");
+  assert.equal(
+    readHeader(calls[0]?.init, "x-mdcms-csrf-token"),
+    "csrf-test-token",
+  );
+  assert.equal(calls[0]?.init?.credentials, "include");
+});

--- a/packages/studio/src/lib/session-api.ts
+++ b/packages/studio/src/lib/session-api.ts
@@ -1,0 +1,180 @@
+import { RuntimeError } from "@mdcms/shared";
+
+import {
+  applyStudioAuthToRequestInit,
+  type StudioRuntimeAuth,
+} from "./request-auth.js";
+
+export type StudioSessionInfo = {
+  id: string;
+  userId: string;
+  email: string;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+export type StudioSessionResponse = {
+  session: StudioSessionInfo;
+  csrfToken: string;
+};
+
+export type StudioSessionApiConfig = {
+  serverUrl: string;
+};
+
+export type StudioSessionApiOptions = {
+  auth?: StudioRuntimeAuth;
+  fetcher?: typeof fetch;
+};
+
+export type StudioSessionApi = {
+  get: () => Promise<StudioSessionResponse>;
+  signOut: (csrfToken: string) => Promise<void>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toRouteFailureError(
+  operation: string,
+  response: Response,
+  payload: unknown,
+  fallbackMessage: string,
+): RuntimeError {
+  const parsed = isRecord(payload) ? payload : {};
+  const code =
+    typeof parsed.code === "string" && parsed.code.trim().length > 0
+      ? parsed.code
+      : "SESSION_REQUEST_FAILED";
+  const message =
+    typeof parsed.message === "string" && parsed.message.trim().length > 0
+      ? parsed.message
+      : fallbackMessage;
+
+  return new RuntimeError({
+    code,
+    message,
+    statusCode: response.status,
+    details: { operation, status: response.status, payload },
+  });
+}
+
+function toInvalidResponseError(
+  operation: string,
+  payload: unknown,
+): RuntimeError {
+  return new RuntimeError({
+    code: "SESSION_RESPONSE_INVALID",
+    message: "Session response is invalid.",
+    statusCode: 500,
+    details: { operation, payload },
+  });
+}
+
+function validateSessionResponse(
+  operation: string,
+  payload: unknown,
+): StudioSessionResponse {
+  if (!isRecord(payload)) {
+    throw toInvalidResponseError(operation, payload);
+  }
+
+  const data = payload.data;
+  if (!isRecord(data)) {
+    throw toInvalidResponseError(operation, payload);
+  }
+
+  const csrfToken = data.csrfToken;
+  if (!isNonEmptyString(csrfToken)) {
+    throw toInvalidResponseError(operation, payload);
+  }
+
+  const session = data.session;
+  if (!isRecord(session)) {
+    throw toInvalidResponseError(operation, payload);
+  }
+
+  if (
+    !isNonEmptyString(session.id) ||
+    !isNonEmptyString(session.userId) ||
+    !isNonEmptyString(session.email) ||
+    !isNonEmptyString(session.issuedAt) ||
+    !isNonEmptyString(session.expiresAt)
+  ) {
+    throw toInvalidResponseError(operation, payload);
+  }
+
+  return {
+    csrfToken,
+    session: {
+      id: session.id as string,
+      userId: session.userId as string,
+      email: session.email as string,
+      issuedAt: session.issuedAt as string,
+      expiresAt: session.expiresAt as string,
+    },
+  };
+}
+
+async function readResponsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createStudioSessionApi(
+  config: StudioSessionApiConfig,
+  options: StudioSessionApiOptions = {},
+): StudioSessionApi {
+  const fetcher = options.fetcher ?? fetch;
+
+  return {
+    async get() {
+      const url = new URL("/api/v1/auth/session", config.serverUrl);
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, { method: "GET" }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        throw toRouteFailureError(
+          "GET /api/v1/auth/session",
+          response,
+          payload,
+          "Session request failed.",
+        );
+      }
+
+      return validateSessionResponse("GET /api/v1/auth/session", payload);
+    },
+
+    async signOut(csrfToken: string) {
+      const url = new URL("/api/v1/auth/logout", config.serverUrl);
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "POST",
+          headers: { "x-mdcms-csrf-token": csrfToken },
+        }),
+      );
+
+      if (!response.ok) {
+        const payload = await readResponsePayload(response);
+        throw toRouteFailureError(
+          "POST /api/v1/auth/logout",
+          response,
+          payload,
+          "Sign-out request failed.",
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Wire Studio shell (sidebar + page header) to real server data instead of mock data
- Add session API client (`GET /api/v1/auth/session`) and environment API client (`GET /api/v1/environments`)
- Expand capabilities context with `canManageUsers` and `canManageSettings` flags
- Gate Users/Settings/Schema sidebar nav items by role-based capabilities
- Remove fake MVP affordances: search button, notification bell, online presence
- Wire real user menu (email from session, sign-out via `POST /api/v1/auth/logout`)
- Add interactive environment dropdown (fetches real list, switches via `hostBridge.onNavigate`)
- Display project as read-only badge (no listing API)
- Extend `HostBridgeV1` with optional `onNavigate` callback for environment switching
- Reduce content card padding on content type grid page

## Test plan

- [x] 231 studio tests pass (8 new for session API, env API, sidebar role-gating)
- [x] 114 shared tests pass (2 new for HostBridgeV1 onNavigate)
- [x] Typecheck clean across all 6 packages
- [x] Prettier format check passes
- [x] Studio embed smoke check passes
- [ ] Manual: verify no search/notifications/presence in UI
- [ ] Manual: verify user menu shows real email after login
- [ ] Manual: verify non-admin can't see Users/Settings in sidebar
- [ ] Manual: verify environment dropdown shows real environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-based access control for admin features (user and settings management).
  * Introduced environment selection in the page header with navigation support.
  * Implemented runtime session authentication and management.
  * Enhanced admin layout with dynamic context-driven configuration.

* **Bug Fixes**
  * Fixed admin content card spacing.

* **Refactor**
  * Removed mock online presence UI from sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->