### PR TITLE
Streamline sidebar and normalize stat card spacing

### DIFF
--- a/apps/studio-review/package.json
+++ b/apps/studio-review/package.json
@@ -16,8 +16,9 @@
     "@mdcms/cli": "workspace:*",
     "@mdcms/shared": "workspace:*",
     "@mdcms/studio": "workspace:*",
+    "lucide-react": "^1.7.0",
     "next": "^15.2.2",
-    "react": "^19.0.0",
+    "react": "^19.2.4",
     "react-dom": "^19.0.0",
     "zod": "^4.3.6"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -74,8 +74,9 @@
         "@mdcms/cli": "workspace:*",
         "@mdcms/shared": "workspace:*",
         "@mdcms/studio": "workspace:*",
+        "lucide-react": "^1.7.0",
         "next": "^15.2.2",
-        "react": "^19.0.0",
+        "react": "^19.2.4",
         "react-dom": "^19.0.0",
         "zod": "^4.3.6",
       },
@@ -1674,6 +1675,8 @@
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@esbuild-kit/core-utils/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "@mdcms/studio-review/lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -44,8 +44,8 @@ export default function ContentPage() {
             const IconComponent = iconMap[type.icon] || FileText;
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
-                <Card className="border-border h-full transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-6">
+                <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
+                  <CardContent className="p-5">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -45,7 +45,7 @@ export default function ContentPage() {
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
                 <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-4">
+                  <CardContent className="px-4 py-2">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -44,8 +44,8 @@ export default function ContentPage() {
             const IconComponent = iconMap[type.icon] || FileText;
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
-                <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="px-4 py-2">
+                <Card className="border-border h-full !py-0 !gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
+                  <CardContent className="p-4">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -45,7 +45,7 @@ export default function ContentPage() {
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
                 <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-5">
+                  <CardContent className="px-5 py-4">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -45,7 +45,7 @@ export default function ContentPage() {
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
                 <Card className="border-border h-full transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-5">
+                  <CardContent className="p-6">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -45,7 +45,7 @@ export default function ContentPage() {
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
                 <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="px-4 py-3">
+                  <CardContent className="p-4">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -45,7 +45,7 @@ export default function ContentPage() {
             return (
               <Link key={type.id} href={`/admin/content/${type.id}`}>
                 <Card className="border-border h-full py-0 gap-0 transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="px-5 py-4">
+                  <CardContent className="px-4 py-3">
                     <div className="flex items-start gap-4">
                       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
                         <IconComponent className="h-6 w-6 text-accent" />

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -89,8 +89,8 @@ export default function DashboardPage() {
         {/* Stats Row */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           {statCards.map((stat) => (
-            <Card key={stat.label} className="border-border py-0 gap-0">
-              <CardContent className="p-4">
+            <Card key={stat.label} className="border-border">
+              <CardContent>
                 <div className="flex items-start justify-between">
                   <div className="space-y-1">
                     <p className="text-sm text-foreground-muted">

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -28,7 +28,6 @@ import {
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
-import { Avatar, AvatarFallback } from "../ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -41,7 +40,6 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { MDCMSLogo } from "../mdcms-logo";
-import { mockUsers } from "../../lib/mock-data";
 import { useState } from "react";
 
 interface AppSidebarProps {
@@ -85,7 +83,6 @@ export function AppSidebar({
   const contextCanReadSchema = useCanReadSchema();
   const effectiveCanReadSchema = canReadSchema ?? contextCanReadSchema;
   const [comingSoonOpen, setComingSoonOpen] = useState(false);
-  const onlineUsers = mockUsers.filter((u) => u.isOnline).slice(0, 5);
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -214,35 +211,6 @@ export function AppSidebar({
 
         {/* Bottom Section */}
         <div className="border-t border-border p-2">
-          {/* Online Users */}
-          {!collapsed && onlineUsers.length > 0 && (
-            <div className="mb-2 px-3 py-2">
-              <div className="mb-2 text-xs font-medium text-foreground-muted">
-                Online now
-              </div>
-              <div className="flex -space-x-2">
-                {onlineUsers.map((user) => (
-                  <Tooltip key={user.id}>
-                    <TooltipTrigger asChild>
-                      <div className="relative">
-                        <Avatar className="h-7 w-7 border-2 border-background">
-                          <AvatarFallback className="text-xs">
-                            {user.name
-                              .split(" ")
-                              .map((n) => n[0])
-                              .join("")}
-                          </AvatarFallback>
-                        </Avatar>
-                        <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-success ring-2 ring-background" />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>{user.name}</TooltipContent>
-                  </Tooltip>
-                ))}
-              </div>
-            </div>
-          )}
-
           {/* Collapse Toggle */}
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
- Removed the "Online now" section from the sidebar to reduce visual clutter and simplify the navigation interface.
- Standardized padding across all stat cards by removing manual overrides, ensuring consistent visual alignment.

[v0 Session](https://v0.app/chat/TlmTvNfLIUm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added icon library support for enhanced UI elements.

* **Style**
  * Adjusted content-type card padding and layout.
  * Refined dashboard stat card spacing.

* **Removed Features**
  * Removed the online-users indicator from the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->