### PR TITLE
fix(studio): remove runtime ui ts-nocheck directives

### DIFF
--- a/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 import { Terminal } from "lucide-react";
-import { ComingSoon } from "../../components/coming-soon";
+import { ComingSoon } from "../../components/coming-soon.js";
 import {
   PageHeader,
   PageHeaderHeading,
   PageHeaderDescription,
-} from "../../components/layout/page-header";
+} from "../../components/layout/page-header.js";
 
 export default function ApiPlaygroundPage() {
   return (

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -1,9 +1,7 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useMemo } from "react";
-import Link from "../../../../adapters/next-link";
-import { useParams, useRouter } from "../../../../adapters/next-navigation";
+import { useParams, useRouter } from "../../../../adapters/next-navigation.js";
 import {
   Search,
   Plus,
@@ -19,18 +17,18 @@ import {
   X,
   FileText,
 } from "lucide-react";
-import { Button } from "../../../../components/ui/button";
-import { Input } from "../../../../components/ui/input";
-import { Badge } from "../../../../components/ui/badge";
-import { Checkbox } from "../../../../components/ui/checkbox";
-import { Avatar, AvatarFallback } from "../../../../components/ui/avatar";
+import { Button } from "../../../../components/ui/button.js";
+import { Input } from "../../../../components/ui/input.js";
+import { Badge } from "../../../../components/ui/badge.js";
+import { Checkbox } from "../../../../components/ui/checkbox.js";
+import { Avatar, AvatarFallback } from "../../../../components/ui/avatar.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../../../../components/ui/select";
+} from "../../../../components/ui/select.js";
 import {
   Table,
   TableBody,
@@ -38,14 +36,14 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "../../../../components/ui/table";
+} from "../../../../components/ui/table.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../../../../components/ui/dropdown-menu";
+} from "../../../../components/ui/dropdown-menu.js";
 import {
   Pagination,
   PaginationContent,
@@ -53,15 +51,14 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-} from "../../../../components/ui/pagination";
-import { PageHeader } from "../../../../components/layout/page-header";
+} from "../../../../components/ui/pagination.js";
+import { PageHeader } from "../../../../components/layout/page-header.js";
 import {
   mockDocuments,
   mockContentTypes,
   formatRelativeTime,
-  type Document,
-} from "../../../../lib/mock-data";
-import { cn } from "../../../../lib/utils";
+} from "../../../../lib/mock-data.js";
+import { cn } from "../../../../lib/utils.js";
 
 const statusConfig = {
   published: {

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/page.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 "use client";
 
-import Link from "../../../adapters/next-link";
+import Link from "../../../adapters/next-link.js";
 import {
   FileText,
   File,
@@ -11,10 +10,10 @@ import {
   Globe,
   ChevronRight,
 } from "lucide-react";
-import { Card, CardContent } from "../../../components/ui/card";
-import { Badge } from "../../../components/ui/badge";
-import { PageHeader } from "../../../components/layout/page-header";
-import { mockContentTypes } from "../../../lib/mock-data";
+import { Card, CardContent } from "../../../components/ui/card.js";
+import { Badge } from "../../../components/ui/badge.js";
+import { PageHeader } from "../../../components/layout/page-header.js";
+import { mockContentTypes } from "../../../lib/mock-data.js";
 
 const iconMap: Record<string, React.ElementType> = {
   FileText,

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState } from "react";
@@ -16,23 +15,23 @@ import {
   PageHeaderHeading,
   PageHeaderDescription,
   PageHeaderActions,
-} from "../../components/layout/page-header";
-import { Button } from "../../components/ui/button";
+} from "../../components/layout/page-header.js";
+import { Button } from "../../components/ui/button.js";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "../../components/ui/card";
-import { Badge } from "../../components/ui/badge";
+} from "../../components/ui/card.js";
+import { Badge } from "../../components/ui/badge.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu";
+} from "../../components/ui/dropdown-menu.js";
 import {
   Dialog,
   DialogContent,
@@ -41,21 +40,53 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "../../components/ui/dialog";
-import { Input } from "../../components/ui/input";
-import { Label } from "../../components/ui/label";
-import { Textarea } from "../../components/ui/textarea";
-import { mockEnvironments } from "../../lib/mock-data";
+} from "../../components/ui/dialog.js";
+import { Input } from "../../components/ui/input.js";
+import { Label } from "../../components/ui/label.js";
+import { Textarea } from "../../components/ui/textarea.js";
+import { mockEnvironments } from "../../lib/mock-data.js";
+
+type EnvironmentCard = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  isProduction: boolean;
+  color: string;
+  documentCount: number;
+  lastPublished: Date | null;
+};
+
+const environmentColorMap = {
+  green: "#22c55e",
+  yellow: "#eab308",
+  blue: "#3b82f6",
+  gray: "#6b7280",
+} as const;
+
+const initialEnvironments: EnvironmentCard[] = mockEnvironments.map(
+  (environment) => ({
+    id: environment.id,
+    name: environment.name,
+    slug: environment.id,
+    description: environment.description ?? "",
+    isProduction: environment.isProduction ?? false,
+    color: environmentColorMap[environment.color],
+    documentCount: environment.documentCount,
+    lastPublished: null,
+  }),
+);
 
 export default function EnvironmentsPage() {
-  const [environments, setEnvironments] = useState(mockEnvironments);
+  const [environments, setEnvironments] =
+    useState<EnvironmentCard[]>(initialEnvironments);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newEnv, setNewEnv] = useState({ name: "", slug: "", description: "" });
 
   const handleCreateEnvironment = () => {
     if (!newEnv.name || !newEnv.slug) return;
 
-    const env = {
+    const env: EnvironmentCard = {
       id: `env-${Date.now()}`,
       name: newEnv.name,
       slug: newEnv.slug,
@@ -242,7 +273,7 @@ export default function EnvironmentsPage() {
                   <p className="text-muted-foreground">Last Published</p>
                   <p className="font-medium">
                     {env.lastPublished
-                      ? new Date(env.lastPublished).toLocaleDateString()
+                      ? env.lastPublished.toLocaleDateString()
                       : "Never"}
                   </p>
                 </div>

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useEffect } from "react";
@@ -14,8 +13,8 @@ import {
 } from "./session-context.js";
 import { StudioMountInfoProvider } from "./mount-info-context.js";
 import { usePathname, useRouter } from "../../navigation.js";
-import { AppSidebar } from "../../components/layout/app-sidebar";
-import { cn } from "../../lib/utils";
+import { AppSidebar } from "../../components/layout/app-sidebar.js";
+import { cn } from "../../lib/utils.js";
 
 type AdminLayoutCapabilitiesLoadInput = {
   config: {

--- a/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/login-page.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useEffect } from "react";
 import { useRouter, useBasePath } from "../../navigation.js";
-import { Button } from "../../components/ui/button";
-import { Input } from "../../components/ui/input";
-import { MDCMSLogo } from "../../components/mdcms-logo";
+import { Button } from "../../components/ui/button.js";
+import { Input } from "../../components/ui/input.js";
+import { MDCMSLogo } from "../../components/mdcms-logo.js";
 import { createLoginApi, type SsoProvider } from "../../../login-api.js";
 import { useStudioSession } from "./session-context.js";
 import { useStudioMountInfo } from "./mount-info-context.js";

--- a/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import {
@@ -11,8 +10,8 @@ import {
   FileAudio,
   File,
 } from "lucide-react";
-import { Badge } from "../../components/ui/badge";
-import { PageHeader } from "../../components/layout/page-header";
+import { Badge } from "../../components/ui/badge.js";
+import { PageHeader } from "../../components/layout/page-header.js";
 
 // Mock media items for the ghosted preview
 const mockMediaItems = [

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useEffect } from "react";
@@ -30,7 +29,6 @@ import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioContentListApi } from "../../../content-list-api.js";
 import {
   loadDashboardData,
-  type DashboardData,
   type DashboardLoadResult,
 } from "../../../dashboard-data.js";
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState } from "react";
@@ -12,32 +11,32 @@ import {
   Copy,
   Plus,
   MoreHorizontal,
-  Eye,
-  EyeOff,
-  Trash2,
 } from "lucide-react";
-import Link from "../../adapters/next-link";
-import { resolveStudioHref, useBasePath } from "../../adapters/next-navigation";
-import { Button } from "../../components/ui/button";
-import { Input } from "../../components/ui/input";
-import { Badge } from "../../components/ui/badge";
-import { Switch } from "../../components/ui/switch";
-import { Label } from "../../components/ui/label";
-import { Separator } from "../../components/ui/separator";
+import Link from "../../adapters/next-link.js";
+import {
+  resolveStudioHref,
+  useBasePath,
+} from "../../adapters/next-navigation.js";
+import { Button } from "../../components/ui/button.js";
+import { Input } from "../../components/ui/input.js";
+import { Badge } from "../../components/ui/badge.js";
+import { Switch } from "../../components/ui/switch.js";
+import { Label } from "../../components/ui/label.js";
+import { Separator } from "../../components/ui/separator.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../../components/ui/select";
+} from "../../components/ui/select.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu";
+} from "../../components/ui/dropdown-menu.js";
 import {
   Table,
   TableBody,
@@ -45,11 +44,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "../../components/ui/table";
+} from "../../components/ui/table.js";
 import { useCanReadSchema } from "./capabilities-context.js";
-import { PageHeader } from "../../components/layout/page-header";
-import { mockEnvironments, currentProject } from "../../lib/mock-data";
-import { cn } from "../../lib/utils";
+import { PageHeader } from "../../components/layout/page-header.js";
+import { mockEnvironments, currentProject } from "../../lib/mock-data.js";
+import { cn } from "../../lib/utils.js";
 
 const settingsTabs = [
   { id: "general", label: "General", icon: Settings },
@@ -114,7 +113,6 @@ export default function SettingsPage({
   initialTab?: string;
 }) {
   const [activeTab, setActiveTab] = useState(initialTab);
-  const [showSecret, setShowSecret] = useState(false);
   const canReadSchema = useCanReadSchema();
   const basePath = useBasePath();
   const schemaBrowserHref = resolveStudioHref(basePath, "/schema");

--- a/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
@@ -1,12 +1,11 @@
-// @ts-nocheck
 import { Trash2 } from "lucide-react";
 
-import { ComingSoon } from "../../components/coming-soon";
+import { ComingSoon } from "../../components/coming-soon.js";
 import {
   PageHeader,
   PageHeaderDescription,
   PageHeaderHeading,
-} from "../../components/layout/page-header";
+} from "../../components/layout/page-header.js";
 
 export default function TrashPage() {
   return (

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState } from "react";
@@ -11,10 +10,10 @@ import {
   Trash2,
   LogOut,
 } from "lucide-react";
-import { Button } from "../../components/ui/button";
-import { Badge } from "../../components/ui/badge";
-import { Avatar, AvatarFallback } from "../../components/ui/avatar";
-import { Input } from "../../components/ui/input";
+import { Button } from "../../components/ui/button.js";
+import { Badge } from "../../components/ui/badge.js";
+import { Avatar, AvatarFallback } from "../../components/ui/avatar.js";
+import { Input } from "../../components/ui/input.js";
 import {
   Table,
   TableBody,
@@ -22,14 +21,14 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "../../components/ui/table";
+} from "../../components/ui/table.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu";
+} from "../../components/ui/dropdown-menu.js";
 import {
   Dialog,
   DialogContent,
@@ -38,19 +37,19 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "../../components/ui/dialog";
+} from "../../components/ui/dialog.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../../components/ui/select";
-import { Switch } from "../../components/ui/switch";
-import { Label } from "../../components/ui/label";
-import { PageHeader } from "../../components/layout/page-header";
-import { mockUsers, formatRelativeTime } from "../../lib/mock-data";
-import { cn } from "../../lib/utils";
+} from "../../components/ui/select.js";
+import { Switch } from "../../components/ui/switch.js";
+import { Label } from "../../components/ui/label.js";
+import { PageHeader } from "../../components/layout/page-header.js";
+import { mockUsers, formatRelativeTime } from "../../lib/mock-data.js";
+import { cn } from "../../lib/utils.js";
 
 const roleConfig = {
   owner: {

--- a/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 import { GitBranch } from "lucide-react";
-import { ComingSoon } from "../../components/coming-soon";
+import { ComingSoon } from "../../components/coming-soon.js";
 import {
   PageHeader,
   PageHeaderHeading,
   PageHeaderDescription,
-} from "../../components/layout/page-header";
+} from "../../components/layout/page-header.js";
 
 export default function WorkflowsPage() {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import { LucideIcon } from "lucide-react";
-import { Button } from "./ui/button";
-import { Card, CardContent } from "./ui/card";
-import { Badge } from "./ui/badge";
+import { Button } from "./ui/button.js";
+import { Card, CardContent } from "./ui/card.js";
+import { Badge } from "./ui/badge.js";
 
 interface ComingSoonProps {
   icon: LucideIcon;

--- a/packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/editor-sidebar.tsx
@@ -1,36 +1,35 @@
-// @ts-nocheck
 "use client";
 
 import { useState } from "react";
 import { Copy, Globe, Sparkles } from "lucide-react";
-import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { Textarea } from "../ui/textarea";
-import { Label } from "../ui/label";
-import { Switch } from "../ui/switch";
-import { Badge } from "../ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
-import { Calendar } from "../ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { Avatar, AvatarFallback } from "../ui/avatar";
-import { ScrollArea } from "../ui/scroll-area";
-import { Separator } from "../ui/separator";
+import { Button } from "../ui/button.js";
+import { Input } from "../ui/input.js";
+import { Textarea } from "../ui/textarea.js";
+import { Label } from "../ui/label.js";
+import { Switch } from "../ui/switch.js";
+import { Badge } from "../ui/badge.js";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs.js";
+import { Calendar } from "../ui/calendar.js";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover.js";
+import { Avatar, AvatarFallback } from "../ui/avatar.js";
+import { ScrollArea } from "../ui/scroll-area.js";
+import { Separator } from "../ui/separator.js";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "../ui/tooltip";
+} from "../ui/tooltip.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../ui/select";
+} from "../ui/select.js";
 import { format } from "date-fns";
-import { cn } from "../../lib/utils";
-import { mockUsers, type Document } from "../../lib/mock-data";
+import { cn } from "../../lib/utils.js";
+import { mockUsers, type Document } from "../../lib/mock-data.js";
 
 interface EditorSidebarProps {
   document: Document;

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import {
@@ -10,7 +9,12 @@ import {
 } from "react";
 
 import type { StudioMountContext } from "@mdcms/shared";
-import { EditorContent, ReactNodeViewRenderer, useEditor } from "@tiptap/react";
+import {
+  EditorContent,
+  ReactNodeViewRenderer,
+  type ReactNodeViewProps,
+  useEditor,
+} from "@tiptap/react";
 
 import {
   Bold,
@@ -37,10 +41,7 @@ import { extractMarkdownFromEditor } from "../../../markdown-pipeline.js";
 import { MdxComponentExtension } from "../../../mdx-component-extension.js";
 import { createEditorToolbarLayout } from "./editor-toolbar.js";
 import { MdxComponentNodeView } from "./mdx-component-node-view.js";
-import {
-  createMdxComponentInsertContent,
-  type MdxComponentKind,
-} from "./mdx-component-catalog.js";
+import { createMdxComponentInsertContent } from "./mdx-component-catalog.js";
 import { MdxComponentPicker } from "./mdx-component-picker.js";
 import { type MdxPropsPanelSelection } from "./mdx-props-panel.js";
 import {
@@ -58,10 +59,10 @@ import {
   replaceSlashTriggerWithMdxComponent,
   type MdxComponentSlashTrigger,
 } from "./mdx-component-slash.js";
-import { Badge } from "../ui/badge";
-import { Button } from "../ui/button";
-import { Separator } from "../ui/separator";
-import { cn } from "../../lib/utils";
+import { Badge } from "../ui/badge.js";
+import { Button } from "../ui/button.js";
+import { Separator } from "../ui/separator.js";
+import { cn } from "../../lib/utils.js";
 
 interface TipTapEditorProps {
   content?: string;
@@ -99,6 +100,8 @@ type ToolbarButtonProps = {
   disabled?: boolean;
   className?: string;
 };
+
+type TipTapEditorInstance = NonNullable<ReturnType<typeof useEditor>>;
 
 function ToolbarButton({
   children,
@@ -158,82 +161,88 @@ export function TipTapEditor({
     useState<MdxComponentSlashTrigger | null>(null);
   const lastPublishedSelectionRef =
     useRef<PublishedMdxComponentSelectionSnapshot | null>(null);
-  const handleEditorUpdate = useEffectEvent((nextEditor) => {
-    onChange?.(extractMarkdownFromEditor(nextEditor));
-  });
-  const syncSlashTrigger = useEffectEvent((nextEditor) => {
-    const nextTrigger = getMdxComponentSlashTrigger(nextEditor);
+  const handleEditorUpdate = useEffectEvent(
+    (nextEditor: TipTapEditorInstance) => {
+      onChange?.(extractMarkdownFromEditor(nextEditor));
+    },
+  );
+  const syncSlashTrigger = useEffectEvent(
+    (nextEditor: TipTapEditorInstance) => {
+      const nextTrigger = getMdxComponentSlashTrigger(nextEditor);
 
-    setSlashTrigger(nextTrigger);
-    setPickerSource((currentSource) => {
-      if (currentSource === "toolbar") {
-        return currentSource;
-      }
+      setSlashTrigger(nextTrigger);
+      setPickerSource((currentSource) => {
+        if (currentSource === "toolbar") {
+          return currentSource;
+        }
 
-      if (nextTrigger) {
-        return "slash";
-      }
+        if (nextTrigger) {
+          return "slash";
+        }
 
-      return currentSource === "slash" ? null : currentSource;
-    });
-  });
-  const publishSelectedMdxComponent = useEffectEvent((nextEditor) => {
-    if (!onActiveMdxComponentChange) {
-      lastPublishedSelectionRef.current = null;
-      return;
-    }
-
-    const selected = getSelectedMdxComponent(nextEditor, catalogComponents);
-
-    if (!selected) {
-      if (lastPublishedSelectionRef.current === null) {
+        return currentSource === "slash" ? null : currentSource;
+      });
+    },
+  );
+  const publishSelectedMdxComponent = useEffectEvent(
+    (nextEditor: TipTapEditorInstance) => {
+      if (!onActiveMdxComponentChange) {
+        lastPublishedSelectionRef.current = null;
         return;
       }
 
-      lastPublishedSelectionRef.current = null;
-      onActiveMdxComponentChange(null);
-      return;
-    }
+      const selected = getSelectedMdxComponent(nextEditor, catalogComponents);
 
-    const nextSnapshot = createPublishedMdxComponentSelectionSnapshot({
-      selected,
-      readOnly,
-      forbidden,
-    });
-
-    if (
-      !hasPublishedMdxComponentSelectionChanged(
-        lastPublishedSelectionRef.current,
-        nextSnapshot,
-      )
-    ) {
-      return;
-    }
-
-    lastPublishedSelectionRef.current = nextSnapshot;
-
-    onActiveMdxComponentChange({
-      ...selected,
-      readOnly,
-      forbidden,
-      onPropsChange: (patch) => {
-        if (
-          updateSelectedMdxComponentProps(
-            nextEditor,
-            catalogComponents,
-            patch,
-            {
-              readOnly,
-              forbidden,
-            },
-          )
-        ) {
-          publishSelectedMdxComponent(nextEditor);
-          handleEditorUpdate(nextEditor);
+      if (!selected) {
+        if (lastPublishedSelectionRef.current === null) {
+          return;
         }
-      },
-    });
-  });
+
+        lastPublishedSelectionRef.current = null;
+        onActiveMdxComponentChange(null);
+        return;
+      }
+
+      const nextSnapshot = createPublishedMdxComponentSelectionSnapshot({
+        selected,
+        readOnly,
+        forbidden,
+      });
+
+      if (
+        !hasPublishedMdxComponentSelectionChanged(
+          lastPublishedSelectionRef.current,
+          nextSnapshot,
+        )
+      ) {
+        return;
+      }
+
+      lastPublishedSelectionRef.current = nextSnapshot;
+
+      onActiveMdxComponentChange({
+        ...selected,
+        readOnly,
+        forbidden,
+        onPropsChange: (patch) => {
+          if (
+            updateSelectedMdxComponentProps(
+              nextEditor,
+              catalogComponents,
+              patch,
+              {
+                readOnly,
+                forbidden,
+              },
+            )
+          ) {
+            publishSelectedMdxComponent(nextEditor);
+            handleEditorUpdate(nextEditor);
+          }
+        },
+      });
+    },
+  );
   const editor = useEditor(
     {
       content,
@@ -243,7 +252,7 @@ export function TipTapEditor({
       extensions: createEditorExtensions({
         mdxComponent: MdxComponentExtension.extend({
           addNodeView() {
-            const NodeView = (props) => (
+            const NodeView = (props: ReactNodeViewProps) => (
               <MdxComponentNodeView
                 {...props}
                 context={context}

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -1,13 +1,12 @@
-// @ts-nocheck
 "use client";
 
-import Link from "../../adapters/next-link";
+import Link from "../../adapters/next-link.js";
 import {
   resolveStudioHref,
   useBasePath,
   usePathname,
-} from "../../adapters/next-navigation";
-import { useCanReadSchema } from "../../app/admin/capabilities-context";
+} from "../../adapters/next-navigation.js";
+import { useCanReadSchema } from "../../app/admin/capabilities-context.js";
 import {
   LayoutDashboard,
   FileText,
@@ -25,21 +24,21 @@ import {
   ChevronsRight,
   ChevronDown,
 } from "lucide-react";
-import { cn } from "../../lib/utils";
-import { Button } from "../ui/button";
-import { Badge } from "../ui/badge";
+import { cn } from "../../lib/utils.js";
+import { Button } from "../ui/button.js";
+import { Badge } from "../ui/badge.js";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "../ui/tooltip";
+} from "../ui/tooltip.js";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "../ui/collapsible";
-import { MDCMSLogo } from "../mdcms-logo";
+} from "../ui/collapsible.js";
+import { MDCMSLogo } from "../mdcms-logo.js";
 import { useState } from "react";
 
 interface AppSidebarProps {
@@ -203,7 +202,7 @@ export function AppSidebar({
               <CollapsibleContent>
                 <ul className="space-y-1 pt-1">
                   {comingSoonItems.map((item) => (
-                    <li key={item.href}>
+                    <li key={item.label}>
                       <Link
                         href="#"
                         className="flex h-10 items-center gap-3 rounded-md px-3 text-sm text-foreground-muted/60 hover:bg-background-subtle hover:text-foreground-muted"

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -1,12 +1,11 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
-import { useTheme } from "../../adapters/next-themes";
-import Link from "../../adapters/next-link";
+import { useTheme } from "../../adapters/next-themes.js";
+import Link from "../../adapters/next-link.js";
 import { Sun, Moon, ChevronRight, LogOut, User, Settings } from "lucide-react";
-import { Button } from "../ui/button";
-import { Avatar, AvatarFallback } from "../ui/avatar";
+import { Button } from "../ui/button.js";
+import { Avatar, AvatarFallback } from "../ui/avatar.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,30 +13,30 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
+} from "../ui/dropdown-menu.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../ui/select";
+} from "../ui/select.js";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "../ui/tooltip";
-import { cn } from "../../lib/utils";
-import { useStudioSession } from "../../app/admin/session-context";
-import { useStudioMountInfo } from "../../app/admin/mount-info-context";
+} from "../ui/tooltip.js";
+import { cn } from "../../lib/utils.js";
+import { useStudioSession } from "../../app/admin/session-context.js";
+import { useStudioMountInfo } from "../../app/admin/mount-info-context.js";
 import { createStudioSessionApi } from "../../../session-api.js";
 
 export type BreadcrumbItem = { label: string; href?: string };
 
 // Page Title Section Components
 interface PageTitleSectionProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   breadcrumbs?: BreadcrumbItem[];
 }
 

--- a/packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/mdcms-logo.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 "use client";
 
-import { cn } from "../lib/utils";
+import { cn } from "../lib/utils.js";
 
 interface MDCMSLogoProps {
   collapsed?: boolean;

--- a/packages/studio/src/lib/runtime-ui/components/ui/avatar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/avatar.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Avatar({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/button.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/packages/studio/src/lib/runtime-ui/components/ui/calendar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/calendar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
@@ -9,8 +8,8 @@ import {
 } from "lucide-react";
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker";
 
-import { cn } from "../../lib/utils";
-import { Button, buttonVariants } from "./button";
+import { cn } from "../../lib/utils.js";
+import { Button, buttonVariants } from "./button.js";
 
 function Calendar({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import * as React from "react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/ui/checkbox.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/checkbox.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Checkbox({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/collapsible.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/collapsible.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";

--- a/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function DropdownMenu({
   ...props

--- a/packages/studio/src/lib/runtime-ui/components/ui/input.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/input.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import * as React from "react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/ui/label.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/label.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Label({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/pagination.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/pagination.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import {
   ChevronLeftIcon,
@@ -6,8 +5,8 @@ import {
   MoreHorizontalIcon,
 } from "lucide-react";
 
-import { cn } from "../../lib/utils";
-import { Button, buttonVariants } from "./button";
+import { cn } from "../../lib/utils.js";
+import { Button, buttonVariants } from "./button.js";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/ui/popover.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/popover.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Popover({
   ...props

--- a/packages/studio/src/lib/runtime-ui/components/ui/scroll-area.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/scroll-area.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function ScrollArea({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Select({
   ...props

--- a/packages/studio/src/lib/runtime-ui/components/ui/separator.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/separator.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Separator({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/switch.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/switch.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Switch({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/table.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/table.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/ui/tabs.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/tabs.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Tabs({
   className,

--- a/packages/studio/src/lib/runtime-ui/components/ui/textarea.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/textarea.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import * as React from "react";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/packages/studio/src/lib/runtime-ui/components/ui/tooltip.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/tooltip.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "../../lib/utils";
+import { cn } from "../../lib/utils.js";
 
 function TooltipProvider({
   delayDuration = 0,

--- a/packages/studio/src/lib/runtime-ui/lib/mock-data.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/mock-data.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Mock data for MDCMS Studio
 
 export type ContentType = {
@@ -419,6 +418,7 @@ export const mockDeletedDocuments: (Document & {
     path: "blog/old-draft",
     type: "BlogPost",
     locale: "en-US",
+    body: createMockDocumentBody("Old Draft Post"),
     status: "draft",
     updatedAt: new Date(Date.now() - 86400000 * 5),
     createdAt: new Date(Date.now() - 86400000 * 30),
@@ -432,6 +432,7 @@ export const mockDeletedDocuments: (Document & {
     path: "pages/deprecated-guide",
     type: "Page",
     locale: "en-US",
+    body: createMockDocumentBody("Deprecated Guide"),
     status: "published",
     updatedAt: new Date(Date.now() - 86400000 * 15),
     createdAt: new Date(Date.now() - 86400000 * 120),

--- a/packages/studio/src/lib/runtime-ui/lib/utils.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/utils.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck
 "use client";
 
 import type { ElementType } from "react";
 
-import Link from "../adapters/next-link";
+import Link from "../adapters/next-link.js";
 import {
   ChevronRight,
   File,
@@ -13,10 +12,10 @@ import {
   Tag,
   User,
 } from "lucide-react";
-import { PageHeader } from "../components/layout/page-header";
-import { Badge } from "../components/ui/badge";
-import { Card, CardContent } from "../components/ui/card";
-import { mockContentTypes } from "../lib/mock-data";
+import { PageHeader } from "../components/layout/page-header.js";
+import { Badge } from "../components/ui/badge.js";
+import { Card, CardContent } from "../components/ui/card.js";
+import { mockContentTypes } from "../lib/mock-data.js";
 
 const iconMap: Record<string, ElementType> = {
   FileText,

--- a/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-type-page.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck
 "use client";
 
 import { useMemo, useState } from "react";
 
-import { useParams, useRouter } from "../adapters/next-navigation";
+import { useParams, useRouter } from "../adapters/next-navigation.js";
 import {
   Copy,
   Edit,
@@ -19,19 +18,19 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { PageHeader } from "../components/layout/page-header";
-import { Avatar, AvatarFallback } from "../components/ui/avatar";
-import { Badge } from "../components/ui/badge";
-import { Button } from "../components/ui/button";
-import { Checkbox } from "../components/ui/checkbox";
+import { PageHeader } from "../components/layout/page-header.js";
+import { Avatar, AvatarFallback } from "../components/ui/avatar.js";
+import { Badge } from "../components/ui/badge.js";
+import { Button } from "../components/ui/button.js";
+import { Checkbox } from "../components/ui/checkbox.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../components/ui/dropdown-menu";
-import { Input } from "../components/ui/input";
+} from "../components/ui/dropdown-menu.js";
+import { Input } from "../components/ui/input.js";
 import {
   Pagination,
   PaginationContent,
@@ -39,14 +38,14 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-} from "../components/ui/pagination";
+} from "../components/ui/pagination.js";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../components/ui/select";
+} from "../components/ui/select.js";
 import {
   Table,
   TableBody,
@@ -54,13 +53,13 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "../components/ui/table";
+} from "../components/ui/table.js";
 import {
   formatRelativeTime,
   mockContentTypes,
   mockDocuments,
-} from "../lib/mock-data";
-import { cn } from "../lib/utils";
+} from "../lib/mock-data.js";
+import { cn } from "../lib/utils.js";
 
 const statusConfig = {
   published: {

--- a/packages/studio/src/lib/runtime-ui/style-installer.test.ts
+++ b/packages/studio/src/lib/runtime-ui/style-installer.test.ts
@@ -1,60 +1,60 @@
-// @ts-nocheck
 import assert from "node:assert/strict";
 import { test } from "bun:test";
 
 import { installStudioRuntimeStyles } from "./style-installer.js";
 
-type FakeLinkNode = {
+type RuntimeStylesheetDocument = NonNullable<
+  Parameters<typeof installStudioRuntimeStyles>[1]
+>;
+type RuntimeStylesheetNode = ReturnType<
+  RuntimeStylesheetDocument["createElement"]
+>;
+
+type FakeLinkNode = RuntimeStylesheetNode & {
   tagName: string;
-  rel: string;
-  href: string;
-  dataset: Record<string, string>;
   parentNode: FakeHeadNode | null;
-  remove: () => void;
 };
 
-type FakeHeadNode = {
+type FakeHeadNode = RuntimeStylesheetDocument["head"] & {
   children: FakeLinkNode[];
-  appendChild: (node: FakeLinkNode) => FakeLinkNode;
 };
 
 function createFakeDocument(): {
-  document: {
-    head: FakeHeadNode;
-    createElement: (tagName: string) => FakeLinkNode;
-    querySelector: (selector: string) => FakeLinkNode | null;
-  };
+  document: RuntimeStylesheetDocument;
   head: FakeHeadNode;
 } {
   const head: FakeHeadNode = {
     children: [],
     appendChild(node) {
-      node.parentNode = head;
-      head.children.push(node);
-      return node;
+      const linkNode = node as FakeLinkNode;
+      linkNode.parentNode = head;
+      head.children.push(linkNode);
+      return linkNode;
     },
   };
 
-  const document = {
+  const document: RuntimeStylesheetDocument = {
     head,
     createElement(tagName: string) {
-      return {
+      const linkNode: FakeLinkNode = {
         tagName: tagName.toUpperCase(),
         rel: "",
         href: "",
         dataset: {},
         parentNode: null,
         remove() {
-          if (!this.parentNode) {
+          if (!linkNode.parentNode) {
             return;
           }
 
-          this.parentNode.children = this.parentNode.children.filter(
-            (child) => child !== this,
+          linkNode.parentNode.children = linkNode.parentNode.children.filter(
+            (child: FakeLinkNode) => child !== linkNode,
           );
-          this.parentNode = null;
+          linkNode.parentNode = null;
         },
       };
+
+      return linkNode;
     },
     querySelector(selector: string) {
       const matchedHref = selector.match(/href="([^"]+)"/)?.[1];


### PR DESCRIPTION
## Summary
- remove all `@ts-nocheck` directives from `packages/studio/src/lib/runtime-ui`
- add explicit `.js` relative ESM imports required by the Studio runtime UI under `nodenext`
- fix the remaining real type issues in shared UI helpers, mock data, editor callbacks, and the stylesheet test harness

## Test Plan
- [x] `bun x --bun tsc --project packages/studio/tsconfig.lib.json --noEmit`
- [x] `bun test packages/studio/src`
- [x] `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enabled comprehensive TypeScript type-checking across the studio codebase to improve code reliability and catch potential errors earlier.
  * Modernized module import patterns for better consistency and alignment with modern development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->