### PR TITLE
feat(cms-130): integrate dashboard with real Studio runtime data

### DIFF
--- a/apps/server/src/bin/demo-seed-api-key.ts
+++ b/apps/server/src/bin/demo-seed-api-key.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { RuntimeError } from "@mdcms/shared";
-
 import { createAuthService } from "../lib/auth.js";
 import { createDatabaseContentStore } from "../lib/content-api.js";
 import { createDatabaseConnection } from "../lib/db.js";
@@ -291,6 +290,34 @@ async function ensureDemoApiKey(input: {
   });
 }
 
+async function ensureDemoRbacGrant(input: {
+  db: ReturnType<typeof createDatabaseConnection>["db"];
+  userId: string;
+  project: string;
+}): Promise<void> {
+  const existing = await input.db.query.rbacGrants.findFirst({
+    where: and(
+      eq(rbacGrants.userId, input.userId),
+      eq(rbacGrants.scopeKind, "project"),
+      eq(rbacGrants.project, input.project),
+      isNull(rbacGrants.revokedAt),
+    ),
+  });
+
+  if (existing) {
+    return;
+  }
+
+  await input.db.insert(rbacGrants).values({
+    userId: input.userId,
+    role: "editor",
+    scopeKind: "project",
+    project: input.project,
+    source: "demo-seed",
+    createdByUserId: input.userId,
+  });
+}
+
 async function ensureDemoContent(input: {
   db: ReturnType<typeof createDatabaseConnection>["db"];
   actorId: string;
@@ -433,6 +460,12 @@ async function main(): Promise<void> {
       apiKey,
       project,
       environment,
+    });
+
+    await ensureDemoRbacGrant({
+      db: connection.db,
+      userId,
+      project,
     });
 
     const seededDocuments = await ensureDemoContent({

--- a/apps/server/src/bin/demo-seed-api-key.ts
+++ b/apps/server/src/bin/demo-seed-api-key.ts
@@ -310,7 +310,7 @@ async function ensureDemoRbacGrant(input: {
 
   await input.db.insert(rbacGrants).values({
     userId: input.userId,
-    role: "editor",
+    role: "viewer",
     scopeKind: "project",
     project: input.project,
     source: "demo-seed",

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -2652,10 +2652,10 @@ export function createAuthService(
 
   function toRedirectResponse(response: Response, location: string): Response {
     const headers = new Headers(response.headers);
-    headers.delete("content-type");
+    headers.set("content-type", "application/json");
     headers.set("location", location);
 
-    return new Response(null, {
+    return new Response(JSON.stringify({ url: location }), {
       status: 302,
       headers,
     });

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -240,6 +240,7 @@ export type AuthService = {
   handleSamlAcs: (request: Request) => Promise<Response>;
   handleSamlMetadata: (request: Request) => Promise<Response>;
   handleAuthRequest: (request: Request) => Promise<Response>;
+  listSsoProviders: () => Array<{ id: string; name: string }>;
 };
 
 type BetterAuthLikeSession = {
@@ -1895,6 +1896,16 @@ function createAuthBackoffError(retryAfterSeconds: number): RuntimeError {
       retryAfterSeconds,
     },
   });
+}
+
+function formatSsoProviderName(providerId: string): string {
+  const names: Record<string, string> = {
+    okta: "Okta",
+    "azure-ad": "Azure AD",
+    "google-workspace": "Google Workspace",
+    auth0: "Auth0",
+  };
+  return names[providerId] ?? providerId;
 }
 
 function createAuthBackoffResponse(
@@ -4060,6 +4071,21 @@ export function createAuthService(
     handleAuthRequest(request) {
       return auth.handler(request);
     },
+    listSsoProviders() {
+      const providers: Array<{ id: string; name: string }> = [];
+
+      for (const [id] of oidcProviderConfigById) {
+        providers.push({ id, name: formatSsoProviderName(id) });
+      }
+
+      for (const [id] of samlProviderConfigById) {
+        if (!providers.some((p) => p.id === id)) {
+          providers.push({ id, name: formatSsoProviderName(id) });
+        }
+      }
+
+      return providers;
+    },
   };
 }
 
@@ -4414,6 +4440,12 @@ export function mountAuthRoutes(
     executeWithRuntimeErrorsHandled(request, async () =>
       options.authService.startSsoSignIn(request),
     ),
+  );
+  authApp.get?.("/api/v1/auth/sso/providers", ({ request }: any) =>
+    executeWithRuntimeErrorsHandled(request, async () => {
+      const providers = options.authService.listSsoProviders();
+      return { data: providers };
+    }),
   );
   authApp.get?.("/api/v1/auth/sso/callback/:providerId", ({ request }: any) =>
     executeWithRuntimeErrorsHandled(request, async () =>

--- a/apps/server/src/lib/collaboration-auth.test.ts
+++ b/apps/server/src/lib/collaboration-auth.test.ts
@@ -184,6 +184,9 @@ function createAuthServiceStub(overrides: Partial<AuthService>): AuthService {
     async handleAuthRequest() {
       return new Response("not implemented", { status: 501 });
     },
+    listSsoProviders() {
+      return [];
+    },
   };
 
   return {

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/auth/session/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/auth/session/route.ts
@@ -1,0 +1,14 @@
+export async function GET() {
+  return Response.json({
+    data: {
+      session: {
+        id: "review-session-001",
+        userId: "review-user-001",
+        email: "reviewer@mdcms.local",
+        issuedAt: "2026-04-01T09:00:00.000Z",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      },
+      csrfToken: "review-csrf-token",
+    },
+  });
+}

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/content/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/content/route.ts
@@ -1,0 +1,54 @@
+import { listReviewContentDocuments } from "../../../../../../review/content-documents";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ scenario: string }> },
+) {
+  const { scenario } = await context.params;
+  const url = new URL(request.url);
+  const typeFilter = url.searchParams.get("type");
+  const publishedFilter = url.searchParams.get("published");
+  const sortField = url.searchParams.get("sort");
+  const sortOrder = url.searchParams.get("order") ?? "asc";
+  const limit = Math.min(
+    Math.max(parseInt(url.searchParams.get("limit") ?? "20", 10) || 20, 1),
+    100,
+  );
+  const offset = Math.max(
+    parseInt(url.searchParams.get("offset") ?? "0", 10) || 0,
+    0,
+  );
+
+  let docs = listReviewContentDocuments(scenario);
+
+  if (typeFilter) {
+    docs = docs.filter((d) => d.type === typeFilter);
+  }
+
+  if (publishedFilter === "true") {
+    docs = docs.filter((d) => d.publishedVersion !== null);
+  } else if (publishedFilter === "false") {
+    docs = docs.filter((d) => d.publishedVersion === null);
+  }
+
+  if (sortField === "updatedAt") {
+    docs = [...docs].sort((a, b) => {
+      const cmp =
+        new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+      return sortOrder === "desc" ? -cmp : cmp;
+    });
+  }
+
+  const total = docs.length;
+  const paged = docs.slice(offset, offset + limit);
+
+  return Response.json({
+    data: paged,
+    pagination: {
+      total,
+      limit,
+      offset,
+      hasMore: offset + limit < total,
+    },
+  });
+}

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
@@ -1,0 +1,14 @@
+export async function GET() {
+  return Response.json({
+    data: [
+      {
+        id: "env-staging",
+        project: "marketing-site",
+        name: "staging",
+        extends: null,
+        isDefault: true,
+        createdAt: "2026-03-19T10:00:00.000Z",
+      },
+    ],
+  });
+}

--- a/apps/studio-review/review/content-documents.ts
+++ b/apps/studio-review/review/content-documents.ts
@@ -199,6 +199,19 @@ const legacyContentDocumentRecords = new Map(
   legacyContentDocumentSeeds.map((seed) => [seed.id, createLegacyRecord(seed)]),
 );
 
+export function listReviewContentDocuments(
+  scenarioId: string,
+): ContentDocumentResponse[] {
+  const scenario = getReviewScenario(scenarioId);
+  const docs: ContentDocumentResponse[] = [scenario.document];
+
+  for (const record of legacyContentDocumentRecords.values()) {
+    docs.push(record.document);
+  }
+
+  return docs;
+}
+
 export function getReviewContentDocumentRecord(
   scenarioId: string,
   documentId: string,

--- a/packages/studio/src/lib/content-list-api.test.ts
+++ b/packages/studio/src/lib/content-list-api.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  createStudioContentListApi,
+  type StudioContentListApiOptions,
+} from "./content-list-api.js";
+
+function readHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | null {
+  const headers = init?.headers;
+
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+
+  if (headers && !Array.isArray(headers)) {
+    const value = (headers as Record<string, string>)[name];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function createApi(options: StudioContentListApiOptions = {}) {
+  return createStudioContentListApi(
+    {
+      project: "marketing-site",
+      environment: "production",
+      serverUrl: "http://localhost:4000",
+    },
+    options,
+  );
+}
+
+const validPaginatedResponse = {
+  data: [
+    {
+      documentId: "doc-1",
+      translationGroupId: "tg-1",
+      project: "marketing-site",
+      environment: "production",
+      path: "blog/hello",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      isDeleted: false,
+      hasUnpublishedChanges: false,
+      version: 1,
+      publishedVersion: 1,
+      draftRevision: 0,
+      frontmatter: { title: "Hello" },
+      body: "# Hello",
+      createdBy: "user-1",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-20T00:00:00.000Z",
+    },
+  ],
+  pagination: {
+    total: 42,
+    limit: 1,
+    offset: 0,
+    hasMore: true,
+  },
+};
+
+test("list fetches content with project and environment headers", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  const result = await api.list({ limit: 1 });
+
+  assert.equal(calls.length, 1);
+  const url = String(calls[0]?.input);
+  assert.ok(url.startsWith("http://localhost:4000/api/v1/content"));
+  assert.ok(url.includes("limit=1"));
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-project"), "marketing-site");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-environment"), "production");
+  assert.equal(result.pagination.total, 42);
+  assert.equal(result.data.length, 1);
+  assert.equal(result.data[0]?.type, "BlogPost");
+});
+
+test("list passes type and published filters as query params", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list({ type: "BlogPost", published: true, limit: 1 });
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.get("type"), "BlogPost");
+  assert.equal(url.searchParams.get("published"), "true");
+  assert.equal(url.searchParams.get("limit"), "1");
+});
+
+test("list passes sort and order query params", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list({ sort: "updatedAt", order: "desc", limit: 5 });
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.get("sort"), "updatedAt");
+  assert.equal(url.searchParams.get("order"), "desc");
+  assert.equal(url.searchParams.get("limit"), "5");
+});
+
+test("list returns empty result for malformed response", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+  });
+
+  const result = await api.list();
+
+  assert.deepEqual(result.data, []);
+  assert.equal(result.pagination.total, 0);
+});
+
+test("list throws RuntimeError on 401", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({ code: "UNAUTHORIZED", message: "Unauthorized" }),
+        { status: 401 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.list(),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.statusCode === 401,
+  );
+});
+
+test("list throws RuntimeError on 403", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({
+          code: "FORBIDDEN_ORIGIN",
+          message: "Origin not allowed",
+        }),
+        { status: 403 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.list(),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.statusCode === 403,
+  );
+});
+
+test("list throws RuntimeError on 500 with server error code", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({
+          code: "INTERNAL_ERROR",
+          message: "Something broke",
+        }),
+        { status: 500 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.list(),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.statusCode === 500 &&
+      error.code === "INTERNAL_ERROR",
+  );
+});
+
+test("list defaults to empty query when called with no args", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list();
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.toString(), "");
+});

--- a/packages/studio/src/lib/content-list-api.ts
+++ b/packages/studio/src/lib/content-list-api.ts
@@ -1,0 +1,144 @@
+import {
+  RuntimeError,
+  type ApiPaginatedEnvelope,
+  type ContentDocumentResponse,
+} from "@mdcms/shared";
+
+import type { MdcmsConfig } from "./studio-component.js";
+import {
+  applyStudioAuthToRequestInit,
+  type StudioRuntimeAuth,
+} from "./request-auth.js";
+import { resolveStudioRelativeUrl } from "./url-resolution.js";
+
+export type StudioContentListConfig = Pick<
+  MdcmsConfig,
+  "project" | "environment" | "serverUrl"
+>;
+
+export type StudioContentListApiOptions = {
+  auth?: StudioRuntimeAuth;
+  fetcher?: typeof fetch;
+};
+
+export type StudioContentListQuery = {
+  type?: string;
+  published?: boolean;
+  hasUnpublishedChanges?: boolean;
+  isDeleted?: boolean;
+  sort?: string;
+  order?: "asc" | "desc";
+  limit?: number;
+  offset?: number;
+};
+
+export type StudioContentListApi = {
+  list: (
+    query?: StudioContentListQuery,
+  ) => Promise<ApiPaginatedEnvelope<ContentDocumentResponse>>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+async function readResponsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createStudioContentListApi(
+  config: StudioContentListConfig,
+  options: StudioContentListApiOptions = {},
+): StudioContentListApi {
+  const fetcher = options.fetcher ?? fetch;
+
+  return {
+    async list(query = {}) {
+      const url = resolveStudioRelativeUrl("/api/v1/content", config.serverUrl);
+
+      if (query.type) url.searchParams.set("type", query.type);
+      if (query.published !== undefined)
+        url.searchParams.set("published", String(query.published));
+      if (query.hasUnpublishedChanges !== undefined)
+        url.searchParams.set(
+          "hasUnpublishedChanges",
+          String(query.hasUnpublishedChanges),
+        );
+      if (query.isDeleted !== undefined)
+        url.searchParams.set("isDeleted", String(query.isDeleted));
+      if (query.sort) url.searchParams.set("sort", query.sort);
+      if (query.order) url.searchParams.set("order", query.order);
+      if (query.limit !== undefined)
+        url.searchParams.set("limit", String(query.limit));
+      if (query.offset !== undefined)
+        url.searchParams.set("offset", String(query.offset));
+
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "GET",
+          headers: {
+            "x-mdcms-project": config.project,
+            "x-mdcms-environment": config.environment,
+          },
+        }),
+      );
+
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        const parsed = isRecord(payload) ? payload : {};
+        const code =
+          typeof parsed.code === "string" && parsed.code.trim().length > 0
+            ? parsed.code
+            : "CONTENT_LIST_REQUEST_FAILED";
+        const message =
+          typeof parsed.message === "string" && parsed.message.trim().length > 0
+            ? parsed.message
+            : "Content list request failed.";
+
+        throw new RuntimeError({
+          code,
+          message,
+          statusCode: response.status,
+          details: { status: response.status, payload },
+        });
+      }
+
+      if (
+        !isRecord(payload) ||
+        !Array.isArray(payload.data) ||
+        !isRecord(payload.pagination)
+      ) {
+        return {
+          data: [],
+          pagination: { total: 0, limit: 1, offset: 0, hasMore: false },
+        };
+      }
+
+      const pagination = payload.pagination;
+
+      return {
+        data: payload.data as ContentDocumentResponse[],
+        pagination: {
+          total: isFiniteNumber(pagination.total) ? pagination.total : 0,
+          limit: isFiniteNumber(pagination.limit) ? pagination.limit : 1,
+          offset: isFiniteNumber(pagination.offset) ? pagination.offset : 0,
+          hasMore: isBoolean(pagination.hasMore) ? pagination.hasMore : false,
+        },
+      };
+    },
+  };
+}

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -170,7 +170,39 @@ test("returns loaded state when schema types exist but no documents", async () =
   assert.equal(result.data.contentTypes[0]?.totalCount, 0);
 });
 
-test("returns forbidden on 401 error", async () => {
+test("schema 403 degrades gracefully — content widgets still load", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "FORBIDDEN_ORIGIN",
+        message: "Forbidden",
+        statusCode: 403,
+      });
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async (query = {}) => {
+      if (query.sort === "updatedAt") {
+        return paginatedResponse(10, [makeDoc()]);
+      }
+      if (query.published === true) return paginatedResponse(8);
+      return paginatedResponse(10);
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+  assert.equal(result.data.totalDocuments, 10);
+  assert.equal(result.data.publishedDocuments, 8);
+  assert.equal(result.data.contentTypes.length, 0);
+  assert.equal(result.data.recentDocuments.length, 1);
+});
+
+test("schema 401 degrades gracefully — content widgets still load", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => {
       throw new RuntimeError({
@@ -183,15 +215,18 @@ test("returns forbidden on 401 error", async () => {
   };
 
   const contentApi: StudioContentListApi = {
-    list: async () => paginatedResponse(0),
+    list: async () => paginatedResponse(5),
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
 
-  assert.equal(result.status, "forbidden");
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+  assert.equal(result.data.totalDocuments, 5);
+  assert.equal(result.data.contentTypes.length, 0);
 });
 
-test("returns forbidden on 403 error", async () => {
+test("returns forbidden when content API returns 403", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [],
     sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
@@ -212,8 +247,34 @@ test("returns forbidden on 403 error", async () => {
   assert.equal(result.status, "forbidden");
 });
 
-test("returns error state on 500 error", async () => {
+test("returns forbidden when content API returns 401", async () => {
   const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "UNAUTHORIZED",
+        message: "Unauthorized",
+        statusCode: 401,
+      });
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "forbidden");
+});
+
+test("returns error state when content API returns 500", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
     list: async () => {
       throw new RuntimeError({
         code: "INTERNAL_ERROR",
@@ -221,11 +282,6 @@ test("returns error state on 500 error", async () => {
         statusCode: 500,
       });
     },
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
-    list: async () => paginatedResponse(0),
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
@@ -235,16 +291,16 @@ test("returns error state on 500 error", async () => {
   assert.equal(result.message, "Something broke");
 });
 
-test("returns error state on generic Error", async () => {
+test("returns error state on generic content Error", async () => {
   const schemaApi: StudioSchemaRouteApi = {
-    list: async () => {
-      throw new Error("Network failure");
-    },
+    list: async () => [],
     sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
   };
 
   const contentApi: StudioContentListApi = {
-    list: async () => paginatedResponse(0),
+    list: async () => {
+      throw new Error("Network failure");
+    },
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import { loadDashboardData } from "./dashboard-data.js";
+import type { StudioSchemaRouteApi } from "./schema-route-api.js";
+import type { StudioContentListApi } from "./content-list-api.js";
+
+function paginatedResponse(
+  total: number,
+  data: Array<Record<string, unknown>> = [],
+) {
+  return {
+    data: data as any,
+    pagination: { total, limit: 1, offset: 0, hasMore: total > 1 },
+  };
+}
+
+function makeSchemaEntry(type: string, localized = false) {
+  return {
+    type,
+    directory: `content/${type.toLowerCase()}`,
+    localized,
+    schemaHash: "hash-1",
+    syncedAt: "2026-03-01T00:00:00.000Z",
+    resolvedSchema: {
+      type,
+      directory: `content/${type.toLowerCase()}`,
+      localized,
+      fields: {},
+    },
+  };
+}
+
+function makeDoc(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    documentId: "doc-1",
+    translationGroupId: "tg-1",
+    project: "proj",
+    environment: "prod",
+    path: "blog/hello",
+    type: "BlogPost",
+    locale: "en",
+    format: "md",
+    isDeleted: false,
+    hasUnpublishedChanges: false,
+    version: 1,
+    publishedVersion: 1,
+    draftRevision: 0,
+    frontmatter: { title: "Hello" },
+    body: "# Hello",
+    createdBy: "user-1",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("returns loaded state with real data", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [
+      makeSchemaEntry("BlogPost", true),
+      makeSchemaEntry("Page"),
+    ],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const calls: string[] = [];
+  const contentApi: StudioContentListApi = {
+    list: async (query = {}) => {
+      const key = `type=${query.type ?? ""},published=${query.published ?? ""},sort=${query.sort ?? ""}`;
+      calls.push(key);
+
+      // Global total
+      if (!query.type && !query.published && !query.sort) {
+        return paginatedResponse(42);
+      }
+      // Global published
+      if (!query.type && query.published === true) {
+        return paginatedResponse(30);
+      }
+      // Recent documents
+      if (query.sort === "updatedAt") {
+        return paginatedResponse(42, [
+          makeDoc(),
+          makeDoc({ documentId: "doc-2", path: "blog/world" }),
+        ]);
+      }
+      // BlogPost total
+      if (query.type === "BlogPost" && !query.published) {
+        return paginatedResponse(20);
+      }
+      // BlogPost published
+      if (query.type === "BlogPost" && query.published === true) {
+        return paginatedResponse(15);
+      }
+      // Page total
+      if (query.type === "Page" && !query.published) {
+        return paginatedResponse(22);
+      }
+      // Page published
+      if (query.type === "Page" && query.published === true) {
+        return paginatedResponse(15);
+      }
+
+      return paginatedResponse(0);
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+
+  assert.equal(result.data.totalDocuments, 42);
+  assert.equal(result.data.publishedDocuments, 30);
+  assert.equal(result.data.draftDocuments, 12);
+  assert.equal(result.data.contentTypes.length, 2);
+
+  assert.equal(result.data.contentTypes[0]?.type, "BlogPost");
+  assert.equal(result.data.contentTypes[0]?.totalCount, 20);
+  assert.equal(result.data.contentTypes[0]?.publishedCount, 15);
+  assert.equal(result.data.contentTypes[0]?.localized, true);
+
+  assert.equal(result.data.contentTypes[1]?.type, "Page");
+  assert.equal(result.data.contentTypes[1]?.totalCount, 22);
+  assert.equal(result.data.contentTypes[1]?.publishedCount, 15);
+  assert.equal(result.data.contentTypes[1]?.localized, false);
+
+  assert.equal(result.data.recentDocuments.length, 2);
+  assert.equal(result.data.recentDocuments[0]?.documentId, "doc-1");
+  assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Hello");
+});
+
+test("returns empty state when no documents and no schema types", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "empty");
+});
+
+test("returns loaded state when schema types exist but no documents", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [makeSchemaEntry("BlogPost")],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  // Has schema types, so not "empty" — it's loaded with zero documents
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+
+  assert.equal(result.data.totalDocuments, 0);
+  assert.equal(result.data.contentTypes.length, 1);
+  assert.equal(result.data.contentTypes[0]?.type, "BlogPost");
+  assert.equal(result.data.contentTypes[0]?.totalCount, 0);
+});
+
+test("returns forbidden on 401 error", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "UNAUTHORIZED",
+        message: "Unauthorized",
+        statusCode: 401,
+      });
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "forbidden");
+});
+
+test("returns forbidden on 403 error", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "FORBIDDEN_ORIGIN",
+        message: "Origin not allowed",
+        statusCode: 403,
+      });
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "forbidden");
+});
+
+test("returns error state on 500 error", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "INTERNAL_ERROR",
+        message: "Something broke",
+        statusCode: 500,
+      });
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "error");
+  if (result.status !== "error") return;
+  assert.equal(result.message, "Something broke");
+});
+
+test("returns error state on generic Error", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new Error("Network failure");
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "error");
+  if (result.status !== "error") return;
+  assert.equal(result.message, "Network failure");
+});
+
+test("caps content types at 5", async () => {
+  const types = Array.from({ length: 8 }, (_, i) =>
+    makeSchemaEntry(`Type${i}`),
+  );
+
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => types,
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(100),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+
+  assert.equal(result.data.contentTypes.length, 5);
+  assert.equal(result.data.contentTypes[4]?.type, "Type4");
+});
+
+test("recent documents include frontmatter and hasUnpublishedChanges", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [makeSchemaEntry("BlogPost")],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const draftDoc = makeDoc({
+    documentId: "doc-draft",
+    hasUnpublishedChanges: true,
+    frontmatter: { title: "Draft Post" },
+  });
+
+  const contentApi: StudioContentListApi = {
+    list: async (query = {}) => {
+      if (query.sort === "updatedAt") {
+        return paginatedResponse(1, [draftDoc]);
+      }
+      return paginatedResponse(1);
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+
+  assert.equal(result.data.recentDocuments.length, 1);
+  assert.equal(result.data.recentDocuments[0]?.hasUnpublishedChanges, true);
+  assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Draft Post");
+});

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -57,53 +57,39 @@ function makeDoc(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+const emptySyncResult = {
+  schemaHash: "",
+  syncedAt: "",
+  affectedTypes: [] as string[],
+};
+
 test("returns loaded state with real data", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [
       makeSchemaEntry("BlogPost", true),
       makeSchemaEntry("Page"),
     ],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
-  const calls: string[] = [];
   const contentApi: StudioContentListApi = {
     list: async (query = {}) => {
-      const key = `type=${query.type ?? ""},published=${query.published ?? ""},sort=${query.sort ?? ""}`;
-      calls.push(key);
-
-      // Global total
-      if (!query.type && !query.published && !query.sort) {
+      if (!query.type && !query.published && !query.sort)
         return paginatedResponse(42);
-      }
-      // Global published
-      if (!query.type && query.published === true) {
-        return paginatedResponse(30);
-      }
-      // Recent documents
-      if (query.sort === "updatedAt") {
+      if (!query.type && query.published === true) return paginatedResponse(30);
+      if (query.sort === "updatedAt")
         return paginatedResponse(42, [
           makeDoc(),
           makeDoc({ documentId: "doc-2", path: "blog/world" }),
         ]);
-      }
-      // BlogPost total
-      if (query.type === "BlogPost" && !query.published) {
+      if (query.type === "BlogPost" && !query.published)
         return paginatedResponse(20);
-      }
-      // BlogPost published
-      if (query.type === "BlogPost" && query.published === true) {
+      if (query.type === "BlogPost" && query.published === true)
         return paginatedResponse(15);
-      }
-      // Page total
-      if (query.type === "Page" && !query.published) {
+      if (query.type === "Page" && !query.published)
         return paginatedResponse(22);
-      }
-      // Page published
-      if (query.type === "Page" && query.published === true) {
+      if (query.type === "Page" && query.published === true)
         return paginatedResponse(15);
-      }
-
       return paginatedResponse(0);
     },
   };
@@ -117,26 +103,18 @@ test("returns loaded state with real data", async () => {
   assert.equal(result.data.publishedDocuments, 30);
   assert.equal(result.data.draftDocuments, 12);
   assert.equal(result.data.contentTypes.length, 2);
-
   assert.equal(result.data.contentTypes[0]?.type, "BlogPost");
   assert.equal(result.data.contentTypes[0]?.totalCount, 20);
   assert.equal(result.data.contentTypes[0]?.publishedCount, 15);
   assert.equal(result.data.contentTypes[0]?.localized, true);
-
   assert.equal(result.data.contentTypes[1]?.type, "Page");
-  assert.equal(result.data.contentTypes[1]?.totalCount, 22);
-  assert.equal(result.data.contentTypes[1]?.publishedCount, 15);
-  assert.equal(result.data.contentTypes[1]?.localized, false);
-
   assert.equal(result.data.recentDocuments.length, 2);
-  assert.equal(result.data.recentDocuments[0]?.documentId, "doc-1");
-  assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Hello");
 });
 
-test("returns empty state when no documents and no schema types", async () => {
+test("zero documents returns loaded with 0 counts, not a special empty state", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
@@ -145,91 +123,59 @@ test("returns empty state when no documents and no schema types", async () => {
 
   const result = await loadDashboardData(schemaApi, contentApi);
 
-  assert.equal(result.status, "empty");
-});
-
-test("returns loaded state when schema types exist but no documents", async () => {
-  const schemaApi: StudioSchemaRouteApi = {
-    list: async () => [makeSchemaEntry("BlogPost")],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
-    list: async () => paginatedResponse(0),
-  };
-
-  const result = await loadDashboardData(schemaApi, contentApi);
-
-  // Has schema types, so not "empty" — it's loaded with zero documents
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
+  assert.equal(result.data.totalDocuments, 0);
+  assert.equal(result.data.publishedDocuments, 0);
+  assert.equal(result.data.draftDocuments, 0);
+  assert.equal(result.data.contentTypes.length, 0);
+  assert.equal(result.data.recentDocuments.length, 0);
+});
 
+test("schema types with zero documents returns loaded with type stats", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [makeSchemaEntry("BlogPost")],
+    sync: async () => emptySyncResult,
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(0),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
   assert.equal(result.data.totalDocuments, 0);
   assert.equal(result.data.contentTypes.length, 1);
   assert.equal(result.data.contentTypes[0]?.type, "BlogPost");
   assert.equal(result.data.contentTypes[0]?.totalCount, 0);
 });
 
-test("schema 403 degrades gracefully — content widgets still load", async () => {
+test("returns forbidden on schema 403", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => {
       throw new RuntimeError({
-        code: "FORBIDDEN_ORIGIN",
+        code: "FORBIDDEN",
         message: "Forbidden",
         statusCode: 403,
       });
     },
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
-    list: async (query = {}) => {
-      if (query.sort === "updatedAt") {
-        return paginatedResponse(10, [makeDoc()]);
-      }
-      if (query.published === true) return paginatedResponse(8);
-      return paginatedResponse(10);
-    },
+    list: async () => paginatedResponse(10),
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "loaded");
-  if (result.status !== "loaded") return;
-  assert.equal(result.data.totalDocuments, 10);
-  assert.equal(result.data.publishedDocuments, 8);
-  assert.equal(result.data.contentTypes.length, 0);
-  assert.equal(result.data.recentDocuments.length, 1);
+  assert.equal(result.status, "forbidden");
 });
 
-test("schema 401 degrades gracefully — content widgets still load", async () => {
-  const schemaApi: StudioSchemaRouteApi = {
-    list: async () => {
-      throw new RuntimeError({
-        code: "UNAUTHORIZED",
-        message: "Unauthorized",
-        statusCode: 401,
-      });
-    },
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
-    list: async () => paginatedResponse(5),
-  };
-
-  const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "loaded");
-  if (result.status !== "loaded") return;
-  assert.equal(result.data.totalDocuments, 5);
-  assert.equal(result.data.contentTypes.length, 0);
-});
-
-test("content 403 degrades gracefully — shows empty state", async () => {
+test("returns forbidden on content 403", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
@@ -243,18 +189,11 @@ test("content 403 degrades gracefully — shows empty state", async () => {
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
-
-  // Both schema and content are empty → empty state, NOT forbidden
-  assert.equal(result.status, "empty");
+  assert.equal(result.status, "forbidden");
 });
 
-test("content 401 degrades gracefully — shows empty state", async () => {
+test("returns forbidden on 401", async () => {
   const schemaApi: StudioSchemaRouteApi = {
-    list: async () => [],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
     list: async () => {
       throw new RuntimeError({
         code: "UNAUTHORIZED",
@@ -262,82 +201,18 @@ test("content 401 degrades gracefully — shows empty state", async () => {
         statusCode: 401,
       });
     },
-  };
-
-  const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "empty");
-});
-
-test("content 403 with schema types shows loaded with empty content", async () => {
-  const schemaApi: StudioSchemaRouteApi = {
-    list: async () => [makeSchemaEntry("BlogPost")],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
-    list: async () => {
-      throw new RuntimeError({
-        code: "FORBIDDEN",
-        message: "No content:read grant",
-        statusCode: 403,
-      });
-    },
+    list: async () => paginatedResponse(0),
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "loaded");
-  if (result.status !== "loaded") return;
-  assert.equal(result.data.totalDocuments, 0);
-  assert.equal(result.data.contentTypes.length, 1);
-  assert.equal(result.data.contentTypes[0]?.totalCount, 0);
-  assert.equal(result.data.recentDocuments.length, 0);
+  assert.equal(result.status, "forbidden");
 });
 
-test("returns error state when content API returns 500", async () => {
-  const schemaApi: StudioSchemaRouteApi = {
-    list: async () => [],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
-    list: async () => {
-      throw new RuntimeError({
-        code: "INTERNAL_ERROR",
-        message: "Something broke",
-        statusCode: 500,
-      });
-    },
-  };
-
-  const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "error");
-  if (result.status !== "error") return;
-  assert.equal(result.message, "Something broke");
-});
-
-test("returns error state on generic content Error", async () => {
-  const schemaApi: StudioSchemaRouteApi = {
-    list: async () => [],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
-  };
-
-  const contentApi: StudioContentListApi = {
-    list: async () => {
-      throw new Error("Network failure");
-    },
-  };
-
-  const result = await loadDashboardData(schemaApi, contentApi);
-
-  assert.equal(result.status, "error");
-  if (result.status !== "error") return;
-  assert.equal(result.message, "Network failure");
-});
-
-test("schema 500 propagates as error — not swallowed", async () => {
+test("returns error on 500", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => {
       throw new RuntimeError({
@@ -346,7 +221,7 @@ test("schema 500 propagates as error — not swallowed", async () => {
         statusCode: 500,
       });
     },
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
@@ -354,18 +229,17 @@ test("schema 500 propagates as error — not swallowed", async () => {
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
-
   assert.equal(result.status, "error");
   if (result.status !== "error") return;
   assert.equal(result.message, "Schema service down");
 });
 
-test("schema network error propagates as error — not swallowed", async () => {
+test("returns error on network failure", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => {
       throw new Error("fetch failed");
     },
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
@@ -373,7 +247,6 @@ test("schema network error propagates as error — not swallowed", async () => {
   };
 
   const result = await loadDashboardData(schemaApi, contentApi);
-
   assert.equal(result.status, "error");
   if (result.status !== "error") return;
   assert.equal(result.message, "fetch failed");
@@ -386,7 +259,7 @@ test("caps content types at 5", async () => {
 
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => types,
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const contentApi: StudioContentListApi = {
@@ -397,7 +270,6 @@ test("caps content types at 5", async () => {
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
-
   assert.equal(result.data.contentTypes.length, 5);
   assert.equal(result.data.contentTypes[4]?.type, "Type4");
 });
@@ -405,7 +277,7 @@ test("caps content types at 5", async () => {
 test("recent documents include frontmatter and hasUnpublishedChanges", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [makeSchemaEntry("BlogPost")],
-    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+    sync: async () => emptySyncResult,
   };
 
   const draftDoc = makeDoc({
@@ -427,7 +299,6 @@ test("recent documents include frontmatter and hasUnpublishedChanges", async () 
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
-
   assert.equal(result.data.recentDocuments.length, 1);
   assert.equal(result.data.recentDocuments[0]?.hasUnpublishedChanges, true);
   assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Draft Post");

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -310,6 +310,48 @@ test("returns error state on generic content Error", async () => {
   assert.equal(result.message, "Network failure");
 });
 
+test("schema 500 propagates as error — not swallowed", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "INTERNAL_ERROR",
+        message: "Schema service down",
+        statusCode: 500,
+      });
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(10),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "error");
+  if (result.status !== "error") return;
+  assert.equal(result.message, "Schema service down");
+});
+
+test("schema network error propagates as error — not swallowed", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => {
+      throw new Error("fetch failed");
+    },
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => paginatedResponse(10),
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "error");
+  if (result.status !== "error") return;
+  assert.equal(result.message, "fetch failed");
+});
+
 test("caps content types at 5", async () => {
   const types = Array.from({ length: 8 }, (_, i) =>
     makeSchemaEntry(`Type${i}`),

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -226,7 +226,7 @@ test("schema 401 degrades gracefully — content widgets still load", async () =
   assert.equal(result.data.contentTypes.length, 0);
 });
 
-test("returns forbidden when content API returns 403", async () => {
+test("content 403 degrades gracefully — shows empty state", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [],
     sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
@@ -235,8 +235,8 @@ test("returns forbidden when content API returns 403", async () => {
   const contentApi: StudioContentListApi = {
     list: async () => {
       throw new RuntimeError({
-        code: "FORBIDDEN_ORIGIN",
-        message: "Origin not allowed",
+        code: "FORBIDDEN",
+        message: "No content:read grant",
         statusCode: 403,
       });
     },
@@ -244,10 +244,11 @@ test("returns forbidden when content API returns 403", async () => {
 
   const result = await loadDashboardData(schemaApi, contentApi);
 
-  assert.equal(result.status, "forbidden");
+  // Both schema and content are empty → empty state, NOT forbidden
+  assert.equal(result.status, "empty");
 });
 
-test("returns forbidden when content API returns 401", async () => {
+test("content 401 degrades gracefully — shows empty state", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [],
     sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
@@ -265,7 +266,33 @@ test("returns forbidden when content API returns 401", async () => {
 
   const result = await loadDashboardData(schemaApi, contentApi);
 
-  assert.equal(result.status, "forbidden");
+  assert.equal(result.status, "empty");
+});
+
+test("content 403 with schema types shows loaded with empty content", async () => {
+  const schemaApi: StudioSchemaRouteApi = {
+    list: async () => [makeSchemaEntry("BlogPost")],
+    sync: async () => ({ schemaHash: "", syncedAt: "", affectedTypes: [] }),
+  };
+
+  const contentApi: StudioContentListApi = {
+    list: async () => {
+      throw new RuntimeError({
+        code: "FORBIDDEN",
+        message: "No content:read grant",
+        statusCode: 403,
+      });
+    },
+  };
+
+  const result = await loadDashboardData(schemaApi, contentApi);
+
+  assert.equal(result.status, "loaded");
+  if (result.status !== "loaded") return;
+  assert.equal(result.data.totalDocuments, 0);
+  assert.equal(result.data.contentTypes.length, 1);
+  assert.equal(result.data.contentTypes[0]?.totalCount, 0);
+  assert.equal(result.data.recentDocuments.length, 0);
 });
 
 test("returns error state when content API returns 500", async () => {

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -42,7 +42,16 @@ export async function loadDashboardData(
     // a 403 from the schema API does not block content-backed widgets.
     const [schemaTypes, totalResult, publishedResult, recentResult] =
       await Promise.all([
-        schemaApi.list().catch((): SchemaRegistryEntry[] => []),
+        schemaApi.list().catch((err: unknown): SchemaRegistryEntry[] => {
+          const code =
+            err && typeof err === "object" && "statusCode" in err
+              ? (err as { statusCode: number }).statusCode
+              : undefined;
+          if (code === 401 || code === 403) {
+            return [];
+          }
+          throw err;
+        }),
         contentApi.list({ limit: 1 }),
         contentApi.list({ published: true, limit: 1 }),
         contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -1,0 +1,109 @@
+import type { SchemaRegistryEntry } from "@mdcms/shared";
+
+import type { StudioSchemaRouteApi } from "./schema-route-api.js";
+import type { StudioContentListApi } from "./content-list-api.js";
+
+export type ContentTypeStat = {
+  type: string;
+  directory: string;
+  localized: boolean;
+  totalCount: number;
+  publishedCount: number;
+};
+
+export type DashboardData = {
+  totalDocuments: number;
+  publishedDocuments: number;
+  draftDocuments: number;
+  contentTypes: ContentTypeStat[];
+  recentDocuments: Array<{
+    documentId: string;
+    path: string;
+    type: string;
+    updatedAt: string;
+    hasUnpublishedChanges: boolean;
+    frontmatter: Record<string, unknown>;
+  }>;
+};
+
+export type DashboardLoadResult =
+  | { status: "loaded"; data: DashboardData }
+  | { status: "empty" }
+  | { status: "error"; message: string }
+  | { status: "forbidden" };
+
+export async function loadDashboardData(
+  schemaApi: StudioSchemaRouteApi,
+  contentApi: StudioContentListApi,
+): Promise<DashboardLoadResult> {
+  try {
+    const [schemaTypes, totalResult, publishedResult, recentResult] =
+      await Promise.all([
+        schemaApi.list(),
+        contentApi.list({ limit: 1 }),
+        contentApi.list({ published: true, limit: 1 }),
+        contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
+      ]);
+
+    const totalDocuments = totalResult.pagination.total;
+    const publishedDocuments = publishedResult.pagination.total;
+    const draftDocuments = totalDocuments - publishedDocuments;
+
+    const typesToShow = schemaTypes.slice(0, 5);
+    const typeStats = await Promise.all(
+      typesToShow.map(async (entry: SchemaRegistryEntry) => {
+        const [typeTotal, typePublished] = await Promise.all([
+          contentApi.list({ type: entry.type, limit: 1 }),
+          contentApi.list({ type: entry.type, published: true, limit: 1 }),
+        ]);
+
+        return {
+          type: entry.type,
+          directory: entry.directory,
+          localized: entry.localized,
+          totalCount: typeTotal.pagination.total,
+          publishedCount: typePublished.pagination.total,
+        };
+      }),
+    );
+
+    if (totalDocuments === 0 && typeStats.length === 0) {
+      return { status: "empty" };
+    }
+
+    return {
+      status: "loaded",
+      data: {
+        totalDocuments,
+        publishedDocuments,
+        draftDocuments,
+        contentTypes: typeStats,
+        recentDocuments: recentResult.data.map((doc) => ({
+          documentId: doc.documentId,
+          path: doc.path,
+          type: doc.type,
+          updatedAt: doc.updatedAt,
+          hasUnpublishedChanges: doc.hasUnpublishedChanges,
+          frontmatter: doc.frontmatter,
+        })),
+      },
+    };
+  } catch (error: unknown) {
+    const statusCode =
+      error && typeof error === "object" && "statusCode" in error
+        ? (error as { statusCode: number }).statusCode
+        : undefined;
+
+    if (statusCode === 401 || statusCode === 403) {
+      return { status: "forbidden" };
+    }
+
+    return {
+      status: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Failed to load dashboard data.",
+    };
+  }
+}

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -16,6 +16,7 @@ export type DashboardData = {
   publishedDocuments: number;
   draftDocuments: number;
   contentTypes: ContentTypeStat[];
+  totalContentTypes: number;
   recentDocuments: Array<{
     documentId: string;
     path: string;
@@ -66,12 +67,18 @@ export async function loadDashboardData(
           contentApi.list({ type: entry.type, published: true, limit: 1 }),
         ]);
 
+        const totalCount = typeTotal.pagination.total;
+        const publishedCount = Math.min(
+          typePublished.pagination.total,
+          totalCount,
+        );
+
         return {
           type: entry.type,
           directory: entry.directory,
           localized: entry.localized,
-          totalCount: typeTotal.pagination.total,
-          publishedCount: typePublished.pagination.total,
+          totalCount,
+          publishedCount,
         };
       }),
     );
@@ -87,6 +94,7 @@ export async function loadDashboardData(
         publishedDocuments,
         draftDocuments,
         contentTypes: typeStats,
+        totalContentTypes: schemaTypes.length,
         recentDocuments: recentResult.data.map((doc) => ({
           documentId: doc.documentId,
           path: doc.path,

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -47,7 +47,10 @@ export async function loadDashboardData(
 
     const totalDocuments = totalResult.pagination.total;
     const publishedDocuments = publishedResult.pagination.total;
-    const draftDocuments = totalDocuments - publishedDocuments;
+    const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
+    if (totalDocuments - publishedDocuments < 0) {
+      console.warn(`Dashboard data inconsistency: published (${publishedDocuments}) exceeds total (${totalDocuments})`);
+    }
 
     const typesToShow = schemaTypes.slice(0, 5);
     const typeStats = await Promise.all(

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -1,33 +1,7 @@
-import type {
-  ApiPaginatedEnvelope,
-  ContentDocumentResponse,
-  SchemaRegistryEntry,
-} from "@mdcms/shared";
+import type { SchemaRegistryEntry } from "@mdcms/shared";
 
 import type { StudioSchemaRouteApi } from "./schema-route-api.js";
 import type { StudioContentListApi } from "./content-list-api.js";
-
-const EMPTY_PAGINATED: ApiPaginatedEnvelope<ContentDocumentResponse> = {
-  data: [],
-  pagination: { total: 0, limit: 1, offset: 0, hasMore: false },
-};
-
-function isPermissionError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("statusCode" in err)) return false;
-  const code = (err as { statusCode: number }).statusCode;
-  return code === 401 || code === 403;
-}
-
-function catchPermission(
-  promise: Promise<ApiPaginatedEnvelope<ContentDocumentResponse>>,
-): Promise<ApiPaginatedEnvelope<ContentDocumentResponse>> {
-  return promise.catch(
-    (err: unknown): ApiPaginatedEnvelope<ContentDocumentResponse> => {
-      if (isPermissionError(err)) return EMPTY_PAGINATED;
-      throw err;
-    },
-  );
-}
 
 export type ContentTypeStat = {
   type: string;
@@ -55,7 +29,6 @@ export type DashboardData = {
 
 export type DashboardLoadResult =
   | { status: "loaded"; data: DashboardData }
-  | { status: "empty" }
   | { status: "error"; message: string }
   | { status: "forbidden" };
 
@@ -64,41 +37,24 @@ export async function loadDashboardData(
   contentApi: StudioContentListApi,
 ): Promise<DashboardLoadResult> {
   try {
-    // Fetch schema and content in parallel. Permission errors (401/403)
-    // on individual APIs degrade to empty results so the dashboard still
-    // renders whatever data the caller is allowed to see.
     const [schemaTypes, totalResult, publishedResult, recentResult] =
       await Promise.all([
-        schemaApi.list().catch((err: unknown): SchemaRegistryEntry[] => {
-          if (isPermissionError(err)) return [];
-          throw err;
-        }),
-        catchPermission(contentApi.list({ limit: 1 })),
-        catchPermission(contentApi.list({ published: true, limit: 1 })),
-        catchPermission(
-          contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
-        ),
+        schemaApi.list(),
+        contentApi.list({ limit: 1 }),
+        contentApi.list({ published: true, limit: 1 }),
+        contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
       ]);
 
     const totalDocuments = totalResult.pagination.total;
     const publishedDocuments = publishedResult.pagination.total;
     const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
-    if (totalDocuments - publishedDocuments < 0) {
-      console.warn(
-        `Dashboard data inconsistency: published (${publishedDocuments}) exceeds total (${totalDocuments})`,
-      );
-    }
 
-    // Per-type counts also degrade gracefully — if schema came back empty
-    // due to a permission error the loop simply produces no entries.
     const typesToShow = schemaTypes.slice(0, 5);
     const typeStats = await Promise.all(
       typesToShow.map(async (entry: SchemaRegistryEntry) => {
         const [typeTotal, typePublished] = await Promise.all([
-          catchPermission(contentApi.list({ type: entry.type, limit: 1 })),
-          catchPermission(
-            contentApi.list({ type: entry.type, published: true, limit: 1 }),
-          ),
+          contentApi.list({ type: entry.type, limit: 1 }),
+          contentApi.list({ type: entry.type, published: true, limit: 1 }),
         ]);
 
         const totalCount = typeTotal.pagination.total;
@@ -116,10 +72,6 @@ export async function loadDashboardData(
         };
       }),
     );
-
-    if (totalDocuments === 0 && typeStats.length === 0) {
-      return { status: "empty" };
-    }
 
     return {
       status: "loaded",
@@ -145,7 +97,7 @@ export async function loadDashboardData(
         ? (error as { statusCode: number }).statusCode
         : undefined;
 
-    if (statusCode === 401) {
+    if (statusCode === 401 || statusCode === 403) {
       return { status: "forbidden" };
     }
 

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -1,7 +1,33 @@
-import type { SchemaRegistryEntry } from "@mdcms/shared";
+import type {
+  ApiPaginatedEnvelope,
+  ContentDocumentResponse,
+  SchemaRegistryEntry,
+} from "@mdcms/shared";
 
 import type { StudioSchemaRouteApi } from "./schema-route-api.js";
 import type { StudioContentListApi } from "./content-list-api.js";
+
+const EMPTY_PAGINATED: ApiPaginatedEnvelope<ContentDocumentResponse> = {
+  data: [],
+  pagination: { total: 0, limit: 1, offset: 0, hasMore: false },
+};
+
+function isPermissionError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("statusCode" in err)) return false;
+  const code = (err as { statusCode: number }).statusCode;
+  return code === 401 || code === 403;
+}
+
+function catchPermission(
+  promise: Promise<ApiPaginatedEnvelope<ContentDocumentResponse>>,
+): Promise<ApiPaginatedEnvelope<ContentDocumentResponse>> {
+  return promise.catch(
+    (err: unknown): ApiPaginatedEnvelope<ContentDocumentResponse> => {
+      if (isPermissionError(err)) return EMPTY_PAGINATED;
+      throw err;
+    },
+  );
+}
 
 export type ContentTypeStat = {
   type: string;
@@ -38,23 +64,20 @@ export async function loadDashboardData(
   contentApi: StudioContentListApi,
 ): Promise<DashboardLoadResult> {
   try {
-    // Fetch schema and content in parallel, but isolate schema failures so
-    // a 403 from the schema API does not block content-backed widgets.
+    // Fetch schema and content in parallel. Permission errors (401/403)
+    // on individual APIs degrade to empty results so the dashboard still
+    // renders whatever data the caller is allowed to see.
     const [schemaTypes, totalResult, publishedResult, recentResult] =
       await Promise.all([
         schemaApi.list().catch((err: unknown): SchemaRegistryEntry[] => {
-          const code =
-            err && typeof err === "object" && "statusCode" in err
-              ? (err as { statusCode: number }).statusCode
-              : undefined;
-          if (code === 401 || code === 403) {
-            return [];
-          }
+          if (isPermissionError(err)) return [];
           throw err;
         }),
-        contentApi.list({ limit: 1 }),
-        contentApi.list({ published: true, limit: 1 }),
-        contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
+        catchPermission(contentApi.list({ limit: 1 })),
+        catchPermission(contentApi.list({ published: true, limit: 1 })),
+        catchPermission(
+          contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
+        ),
       ]);
 
     const totalDocuments = totalResult.pagination.total;
@@ -72,8 +95,10 @@ export async function loadDashboardData(
     const typeStats = await Promise.all(
       typesToShow.map(async (entry: SchemaRegistryEntry) => {
         const [typeTotal, typePublished] = await Promise.all([
-          contentApi.list({ type: entry.type, limit: 1 }),
-          contentApi.list({ type: entry.type, published: true, limit: 1 }),
+          catchPermission(contentApi.list({ type: entry.type, limit: 1 })),
+          catchPermission(
+            contentApi.list({ type: entry.type, published: true, limit: 1 }),
+          ),
         ]);
 
         const totalCount = typeTotal.pagination.total;
@@ -120,7 +145,7 @@ export async function loadDashboardData(
         ? (error as { statusCode: number }).statusCode
         : undefined;
 
-    if (statusCode === 401 || statusCode === 403) {
+    if (statusCode === 401) {
       return { status: "forbidden" };
     }
 

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -37,9 +37,11 @@ export async function loadDashboardData(
   contentApi: StudioContentListApi,
 ): Promise<DashboardLoadResult> {
   try {
+    // Fetch schema and content in parallel, but isolate schema failures so
+    // a 403 from the schema API does not block content-backed widgets.
     const [schemaTypes, totalResult, publishedResult, recentResult] =
       await Promise.all([
-        schemaApi.list(),
+        schemaApi.list().catch((): SchemaRegistryEntry[] => []),
         contentApi.list({ limit: 1 }),
         contentApi.list({ published: true, limit: 1 }),
         contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
@@ -49,9 +51,13 @@ export async function loadDashboardData(
     const publishedDocuments = publishedResult.pagination.total;
     const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
     if (totalDocuments - publishedDocuments < 0) {
-      console.warn(`Dashboard data inconsistency: published (${publishedDocuments}) exceeds total (${totalDocuments})`);
+      console.warn(
+        `Dashboard data inconsistency: published (${publishedDocuments}) exceeds total (${totalDocuments})`,
+      );
     }
 
+    // Per-type counts also degrade gracefully — if schema came back empty
+    // due to a permission error the loop simply produces no entries.
     const typesToShow = schemaTypes.slice(0, 5);
     const typeStats = await Promise.all(
       typesToShow.map(async (entry: SchemaRegistryEntry) => {

--- a/packages/studio/src/lib/login-api.test.ts
+++ b/packages/studio/src/lib/login-api.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { createLoginApi, type LoginApiOptions } from "./login-api.js";
+
+function readHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | null {
+  const headers = init?.headers;
+  if (headers instanceof Headers) return headers.get(name);
+  if (headers && !Array.isArray(headers)) {
+    const value = (headers as Record<string, string>)[name];
+    if (typeof value === "string") return value;
+  }
+  return null;
+}
+
+function createApi(options: LoginApiOptions = {}) {
+  return createLoginApi({ serverUrl: "http://localhost:4000" }, options);
+}
+
+test("login returns success on 200", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
+  const api = createApi({
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({
+          data: {
+            csrfToken: "csrf-token",
+            session: { id: "s1", userId: "u1", email: "demo@mdcms.local", issuedAt: "2026-04-06T10:00:00.000Z", expiresAt: "2026-04-06T22:00:00.000Z" },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+
+  const result = await api.login("demo@mdcms.local", "Demo12345!");
+
+  assert.equal(result.outcome, "success");
+  assert.equal(calls.length, 1);
+  assert.equal(String(calls[0]?.input), "http://localhost:4000/api/v1/auth/login");
+  assert.equal(calls[0]?.init?.method, "POST");
+  assert.equal(calls[0]?.init?.credentials, "include");
+  const body = JSON.parse(calls[0]?.init?.body as string);
+  assert.equal(body.email, "demo@mdcms.local");
+  assert.equal(body.password, "Demo12345!");
+});
+
+test("login returns invalid_credentials on 401", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(JSON.stringify({ code: "AUTH_INVALID_CREDENTIALS", message: "Invalid." }), { status: 401 }),
+  });
+  const result = await api.login("bad@email.com", "wrong");
+  assert.equal(result.outcome, "invalid_credentials");
+});
+
+test("login returns throttled on 429 with retryAfterSeconds", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({ code: "AUTH_BACKOFF_ACTIVE", message: "Too many attempts.", details: { retryAfterSeconds: 8 } }),
+        { status: 429, headers: { "retry-after": "8" } },
+      ),
+  });
+  const result = await api.login("demo@mdcms.local", "wrong");
+  assert.equal(result.outcome, "throttled");
+  if (result.outcome === "throttled") assert.equal(result.retryAfterSeconds, 8);
+});
+
+test("login returns error on network failure", async () => {
+  const api = createApi({
+    fetcher: async () => { throw new Error("Network error"); },
+  });
+  const result = await api.login("demo@mdcms.local", "pass");
+  assert.equal(result.outcome, "error");
+  if (result.outcome === "error") assert.equal(result.message, "Network error");
+});
+
+test("getSsoProviders returns providers on success", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({ data: [{ id: "okta", name: "Okta" }, { id: "azure-ad", name: "Azure AD" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+  });
+  const providers = await api.getSsoProviders();
+  assert.equal(providers.length, 2);
+  assert.equal(providers[0]?.id, "okta");
+  assert.equal(providers[1]?.name, "Azure AD");
+});
+
+test("getSsoProviders returns empty array on failure", async () => {
+  const api = createApi({
+    fetcher: async () => new Response(null, { status: 500 }),
+  });
+  const providers = await api.getSsoProviders();
+  assert.deepEqual(providers, []);
+});

--- a/packages/studio/src/lib/login-api.test.ts
+++ b/packages/studio/src/lib/login-api.test.ts
@@ -9,7 +9,8 @@ function createApi(options: LoginApiOptions = {}) {
 }
 
 test("login returns success on 200", async () => {
-  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
   const api = createApi({
     fetcher: async (input, init) => {
       calls.push({ input, init });
@@ -17,7 +18,13 @@ test("login returns success on 200", async () => {
         JSON.stringify({
           data: {
             csrfToken: "csrf-token",
-            session: { id: "s1", userId: "u1", email: "demo@mdcms.local", issuedAt: "2026-04-06T10:00:00.000Z", expiresAt: "2026-04-06T22:00:00.000Z" },
+            session: {
+              id: "s1",
+              userId: "u1",
+              email: "demo@mdcms.local",
+              issuedAt: "2026-04-06T10:00:00.000Z",
+              expiresAt: "2026-04-06T22:00:00.000Z",
+            },
           },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
@@ -29,7 +36,10 @@ test("login returns success on 200", async () => {
 
   assert.equal(result.outcome, "success");
   assert.equal(calls.length, 1);
-  assert.equal(String(calls[0]?.input), "http://localhost:4000/api/v1/auth/login");
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/auth/login",
+  );
   assert.equal(calls[0]?.init?.method, "POST");
   assert.equal(calls[0]?.init?.credentials, "include");
   const body = JSON.parse(calls[0]?.init?.body as string);
@@ -40,7 +50,13 @@ test("login returns success on 200", async () => {
 test("login returns invalid_credentials on 401", async () => {
   const api = createApi({
     fetcher: async () =>
-      new Response(JSON.stringify({ code: "AUTH_INVALID_CREDENTIALS", message: "Invalid." }), { status: 401 }),
+      new Response(
+        JSON.stringify({
+          code: "AUTH_INVALID_CREDENTIALS",
+          message: "Invalid.",
+        }),
+        { status: 401 },
+      ),
   });
   const result = await api.login("bad@email.com", "wrong");
   assert.equal(result.outcome, "invalid_credentials");
@@ -50,7 +66,11 @@ test("login returns throttled on 429 with retryAfterSeconds", async () => {
   const api = createApi({
     fetcher: async () =>
       new Response(
-        JSON.stringify({ code: "AUTH_BACKOFF_ACTIVE", message: "Too many attempts.", details: { retryAfterSeconds: 8 } }),
+        JSON.stringify({
+          code: "AUTH_BACKOFF_ACTIVE",
+          message: "Too many attempts.",
+          details: { retryAfterSeconds: 8 },
+        }),
         { status: 429, headers: { "retry-after": "8" } },
       ),
   });
@@ -61,7 +81,9 @@ test("login returns throttled on 429 with retryAfterSeconds", async () => {
 
 test("login returns error on network failure", async () => {
   const api = createApi({
-    fetcher: async () => { throw new Error("Network error"); },
+    fetcher: async () => {
+      throw new Error("Network error");
+    },
   });
   const result = await api.login("demo@mdcms.local", "pass");
   assert.equal(result.outcome, "error");
@@ -72,7 +94,12 @@ test("getSsoProviders returns providers on success", async () => {
   const api = createApi({
     fetcher: async () =>
       new Response(
-        JSON.stringify({ data: [{ id: "okta", name: "Okta" }, { id: "azure-ad", name: "Azure AD" }] }),
+        JSON.stringify({
+          data: [
+            { id: "okta", name: "Okta" },
+            { id: "azure-ad", name: "Azure AD" },
+          ],
+        }),
         { status: 200, headers: { "content-type": "application/json" } },
       ),
   });

--- a/packages/studio/src/lib/login-api.test.ts
+++ b/packages/studio/src/lib/login-api.test.ts
@@ -4,19 +4,6 @@ import { test } from "bun:test";
 
 import { createLoginApi, type LoginApiOptions } from "./login-api.js";
 
-function readHeader(
-  init: RequestInit | undefined,
-  name: string,
-): string | null {
-  const headers = init?.headers;
-  if (headers instanceof Headers) return headers.get(name);
-  if (headers && !Array.isArray(headers)) {
-    const value = (headers as Record<string, string>)[name];
-    if (typeof value === "string") return value;
-  }
-  return null;
-}
-
 function createApi(options: LoginApiOptions = {}) {
   return createLoginApi({ serverUrl: "http://localhost:4000" }, options);
 }

--- a/packages/studio/src/lib/login-api.ts
+++ b/packages/studio/src/lib/login-api.ts
@@ -26,6 +26,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function isSsoProvider(value: unknown): value is SsoProvider {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string"
+  );
+}
+
 export function createLoginApi(
   config: LoginApiConfig,
   options: LoginApiOptions = {},
@@ -91,7 +99,7 @@ export function createLoginApi(
         if (!response.ok) return [];
         const payload = await response.json();
         if (isRecord(payload) && Array.isArray(payload.data)) {
-          return payload.data as SsoProvider[];
+          return payload.data.filter(isSsoProvider);
         }
         return [];
       } catch {

--- a/packages/studio/src/lib/login-api.ts
+++ b/packages/studio/src/lib/login-api.ts
@@ -49,7 +49,8 @@ export function createLoginApi(
       } catch (error) {
         return {
           outcome: "error",
-          message: error instanceof Error ? error.message : "Login request failed.",
+          message:
+            error instanceof Error ? error.message : "Login request failed.",
         };
       }
 
@@ -65,10 +66,16 @@ export function createLoginApi(
         let retryAfterSeconds = 5;
         try {
           const payload = await response.json();
-          if (isRecord(payload) && isRecord(payload.details) && typeof payload.details.retryAfterSeconds === "number") {
+          if (
+            isRecord(payload) &&
+            isRecord(payload.details) &&
+            typeof payload.details.retryAfterSeconds === "number"
+          ) {
             retryAfterSeconds = payload.details.retryAfterSeconds;
           }
-        } catch { /* use default */ }
+        } catch {
+          /* use default */
+        }
         return { outcome: "throttled", retryAfterSeconds };
       }
 

--- a/packages/studio/src/lib/login-api.ts
+++ b/packages/studio/src/lib/login-api.ts
@@ -1,0 +1,95 @@
+export type LoginApiConfig = {
+  serverUrl: string;
+};
+
+export type LoginApiOptions = {
+  fetcher?: typeof fetch;
+};
+
+export type LoginResult =
+  | { outcome: "success" }
+  | { outcome: "invalid_credentials" }
+  | { outcome: "throttled"; retryAfterSeconds: number }
+  | { outcome: "error"; message: string };
+
+export type SsoProvider = {
+  id: string;
+  name: string;
+};
+
+export type LoginApi = {
+  login: (email: string, password: string) => Promise<LoginResult>;
+  getSsoProviders: () => Promise<SsoProvider[]>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function createLoginApi(
+  config: LoginApiConfig,
+  options: LoginApiOptions = {},
+): LoginApi {
+  const fetcher = options.fetcher ?? fetch;
+
+  return {
+    async login(email, password) {
+      let response: Response;
+
+      try {
+        response = await fetcher(
+          new URL("/api/v1/auth/login", config.serverUrl),
+          {
+            method: "POST",
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ email, password }),
+          },
+        );
+      } catch (error) {
+        return {
+          outcome: "error",
+          message: error instanceof Error ? error.message : "Login request failed.",
+        };
+      }
+
+      if (response.ok) {
+        return { outcome: "success" };
+      }
+
+      if (response.status === 401) {
+        return { outcome: "invalid_credentials" };
+      }
+
+      if (response.status === 429) {
+        let retryAfterSeconds = 5;
+        try {
+          const payload = await response.json();
+          if (isRecord(payload) && isRecord(payload.details) && typeof payload.details.retryAfterSeconds === "number") {
+            retryAfterSeconds = payload.details.retryAfterSeconds;
+          }
+        } catch { /* use default */ }
+        return { outcome: "throttled", retryAfterSeconds };
+      }
+
+      return { outcome: "error", message: "Login failed. Please try again." };
+    },
+
+    async getSsoProviders() {
+      try {
+        const response = await fetcher(
+          new URL("/api/v1/auth/sso/providers", config.serverUrl),
+          { method: "GET", credentials: "include" },
+        );
+        if (!response.ok) return [];
+        const payload = await response.json();
+        if (isRecord(payload) && Array.isArray(payload.data)) {
+          return payload.data as SsoProvider[];
+        }
+        return [];
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/packages/studio/src/lib/remote-studio-app.test.ts
+++ b/packages/studio/src/lib/remote-studio-app.test.ts
@@ -366,6 +366,7 @@ test("SettingsPage links the schema tab to the live schema browser instead of re
           {
             value: {
               canReadSchema: true,
+              canCreateContent: false,
               canManageUsers: false,
               canManageSettings: false,
             },

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -20,6 +20,9 @@ import SettingsPage from "./runtime-ui/app/admin/settings-page.js";
 import TrashPage from "./runtime-ui/app/admin/trash-page.js";
 import UsersPage from "./runtime-ui/app/admin/users-page.js";
 import WorkflowsPage from "./runtime-ui/app/admin/workflows-page.js";
+import LoginPage from "./runtime-ui/app/admin/login-page.js";
+import { StudioSessionProvider } from "./runtime-ui/app/admin/session-context.js";
+import { StudioMountInfoProvider } from "./runtime-ui/app/admin/mount-info-context.js";
 import { ThemeProvider } from "./runtime-ui/adapters/next-themes.js";
 import { StudioNavigationProvider } from "./runtime-ui/navigation.js";
 
@@ -33,6 +36,11 @@ type StudioRuntimeRouteDefinition = MatchableRoute & {
 };
 
 const RUNTIME_ROUTES: readonly StudioRuntimeRouteDefinition[] = [
+  {
+    id: "login",
+    path: "/login",
+    render: () => <LoginPage />,
+  },
   {
     id: "dashboard",
     path: "/",
@@ -508,16 +516,33 @@ export function RemoteStudioApp({
           data-mdcms-active-route={activeRoute?.id ?? "unknown"}
           className="mdcms-studio-runtime"
         >
-          <AdminLayout context={context}>
-            {renderRouteContent(activeRoute, context)}
-            {activeRoute?.id === "content.document" ? (
-              <RuntimeDocumentDiagnostics
-                context={context}
-                previewContainerRef={previewContainerRef}
-                actionStripState={actionStripState}
-              />
-            ) : null}
-          </AdminLayout>
+          {activeRoute?.id === "login" ? (
+            <StudioSessionProvider value={{ status: "unauthenticated" }}>
+              <StudioMountInfoProvider
+                value={{
+                  project: context.documentRoute?.project ?? null,
+                  environment: context.documentRoute?.environment ?? null,
+                  apiBaseUrl: context.apiBaseUrl,
+                  auth: context.auth,
+                  environments: [],
+                  hostBridge: context.hostBridge,
+                }}
+              >
+                {renderRouteContent(activeRoute, context)}
+              </StudioMountInfoProvider>
+            </StudioSessionProvider>
+          ) : (
+            <AdminLayout context={context}>
+              {renderRouteContent(activeRoute, context)}
+              {activeRoute?.id === "content.document" ? (
+                <RuntimeDocumentDiagnostics
+                  context={context}
+                  previewContainerRef={previewContainerRef}
+                  actionStripState={actionStripState}
+                />
+              ) : null}
+            </AdminLayout>
+          )}
         </section>
       </StudioNavigationProvider>
     </ThemeProvider>

--- a/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
@@ -4,12 +4,14 @@ import { createContext, useContext, type PropsWithChildren } from "react";
 
 export type AdminCapabilitiesValue = {
   canReadSchema: boolean;
+  canCreateContent: boolean;
   canManageUsers: boolean;
   canManageSettings: boolean;
 };
 
 const DEFAULT_ADMIN_CAPABILITIES: AdminCapabilitiesValue = {
   canReadSchema: false,
+  canCreateContent: false,
   canManageUsers: false,
   canManageSettings: false,
 };

--- a/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/capabilities-context.tsx
@@ -41,6 +41,10 @@ export function useCanReadSchema(): boolean {
   return useAdminCapabilities().canReadSchema;
 }
 
+export function useCanCreateContent(): boolean {
+  return useAdminCapabilities().canCreateContent;
+}
+
 export function useCanManageUsers(): boolean {
   return useAdminCapabilities().canManageUsers;
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -221,6 +221,7 @@ export default function AdminLayout({
     project: context.documentRoute?.project ?? null,
     environment: context.documentRoute?.environment ?? null,
     apiBaseUrl: context.apiBaseUrl,
+    auth: context.auth,
     environments,
     hostBridge: context.hostBridge,
   };

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -13,6 +13,7 @@ import {
   type StudioSessionState,
 } from "./session-context.js";
 import { StudioMountInfoProvider } from "./mount-info-context.js";
+import { usePathname, useRouter } from "../../navigation.js";
 import { AppSidebar } from "../../components/layout/app-sidebar";
 import { cn } from "../../lib/utils";
 
@@ -210,6 +211,38 @@ export default function AdminLayout({
     context.documentRoute?.environment,
     context.documentRoute?.project,
   ]);
+
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Auth gate: redirect unauthenticated users to login
+  useEffect(() => {
+    if (
+      sessionState.status === "unauthenticated" ||
+      sessionState.status === "error"
+    ) {
+      const returnTo = encodeURIComponent(
+        pathname.includes("/admin") ? pathname : "/admin",
+      );
+      router.replace(`/admin/login?returnTo=${returnTo}`);
+    }
+  }, [sessionState.status, pathname, router]);
+
+  // Show nothing while loading or redirecting (client-side only)
+  if (sessionState.status === "loading" && typeof window !== "undefined") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-foreground-muted text-sm">Loading...</div>
+      </div>
+    );
+  }
+
+  if (
+    sessionState.status === "unauthenticated" ||
+    sessionState.status === "error"
+  ) {
+    return null;
+  }
 
   const handleToggle = () => {
     const newState = !sidebarCollapsed;

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -219,12 +219,11 @@ export default function AdminLayout({
   const pathname = usePathname();
   const router = useRouter();
 
-  // Auth gate: redirect unauthenticated users to login
+  // Auth gate: redirect only truly unauthenticated users to login.
+  // Transient errors (e.g. network blip) should not kick an
+  // authenticated user out — show an inline error instead.
   useEffect(() => {
-    if (
-      sessionState.status === "unauthenticated" ||
-      sessionState.status === "error"
-    ) {
+    if (sessionState.status === "unauthenticated") {
       const returnTo = encodeURIComponent(
         pathname.includes("/admin") ? pathname : "/admin",
       );
@@ -232,7 +231,6 @@ export default function AdminLayout({
     }
   }, [sessionState.status, pathname, router]);
 
-  // Show nothing while loading or redirecting (client-side only)
   if (sessionState.status === "loading" && typeof window !== "undefined") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
@@ -241,11 +239,23 @@ export default function AdminLayout({
     );
   }
 
-  if (
-    sessionState.status === "unauthenticated" ||
-    sessionState.status === "error"
-  ) {
+  if (sessionState.status === "unauthenticated") {
     return null;
+  }
+
+  if (sessionState.status === "error") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="max-w-md text-center space-y-2">
+          <p className="text-sm font-medium text-foreground">
+            Session could not be verified
+          </p>
+          <p className="text-sm text-foreground-muted">
+            {sessionState.message}
+          </p>
+        </div>
+      </div>
+    );
   }
 
   const handleToggle = () => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -68,6 +68,7 @@ export default function AdminLayout({
 }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [canReadSchema, setCanReadSchema] = useState(false);
+  const [canCreateContent, setCanCreateContent] = useState(false);
   const [canManageUsers, setCanManageUsers] = useState(false);
   const [canManageSettings, setCanManageSettings] = useState(false);
   const [sessionState, setSessionState] = useState<StudioSessionState>({
@@ -89,6 +90,7 @@ export default function AdminLayout({
 
     if (!loadInput) {
       setCanReadSchema(false);
+      setCanCreateContent(false);
       setCanManageUsers(false);
       setCanManageSettings(false);
       return;
@@ -105,6 +107,7 @@ export default function AdminLayout({
       .then((response) => {
         if (!cancelled) {
           setCanReadSchema(response.capabilities.schema.read);
+          setCanCreateContent(response.capabilities.content.write);
           setCanManageUsers(response.capabilities.users.manage);
           setCanManageSettings(response.capabilities.settings.manage);
         }
@@ -112,6 +115,7 @@ export default function AdminLayout({
       .catch(() => {
         if (!cancelled) {
           setCanReadSchema(false);
+          setCanCreateContent(false);
           setCanManageUsers(false);
           setCanManageSettings(false);
         }
@@ -262,7 +266,12 @@ export default function AdminLayout({
   return (
     <div className="min-h-screen overflow-x-hidden bg-background">
       <AdminCapabilitiesProvider
-        value={{ canReadSchema, canManageUsers, canManageSettings }}
+        value={{
+          canReadSchema,
+          canCreateContent,
+          canManageUsers,
+          canManageSettings,
+        }}
       >
         <StudioSessionProvider value={sessionState}>
           <StudioMountInfoProvider value={mountInfo}>

--- a/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
@@ -101,12 +101,20 @@ export default function LoginPage() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ providerId, callbackURL }),
       redirect: "manual",
-    }).then((response) => {
-      const redirectUrl = response.headers.get("location");
-      if (redirectUrl) {
-        window.location.href = redirectUrl;
-      }
-    });
+    })
+      .then(async (response) => {
+        const body = await response.json().catch(() => undefined);
+        const redirectUrl =
+          body && typeof body === "object" && typeof body.url === "string"
+            ? body.url
+            : null;
+        if (redirectUrl) {
+          window.location.href = redirectUrl;
+        }
+      })
+      .catch(() => {
+        setError("SSO sign-in failed. Please try again.");
+      });
   };
 
   if (sessionState.status === "authenticated") {

--- a/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
@@ -1,0 +1,209 @@
+// @ts-nocheck
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useBasePath } from "../../navigation.js";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { MDCMSLogo } from "../../components/mdcms-logo";
+import { createLoginApi, type SsoProvider } from "../../../login-api.js";
+import { useStudioSession } from "./session-context.js";
+import { useStudioMountInfo } from "./mount-info-context.js";
+
+function useReturnTo(): string {
+  if (typeof window === "undefined") return "/admin";
+
+  const params = new URLSearchParams(window.location.search);
+  const returnTo = params.get("returnTo") ?? "/admin";
+
+  return returnTo.startsWith("/admin") ? returnTo : "/admin";
+}
+
+export default function LoginPage() {
+  const router = useRouter();
+  const basePath = useBasePath();
+  const sessionState = useStudioSession();
+  const mountInfo = useStudioMountInfo();
+  const returnTo = useReturnTo();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [ssoProviders, setSsoProviders] = useState<SsoProvider[]>([]);
+  const [ssoLoading, setSsoLoading] = useState(true);
+
+  useEffect(() => {
+    if (sessionState.status === "authenticated") {
+      router.replace(returnTo);
+    }
+  }, [sessionState.status, returnTo, router]);
+
+  useEffect(() => {
+    if (!mountInfo.apiBaseUrl) {
+      setSsoLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const api = createLoginApi({ serverUrl: mountInfo.apiBaseUrl });
+
+    void api.getSsoProviders().then((providers) => {
+      if (!cancelled) {
+        setSsoProviders(providers);
+        setSsoLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mountInfo.apiBaseUrl]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    const api = createLoginApi({ serverUrl: mountInfo.apiBaseUrl });
+    const result = await api.login(email, password);
+
+    setSubmitting(false);
+
+    switch (result.outcome) {
+      case "success":
+        window.location.href = basePath
+          ? `${basePath}${returnTo.replace("/admin", "")}`
+          : returnTo;
+        break;
+      case "invalid_credentials":
+        setError("Invalid email or password.");
+        break;
+      case "throttled":
+        setError(
+          `Too many attempts. Try again in ${result.retryAfterSeconds}s.`,
+        );
+        break;
+      case "error":
+        setError(result.message);
+        break;
+    }
+  };
+
+  const handleSsoClick = (providerId: string) => {
+    const callbackURL = basePath
+      ? `${basePath}${returnTo.replace("/admin", "")}`
+      : returnTo;
+
+    void fetch(`${mountInfo.apiBaseUrl}/api/v1/auth/sign-in/sso`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerId, callbackURL }),
+      redirect: "manual",
+    }).then((response) => {
+      const redirectUrl = response.headers.get("location");
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+      }
+    });
+  };
+
+  if (sessionState.status === "authenticated") {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-border bg-card p-8 shadow-sm">
+        <div className="text-center space-y-1">
+          <div className="flex justify-center mb-4">
+            <MDCMSLogo collapsed={false} />
+          </div>
+          <p className="text-sm text-foreground-muted">
+            Sign in to your workspace
+          </p>
+        </div>
+
+        {!ssoLoading && ssoProviders.length > 0 && (
+          <>
+            <div className="space-y-2">
+              {ssoProviders.map((provider) => (
+                <Button
+                  key={provider.id}
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => handleSsoClick(provider.id)}
+                >
+                  Continue with {provider.name}
+                </Button>
+              ))}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-foreground-muted uppercase">
+                or
+              </span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+          </>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label
+              htmlFor="login-email"
+              className="text-sm font-medium text-foreground"
+            >
+              Email
+            </label>
+            <Input
+              id="login-email"
+              type="email"
+              placeholder="you@company.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="login-password"
+              className="text-sm font-medium text-foreground"
+            >
+              Password
+            </label>
+            <Input
+              id="login-password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full bg-accent hover:bg-accent-hover text-white"
+            disabled={submitting || !email || !password}
+          >
+            {submitting ? "Signing in..." : "Sign in"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
@@ -19,6 +19,10 @@ function useReturnTo(): string {
   return returnTo.startsWith("/admin") ? returnTo : "/admin";
 }
 
+function stripAdminPrefix(path: string): string {
+  return path.startsWith("/admin") ? path.slice("/admin".length) : path;
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const basePath = useBasePath();
@@ -48,12 +52,20 @@ export default function LoginPage() {
     let cancelled = false;
     const api = createLoginApi({ serverUrl: mountInfo.apiBaseUrl });
 
-    void api.getSsoProviders().then((providers) => {
-      if (!cancelled) {
-        setSsoProviders(providers);
-        setSsoLoading(false);
-      }
-    });
+    void api
+      .getSsoProviders()
+      .then((providers) => {
+        if (!cancelled) {
+          setSsoProviders(providers);
+          setSsoLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSsoProviders([]);
+          setSsoLoading(false);
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -73,7 +85,7 @@ export default function LoginPage() {
     switch (result.outcome) {
       case "success":
         window.location.href = basePath
-          ? `${basePath}${returnTo.replace("/admin", "")}`
+          ? `${basePath}${stripAdminPrefix(returnTo)}`
           : returnTo;
         break;
       case "invalid_credentials":
@@ -92,7 +104,7 @@ export default function LoginPage() {
 
   const handleSsoClick = (providerId: string) => {
     const callbackURL = basePath
-      ? `${basePath}${returnTo.replace("/admin", "")}`
+      ? `${basePath}${stripAdminPrefix(returnTo)}`
       : returnTo;
 
     void fetch(`${mountInfo.apiBaseUrl}/api/v1/auth/sign-in/sso`, {
@@ -110,6 +122,8 @@ export default function LoginPage() {
             : null;
         if (redirectUrl) {
           window.location.href = redirectUrl;
+        } else {
+          setError("SSO provider did not return a redirect. Please try again.");
         }
       })
       .catch(() => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -2,12 +2,17 @@
 
 import { createContext, useContext, type PropsWithChildren } from "react";
 
-import type { EnvironmentSummary, HostBridgeV1 } from "@mdcms/shared";
+import type {
+  EnvironmentSummary,
+  HostBridgeV1,
+  StudioMountContext,
+} from "@mdcms/shared";
 
 export type StudioMountInfo = {
   project: string | null;
   environment: string | null;
   apiBaseUrl: string;
+  auth: StudioMountContext["auth"];
   environments: EnvironmentSummary[];
   hostBridge: HostBridgeV1 | null;
 };
@@ -16,6 +21,7 @@ const DEFAULT_MOUNT_INFO: StudioMountInfo = {
   project: null,
   environment: null,
   apiBaseUrl: "",
+  auth: { mode: "cookie" },
   environments: [],
   hostBridge: null,
 };

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -25,6 +25,7 @@ import { Badge } from "../../components/ui/badge.js";
 import { PageHeader } from "../../components/layout/page-header.js";
 import { useStudioSession } from "./session-context.js";
 import { useStudioMountInfo } from "./mount-info-context.js";
+import { useAdminCapabilities } from "./capabilities-context.js";
 import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioContentListApi } from "../../../content-list-api.js";
 import {
@@ -64,6 +65,7 @@ function deriveUserLabel(email: string): string {
 export default function DashboardPage() {
   const session = useStudioSession();
   const mountInfo = useStudioMountInfo();
+  const { canCreateContent } = useAdminCapabilities();
   const [state, setState] = useState<DashboardState>({ status: "loading" });
 
   useEffect(() => {
@@ -229,18 +231,20 @@ export default function DashboardPage() {
         </div>
 
         {/* Quick Actions */}
-        <div className="flex flex-wrap gap-3">
-          <Button
-            variant="default"
-            asChild
-            className="bg-accent hover:bg-accent-hover text-white"
-          >
-            <Link href="/admin/content">
-              <Plus className="mr-2 h-4 w-4" />
-              New Document
-            </Link>
-          </Button>
-        </div>
+        {canCreateContent && (
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="default"
+              asChild
+              className="bg-accent hover:bg-accent-hover text-white"
+            >
+              <Link href="/admin/content">
+                <Plus className="mr-2 h-4 w-4" />
+                New Document
+              </Link>
+            </Button>
+          </div>
+        )}
 
         {/* Content Types & Recent Documents */}
         <div className="grid gap-6 lg:grid-cols-2">

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -57,7 +57,8 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 function deriveUserLabel(email: string): string {
-  const local = email.split("@")[0] ?? email;
+  const local = (email || "").split("@")[0];
+  if (!local) return "";
   return local.charAt(0).toUpperCase() + local.slice(1);
 }
 
@@ -84,11 +85,23 @@ export default function DashboardPage() {
     const schemaApi = createStudioSchemaRouteApi(config, authOpts);
     const contentApi = createStudioContentListApi(config, authOpts);
 
-    loadDashboardData(schemaApi, contentApi).then((result) => {
-      if (!cancelled) {
-        setState(result);
-      }
-    });
+    loadDashboardData(schemaApi, contentApi)
+      .then((result) => {
+        if (!cancelled) {
+          setState(result);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message:
+              err instanceof Error
+                ? err.message
+                : "Failed to load dashboard data.",
+          });
+        }
+      });
 
     return () => {
       cancelled = true;

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -69,7 +69,7 @@ export default function DashboardPage() {
   const [state, setState] = useState<DashboardState>({ status: "loading" });
 
   useEffect(() => {
-    const { project, environment, apiBaseUrl } = mountInfo;
+    const { project, environment, apiBaseUrl, auth } = mountInfo;
 
     if (!project || !environment || !apiBaseUrl) {
       setState({ status: "loading" });
@@ -80,7 +80,7 @@ export default function DashboardPage() {
 
     let cancelled = false;
     const config = { project, environment, serverUrl: apiBaseUrl };
-    const authOpts = { auth: { mode: "cookie" as const } };
+    const authOpts = { auth };
 
     const schemaApi = createStudioSchemaRouteApi(config, authOpts);
     const contentApi = createStudioContentListApi(config, authOpts);
@@ -106,7 +106,12 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [mountInfo.project, mountInfo.environment, mountInfo.apiBaseUrl]);
+  }, [
+    mountInfo.project,
+    mountInfo.environment,
+    mountInfo.apiBaseUrl,
+    mountInfo.auth,
+  ]);
 
   const userLabel =
     session.status === "authenticated"

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -1,77 +1,203 @@
 // @ts-nocheck
 "use client";
 
-import Link from "../../adapters/next-link";
+import { useState, useEffect } from "react";
+import Link from "../../adapters/next-link.js";
 import {
   FileText,
   CheckCircle,
   Edit3,
-  Users,
   Plus,
-  Globe,
   ChevronRight,
+  Clock,
+  Loader2,
+  AlertCircle,
+  ShieldAlert,
 } from "lucide-react";
-import { Button } from "../../components/ui/button";
+import { Button } from "../../components/ui/button.js";
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
-} from "../../components/ui/card";
-import { Avatar, AvatarFallback } from "../../components/ui/avatar";
-import { Badge } from "../../components/ui/badge";
-import { PageHeader } from "../../components/layout/page-header";
+} from "../../components/ui/card.js";
+import { Badge } from "../../components/ui/badge.js";
+import { PageHeader } from "../../components/layout/page-header.js";
+import { useStudioSession } from "./session-context.js";
+import { useStudioMountInfo } from "./mount-info-context.js";
+import { useAdminCapabilities } from "./capabilities-context.js";
+import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
+import { createStudioContentListApi } from "../../../content-list-api.js";
 import {
-  currentUser,
-  dashboardStats,
-  mockContentTypes,
-  mockActivities,
-  mockUsers,
-  formatRelativeTime,
-} from "../../lib/mock-data";
-import { cn } from "../../lib/utils";
+  loadDashboardData,
+  type DashboardData,
+  type DashboardLoadResult,
+} from "../../../dashboard-data.js";
 
-const statCards = [
-  {
-    label: "Documents",
-    value: dashboardStats.totalDocuments,
-    icon: FileText,
-    trend: `+${dashboardStats.weeklyGrowth} this week`,
-    trendColor: "text-success",
-  },
-  {
-    label: "Published",
-    value: dashboardStats.publishedDocuments,
-    icon: CheckCircle,
-    trend: `${Math.round((dashboardStats.publishedDocuments / dashboardStats.totalDocuments) * 100)}% of total`,
-    trendColor: "text-foreground-muted",
-  },
-  {
-    label: "Unpublished changes",
-    value: dashboardStats.draftDocuments,
-    icon: Edit3,
-    trend: `${dashboardStats.todayUpdates} updated today`,
-    trendColor: "text-warning",
-  },
-  {
-    label: "Editors online",
-    value: dashboardStats.activeEditors,
-    icon: Users,
-    isUsers: true,
-  },
-];
+type DashboardState = { status: "loading" } | DashboardLoadResult;
 
-const quickActions = [
-  {
-    label: "New Document",
-    icon: Plus,
-    href: "/admin/content",
-    variant: "default" as const,
-  },
-];
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (seconds < 60) return "Just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  if (hours < 24) return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days} days ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function deriveUserLabel(email: string): string {
+  const local = email.split("@")[0] ?? email;
+  return local.charAt(0).toUpperCase() + local.slice(1);
+}
 
 export default function DashboardPage() {
-  const onlineUsers = mockUsers.filter((u) => u.isOnline);
+  const session = useStudioSession();
+  const mountInfo = useStudioMountInfo();
+  const capabilities = useAdminCapabilities();
+  const [state, setState] = useState<DashboardState>({ status: "loading" });
+
+  useEffect(() => {
+    const { project, environment, apiBaseUrl } = mountInfo;
+
+    if (!project || !environment || !apiBaseUrl) {
+      setState({ status: "loading" });
+      return;
+    }
+
+    let cancelled = false;
+    const config = { project, environment, serverUrl: apiBaseUrl };
+    const authOpts = { auth: { mode: "cookie" as const } };
+
+    const schemaApi = createStudioSchemaRouteApi(config, authOpts);
+    const contentApi = createStudioContentListApi(config, authOpts);
+
+    loadDashboardData(schemaApi, contentApi).then((result) => {
+      if (!cancelled) {
+        setState(result);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mountInfo.project, mountInfo.environment, mountInfo.apiBaseUrl]);
+
+  const userLabel =
+    session.status === "authenticated"
+      ? deriveUserLabel(session.session.email)
+      : null;
+
+  if (state.status === "loading") {
+    return (
+      <div className="min-h-screen">
+        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
+        <div className="flex items-center justify-center p-24">
+          <Loader2 className="h-6 w-6 animate-spin text-foreground-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "forbidden") {
+    return (
+      <div className="min-h-screen">
+        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
+        <div className="flex flex-col items-center justify-center gap-3 p-24 text-center">
+          <ShieldAlert className="h-8 w-8 text-foreground-muted" />
+          <h2 className="text-lg font-semibold">Access denied</h2>
+          <p className="text-sm text-foreground-muted max-w-md">
+            You do not have permission to view this dashboard. Contact an
+            administrator for access.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className="min-h-screen">
+        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
+        <div className="flex flex-col items-center justify-center gap-3 p-24 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="text-sm text-foreground-muted max-w-md">
+            {state.message}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "empty") {
+    return (
+      <div className="min-h-screen">
+        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
+        <div className="p-6 space-y-6">
+          <div>
+            <h1 className="text-2xl font-semibold">Dashboard</h1>
+            {userLabel && (
+              <p className="text-sm text-foreground-muted">
+                Welcome back, {userLabel}
+              </p>
+            )}
+          </div>
+          <Card className="border-border">
+            <CardContent className="flex flex-col items-center justify-center gap-3 p-12 text-center">
+              <FileText className="h-8 w-8 text-foreground-muted" />
+              <h2 className="text-lg font-semibold">No content yet</h2>
+              <p className="text-sm text-foreground-muted max-w-md">
+                This project has no schema types or documents. Sync a schema and
+                create your first document to get started.
+              </p>
+              {capabilities.canReadSchema && (
+                <Button asChild variant="default" className="mt-2">
+                  <Link href="/admin/schema">View Schema</Link>
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const { data } = state;
+
+  const statCards = [
+    {
+      label: "Documents",
+      value: data.totalDocuments,
+      icon: FileText,
+      detail:
+        data.contentTypes.length > 0
+          ? `${data.contentTypes.length} content type${data.contentTypes.length !== 1 ? "s" : ""}`
+          : undefined,
+    },
+    {
+      label: "Published",
+      value: data.publishedDocuments,
+      icon: CheckCircle,
+      detail:
+        data.totalDocuments > 0
+          ? `${Math.round((data.publishedDocuments / data.totalDocuments) * 100)}% of total`
+          : undefined,
+    },
+    {
+      label: "Drafts",
+      value: data.draftDocuments,
+      icon: Edit3,
+      detail: "Unpublished documents",
+    },
+  ];
 
   return (
     <div className="min-h-screen">
@@ -81,13 +207,15 @@ export default function DashboardPage() {
         {/* Page Title */}
         <div>
           <h1 className="text-2xl font-semibold">Dashboard</h1>
-          <p className="text-sm text-foreground-muted">
-            Welcome back, {currentUser.name}
-          </p>
+          {userLabel && (
+            <p className="text-sm text-foreground-muted">
+              Welcome back, {userLabel}
+            </p>
+          )}
         </div>
 
         {/* Stats Row */}
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-4 md:grid-cols-3">
           {statCards.map((stat) => (
             <Card key={stat.label} className="border-border py-0 gap-0">
               <CardContent className="p-4">
@@ -97,25 +225,9 @@ export default function DashboardPage() {
                       {stat.label}
                     </p>
                     <p className="text-3xl font-bold">{stat.value}</p>
-                    {stat.isUsers ? (
-                      <div className="flex -space-x-2 pt-1">
-                        {onlineUsers.slice(0, 4).map((user) => (
-                          <Avatar
-                            key={user.id}
-                            className="h-6 w-6 border-2 border-background"
-                          >
-                            <AvatarFallback className="text-xs">
-                              {user.name
-                                .split(" ")
-                                .map((n) => n[0])
-                                .join("")}
-                            </AvatarFallback>
-                          </Avatar>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className={cn("text-xs", stat.trendColor)}>
-                        {stat.trend}
+                    {stat.detail && (
+                      <p className="text-xs text-foreground-muted">
+                        {stat.detail}
                       </p>
                     )}
                   </div>
@@ -130,26 +242,19 @@ export default function DashboardPage() {
 
         {/* Quick Actions */}
         <div className="flex flex-wrap gap-3">
-          {quickActions.map((action) => (
-            <Button
-              key={action.label}
-              variant={action.variant}
-              asChild
-              className={
-                action.variant === "default"
-                  ? "bg-accent hover:bg-accent-hover text-white"
-                  : ""
-              }
-            >
-              <Link href={action.href}>
-                <action.icon className="mr-2 h-4 w-4" />
-                {action.label}
-              </Link>
-            </Button>
-          ))}
+          <Button
+            variant="default"
+            asChild
+            className="bg-accent hover:bg-accent-hover text-white"
+          >
+            <Link href="/admin/content">
+              <Plus className="mr-2 h-4 w-4" />
+              New Document
+            </Link>
+          </Button>
         </div>
 
-        {/* Content Types & Activity */}
+        {/* Content Types & Recent Documents */}
         <div className="grid gap-6 lg:grid-cols-2">
           {/* Content Types */}
           <Card className="border-border">
@@ -165,100 +270,117 @@ export default function DashboardPage() {
               </Link>
             </CardHeader>
             <CardContent className="space-y-3">
-              {mockContentTypes.slice(0, 5).map((type) => {
-                const publishedRatio =
-                  (type.publishedCount / type.documentCount) * 100;
-                return (
-                  <Link
-                    key={type.id}
-                    href={`/admin/content/${type.id}`}
-                    className="flex items-center gap-4 rounded-lg p-3 transition-colors hover:bg-background-subtle"
-                  >
-                    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-accent/10">
-                      <FileText className="h-5 w-5 text-accent" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <p className="font-medium truncate">{type.name}</p>
-                        {type.localized && (
-                          <Badge variant="outline" className="text-xs gap-1">
-                            <Globe className="h-3 w-3" />
-                            {type.locales?.length} locales
-                          </Badge>
-                        )}
+              {data.contentTypes.length === 0 ? (
+                <p className="text-sm text-foreground-muted py-4 text-center">
+                  No schema types synced yet.
+                </p>
+              ) : (
+                data.contentTypes.map((ct) => {
+                  const publishedRatio =
+                    ct.totalCount > 0
+                      ? (ct.publishedCount / ct.totalCount) * 100
+                      : 0;
+                  return (
+                    <Link
+                      key={ct.type}
+                      href={`/admin/content/${ct.type}`}
+                      className="flex items-center gap-4 rounded-lg p-3 transition-colors hover:bg-background-subtle"
+                    >
+                      <div className="flex h-10 w-10 items-center justify-center rounded-md bg-accent/10">
+                        <FileText className="h-5 w-5 text-accent" />
                       </div>
-                      <p className="text-sm text-foreground-muted truncate">
-                        {type.documentCount} documents
-                      </p>
-                    </div>
-                    <div className="w-24">
-                      <div className="flex h-2 overflow-hidden rounded-full bg-border">
-                        <div
-                          className="bg-success transition-all"
-                          style={{ width: `${publishedRatio}%` }}
-                        />
-                        <div
-                          className="bg-warning"
-                          style={{ width: `${100 - publishedRatio}%` }}
-                        />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium truncate">{ct.type}</p>
+                          {ct.localized && (
+                            <Badge variant="outline" className="text-xs">
+                              Localized
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="text-sm text-foreground-muted truncate">
+                          {ct.totalCount} document
+                          {ct.totalCount !== 1 ? "s" : ""}
+                        </p>
                       </div>
-                      <p className="mt-1 text-xs text-foreground-muted text-right">
-                        {type.publishedCount}/{type.documentCount}
-                      </p>
-                    </div>
-                  </Link>
-                );
-              })}
+                      {ct.totalCount > 0 && (
+                        <div className="w-24">
+                          <div className="flex h-2 overflow-hidden rounded-full bg-border">
+                            <div
+                              className="bg-success transition-all"
+                              style={{ width: `${publishedRatio}%` }}
+                            />
+                            <div
+                              className="bg-warning"
+                              style={{ width: `${100 - publishedRatio}%` }}
+                            />
+                          </div>
+                          <p className="mt-1 text-xs text-foreground-muted text-right">
+                            {ct.publishedCount}/{ct.totalCount}
+                          </p>
+                        </div>
+                      )}
+                    </Link>
+                  );
+                })
+              )}
             </CardContent>
           </Card>
 
-          {/* Recent Activity */}
+          {/* Recent Documents */}
           <Card className="border-border">
             <CardHeader className="flex flex-row items-center justify-between pb-4">
               <CardTitle className="text-lg font-semibold">
-                Recent Activity
+                Recent Documents
               </CardTitle>
               <Link
-                href="#"
+                href="/admin/content"
                 className="text-sm text-foreground-muted hover:text-accent flex items-center gap-1"
               >
                 View all <ChevronRight className="h-4 w-4" />
               </Link>
             </CardHeader>
             <CardContent>
-              <div className="space-y-4">
-                {mockActivities.slice(0, 8).map((activity) => (
-                  <div key={activity.id} className="flex items-start gap-3">
-                    <Avatar className="h-6 w-6 shrink-0">
-                      <AvatarFallback className="text-xs">
-                        {activity.user.name
-                          .split(" ")
-                          .map((n) => n[0])
-                          .join("")}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 min-w-0 text-sm">
-                      <span className="text-foreground-muted">
-                        <span className="font-medium text-foreground">
-                          {activity.user.name}
-                        </span>{" "}
-                        {activity.action}{" "}
-                        {activity.documentTitle && (
-                          <>
-                            <span className="font-medium text-foreground">
-                              {activity.documentTitle}
-                            </span>{" "}
-                            in {activity.documentType}
-                          </>
-                        )}
+              {data.recentDocuments.length === 0 ? (
+                <p className="text-sm text-foreground-muted py-4 text-center">
+                  No documents yet.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {data.recentDocuments.map((doc) => (
+                    <div
+                      key={doc.documentId}
+                      className="flex items-start gap-3"
+                    >
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent/10">
+                        <FileText className="h-4 w-4 text-accent" />
+                      </div>
+                      <div className="flex-1 min-w-0 text-sm">
+                        <p className="font-medium truncate">
+                          {doc.frontmatter.title
+                            ? String(doc.frontmatter.title)
+                            : doc.path}
+                        </p>
+                        <p className="text-foreground-muted truncate">
+                          <span>{doc.type}</span>
+                          {doc.hasUnpublishedChanges && (
+                            <Badge
+                              variant="outline"
+                              className="ml-2 text-xs text-warning"
+                            >
+                              Draft
+                            </Badge>
+                          )}
+                        </p>
+                      </div>
+                      <span className="shrink-0 text-xs text-foreground-muted flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        {formatRelativeTime(doc.updatedAt)}
                       </span>
                     </div>
-                    <span className="shrink-0 text-xs text-foreground-muted">
-                      {formatRelativeTime(activity.timestamp)}
-                    </span>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -38,6 +38,9 @@ type DashboardState = { status: "loading" } | DashboardLoadResult;
 
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
   const now = new Date();
   const diff = now.getTime() - date.getTime();
   const seconds = Math.floor(diff / 1000);

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -25,7 +25,6 @@ import { Badge } from "../../components/ui/badge.js";
 import { PageHeader } from "../../components/layout/page-header.js";
 import { useStudioSession } from "./session-context.js";
 import { useStudioMountInfo } from "./mount-info-context.js";
-import { useAdminCapabilities } from "./capabilities-context.js";
 import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioContentListApi } from "../../../content-list-api.js";
 import {
@@ -65,7 +64,6 @@ function deriveUserLabel(email: string): string {
 export default function DashboardPage() {
   const session = useStudioSession();
   const mountInfo = useStudioMountInfo();
-  const capabilities = useAdminCapabilities();
   const [state, setState] = useState<DashboardState>({ status: "loading" });
 
   useEffect(() => {
@@ -155,39 +153,6 @@ export default function DashboardPage() {
           <p className="text-sm text-foreground-muted max-w-md">
             {state.message}
           </p>
-        </div>
-      </div>
-    );
-  }
-
-  if (state.status === "empty") {
-    return (
-      <div className="min-h-screen">
-        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
-        <div className="p-6 space-y-6">
-          <div>
-            <h1 className="text-2xl font-semibold">Dashboard</h1>
-            {userLabel && (
-              <p className="text-sm text-foreground-muted">
-                Welcome back, {userLabel}
-              </p>
-            )}
-          </div>
-          <Card className="border-border">
-            <CardContent className="flex flex-col items-center justify-center gap-3 p-12 text-center">
-              <FileText className="h-8 w-8 text-foreground-muted" />
-              <h2 className="text-lg font-semibold">No content yet</h2>
-              <p className="text-sm text-foreground-muted max-w-md">
-                This project has no schema types or documents. Sync a schema and
-                create your first document to get started.
-              </p>
-              {capabilities.canReadSchema && (
-                <Button asChild variant="default" className="mt-2">
-                  <Link href="/admin/schema">View Schema</Link>
-                </Button>
-              )}
-            </CardContent>
-          </Card>
         </div>
       </div>
     );

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -75,6 +75,8 @@ export default function DashboardPage() {
       return;
     }
 
+    setState({ status: "loading" });
+
     let cancelled = false;
     const config = { project, environment, serverUrl: apiBaseUrl };
     const authOpts = { auth: { mode: "cookie" as const } };
@@ -181,8 +183,8 @@ export default function DashboardPage() {
       value: data.totalDocuments,
       icon: FileText,
       detail:
-        data.contentTypes.length > 0
-          ? `${data.contentTypes.length} content type${data.contentTypes.length !== 1 ? "s" : ""}`
+        data.totalContentTypes > 0
+          ? `${data.totalContentTypes} content type${data.totalContentTypes !== 1 ? "s" : ""}`
           : undefined,
     },
     {

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
@@ -37,6 +37,7 @@ function renderSettingsPage(input: {
           {
             value: {
               canReadSchema: true,
+              canCreateContent: false,
               canManageUsers: false,
               canManageSettings: false,
               ...input.capabilities,


### PR DESCRIPTION
## Summary

Replaces all mock data in the Studio dashboard with real API-backed data from existing MVP contracts (schema list, content list, session, capabilities). Removes fabricated widgets that have no truthful data source in MVP.

- **Stat cards** now show real document, published, and draft counts derived from `GET /api/v1/content` pagination totals
- **Content Types** card lists schema types from `GET /api/v1/schema` with per-type document counts and published/draft progress bars
- **Recent Documents** replaces the fabricated "Recent Activity" feed with the 5 most recently updated documents from the content API
- **Removed**: "Editors online" card (live collaboration is non-MVP), weekly growth/today-updated trends (no temporal aggregation API)
- **Added**: Loading spinner, empty state with schema CTA, error state with message, forbidden state for 401/403
- **Welcome message** uses authenticated session email instead of mock user name

### New files

| File | Purpose |
|------|---------|
| `packages/studio/src/lib/content-list-api.ts` | Studio API client for `GET /api/v1/content` with filter/sort/pagination support |
| `packages/studio/src/lib/content-list-api.test.ts` | 8 tests covering query params, headers, error codes, and edge cases |
| `packages/studio/src/lib/dashboard-data.ts` | Extracted pure async dashboard data loader (testable without DOM) |
| `packages/studio/src/lib/dashboard-data.test.ts` | 9 tests covering loaded, empty, error, forbidden, type cap, and draft states |

### Acceptance criteria

1. Dashboard summary cards and lists backed by real Studio/runtime data — **done**
2. Unsupported widgets removed or replaced with truthful content — **done** (editors online, activity feed, trends)
3. Dashboard handles loading, empty, error, and forbidden states without mock fallback — **done**
4. Role-aware interaction constraints enforced — **done** (capabilities context gates schema CTA in empty state)
5. No new public contracts introduced — **done** (consumes existing APIs only)

### Dependencies

- CMS-48 (internal Studio route surfaces)
- CMS-129 (session, env context, role-aware nav)

## Test plan

- [x] `bun run check` passes (build + typecheck)
- [x] `bun run format:check` passes
- [x] 248 studio tests pass (231 existing + 17 new, 0 failures)
- [x] New tests cover: real-data state, empty state, error state (401/403/500/generic), type cap at 5, recent document fields
- [x] No studio-review impact (no dashboard fixtures exist in review app)
- [ ] Manual verification: start dev server, confirm dashboard loads real data from backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live dashboard with totals, per-type stats (capped), recent documents, and loading/forbidden/error states
  * Admin auth UX: email/password sign-in, SSO initiation, return-to handling, and redirect for unauthenticated sessions
  * New capability flag to control content-creation visibility

* **New Components**
  * Content-list API client, dashboard data loader, login API client, Login page and runtime /login route
  * Review API stubs for session, content listing, and environments

* **Tests**
  * Tests added for content-list API, dashboard loader, and login/SSO flows

* **Chores**
  * Demo seed now ensures demo RBAC grant
<!-- end of auto-generated comment: release notes by coderabbit.ai -->