### PR TITLE
CMS-131: finish content overview integration

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -113,6 +113,7 @@ Backend API/runtime package boundary for MDCMS.
 
 - Content routes are mounted under `/api/v1/content` in the server runtime.
 - Implemented endpoints:
+  - `GET /api/v1/content/overview`
   - `GET /api/v1/content`
   - `GET /api/v1/content/:documentId`
   - `GET /api/v1/content/:documentId/versions`
@@ -132,6 +133,8 @@ Backend API/runtime package boundary for MDCMS.
 - `reference('Type')` values are stored as plain environment-local `document_id` UUID strings, not `{$ref, type}` objects.
 - List endpoint query contract supports:
   - `type`, `path`, `locale`, `slug`, `published`, `isDeleted`, `hasUnpublishedChanges`, `draft`, `resolve`, `project`, `environment`, `limit`, `offset`, `sort`, `order`, `q`
+- Overview endpoint query contract supports:
+  - repeated `type` values plus `project`, `environment`
 - Version-history list query contract supports:
   - `limit`, `offset`
 - Pagination defaults:
@@ -140,6 +143,12 @@ Backend API/runtime package boundary for MDCMS.
 - Read semantics:
   - default (`draft` omitted or `draft=false`) returns only published snapshots from `document_versions` for non-deleted documents.
   - `draft=true` returns mutable head rows from `documents`.
+- Overview count semantics:
+  - `GET /api/v1/content/overview` returns metadata-only per-type rows `{ type, total, published, drafts }`
+  - `total` counts non-deleted head rows for the requested type
+  - `published` counts non-deleted rows with `published_version`
+  - `drafts` counts non-deleted rows with no `published_version`
+  - the endpoint never returns document rows or draft bodies
 - Publish lifecycle semantics:
   - publish appends immutable row to `document_versions`, updates `documents.published_version`, and sets `documents.has_unpublished_changes = FALSE`.
   - unpublish clears `documents.published_version` and sets `documents.has_unpublished_changes = TRUE`.

--- a/apps/server/src/bin/demo-seed-api-key.ts
+++ b/apps/server/src/bin/demo-seed-api-key.ts
@@ -21,6 +21,7 @@ const LOCAL_AUTH_ORIGIN = "http://localhost";
 const DEMO_CONTENT_CHANGE_SUMMARY = "compose demo seed";
 
 type DemoSeedDocument = {
+  key: string;
   type: string;
   path: string;
   locale: string;
@@ -28,10 +29,12 @@ type DemoSeedDocument = {
   frontmatter: Record<string, unknown>;
   body: string;
   publish: boolean;
+  sourceKey?: string;
 };
 
 const DEMO_CONTENT_DOCUMENTS: readonly DemoSeedDocument[] = [
   {
+    key: "post:hello-mdcms:en",
     type: "post",
     path: "content/posts/hello-mdcms",
     locale: "en",
@@ -55,6 +58,7 @@ const DEMO_CONTENT_DOCUMENTS: readonly DemoSeedDocument[] = [
     publish: true,
   },
   {
+    key: "post:pull-push-demo:en",
     type: "post",
     path: "content/posts/pull-push-demo",
     locale: "en",
@@ -78,6 +82,7 @@ const DEMO_CONTENT_DOCUMENTS: readonly DemoSeedDocument[] = [
     publish: true,
   },
   {
+    key: "page:about:en",
     type: "page",
     path: "content/pages/about",
     locale: "en",
@@ -95,6 +100,51 @@ const DEMO_CONTENT_DOCUMENTS: readonly DemoSeedDocument[] = [
       "- one demo user",
       "- one fixed demo API key",
       "- sample content documents",
+    ].join("\n"),
+    publish: true,
+  },
+  {
+    key: "campaign:global-launch:en",
+    type: "campaign",
+    path: "content/campaigns/global-launch",
+    locale: "en",
+    format: "md",
+    frontmatter: {
+      title: "Global Launch",
+      slug: "global-launch",
+      summary: "English launch copy seeded for localized overview testing.",
+    },
+    body: [
+      "# Global Launch",
+      "",
+      "This localized demo document is the default English campaign source.",
+      "",
+      "- locale: en",
+      "- translation group: global-launch",
+      "- created by `demo:seed`",
+    ].join("\n"),
+    publish: true,
+  },
+  {
+    key: "campaign:global-launch:fr",
+    sourceKey: "campaign:global-launch:en",
+    type: "campaign",
+    path: "content/campaigns/global-launch",
+    locale: "fr",
+    format: "md",
+    frontmatter: {
+      title: "Lancement mondial",
+      slug: "lancement-mondial",
+      summary: "Copie francaise generee pour tester les variantes localisees.",
+    },
+    body: [
+      "# Lancement mondial",
+      "",
+      "Cette variante partage le meme groupe de traduction que la campagne anglaise.",
+      "",
+      "- langue: fr",
+      "- groupe de traduction: global-launch",
+      "- cree par `demo:seed`",
     ].join("\n"),
     publish: true,
   },
@@ -325,6 +375,7 @@ async function ensureDemoContent(input: {
   environment: string;
 }): Promise<number> {
   const store = createDatabaseContentStore({ db: input.db });
+  const seededDocuments = new Map<string, { documentId: string }>();
   let seededCount = 0;
 
   for (const template of DEMO_CONTENT_DOCUMENTS) {
@@ -366,8 +417,21 @@ async function ensureDemoContent(input: {
         );
       }
 
+      seededDocuments.set(template.key, {
+        documentId: existing.documentId,
+      });
       seededCount += 1;
       continue;
+    }
+
+    const sourceDocumentId = template.sourceKey
+      ? seededDocuments.get(template.sourceKey)?.documentId
+      : undefined;
+
+    if (template.sourceKey && !sourceDocumentId) {
+      throw new Error(
+        `Demo seed source document ${template.sourceKey} was not available before creating ${template.key}.`,
+      );
     }
 
     const created = await store.create(
@@ -384,6 +448,7 @@ async function ensureDemoContent(input: {
         body: template.body,
         createdBy: input.actorId,
         updatedBy: input.actorId,
+        ...(sourceDocumentId ? { sourceDocumentId } : {}),
       },
     );
 
@@ -401,6 +466,9 @@ async function ensureDemoContent(input: {
       );
     }
 
+    seededDocuments.set(template.key, {
+      documentId: created.documentId,
+    });
     seededCount += 1;
   }
 

--- a/apps/server/src/lib/content-api.integration.test.ts
+++ b/apps/server/src/lib/content-api.integration.test.ts
@@ -357,6 +357,166 @@ testWithDatabase(
 );
 
 testWithDatabase(
+  "content API overview returns metadata counts without exposing draft rows",
+  async () => {
+    const { handler, dbConnection, csrfHeaders } =
+      await createDatabaseTestContext("test:content-api-overview-counts");
+    const testScopeHeaders = {
+      ...scopeHeaders,
+      "x-mdcms-project": stableFixtureName("content-overview-counts"),
+      "x-mdcms-environment": "production",
+    };
+
+    try {
+      const publishedCreateResponse = await handler(
+        new Request("http://localhost/api/v1/content", {
+          method: "POST",
+          headers: csrfHeaders({
+            ...testScopeHeaders,
+            "content-type": "application/json",
+          }),
+          body: JSON.stringify({
+            path: stableFixturePath("blog", "overview-published"),
+            type: "BlogPost",
+            locale: "en",
+            format: "md",
+            frontmatter: { slug: "overview-published" },
+            body: "published body",
+          }),
+        }),
+      );
+      const publishedCreated = (await publishedCreateResponse.json()) as {
+        data: { documentId: string };
+      };
+      assert.equal(publishedCreateResponse.status, 200);
+
+      const publishResponse = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${publishedCreated.data.documentId}/publish`,
+          {
+            method: "POST",
+            headers: csrfHeaders({
+              ...testScopeHeaders,
+              "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+              change_summary: "publish overview baseline",
+            }),
+          },
+        ),
+      );
+      assert.equal(publishResponse.status, 200);
+
+      const publishedUpdateResponse = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${publishedCreated.data.documentId}`,
+          {
+            method: "PUT",
+            headers: csrfHeaders({
+              ...testScopeHeaders,
+              "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+              body: "published document with newer draft changes",
+            }),
+          },
+        ),
+      );
+      assert.equal(publishedUpdateResponse.status, 200);
+
+      const draftOnlyCreateResponse = await handler(
+        new Request("http://localhost/api/v1/content", {
+          method: "POST",
+          headers: csrfHeaders({
+            ...testScopeHeaders,
+            "content-type": "application/json",
+          }),
+          body: JSON.stringify({
+            path: stableFixturePath("blog", "overview-draft-only"),
+            type: "BlogPost",
+            locale: "en",
+            format: "md",
+            frontmatter: { slug: "overview-draft-only" },
+            body: "draft only body",
+          }),
+        }),
+      );
+      assert.equal(draftOnlyCreateResponse.status, 200);
+
+      const deletedCreateResponse = await handler(
+        new Request("http://localhost/api/v1/content", {
+          method: "POST",
+          headers: csrfHeaders({
+            ...testScopeHeaders,
+            "content-type": "application/json",
+          }),
+          body: JSON.stringify({
+            path: stableFixturePath("blog", "overview-deleted"),
+            type: "BlogPost",
+            locale: "en",
+            format: "md",
+            frontmatter: { slug: "overview-deleted" },
+            body: "deleted body",
+          }),
+        }),
+      );
+      const deletedCreated = (await deletedCreateResponse.json()) as {
+        data: { documentId: string };
+      };
+      assert.equal(deletedCreateResponse.status, 200);
+
+      const deletedResponse = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${deletedCreated.data.documentId}`,
+          {
+            method: "DELETE",
+            headers: csrfHeaders(testScopeHeaders),
+          },
+        ),
+      );
+      assert.equal(deletedResponse.status, 200);
+
+      const overviewResponse = await handler(
+        new Request(
+          "http://localhost/api/v1/content/overview?type=BlogPost&type=Page",
+          {
+            headers: testScopeHeaders,
+          },
+        ),
+      );
+      const overviewBody = (await overviewResponse.json()) as {
+        data: Array<{
+          type: string;
+          total: number;
+          published: number;
+          drafts: number;
+          documentId?: string;
+          body?: string;
+        }>;
+      };
+
+      assert.equal(overviewResponse.status, 200);
+      assert.deepEqual(overviewBody.data, [
+        {
+          type: "BlogPost",
+          total: 2,
+          published: 1,
+          drafts: 1,
+        },
+        {
+          type: "Page",
+          total: 0,
+          published: 0,
+          drafts: 0,
+        },
+      ]);
+    } finally {
+      await dbConnection.close();
+    }
+  },
+);
+
+testWithDatabase(
   "content API publish persists change_summary to immutable document_versions row",
   async () => {
     const { handler, dbConnection, csrfHeaders } =

--- a/apps/server/src/lib/content-api.test.ts
+++ b/apps/server/src/lib/content-api.test.ts
@@ -250,6 +250,135 @@ test("content API supports create/list filters/sort/pagination", async () => {
   assert.equal(body.data[0]?.type, "BlogPost");
 });
 
+test("content API overview returns metadata-only counts per type using content:read scope", async () => {
+  const authorizeCalls: Array<Record<string, unknown>> = [];
+  const store = createInMemoryContentStore({
+    schemaScopes: [
+      {
+        project: scopeHeaders["x-mdcms-project"],
+        environment: scopeHeaders["x-mdcms-environment"],
+        schemas: createCms26ResolvedSchemas(),
+      },
+    ],
+  });
+  const rawHandler = createServerRequestHandler({
+    env: baseEnv,
+    configureApp: (app) => {
+      mountContentApiRoutes(app, {
+        store,
+        authorize: async (_request, requirement) => {
+          authorizeCalls.push(requirement as Record<string, unknown>);
+        },
+        requireCsrf: async () => undefined,
+        getWriteSchemaSyncState: async () => ({
+          schemaHash: inMemorySchemaHash,
+        }),
+      });
+    },
+    now: () => new Date("2026-03-02T10:00:00.000Z"),
+  });
+  const handler = wrapHandlerWithAutoSchemaHash(
+    rawHandler,
+    () => inMemorySchemaHash,
+  );
+
+  const publishedCreateResponse = await handler(
+    new Request("http://localhost/api/v1/content", {
+      method: "POST",
+      headers: {
+        ...scopeHeaders,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        path: "blog/overview-published",
+        type: "BlogPost",
+        locale: "en",
+        format: "md",
+        frontmatter: { slug: "overview-published" },
+        body: "published body",
+      }),
+    }),
+  );
+  const publishedCreated = (await publishedCreateResponse.json()) as {
+    data: { documentId: string };
+  };
+  assert.equal(publishedCreateResponse.status, 200);
+
+  const publishResponse = await handler(
+    new Request(
+      `http://localhost/api/v1/content/${publishedCreated.data.documentId}/publish`,
+      {
+        method: "POST",
+        headers: {
+          ...scopeHeaders,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    ),
+  );
+  assert.equal(publishResponse.status, 200);
+
+  const draftCreateResponse = await handler(
+    new Request("http://localhost/api/v1/content", {
+      method: "POST",
+      headers: {
+        ...scopeHeaders,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        path: "blog/overview-draft",
+        type: "BlogPost",
+        locale: "en",
+        format: "md",
+        frontmatter: { slug: "overview-draft" },
+        body: "draft body",
+      }),
+    }),
+  );
+  assert.equal(draftCreateResponse.status, 200);
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/content/overview?type=BlogPost&type=Page",
+      {
+        headers: scopeHeaders,
+      },
+    ),
+  );
+  const body = (await response.json()) as {
+    data: Array<{
+      type: string;
+      total: number;
+      published: number;
+      drafts: number;
+      documentId?: string;
+      path?: string;
+    }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(authorizeCalls.at(-1), {
+    requiredScope: "content:read",
+    project: scopeHeaders["x-mdcms-project"],
+    environment: scopeHeaders["x-mdcms-environment"],
+  });
+  assert.deepEqual(body.data, [
+    {
+      type: "BlogPost",
+      total: 2,
+      published: 1,
+      drafts: 1,
+    },
+    {
+      type: "Page",
+      total: 0,
+      published: 0,
+      drafts: 0,
+    },
+  ]);
+});
+
 test("content API creates a locale variant from sourceDocumentId with a fresh documentId", async () => {
   const handler = createHandler();
 

--- a/apps/server/src/lib/content-api/database-store.ts
+++ b/apps/server/src/lib/content-api/database-store.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { RuntimeError, type SchemaRegistryTypeSnapshot } from "@mdcms/shared";
-import { and, eq, ne, sql, type SQL } from "drizzle-orm";
+import { and, eq, inArray, ne, sql, type SQL } from "drizzle-orm";
 
 import type { DrizzleDatabase } from "../db.js";
 import {
@@ -840,6 +840,65 @@ export function createDatabaseContentStore(
         limit,
         offset,
       };
+    },
+
+    async getOverviewCounts(scope, input) {
+      const requestedTypes = [
+        ...new Set(input.types.map((type) => type.trim())),
+      ];
+      const scopeIds = await resolveScopeIds(scope, false);
+
+      if (!scopeIds) {
+        return requestedTypes.map((type) => ({
+          type,
+          total: 0,
+          published: 0,
+          drafts: 0,
+        }));
+      }
+
+      const rows =
+        requestedTypes.length === 0
+          ? []
+          : await db
+              .select({
+                type: documents.schemaType,
+                total: sql<number>`cast(count(*) as integer)`,
+                published: sql<number>`cast(count(*) filter (where ${documents.publishedVersion} is not null) as integer)`,
+                drafts: sql<number>`cast(count(*) filter (where ${documents.publishedVersion} is null) as integer)`,
+              })
+              .from(documents)
+              .where(
+                and(
+                  eq(documents.projectId, scopeIds.projectId),
+                  eq(documents.environmentId, scopeIds.environmentId),
+                  eq(documents.isDeleted, false),
+                  inArray(documents.schemaType, requestedTypes),
+                ),
+              )
+              .groupBy(documents.schemaType);
+
+      const countsByType = new Map(
+        rows.map((row) => [
+          row.type,
+          {
+            total: row.total,
+            published: row.published,
+            drafts: row.drafts,
+          },
+        ]),
+      );
+
+      return requestedTypes.map((type) => {
+        const counts = countsByType.get(type);
+
+        return {
+          type,
+          total: counts?.total ?? 0,
+          published: counts?.published ?? 0,
+          drafts: counts?.drafts ?? 0,
+        };
+      });
     },
 
     async getById(scope, documentId, options) {

--- a/apps/server/src/lib/content-api/in-memory-store.ts
+++ b/apps/server/src/lib/content-api/in-memory-store.ts
@@ -473,6 +473,32 @@ export function createInMemoryContentStore(
       };
     },
 
+    async getOverviewCounts(scope, input) {
+      const requestedTypes = [
+        ...new Set(input.types.map((type) => type.trim())),
+      ];
+      const scopedDocuments = [...getScopeStore(scope).values()].filter(
+        (document) => !document.isDeleted,
+      );
+
+      return requestedTypes.map((type) => {
+        const matchingDocuments = scopedDocuments.filter(
+          (document) => document.type === type,
+        );
+
+        return {
+          type,
+          total: matchingDocuments.length,
+          published: matchingDocuments.filter(
+            (document) => document.publishedVersion !== null,
+          ).length,
+          drafts: matchingDocuments.filter(
+            (document) => document.publishedVersion === null,
+          ).length,
+        };
+      });
+    },
+
     async getById(scope, documentId, options) {
       const store = getScopeStore(scope);
       const publishedSnapshots = getScopePublishedSnapshots(scope);

--- a/apps/server/src/lib/content-api/in-memory-store.ts
+++ b/apps/server/src/lib/content-api/in-memory-store.ts
@@ -477,26 +477,39 @@ export function createInMemoryContentStore(
       const requestedTypes = [
         ...new Set(input.types.map((type) => type.trim())),
       ];
-      const scopedDocuments = [...getScopeStore(scope).values()].filter(
-        (document) => !document.isDeleted,
+      const countsByType = new Map(
+        requestedTypes.map((type) => [
+          type,
+          {
+            type,
+            total: 0,
+            published: 0,
+            drafts: 0,
+          },
+        ]),
       );
 
-      return requestedTypes.map((type) => {
-        const matchingDocuments = scopedDocuments.filter(
-          (document) => document.type === type,
-        );
+      for (const document of getScopeStore(scope).values()) {
+        if (document.isDeleted) {
+          continue;
+        }
 
-        return {
-          type,
-          total: matchingDocuments.length,
-          published: matchingDocuments.filter(
-            (document) => document.publishedVersion !== null,
-          ).length,
-          drafts: matchingDocuments.filter(
-            (document) => document.publishedVersion === null,
-          ).length,
-        };
-      });
+        const counts = countsByType.get(document.type);
+
+        if (!counts) {
+          continue;
+        }
+
+        counts.total += 1;
+
+        if (document.publishedVersion === null) {
+          counts.drafts += 1;
+        } else {
+          counts.published += 1;
+        }
+      }
+
+      return requestedTypes.map((type) => countsByType.get(type)!);
     },
 
     async getById(scope, documentId, options) {

--- a/apps/server/src/lib/content-api/routes.ts
+++ b/apps/server/src/lib/content-api/routes.ts
@@ -74,11 +74,56 @@ function getResolveQueryValue(
   return values.length === 1 ? values[0] : values;
 }
 
+function parseOverviewTypes(request: Request): string[] {
+  const types = new URL(request.url).searchParams.getAll("type");
+
+  if (types.length === 0) {
+    throw new RuntimeError({
+      code: "INVALID_QUERY_PARAM",
+      message: 'Query parameter "type" is required.',
+      statusCode: 400,
+      details: { field: "type" },
+    });
+  }
+
+  return types.map((type) => {
+    const normalized = type.trim();
+
+    if (normalized.length === 0) {
+      throw new RuntimeError({
+        code: "INVALID_QUERY_PARAM",
+        message: 'Query parameter "type" is required.',
+        statusCode: 400,
+        details: { field: "type", value: type },
+      });
+    }
+
+    return normalized;
+  });
+}
+
 export function mountContentApiRoutes(
   app: unknown,
   options: MountContentApiRoutesOptions,
 ): void {
   const contentApp = app as ContentRouteApp;
+
+  contentApp.get?.("/api/v1/content/overview", ({ request }: any) => {
+    return executeWithRuntimeErrorsHandled(request, async () => {
+      const scope = pickScope(request);
+      const types = parseOverviewTypes(request);
+
+      await options.authorize(request, {
+        requiredScope: "content:read",
+        project: scope.project,
+        environment: scope.environment,
+      });
+
+      return {
+        data: await options.store.getOverviewCounts(scope, { types }),
+      };
+    });
+  });
 
   contentApp.get?.("/api/v1/content", ({ request, query }: any) => {
     return executeWithRuntimeErrorsHandled(request, async () => {

--- a/apps/server/src/lib/content-api/types.ts
+++ b/apps/server/src/lib/content-api/types.ts
@@ -120,6 +120,13 @@ export type ContentListResult<Row> = {
   offset: number;
 };
 
+export type ContentOverviewCounts = {
+  type: string;
+  total: number;
+  published: number;
+  drafts: number;
+};
+
 export type ContentStore = {
   getSchema: (
     scope: ContentScope,
@@ -134,6 +141,10 @@ export type ContentStore = {
     scope: ContentScope,
     query: ContentListQuery,
   ) => Promise<ContentListResult<ContentDocument>>;
+  getOverviewCounts: (
+    scope: ContentScope,
+    input: { types: string[] },
+  ) => Promise<ContentOverviewCounts[]>;
   getById: (
     scope: ContentScope,
     documentId: string,

--- a/apps/server/src/lib/content-api/types.ts
+++ b/apps/server/src/lib/content-api/types.ts
@@ -1,5 +1,6 @@
 import type {
   ContentDocumentResponse,
+  ContentOverviewCountsResponse,
   ContentVersionDocumentResponse,
   ContentVersionSummaryResponse,
   SchemaRegistryTypeSnapshot,
@@ -120,12 +121,7 @@ export type ContentListResult<Row> = {
   offset: number;
 };
 
-export type ContentOverviewCounts = {
-  type: string;
-  total: number;
-  published: number;
-  drafts: number;
-};
+export type ContentOverviewCounts = ContentOverviewCountsResponse;
 
 export type ContentStore = {
   getSchema: (

--- a/apps/server/src/lib/demo-seed.test.ts
+++ b/apps/server/src/lib/demo-seed.test.ts
@@ -11,6 +11,7 @@ import postgres from "postgres";
 
 import { createDatabaseConnection } from "./db.js";
 import {
+  documents,
   environments,
   projects,
   schemaRegistryEntries,
@@ -269,6 +270,7 @@ testWithDatabase(
 
       assert.deepEqual(schemaRows.map((row) => row.schemaType).sort(), [
         "author",
+        "campaign",
         "page",
         "post",
       ]);
@@ -296,5 +298,54 @@ testWithDatabase(
       0,
       `demo:seed failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
     );
+
+    const connection = createDatabaseConnection({ env });
+
+    try {
+      const projectRow = await connection.db.query.projects.findFirst({
+        where: eq(projects.slug, project),
+      });
+      assert.ok(projectRow);
+
+      const environmentRow = await connection.db.query.environments.findFirst({
+        where: and(
+          eq(environments.projectId, projectRow.id),
+          eq(environments.name, "staging"),
+        ),
+      });
+      assert.ok(environmentRow);
+
+      const campaignRows = await connection.db
+        .select({
+          documentId: documents.documentId,
+          translationGroupId: documents.translationGroupId,
+          locale: documents.locale,
+          path: documents.path,
+          schemaType: documents.schemaType,
+          publishedVersion: documents.publishedVersion,
+        })
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, projectRow.id),
+            eq(documents.environmentId, environmentRow.id),
+            eq(documents.schemaType, "campaign"),
+            eq(documents.path, "content/campaigns/global-launch"),
+          ),
+        );
+
+      assert.equal(campaignRows.length, 2);
+      assert.deepEqual(campaignRows.map((row) => row.locale).sort(), [
+        "en",
+        "fr",
+      ]);
+      assert.equal(
+        new Set(campaignRows.map((row) => row.translationGroupId)).size,
+        1,
+      );
+      assert.ok(campaignRows.every((row) => row.publishedVersion !== null));
+    } finally {
+      await connection.close();
+    }
   },
 );

--- a/apps/studio-example/README.md
+++ b/apps/studio-example/README.md
@@ -105,16 +105,22 @@ Notes:
   - email: `demo@mdcms.local`
   - password: `Demo12345!`
 - `apps/studio-example/mdcms.config.ts` includes ready `types` mappings for
-  `post`, `author`, and `page`, and uses the shared `defineConfig(...)`
-  contract from `@mdcms/cli`, so `pull/push` path mapping works out of the box.
+  `post`, `author`, `page`, and localized `campaign`, and uses the shared
+  `defineConfig(...)` contract from `@mdcms/cli`, so `pull/push` path mapping
+  works out of the box.
+- `apps/studio-example/mdcms.config.ts` also declares explicit demo locales
+  (`en`, `fr`) so localized Studio and API flows can be exercised in the
+  embedded app.
 - `apps/studio-example/mdcms.config.ts` also registers example local MDX
   components (`Chart`, `Callout`, `PricingTable`) for Studio insertion,
   preview, and props-panel testing.
 - `/admin/*` prepares the full Studio config through
   `prepareStudioConfig(...)`, so the embedded Studio runtime receives local MDX
   component metadata, extracted props, and custom props editor loaders.
-- `compose:dev` seeds example content in `marketing-site/staging` (posts/pages),
-  so first `mdcms pull` returns real files immediately.
+- `compose:dev` seeds example content in `marketing-site/staging`
+  (posts/pages/localized campaigns), including an `en` + `fr` campaign
+  translation group for `/admin/content` and `/demo/content*` checks, so first
+  `mdcms pull` returns real files immediately.
 - `/demo/content*` remains a raw-content inspection surface and does not render
   those MDX components.
 - `/demo/sdk-content*` demonstrates the same seeded scope through

--- a/apps/studio-example/mdcms.config.test.ts
+++ b/apps/studio-example/mdcms.config.test.ts
@@ -39,6 +39,19 @@ test("studio-example registers the expected demo MDX components", async () => {
   assert.ok(pricingEditor);
 });
 
+test("studio-example config includes a localized demo type with explicit locales", () => {
+  assert.deepEqual(config.locales, {
+    default: "en",
+    supported: ["en", "fr"],
+  });
+
+  const campaignType = config.types.find((type) => type.name === "campaign");
+
+  assert.ok(campaignType);
+  assert.equal(campaignType?.localized, true);
+  assert.equal(campaignType?.directory, "content/campaigns");
+});
+
 test("demo MDX components tolerate empty preview props during insertion", () => {
   const chartMarkup = renderToStaticMarkup(createElement(Chart, {} as never));
   const calloutMarkup = renderToStaticMarkup(

--- a/apps/studio-example/mdcms.config.ts
+++ b/apps/studio-example/mdcms.config.ts
@@ -31,11 +31,25 @@ const page = defineType("page", {
   },
 });
 
+const campaign = defineType("campaign", {
+  directory: "content/campaigns",
+  localized: true,
+  fields: {
+    title: z.string().min(1),
+    slug: z.string().min(1),
+    summary: z.string().min(1),
+  },
+});
+
 export default defineConfig({
   project: studioExampleProject,
   environment: studioExampleEnvironment,
   serverUrl: studioExampleServerUrl,
   contentDirectories: ["content"],
+  locales: {
+    default: "en",
+    supported: ["en", "fr"],
+  },
   environments: {
     production: {},
     staging: {
@@ -43,5 +57,5 @@ export default defineConfig({
     },
   },
   components: [...studioExampleMdxComponents],
-  types: [post, author, page],
+  types: [post, author, page, campaign],
 });

--- a/bun.lock
+++ b/bun.lock
@@ -147,7 +147,7 @@
         "clsx": "^2.1.1",
         "date-fns": "4.1.0",
         "elysia": "^1.4.25",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^1.7.0",
         "postcss": "^8.5.6",
         "react-day-picker": "9.13.2",
         "tailwind-merge": "^3.3.1",
@@ -1307,7 +1307,7 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
-    "lucide-react": ["lucide-react@0.564.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg=="],
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
+++ b/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
@@ -272,6 +272,51 @@ Reference fields persist plain env-local `document_id` UUID strings in
 | `sort`                  | string   | Sort field (e.g., `createdAt`, `updatedAt`, `path`)                                                                                                                                                                                                              |
 | `order`                 | string   | Sort direction (`asc` or `desc`)                                                                                                                                                                                                                                 |
 
+## Content Overview Counts
+
+`GET /api/v1/content/overview` is a metadata-only endpoint for schema-first UI
+surfaces such as Studio's `/admin/content` overview. It exposes truthful
+aggregate counts without granting draft list or draft body access.
+
+Contract:
+
+- Required scope is `content:read`.
+- Explicit target routing for `project` and `environment` is required with the
+  same rules as the rest of `/api/v1/content*`.
+- The request accepts one or more `type` query parameters. Repeating `type`
+  requests counts for multiple schema types in a single round trip.
+- The response is metadata only:
+
+```json
+{
+  "data": [
+    {
+      "type": "BlogPost",
+      "total": 12,
+      "published": 9,
+      "drafts": 3
+    }
+  ]
+}
+```
+
+Count semantics:
+
+- `total`: all non-deleted documents of the type
+- `published`: non-deleted documents with `published_version IS NOT NULL`
+- `drafts`: non-deleted documents with `published_version IS NULL`
+
+Additional rules:
+
+- The endpoint must not return document IDs, paths, locales, frontmatter, body,
+  or any other document-row payload.
+- If a requested type has zero matching documents, the response still includes a
+  row for that type with zero counts.
+- Unknown types return a zero-count row so overview consumers can render
+  deterministic schema cards when the backend has no documents yet.
+- This endpoint does not change the meaning of `GET /api/v1/content?draft=true`;
+  mutable draft list and detail reads still require `content:read:draft`.
+
 ## Version History
 
 ### How It Works
@@ -386,6 +431,7 @@ All `/api/v1/content*` endpoints require explicit target routing for `project` a
 
 | Method | Path                                                    | Auth Mode          | Required Scope                                                                           | Target Routing                  | Request                                                                                                                                                                                               | Success                                                                                   | Deterministic Errors                                                                                                                                                                                                                                                                                                                                                             |
 | ------ | ------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/v1/content/overview`                              | session_or_api_key | `content:read`                                                                           | required: `project_environment` | Query supports repeated `type` values plus `project`, `environment`                                                                                                                                   | `200` `{ data: { type, total, published, drafts }[] }`                                    | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_QUERY_PARAM` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`)                                                                                                                                                                                                                                  |
 | GET    | `/api/v1/content`                                       | session_or_api_key | `content:read` (published mode), `content:read:draft` when `draft=true`                  | required: `project_environment` | Query supports: `type`, `path`, `locale`, `slug`, `published`, `isDeleted`, `hasUnpublishedChanges`, `draft`, `resolve` (type required), `project`, `environment`, `limit`, `offset`, `sort`, `order` | `200` `{ data: ContentDocument[], pagination: { total, limit, offset, hasMore } }`        | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_QUERY_PARAM` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`)                                                                                                                                                                                                                                  |
 | GET    | `/api/v1/content/:documentId`                           | session_or_api_key | `content:read` (published mode), `content:read:draft` when `draft=true`                  | required: `project_environment` | path `documentId`, optional `draft=true`, optional `resolve`                                                                                                                                          | `200` `{ data: ContentDocument }`                                                         | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_QUERY_PARAM` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`)                                                                                                                                                                                                             |
 | GET    | `/api/v1/content/:documentId/versions`                  | session_or_api_key | `content:read`                                                                           | required: `project_environment` | path `documentId`, optional `limit`, optional `offset`                                                                                                                                                | `200` `{ data: DocumentVersionSummary[], pagination: { total, limit, offset, hasMore } }` | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_QUERY_PARAM` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`)                                                                                                                                                                                                             |

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-03-31
+last_updated: 2026-04-06
 ---
 
 # SPEC-006 Studio Runtime and UI
@@ -203,6 +203,74 @@ changes in the UI.
 The primary navigation model is **schema-first**: users navigate by content type (BlogPost, Page, Author) rather than folder structure. Each type shows a sortable, filterable list of documents.
 
 Secondary navigation by folder path is available as an alternative view.
+
+### Content Overview (`/admin/content`)
+
+The `/admin/content` route is a live schema-first overview for the active
+`(project, environment)` target. It is backed by:
+
+- `GET /api/v1/me/capabilities` for target-scoped capability gating
+- `GET /api/v1/schema` for the canonical list of schema types
+- `GET /api/v1/content/overview` for metadata-only per-type counts
+
+Normative behavior:
+
+- Overview cards are keyed by live schema registry entries. Studio must not use
+  mock content-type fixtures to decide which types appear.
+- Each card links to `/admin/content/:type` only when the current caller can
+  read content for that target. When the caller cannot read content, Studio
+  keeps the card visible for schema discovery but disables list navigation.
+- Studio must not present a count or label that the current route contracts
+  cannot prove. Unsupported metrics are omitted instead of estimated.
+- When `capabilities.content.read` is `true`, Studio may show a per-type
+  `total`, `published`, and `drafts` counts derived from
+  `GET /api/v1/content/overview`.
+- On `/admin/content`, `drafts` means non-deleted documents whose current head
+  has no published version. It does not include published documents that also
+  have newer unpublished changes.
+- The overview count contract is metadata-only. Showing these counts does not
+  grant access to draft document rows, draft document bodies, or any broader
+  draft list access outside the overview itself.
+- Localization presentation on `/admin/content` is schema-derived in MVP:
+  localized types may show a `Localized` badge from the schema contract and
+  non-localized types may show `Single locale`.
+- When the embedded runtime has explicit locale configuration for the active
+  project, `/admin/content` may show that configured locale-code list next to a
+  localized type badge. This list is config-derived only and must not be
+  presented as translation coverage.
+
+Deterministic states:
+
+- If `GET /api/v1/schema` returns `401` or `403`, the route renders a forbidden
+  state because Studio cannot determine which schema types exist.
+- If schema loading succeeds but both `capabilities.content.read` and
+  `capabilities.content.readDraft` are `false`, the route renders a
+  permission-constrained overview: schema cards stay visible, all content
+  counts are omitted, list navigation is disabled, and the page shows a clear
+  permission banner instead of a full route-level forbidden state.
+- If schema loading succeeds and returns zero types, the route renders a
+  deterministic empty state for the active target.
+- Non-auth, non-forbidden failures from the live schema or content overview
+  requests render a deterministic error state. Partial metric failures must not
+  fall back to mock values.
+
+### Theme Preference Persistence
+
+Studio-owned theme preference persists in browser-local storage.
+
+Normative behavior:
+
+- The runtime stores the selected theme in `localStorage`; it is not persisted
+  through the backend and is not host-bridge-owned in MVP.
+- Preference precedence is:
+  1. persisted Studio preference
+  2. explicit runtime `defaultTheme`
+  3. system theme when `enableSystem` is enabled
+  4. `light`
+- Persistence scope is browser-local across full page reloads and Studio
+  remounts for the same browser profile.
+- The theme toggle must continue to support both light and dark rendering even
+  when the persisted preference was set by an earlier Studio runtime version.
 
 ### Project Scope and Switching
 

--- a/packages/shared/src/lib/contracts/content-api.ts
+++ b/packages/shared/src/lib/contracts/content-api.ts
@@ -71,3 +71,10 @@ export type ContentVersionDocumentResponse = ContentVersionSummaryResponse & {
   body: string;
   resolveErrors?: ResolveErrorsMap;
 };
+
+export type ContentOverviewCountsResponse = {
+  type: string;
+  total: number;
+  published: number;
+  drafts: number;
+};

--- a/packages/shared/src/lib/contracts/extensibility.test.ts
+++ b/packages/shared/src/lib/contracts/extensibility.test.ts
@@ -375,6 +375,7 @@ test("runtime contract validators cover positive and negative shapes", () => {
       documentRoute: {
         project: "marketing-site",
         environment: "staging",
+        supportedLocales: ["en-US", "fr"],
         write: {
           canWrite: true,
           schemaHash: "schema-hash",

--- a/packages/shared/src/lib/contracts/extensibility.ts
+++ b/packages/shared/src/lib/contracts/extensibility.ts
@@ -144,6 +144,7 @@ export type StudioDocumentRouteWriteContext =
 export type StudioDocumentRouteMountContext = {
   project: string;
   environment: string;
+  supportedLocales?: string[];
   write: StudioDocumentRouteWriteContext;
 };
 
@@ -545,6 +546,7 @@ const studioDocumentRouteContextSchema = z
   .object({
     project: nonEmptyStringSchema,
     environment: nonEmptyStringSchema,
+    supportedLocales: z.array(nonEmptyStringSchema).optional(),
     write: studioDocumentRouteWriteSchema,
   })
   .strict();

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -104,7 +104,7 @@
     "clsx": "^2.1.1",
     "date-fns": "4.1.0",
     "elysia": "^1.4.25",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^1.7.0",
     "postcss": "^8.5.6",
     "react-day-picker": "9.13.2",
     "tailwindcss": "^4.2.0",

--- a/packages/studio/src/lib/content-list-api.test.ts
+++ b/packages/studio/src/lib/content-list-api.test.ts
@@ -116,6 +116,31 @@ test("list passes type and published filters as query params", async () => {
   assert.equal(url.searchParams.get("limit"), "1");
 });
 
+test("list passes draft and hasUnpublishedChanges filters as query params", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list({
+    type: "BlogPost",
+    draft: true,
+    hasUnpublishedChanges: true,
+    limit: 1,
+  });
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.get("type"), "BlogPost");
+  assert.equal(url.searchParams.get("draft"), "true");
+  assert.equal(url.searchParams.get("hasUnpublishedChanges"), "true");
+  assert.equal(url.searchParams.get("limit"), "1");
+});
+
 test("list passes sort and order query params", async () => {
   const calls: Array<{ input: string | URL | Request }> = [];
   const api = createApi({

--- a/packages/studio/src/lib/content-list-api.test.ts
+++ b/packages/studio/src/lib/content-list-api.test.ts
@@ -141,6 +141,23 @@ test("list passes draft and hasUnpublishedChanges filters as query params", asyn
   assert.equal(url.searchParams.get("limit"), "1");
 });
 
+test("list serializes an explicit false draft filter", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list({ type: "BlogPost", draft: false, limit: 1 });
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.get("draft"), "false");
+});
+
 test("list passes sort and order query params", async () => {
   const calls: Array<{ input: string | URL | Request }> = [];
   const api = createApi({

--- a/packages/studio/src/lib/content-list-api.ts
+++ b/packages/studio/src/lib/content-list-api.ts
@@ -23,6 +23,7 @@ export type StudioContentListApiOptions = {
 
 export type StudioContentListQuery = {
   type?: string;
+  draft?: boolean;
   published?: boolean;
   hasUnpublishedChanges?: boolean;
   isDeleted?: boolean;
@@ -69,6 +70,8 @@ export function createStudioContentListApi(
       const url = resolveStudioRelativeUrl("/api/v1/content", config.serverUrl);
 
       if (query.type) url.searchParams.set("type", query.type);
+      if (query.draft !== undefined)
+        url.searchParams.set("draft", String(query.draft));
       if (query.published !== undefined)
         url.searchParams.set("published", String(query.published));
       if (query.hasUnpublishedChanges !== undefined)

--- a/packages/studio/src/lib/content-overview-api.test.ts
+++ b/packages/studio/src/lib/content-overview-api.test.ts
@@ -75,17 +75,19 @@ test("get fetches overview counts with repeated type params and routed headers",
   ]);
 });
 
-test("get returns zero-count rows for malformed success payloads", async () => {
+test("get throws RuntimeError when a success response payload is malformed", async () => {
   const api = createApi({
     fetcher: async () =>
       new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
   });
 
-  const result = await api.get({ types: ["BlogPost"] });
-
-  assert.deepEqual(result, [
-    { type: "BlogPost", total: 0, published: 0, drafts: 0 },
-  ]);
+  await assert.rejects(
+    () => api.get({ types: ["BlogPost"] }),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.code === "CONTENT_OVERVIEW_RESPONSE_INVALID" &&
+      error.statusCode === 502,
+  );
 });
 
 test("get throws RuntimeError on forbidden responses", async () => {

--- a/packages/studio/src/lib/content-overview-api.test.ts
+++ b/packages/studio/src/lib/content-overview-api.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  createStudioContentOverviewApi,
+  type StudioContentOverviewApiOptions,
+} from "./content-overview-api.js";
+
+function readHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | null {
+  const headers = init?.headers;
+
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+
+  if (headers && !Array.isArray(headers)) {
+    const value = (headers as Record<string, string>)[name];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function createApi(options: StudioContentOverviewApiOptions = {}) {
+  return createStudioContentOverviewApi(
+    {
+      project: "marketing-site",
+      environment: "production",
+      serverUrl: "http://localhost:4000",
+    },
+    options,
+  );
+}
+
+test("get fetches overview counts with repeated type params and routed headers", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({
+          data: [
+            { type: "BlogPost", total: 2, published: 1, drafts: 1 },
+            { type: "Page", total: 0, published: 0, drafts: 0 },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    },
+  });
+
+  const result = await api.get({ types: ["BlogPost", "Page"] });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.pathname, "/api/v1/content/overview");
+  assert.deepEqual(url.searchParams.getAll("type"), ["BlogPost", "Page"]);
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-project"), "marketing-site");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-environment"), "production");
+  assert.deepEqual(result, [
+    { type: "BlogPost", total: 2, published: 1, drafts: 1 },
+    { type: "Page", total: 0, published: 0, drafts: 0 },
+  ]);
+});
+
+test("get returns zero-count rows for malformed success payloads", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+  });
+
+  const result = await api.get({ types: ["BlogPost"] });
+
+  assert.deepEqual(result, [
+    { type: "BlogPost", total: 0, published: 0, drafts: 0 },
+  ]);
+});
+
+test("get throws RuntimeError on forbidden responses", async () => {
+  const api = createApi({
+    fetcher: async () =>
+      new Response(
+        JSON.stringify({ code: "FORBIDDEN", message: "Forbidden" }),
+        { status: 403 },
+      ),
+  });
+
+  await assert.rejects(
+    () => api.get({ types: ["BlogPost"] }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.statusCode === 403,
+  );
+});

--- a/packages/studio/src/lib/content-overview-api.ts
+++ b/packages/studio/src/lib/content-overview-api.ts
@@ -1,0 +1,138 @@
+import {
+  RuntimeError,
+  type ContentOverviewCountsResponse,
+} from "@mdcms/shared";
+
+import type { MdcmsConfig } from "./studio-component.js";
+import {
+  applyStudioAuthToRequestInit,
+  type StudioRuntimeAuth,
+} from "./request-auth.js";
+import { resolveStudioRelativeUrl } from "./url-resolution.js";
+
+export type StudioContentOverviewConfig = Pick<
+  MdcmsConfig,
+  "project" | "environment" | "serverUrl"
+>;
+
+export type StudioContentOverviewApiOptions = {
+  auth?: StudioRuntimeAuth;
+  fetcher?: typeof fetch;
+};
+
+export type StudioContentOverviewApi = {
+  get: (input: { types: string[] }) => Promise<ContentOverviewCountsResponse[]>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+async function readResponsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createStudioContentOverviewApi(
+  config: StudioContentOverviewConfig,
+  options: StudioContentOverviewApiOptions = {},
+): StudioContentOverviewApi {
+  const fetcher = options.fetcher ?? fetch;
+
+  return {
+    async get(input) {
+      if (input.types.length === 0) {
+        return [];
+      }
+
+      const url = resolveStudioRelativeUrl(
+        "/api/v1/content/overview",
+        config.serverUrl,
+      );
+
+      for (const type of input.types) {
+        url.searchParams.append("type", type);
+      }
+
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "GET",
+          headers: {
+            "x-mdcms-project": config.project,
+            "x-mdcms-environment": config.environment,
+          },
+        }),
+      );
+
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        const parsed = isRecord(payload) ? payload : {};
+        const code =
+          typeof parsed.code === "string" && parsed.code.trim().length > 0
+            ? parsed.code
+            : "CONTENT_OVERVIEW_REQUEST_FAILED";
+        const message =
+          typeof parsed.message === "string" && parsed.message.trim().length > 0
+            ? parsed.message
+            : "Content overview request failed.";
+
+        throw new RuntimeError({
+          code,
+          message,
+          statusCode: response.status,
+          details: { status: response.status, payload },
+        });
+      }
+
+      if (!isRecord(payload) || !Array.isArray(payload.data)) {
+        return input.types.map((type) => ({
+          type,
+          total: 0,
+          published: 0,
+          drafts: 0,
+        }));
+      }
+
+      const countsByType = new Map<string, ContentOverviewCountsResponse>();
+
+      for (const row of payload.data) {
+        if (!isRecord(row) || !isNonEmptyString(row.type)) {
+          continue;
+        }
+
+        countsByType.set(row.type, {
+          type: row.type,
+          total: isFiniteNumber(row.total) ? row.total : 0,
+          published: isFiniteNumber(row.published) ? row.published : 0,
+          drafts: isFiniteNumber(row.drafts) ? row.drafts : 0,
+        });
+      }
+
+      return input.types.map((type) => {
+        const counts = countsByType.get(type);
+
+        return (
+          counts ?? {
+            type,
+            total: 0,
+            published: 0,
+            drafts: 0,
+          }
+        );
+      });
+    },
+  };
+}

--- a/packages/studio/src/lib/content-overview-api.ts
+++ b/packages/studio/src/lib/content-overview-api.ts
@@ -44,6 +44,15 @@ async function readResponsePayload(response: Response): Promise<unknown> {
   }
 }
 
+function createInvalidOverviewPayloadError(payload: unknown): RuntimeError {
+  return new RuntimeError({
+    code: "CONTENT_OVERVIEW_RESPONSE_INVALID",
+    message: "Content overview response payload had an unexpected shape.",
+    statusCode: 502,
+    details: { payload },
+  });
+}
+
 export function createStudioContentOverviewApi(
   config: StudioContentOverviewConfig,
   options: StudioContentOverviewApiOptions = {},
@@ -98,40 +107,38 @@ export function createStudioContentOverviewApi(
       }
 
       if (!isRecord(payload) || !Array.isArray(payload.data)) {
-        return input.types.map((type) => ({
-          type,
-          total: 0,
-          published: 0,
-          drafts: 0,
-        }));
+        throw createInvalidOverviewPayloadError(payload);
       }
 
       const countsByType = new Map<string, ContentOverviewCountsResponse>();
 
       for (const row of payload.data) {
-        if (!isRecord(row) || !isNonEmptyString(row.type)) {
-          continue;
+        if (
+          !isRecord(row) ||
+          !isNonEmptyString(row.type) ||
+          !isFiniteNumber(row.total) ||
+          !isFiniteNumber(row.published) ||
+          !isFiniteNumber(row.drafts)
+        ) {
+          throw createInvalidOverviewPayloadError(payload);
         }
 
         countsByType.set(row.type, {
           type: row.type,
-          total: isFiniteNumber(row.total) ? row.total : 0,
-          published: isFiniteNumber(row.published) ? row.published : 0,
-          drafts: isFiniteNumber(row.drafts) ? row.drafts : 0,
+          total: row.total,
+          published: row.published,
+          drafts: row.drafts,
         });
       }
 
       return input.types.map((type) => {
         const counts = countsByType.get(type);
 
-        return (
-          counts ?? {
-            type,
-            total: 0,
-            published: 0,
-            drafts: 0,
-          }
-        );
+        if (!counts) {
+          throw createInvalidOverviewPayloadError(payload);
+        }
+
+        return counts;
       });
     },
   };

--- a/packages/studio/src/lib/content-overview-state.test.ts
+++ b/packages/studio/src/lib/content-overview-state.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  loadStudioContentOverviewState,
+  type LoadStudioContentOverviewStateInput,
+} from "./content-overview-state.js";
+import type { StudioContentListApi } from "./content-list-api.js";
+import type { StudioContentOverviewApi } from "./content-overview-api.js";
+import type { StudioCurrentPrincipalCapabilitiesApi } from "./current-principal-capabilities-api.js";
+import type { StudioSchemaRouteApi } from "./schema-route-api.js";
+
+const emptySyncResult = {
+  schemaHash: "",
+  syncedAt: "",
+  affectedTypes: [] as string[],
+};
+
+function createSchemaApi(
+  entries: Array<{
+    type: string;
+    directory: string;
+    localized?: boolean;
+  }>,
+): StudioSchemaRouteApi {
+  return {
+    list: async () =>
+      entries.map((entry) => ({
+        type: entry.type,
+        directory: entry.directory,
+        localized: entry.localized ?? false,
+        schemaHash: "schema-hash",
+        syncedAt: "2026-04-06T00:00:00.000Z",
+        resolvedSchema: {
+          type: entry.type,
+          directory: entry.directory,
+          localized: entry.localized ?? false,
+          fields: {},
+        },
+      })),
+    sync: async () => emptySyncResult,
+  };
+}
+
+function createCapabilitiesApi(overrides?: {
+  schemaRead?: boolean;
+  contentRead?: boolean;
+  contentReadDraft?: boolean;
+}) {
+  return {
+    get: async () => ({
+      project: "marketing-site",
+      environment: "staging",
+      capabilities: {
+        schema: {
+          read: overrides?.schemaRead ?? true,
+          write: false,
+        },
+        content: {
+          read: overrides?.contentRead ?? true,
+          readDraft: overrides?.contentReadDraft ?? true,
+          write: false,
+          publish: false,
+          unpublish: false,
+          delete: false,
+        },
+        users: {
+          manage: false,
+        },
+        settings: {
+          manage: false,
+        },
+      },
+    }),
+  } satisfies StudioCurrentPrincipalCapabilitiesApi;
+}
+
+function createLoadInput(overrides?: {
+  schemaApi?: StudioSchemaRouteApi;
+  capabilitiesApi?: StudioCurrentPrincipalCapabilitiesApi;
+  contentApi?: StudioContentListApi;
+  contentOverviewApi?: StudioContentOverviewApi;
+  supportedLocales?: string[];
+}): LoadStudioContentOverviewStateInput {
+  return {
+    config: {
+      project: "marketing-site",
+      environment: "staging",
+      serverUrl: "http://localhost:4000",
+      supportedLocales: overrides?.supportedLocales,
+    },
+    auth: { mode: "cookie" },
+    schemaApi:
+      overrides?.schemaApi ??
+      createSchemaApi([
+        { type: "BlogPost", directory: "content/blog", localized: true },
+      ]),
+    capabilitiesApi: overrides?.capabilitiesApi ?? createCapabilitiesApi(),
+    contentOverviewApi:
+      overrides?.contentOverviewApi ??
+      ({
+        get: async ({ types }) =>
+          types.map((type) => ({
+            type,
+            total: 0,
+            published: 0,
+            drafts: 0,
+          })),
+      } satisfies StudioContentOverviewApi),
+    contentApi:
+      overrides?.contentApi ??
+      ({
+        list: async () => ({
+          data: [],
+          pagination: {
+            total: 0,
+            limit: 1,
+            offset: 0,
+            hasMore: false,
+          },
+        }),
+      } satisfies StudioContentListApi),
+  };
+}
+
+test("loadStudioContentOverviewState returns ready entries with truthful live metrics", async () => {
+  const calls: Array<readonly string[]> = [];
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      supportedLocales: ["en-US", "fr", "de", "ja"],
+      schemaApi: createSchemaApi([
+        { type: "BlogPost", directory: "content/blog", localized: true },
+        { type: "Author", directory: "content/authors" },
+      ]),
+      contentOverviewApi: {
+        get: async ({ types }) => {
+          calls.push(types);
+          return [
+            { type: "BlogPost", total: 7, published: 5, drafts: 2 },
+            { type: "Author", total: 3, published: 3, drafts: 0 },
+          ];
+        },
+      },
+    }),
+  );
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") return;
+
+  assert.equal(state.entries.length, 2);
+  assert.equal(state.entries[0]?.type, "Author");
+  assert.equal(state.entries[0]?.canNavigate, true);
+  assert.equal(state.entries[0]?.locales, undefined);
+  assert.deepEqual(state.entries[1]?.locales, ["en-US", "fr", "de", "ja"]);
+  assert.deepEqual(
+    state.entries[1]?.metrics.map((metric) => [metric.id, metric.value]),
+    [
+      ["documents", 7],
+      ["published", 5],
+      ["withDrafts", 2],
+    ],
+  );
+  assert.deepEqual(calls, [["Author", "BlogPost"]]);
+});
+
+test("loadStudioContentOverviewState uses overview counts for callers without draft-read access", async () => {
+  let listCalls = 0;
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      capabilitiesApi: createCapabilitiesApi({
+        schemaRead: true,
+        contentRead: true,
+        contentReadDraft: false,
+      }),
+      schemaApi: createSchemaApi([
+        { type: "BlogPost", directory: "content/blog", localized: true },
+      ]),
+      contentOverviewApi: {
+        get: async () => [
+          { type: "BlogPost", total: 4, published: 1, drafts: 3 },
+        ],
+      },
+      contentApi: {
+        list: async () => {
+          listCalls += 1;
+          throw new Error("content list API should not be called");
+        },
+      },
+    }),
+  );
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") return;
+
+  assert.deepEqual(
+    state.entries[0]?.metrics.map((metric) => [metric.id, metric.value]),
+    [
+      ["documents", 4],
+      ["published", 1],
+      ["withDrafts", 3],
+    ],
+  );
+  assert.equal(listCalls, 0);
+});
+
+test("loadStudioContentOverviewState returns permission-constrained state when schema is readable but content is not", async () => {
+  let contentCalls = 0;
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      supportedLocales: ["en-US", "fr"],
+      schemaApi: createSchemaApi([
+        { type: "BlogPost", directory: "content/blog", localized: true },
+      ]),
+      capabilitiesApi: createCapabilitiesApi({
+        schemaRead: true,
+        contentRead: false,
+        contentReadDraft: false,
+      }),
+      contentApi: {
+        list: async () => {
+          contentCalls += 1;
+          throw new Error("content API should not be called");
+        },
+      },
+    }),
+  );
+
+  assert.equal(state.status, "permission-constrained");
+  if (state.status !== "permission-constrained") return;
+
+  assert.equal(state.entries.length, 1);
+  assert.equal(state.entries[0]?.canNavigate, false);
+  assert.deepEqual(state.entries[0]?.locales, ["en-US", "fr"]);
+  assert.equal(state.entries[0]?.metrics.length, 0);
+  assert.equal(contentCalls, 0);
+});
+
+test("loadStudioContentOverviewState returns ready empty state when schema has no entries", async () => {
+  let overviewCalls = 0;
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      schemaApi: createSchemaApi([]),
+      contentOverviewApi: {
+        get: async () => {
+          overviewCalls += 1;
+          throw new Error("overview API should not be called for empty schema");
+        },
+      },
+    }),
+  );
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") return;
+
+  assert.deepEqual(state.entries, []);
+  assert.equal(overviewCalls, 0);
+});
+
+test("loadStudioContentOverviewState maps forbidden schema access deterministically", async () => {
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      schemaApi: {
+        list: async () => {
+          throw new RuntimeError({
+            code: "FORBIDDEN",
+            message: "Forbidden",
+            statusCode: 403,
+          });
+        },
+        sync: async () => emptySyncResult,
+      },
+    }),
+  );
+
+  assert.equal(state.status, "forbidden");
+  if (state.status !== "forbidden") return;
+
+  assert.equal(state.project, "marketing-site");
+  assert.equal(state.environment, "staging");
+});

--- a/packages/studio/src/lib/content-overview-state.test.ts
+++ b/packages/studio/src/lib/content-overview-state.test.ts
@@ -205,6 +205,69 @@ test("loadStudioContentOverviewState uses overview counts for callers without dr
   assert.equal(listCalls, 0);
 });
 
+test("loadStudioContentOverviewState keeps the draft-only fallback in draft mode", async () => {
+  const queries: Array<Parameters<StudioContentListApi["list"]>[0]> = [];
+  const state = await loadStudioContentOverviewState(
+    createLoadInput({
+      capabilitiesApi: createCapabilitiesApi({
+        schemaRead: true,
+        contentRead: false,
+        contentReadDraft: true,
+      }),
+      schemaApi: createSchemaApi([
+        { type: "BlogPost", directory: "content/blog", localized: true },
+      ]),
+      contentApi: {
+        list: async (query = {}) => {
+          queries.push(query);
+
+          if (query.published === true && query.draft !== true) {
+            throw new RuntimeError({
+              code: "FORBIDDEN",
+              message: "Published-only reads are not allowed for draft access.",
+              statusCode: 403,
+            });
+          }
+
+          const total =
+            query.draft === true && query.published === true
+              ? 2
+              : query.draft === true && query.published === false
+                ? 4
+                : 6;
+
+          return {
+            data: [],
+            pagination: {
+              total,
+              limit: 1,
+              offset: 0,
+              hasMore: false,
+            },
+          };
+        },
+      },
+    }),
+  );
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") return;
+
+  assert.deepEqual(
+    state.entries[0]?.metrics.map((metric) => [metric.id, metric.value]),
+    [
+      ["documents", 6],
+      ["published", 2],
+      ["withDrafts", 4],
+    ],
+  );
+  assert.deepEqual(queries, [
+    { type: "BlogPost", draft: true, limit: 1 },
+    { type: "BlogPost", draft: true, published: true, limit: 1 },
+    { type: "BlogPost", draft: true, published: false, limit: 1 },
+  ]);
+});
+
 test("loadStudioContentOverviewState returns permission-constrained state when schema is readable but content is not", async () => {
   let contentCalls = 0;
   const state = await loadStudioContentOverviewState(

--- a/packages/studio/src/lib/content-overview-state.ts
+++ b/packages/studio/src/lib/content-overview-state.ts
@@ -1,0 +1,470 @@
+import { RuntimeError, type CurrentPrincipalCapabilities } from "@mdcms/shared";
+
+import {
+  createStudioContentListApi,
+  type StudioContentListApi,
+} from "./content-list-api.js";
+import {
+  createStudioContentOverviewApi,
+  type StudioContentOverviewApi,
+} from "./content-overview-api.js";
+import {
+  createStudioCurrentPrincipalCapabilitiesApi,
+  type StudioCurrentPrincipalCapabilitiesApi,
+} from "./current-principal-capabilities-api.js";
+import {
+  createStudioSchemaRouteApi,
+  type StudioSchemaRouteApi,
+} from "./schema-route-api.js";
+import type { StudioRuntimeAuth } from "./request-auth.js";
+import type { MdcmsConfig } from "./studio-component.js";
+
+export type StudioContentOverviewMetricId =
+  | "documents"
+  | "published"
+  | "withDrafts";
+
+export type StudioContentOverviewMetric = {
+  id: StudioContentOverviewMetricId;
+  label: string;
+  value: number;
+};
+
+export type StudioContentOverviewEntry = {
+  type: string;
+  directory: string;
+  localized: boolean;
+  locales?: string[];
+  canNavigate: boolean;
+  metrics: StudioContentOverviewMetric[];
+};
+
+export type StudioContentOverviewLoadingState = {
+  status: "loading";
+  message: string;
+};
+
+export type StudioContentOverviewReadyState = {
+  status: "ready";
+  project: string;
+  environment: string;
+  entries: StudioContentOverviewEntry[];
+};
+
+export type StudioContentOverviewPermissionConstrainedState = {
+  status: "permission-constrained";
+  project: string;
+  environment: string;
+  message: string;
+  entries: StudioContentOverviewEntry[];
+};
+
+export type StudioContentOverviewForbiddenState = {
+  status: "forbidden";
+  project: string;
+  environment: string;
+  message: string;
+};
+
+export type StudioContentOverviewErrorState = {
+  status: "error";
+  project: string;
+  environment: string;
+  message: string;
+};
+
+export type StudioContentOverviewState =
+  | StudioContentOverviewLoadingState
+  | StudioContentOverviewReadyState
+  | StudioContentOverviewPermissionConstrainedState
+  | StudioContentOverviewForbiddenState
+  | StudioContentOverviewErrorState;
+
+export type LoadStudioContentOverviewStateInput = {
+  config: Pick<MdcmsConfig, "project" | "environment" | "serverUrl"> & {
+    supportedLocales?: string[];
+  };
+  auth?: StudioRuntimeAuth;
+  fetcher?: typeof fetch;
+  schemaApi?: StudioSchemaRouteApi;
+  capabilitiesApi?: StudioCurrentPrincipalCapabilitiesApi;
+  contentOverviewApi?: StudioContentOverviewApi;
+  contentApi?: StudioContentListApi;
+};
+
+function createSchemaApi(
+  input: LoadStudioContentOverviewStateInput,
+): StudioSchemaRouteApi {
+  if (input.schemaApi) {
+    return input.schemaApi;
+  }
+
+  return createStudioSchemaRouteApi(
+    {
+      project: input.config.project,
+      environment: input.config.environment,
+      serverUrl: input.config.serverUrl,
+    },
+    {
+      auth: input.auth,
+      fetcher: input.fetcher,
+    },
+  );
+}
+
+function createCapabilitiesApi(
+  input: LoadStudioContentOverviewStateInput,
+): StudioCurrentPrincipalCapabilitiesApi {
+  if (input.capabilitiesApi) {
+    return input.capabilitiesApi;
+  }
+
+  return createStudioCurrentPrincipalCapabilitiesApi(
+    {
+      project: input.config.project,
+      environment: input.config.environment,
+      serverUrl: input.config.serverUrl,
+    },
+    {
+      auth: input.auth,
+      fetcher: input.fetcher,
+    },
+  );
+}
+
+function createContentApi(
+  input: LoadStudioContentOverviewStateInput,
+): StudioContentListApi {
+  if (input.contentApi) {
+    return input.contentApi;
+  }
+
+  return createStudioContentListApi(
+    {
+      project: input.config.project,
+      environment: input.config.environment,
+      serverUrl: input.config.serverUrl,
+    },
+    {
+      auth: input.auth,
+      fetcher: input.fetcher,
+    },
+  );
+}
+
+function createContentOverviewApi(
+  input: LoadStudioContentOverviewStateInput,
+): StudioContentOverviewApi {
+  if (input.contentOverviewApi) {
+    return input.contentOverviewApi;
+  }
+
+  return createStudioContentOverviewApi(
+    {
+      project: input.config.project,
+      environment: input.config.environment,
+      serverUrl: input.config.serverUrl,
+    },
+    {
+      auth: input.auth,
+      fetcher: input.fetcher,
+    },
+  );
+}
+
+function canReadAnyContent(
+  capabilities: CurrentPrincipalCapabilities,
+): boolean {
+  return capabilities.content.read || capabilities.content.readDraft;
+}
+
+function isAuthFailure(error: unknown): boolean {
+  return (
+    error instanceof RuntimeError &&
+    (error.statusCode === 401 || error.statusCode === 403)
+  );
+}
+
+function toStateErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof RuntimeError && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function createOverviewEntry(input: {
+  type: string;
+  directory: string;
+  localized: boolean;
+  locales?: string[];
+  canNavigate: boolean;
+  metrics?: StudioContentOverviewMetric[];
+}): StudioContentOverviewEntry {
+  return {
+    type: input.type,
+    directory: input.directory,
+    localized: input.localized,
+    ...(input.locales && input.locales.length > 0
+      ? { locales: input.locales }
+      : {}),
+    canNavigate: input.canNavigate,
+    metrics: input.metrics ?? [],
+  };
+}
+
+function createReadyState(input: {
+  project: string;
+  environment: string;
+  entries: StudioContentOverviewEntry[];
+}): StudioContentOverviewReadyState {
+  return {
+    status: "ready",
+    project: input.project,
+    environment: input.environment,
+    entries: input.entries,
+  };
+}
+
+function createPermissionConstrainedState(input: {
+  project: string;
+  environment: string;
+  entries: StudioContentOverviewEntry[];
+}): StudioContentOverviewPermissionConstrainedState {
+  return {
+    status: "permission-constrained",
+    project: input.project,
+    environment: input.environment,
+    message:
+      "You can inspect schema types here, but you do not have permission to read content counts.",
+    entries: input.entries,
+  };
+}
+
+function createForbiddenState(input: {
+  project: string;
+  environment: string;
+  message: string;
+}): StudioContentOverviewForbiddenState {
+  return {
+    status: "forbidden",
+    project: input.project,
+    environment: input.environment,
+    message: input.message,
+  };
+}
+
+function createErrorState(input: {
+  project: string;
+  environment: string;
+  message: string;
+}): StudioContentOverviewErrorState {
+  return {
+    status: "error",
+    project: input.project,
+    environment: input.environment,
+    message: input.message,
+  };
+}
+
+function sortEntries(entries: StudioContentOverviewEntry[]) {
+  return [...entries].sort((left, right) =>
+    left.type.localeCompare(right.type),
+  );
+}
+
+async function loadEntryMetrics(input: {
+  type: string;
+  capabilities: CurrentPrincipalCapabilities;
+  contentApi: StudioContentListApi;
+}): Promise<StudioContentOverviewMetric[]> {
+  if (!input.capabilities.content.readDraft) {
+    return [];
+  }
+
+  const [documents, published, drafts] = await Promise.all([
+    input.contentApi.list({
+      type: input.type,
+      draft: true,
+      limit: 1,
+    }),
+    input.contentApi.list({
+      type: input.type,
+      published: true,
+      limit: 1,
+    }),
+    input.contentApi.list({
+      type: input.type,
+      draft: true,
+      published: false,
+      limit: 1,
+    }),
+  ]);
+
+  return [
+    {
+      id: "documents",
+      label: "Documents",
+      value: documents.pagination.total,
+    },
+    {
+      id: "published",
+      label: "Published",
+      value: published.pagination.total,
+    },
+    {
+      id: "withDrafts",
+      label: "Drafts",
+      value: drafts.pagination.total,
+    },
+  ];
+}
+
+function createMetricsFromOverviewCounts(input: {
+  total: number;
+  published: number;
+  drafts: number;
+}): StudioContentOverviewMetric[] {
+  return [
+    {
+      id: "documents",
+      label: "Documents",
+      value: input.total,
+    },
+    {
+      id: "published",
+      label: "Published",
+      value: input.published,
+    },
+    {
+      id: "withDrafts",
+      label: "Drafts",
+      value: input.drafts,
+    },
+  ];
+}
+
+export function createStudioContentOverviewLoadingState(
+  message = "Loading content overview.",
+): StudioContentOverviewLoadingState {
+  return {
+    status: "loading",
+    message,
+  };
+}
+
+export async function loadStudioContentOverviewState(
+  input: LoadStudioContentOverviewStateInput,
+): Promise<StudioContentOverviewState> {
+  const capabilitiesApi = createCapabilitiesApi(input);
+  const schemaApi = createSchemaApi(input);
+  const contentApi = createContentApi(input);
+  const contentOverviewApi = createContentOverviewApi(input);
+
+  try {
+    const capabilitiesResponse = await capabilitiesApi.get();
+    const capabilities = capabilitiesResponse.capabilities;
+    const project = capabilitiesResponse.project;
+    const environment = capabilitiesResponse.environment;
+
+    if (!capabilities.schema.read) {
+      return createForbiddenState({
+        project,
+        environment,
+        message:
+          "You do not have permission to view schema types for this target.",
+      });
+    }
+
+    const schemaEntries = await schemaApi.list();
+    const baseEntries = sortEntries(
+      schemaEntries.map((entry) =>
+        createOverviewEntry({
+          type: entry.type,
+          directory: entry.directory,
+          localized: entry.localized,
+          locales: entry.localized ? input.config.supportedLocales : undefined,
+          canNavigate: canReadAnyContent(capabilities),
+        }),
+      ),
+    );
+
+    if (baseEntries.length === 0) {
+      return createReadyState({
+        project,
+        environment,
+        entries: [],
+      });
+    }
+
+    if (!canReadAnyContent(capabilities)) {
+      return createPermissionConstrainedState({
+        project,
+        environment,
+        entries: baseEntries,
+      });
+    }
+
+    const entries = await (capabilities.content.read
+      ? (() => {
+          const requestedTypes = baseEntries.map((entry) => entry.type);
+
+          return contentOverviewApi
+            .get({ types: requestedTypes })
+            .then((counts) => {
+              const countsByType = new Map(
+                counts.map((count) => [count.type, count]),
+              );
+
+              return baseEntries.map((entry) => {
+                const count = countsByType.get(entry.type);
+
+                return createOverviewEntry({
+                  ...entry,
+                  metrics: createMetricsFromOverviewCounts({
+                    total: count?.total ?? 0,
+                    published: count?.published ?? 0,
+                    drafts: count?.drafts ?? 0,
+                  }),
+                });
+              });
+            });
+        })()
+      : Promise.all(
+          baseEntries.map(async (entry) =>
+            createOverviewEntry({
+              ...entry,
+              metrics: await loadEntryMetrics({
+                type: entry.type,
+                capabilities,
+                contentApi,
+              }),
+            }),
+          ),
+        ));
+
+    return createReadyState({
+      project,
+      environment,
+      entries,
+    });
+  } catch (error: unknown) {
+    if (isAuthFailure(error)) {
+      return createForbiddenState({
+        project: input.config.project,
+        environment: input.config.environment,
+        message: toStateErrorMessage(error, "Forbidden."),
+      });
+    }
+
+    return createErrorState({
+      project: input.config.project,
+      environment: input.config.environment,
+      message: toStateErrorMessage(error, "Failed to load content overview."),
+    });
+  }
+}

--- a/packages/studio/src/lib/content-overview-state.ts
+++ b/packages/studio/src/lib/content-overview-state.ts
@@ -294,6 +294,7 @@ async function loadEntryMetrics(input: {
     }),
     input.contentApi.list({
       type: input.type,
+      draft: true,
       published: true,
       limit: 1,
     }),

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -49,7 +49,7 @@ const RUNTIME_ROUTES: readonly StudioRuntimeRouteDefinition[] = [
   {
     id: "content.index",
     path: "/content",
-    render: () => <ContentPage />,
+    render: (context) => <ContentPage context={context} />,
   },
   {
     id: "content.type",

--- a/packages/studio/src/lib/runtime-ui/adapters/next-themes.test.ts
+++ b/packages/studio/src/lib/runtime-ui/adapters/next-themes.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "bun:test";
 
 import {
+  applyThemePreferencePersistence,
   STUDIO_THEME_STORAGE_KEY,
   persistStoredThemePreference,
   readStoredThemePreference,
@@ -34,6 +35,27 @@ test("persistStoredThemePreference writes to the Studio localStorage key", () =>
   const storage = createStorage();
 
   persistStoredThemePreference(storage, "dark");
+
+  assert.equal(storage.getItem(STUDIO_THEME_STORAGE_KEY), "dark");
+});
+
+test("applyThemePreferencePersistence skips the initial mount and persists subsequent theme changes", () => {
+  const storage = createStorage();
+
+  const hasMounted = applyThemePreferencePersistence({
+    storage,
+    theme: "dark",
+    hasMounted: false,
+  });
+
+  assert.equal(storage.getItem(STUDIO_THEME_STORAGE_KEY), null);
+  assert.equal(hasMounted, true);
+
+  applyThemePreferencePersistence({
+    storage,
+    theme: "dark",
+    hasMounted,
+  });
 
   assert.equal(storage.getItem(STUDIO_THEME_STORAGE_KEY), "dark");
 });

--- a/packages/studio/src/lib/runtime-ui/adapters/next-themes.test.ts
+++ b/packages/studio/src/lib/runtime-ui/adapters/next-themes.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import {
+  STUDIO_THEME_STORAGE_KEY,
+  persistStoredThemePreference,
+  readStoredThemePreference,
+  resolveAppliedTheme,
+  resolveThemePreference,
+} from "./next-themes.js";
+
+function createStorage() {
+  const values = new Map<string, string>();
+
+  return {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+test("readStoredThemePreference prefers the Studio localStorage key", () => {
+  const storage = createStorage();
+  storage.setItem(STUDIO_THEME_STORAGE_KEY, "dark");
+
+  assert.equal(readStoredThemePreference(storage), "dark");
+});
+
+test("persistStoredThemePreference writes to the Studio localStorage key", () => {
+  const storage = createStorage();
+
+  persistStoredThemePreference(storage, "dark");
+
+  assert.equal(storage.getItem(STUDIO_THEME_STORAGE_KEY), "dark");
+});
+
+test("resolveThemePreference prefers stored theme over runtime defaults", () => {
+  assert.equal(
+    resolveThemePreference({
+      storedTheme: "dark",
+      defaultTheme: "light",
+      enableSystem: true,
+      systemPrefersDark: false,
+    }),
+    "dark",
+  );
+});
+
+test("resolveThemePreference falls back to system when enabled", () => {
+  assert.equal(
+    resolveThemePreference({
+      storedTheme: null,
+      defaultTheme: "system",
+      enableSystem: true,
+      systemPrefersDark: true,
+    }),
+    "system",
+  );
+  assert.equal(resolveAppliedTheme("system", true), "dark");
+});

--- a/packages/studio/src/lib/runtime-ui/adapters/next-themes.tsx
+++ b/packages/studio/src/lib/runtime-ui/adapters/next-themes.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 
 type Theme = "light" | "dark" | "system";
+type AppliedTheme = "light" | "dark";
+type ThemeStorage = Pick<Storage, "getItem" | "setItem">;
 
 export type ThemeProviderProps = PropsWithChildren<{
   attribute?: string;
@@ -23,28 +25,173 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-function resolveInitialTheme(defaultTheme: Theme | undefined): Theme {
-  if (defaultTheme === "dark") {
-    return "dark";
+export const STUDIO_THEME_STORAGE_KEY = "mdcms-studio-theme";
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+export function readStoredThemePreference(
+  storage: ThemeStorage | null | undefined,
+): Theme | null {
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const value = storage.getItem(STUDIO_THEME_STORAGE_KEY);
+    return isTheme(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function persistStoredThemePreference(
+  storage: ThemeStorage | null | undefined,
+  theme: Theme,
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(STUDIO_THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore browser storage failures and keep the in-memory preference active.
+  }
+}
+
+function readSystemPrefersDark(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function resolveThemePreference(input: {
+  storedTheme: Theme | null;
+  defaultTheme: Theme | undefined;
+  enableSystem: boolean | undefined;
+  systemPrefersDark: boolean;
+}): Theme {
+  if (input.storedTheme) {
+    return input.storedTheme;
+  }
+
+  if (input.defaultTheme === "light" || input.defaultTheme === "dark") {
+    return input.defaultTheme;
+  }
+
+  if (input.defaultTheme === "system" && input.enableSystem) {
+    return "system";
+  }
+
+  if (input.enableSystem) {
+    return "system";
   }
 
   return "light";
 }
 
+export function resolveAppliedTheme(
+  theme: Theme,
+  systemPrefersDark: boolean,
+): AppliedTheme {
+  if (theme === "system") {
+    return systemPrefersDark ? "dark" : "light";
+  }
+
+  return theme === "dark" ? "dark" : "light";
+}
+
+function resolveInitialTheme(input: {
+  defaultTheme: Theme | undefined;
+  enableSystem: boolean | undefined;
+}): Theme {
+  const systemPrefersDark = readSystemPrefersDark();
+  const storage =
+    typeof window === "undefined" ? null : (window.localStorage ?? null);
+
+  return resolveThemePreference({
+    storedTheme: readStoredThemePreference(storage),
+    defaultTheme: input.defaultTheme,
+    enableSystem: input.enableSystem,
+    systemPrefersDark,
+  });
+}
+
 export function ThemeProvider({
   children,
+  attribute = "class",
   defaultTheme = "light",
+  enableSystem = false,
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(() =>
-    resolveInitialTheme(defaultTheme),
+    resolveInitialTheme({
+      defaultTheme,
+      enableSystem,
+    }),
   );
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(() =>
+    readSystemPrefersDark(),
+  );
+
+  useEffect(() => {
+    if (
+      !enableSystem ||
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemPrefersDark(event.matches);
+    };
+
+    setSystemPrefersDark(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+
+      return () => {
+        mediaQuery.removeEventListener("change", handleChange);
+      };
+    }
+
+    mediaQuery.addListener(handleChange);
+
+    return () => {
+      mediaQuery.removeListener(handleChange);
+    };
+  }, [enableSystem]);
 
   useEffect(() => {
     if (typeof document === "undefined") {
       return;
     }
 
-    document.documentElement.classList.toggle("dark", theme === "dark");
+    const nextTheme = resolveAppliedTheme(theme, systemPrefersDark);
+
+    if (attribute === "class") {
+      document.documentElement.classList.toggle("dark", nextTheme === "dark");
+      return;
+    }
+
+    document.documentElement.setAttribute(attribute, nextTheme);
+  }, [attribute, systemPrefersDark, theme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    persistStoredThemePreference(window.localStorage ?? null, theme);
   }, [theme]);
 
   const value = useMemo(

--- a/packages/studio/src/lib/runtime-ui/adapters/next-themes.tsx
+++ b/packages/studio/src/lib/runtime-ui/adapters/next-themes.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type PropsWithChildren,
 } from "react";
@@ -59,6 +60,19 @@ export function persistStoredThemePreference(
   } catch {
     // Ignore browser storage failures and keep the in-memory preference active.
   }
+}
+
+export function applyThemePreferencePersistence(input: {
+  storage: ThemeStorage | null | undefined;
+  theme: Theme;
+  hasMounted: boolean;
+}): boolean {
+  if (!input.hasMounted) {
+    return true;
+  }
+
+  persistStoredThemePreference(input.storage, input.theme);
+  return true;
 }
 
 function readSystemPrefersDark(): boolean {
@@ -139,6 +153,7 @@ export function ThemeProvider({
   const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(() =>
     readSystemPrefersDark(),
   );
+  const hasMountedThemePersistence = useRef(false);
 
   useEffect(() => {
     if (
@@ -191,7 +206,11 @@ export function ThemeProvider({
       return;
     }
 
-    persistStoredThemePreference(window.localStorage ?? null, theme);
+    hasMountedThemePersistence.current = applyThemePreferencePersistence({
+      storage: window.localStorage ?? null,
+      theme,
+      hasMounted: hasMountedThemePersistence.current,
+    });
   }, [theme]);
 
   const value = useMemo(

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -37,7 +37,7 @@ export type BreadcrumbItem = { label: string; href?: string };
 
 // Page Title Section Components
 interface PageTitleSectionProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   breadcrumbs?: BreadcrumbItem[];
 }
 

--- a/packages/studio/src/lib/runtime-ui/components/ui/calendar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/calendar.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import * as React from "react";
-import {
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker";
 
 import { cn } from "../../lib/utils.js";
@@ -138,22 +134,17 @@ function Calendar({
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === "left") {
             return (
-              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+              <ChevronLeft className={cn("size-4", className)} {...props} />
             );
           }
 
           if (orientation === "right") {
             return (
-              <ChevronRightIcon
-                className={cn("size-4", className)}
-                {...props}
-              />
+              <ChevronRight className={cn("size-4", className)} {...props} />
             );
           }
 
-          return (
-            <ChevronDownIcon className={cn("size-4", className)} {...props} />
-          );
+          return <ChevronDown className={cn("size-4", className)} {...props} />;
         },
         DayButton: CalendarDayButton,
         WeekNumber: ({ children, ...props }) => {

--- a/packages/studio/src/lib/runtime-ui/components/ui/checkbox.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { CheckIcon } from "lucide-react";
+import { Check } from "lucide-react";
 
 import { cn } from "../../lib/utils.js";
 
@@ -23,7 +23,7 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <Check className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/packages/studio/src/lib/runtime-ui/components/ui/dialog.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
+import { X } from "lucide-react";
 
 import { cn } from "../../lib/utils.js";
 
@@ -71,7 +71,7 @@ function DialogContent({
           data-slot="dialog-close"
           className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
         >
-          <XIcon />
+          <X />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       )}

--- a/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import { Check, ChevronRight, Circle } from "lucide-react";
 
 import { cn } from "../../lib/utils.js";
 
@@ -100,7 +100,7 @@ function DropdownMenuCheckboxItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <Check className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -135,7 +135,7 @@ function DropdownMenuRadioItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <Circle className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -217,7 +217,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <ChevronRight className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/components/ui/pagination.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/pagination.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  MoreHorizontalIcon,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "../../lib/utils.js";
 import { Button, buttonVariants } from "./button.js";
@@ -76,7 +72,7 @@ function PaginationPrevious({
       className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
       {...props}
     >
-      <ChevronLeftIcon />
+      <ChevronLeft />
       <span className="hidden sm:block">Previous</span>
     </PaginationLink>
   );
@@ -94,7 +90,7 @@ function PaginationNext({
       {...props}
     >
       <span className="hidden sm:block">Next</span>
-      <ChevronRightIcon />
+      <ChevronRight />
     </PaginationLink>
   );
 }
@@ -110,7 +106,7 @@ function PaginationEllipsis({
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontal className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
   );

--- a/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "../../lib/utils.js";
 
@@ -44,7 +44,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <ChevronDown className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -114,7 +114,7 @@ function SelectItem({
     >
       <span className="absolute right-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <Check className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -148,7 +148,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon className="size-4" />
+      <ChevronUp className="size-4" />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -166,7 +166,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon className="size-4" />
+      <ChevronDown className="size-4" />
     </SelectPrimitive.ScrollDownButton>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
@@ -39,7 +39,10 @@ function createReadyState(
   };
 }
 
-function renderMarkup(state: StudioContentOverviewState): string {
+function renderMarkup(
+  state: StudioContentOverviewState,
+  options?: { basePath?: string },
+): string {
   return renderToStaticMarkup(
     createElement(
       ThemeProvider,
@@ -67,7 +70,7 @@ function renderMarkup(state: StudioContentOverviewState): string {
               value: {
                 pathname: "/content",
                 params: {},
-                basePath: "/admin",
+                basePath: options?.basePath ?? "/admin",
                 push: () => {},
                 replace: () => {},
                 back: () => {},
@@ -137,6 +140,14 @@ test("ContentPageView renders populated live overview cards with subtitle, compa
   assert.match(markup, /5.*published/);
   assert.match(markup, /2.*drafts/);
   assert.match(markup, /href="\/admin\/content\/BlogPost"/);
+});
+
+test("ContentPageView uses the configured Studio base path for card navigation", () => {
+  const markup = renderMarkup(createReadyState(), {
+    basePath: "/review/editor/admin",
+  });
+
+  assert.match(markup, /href="\/review\/editor\/admin\/content\/BlogPost"/);
 });
 
 test("ContentPageView renders permission-constrained cards with disabled navigation", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type {
+  StudioContentOverviewState,
+  StudioContentOverviewReadyState,
+} from "../../content-overview-state.js";
+import { StudioMountInfoProvider } from "../app/admin/mount-info-context.js";
+import { StudioSessionProvider } from "../app/admin/session-context.js";
+import { StudioNavigationProvider } from "../navigation.js";
+import { ThemeProvider } from "../adapters/next-themes.js";
+import { ContentPageView } from "./content-page.js";
+
+function createReadyState(
+  overrides: Partial<StudioContentOverviewReadyState> = {},
+): StudioContentOverviewReadyState {
+  return {
+    status: "ready",
+    project: "marketing-site",
+    environment: "staging",
+    entries: [
+      {
+        type: "BlogPost",
+        directory: "content/blog",
+        localized: true,
+        locales: ["en-US", "fr"],
+        canNavigate: true,
+        metrics: [
+          { id: "documents", label: "Documents", value: 7 },
+          { id: "published", label: "Published", value: 5 },
+          { id: "withDrafts", label: "With drafts", value: 2 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderMarkup(state: StudioContentOverviewState): string {
+  return renderToStaticMarkup(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(
+        StudioSessionProvider,
+        {
+          value: { status: "unauthenticated" },
+        },
+        createElement(
+          StudioMountInfoProvider,
+          {
+            value: {
+              project: "marketing-site",
+              environment: "staging",
+              apiBaseUrl: "http://localhost:4000",
+              auth: { mode: "cookie" },
+              environments: [],
+              hostBridge: null,
+            },
+          },
+          createElement(
+            StudioNavigationProvider,
+            {
+              value: {
+                pathname: "/content",
+                params: {},
+                basePath: "/admin",
+                push: () => {},
+                replace: () => {},
+                back: () => {},
+              },
+            },
+            createElement(ContentPageView, { state }),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+test("ContentPageView renders loading and empty states deterministically", () => {
+  const loadingMarkup = renderMarkup({
+    status: "loading",
+    message: "Loading content overview.",
+  });
+  const emptyMarkup = renderMarkup(createReadyState({ entries: [] }));
+
+  assert.match(loadingMarkup, /class="min-h-screen"/);
+  assert.match(loadingMarkup, />Content</);
+  assert.match(loadingMarkup, /data-mdcms-content-page-state="loading"/);
+  assert.match(loadingMarkup, /Loading content overview\./);
+  assert.match(emptyMarkup, /data-mdcms-content-page-state="empty"/);
+  assert.match(emptyMarkup, /No schema types were returned/);
+});
+
+test("ContentPageView renders populated live overview cards with subtitle, compact stats, and locale badges", () => {
+  const markup = renderMarkup(
+    createReadyState({
+      entries: [
+        {
+          type: "BlogPost",
+          directory: "content/blog",
+          localized: true,
+          locales: ["en-US", "fr", "de", "ja"],
+          canNavigate: true,
+          metrics: [
+            { id: "documents", label: "Documents", value: 7 },
+            { id: "published", label: "Published", value: 5 },
+            { id: "withDrafts", label: "With drafts", value: 2 },
+          ],
+        },
+        {
+          type: "Author",
+          directory: "content/authors",
+          localized: false,
+          canNavigate: true,
+          metrics: [
+            { id: "documents", label: "Documents", value: 3 },
+            { id: "published", label: "Published", value: 3 },
+            { id: "withDrafts", label: "With drafts", value: 0 },
+          ],
+        },
+      ],
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-content-page-state="ready"/);
+  assert.match(markup, /data-mdcms-content-card-type="BlogPost"/);
+  assert.match(markup, /Browse and manage your content by type/);
+  assert.match(markup, />Localized</);
+  assert.match(markup, /en-US, fr, de, ja/);
+  assert.match(markup, />Single locale</);
+  assert.match(markup, /7.*total/);
+  assert.match(markup, /5.*published/);
+  assert.match(markup, /2.*drafts/);
+  assert.match(markup, /href="\/admin\/content\/BlogPost"/);
+});
+
+test("ContentPageView renders permission-constrained cards with disabled navigation", () => {
+  const markup = renderMarkup({
+    status: "permission-constrained",
+    project: "marketing-site",
+    environment: "staging",
+    message:
+      "You can inspect schema types here, but you do not have permission to read content counts.",
+    entries: [
+      {
+        type: "BlogPost",
+        directory: "content/blog",
+        localized: true,
+        locales: ["en-US", "fr"],
+        canNavigate: false,
+        metrics: [],
+      },
+    ],
+  });
+
+  assert.match(
+    markup,
+    /data-mdcms-content-page-state="permission-constrained"/,
+  );
+  assert.match(markup, /do not have permission to read content counts/i);
+  assert.match(markup, /en-US, fr/);
+  assert.match(markup, /data-mdcms-content-card-disabled="true"/);
+  assert.doesNotMatch(markup, /href="\/admin\/content\/BlogPost"/);
+});
+
+test("ContentPageView renders forbidden and error states", () => {
+  const forbiddenMarkup = renderMarkup({
+    status: "forbidden",
+    project: "marketing-site",
+    environment: "staging",
+    message: "Forbidden.",
+  });
+  const errorMarkup = renderMarkup({
+    status: "error",
+    project: "marketing-site",
+    environment: "staging",
+    message: "Content overview failed.",
+  });
+
+  assert.match(forbiddenMarkup, /data-mdcms-content-page-state="forbidden"/);
+  assert.match(errorMarkup, /data-mdcms-content-page-state="error"/);
+});

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -1,112 +1,310 @@
-// @ts-nocheck
 "use client";
 
-import type { ElementType } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
-import Link from "../adapters/next-link";
+import type { StudioMountContext } from "@mdcms/shared";
+
 import {
-  ChevronRight,
-  File,
-  FileText,
-  Globe,
-  Package,
-  Tag,
-  User,
-} from "lucide-react";
-import { PageHeader } from "../components/layout/page-header";
-import { Badge } from "../components/ui/badge";
-import { Card, CardContent } from "../components/ui/card";
-import { mockContentTypes } from "../lib/mock-data";
+  createStudioContentOverviewLoadingState,
+  loadStudioContentOverviewState,
+  type LoadStudioContentOverviewStateInput,
+  type StudioContentOverviewEntry,
+  type StudioContentOverviewState,
+} from "../../content-overview-state.js";
+import Link from "../adapters/next-link.js";
+import { ChevronRight, FileText, Globe, GlobeOff } from "lucide-react";
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderHeading,
+} from "../components/layout/page-header.js";
+import { Badge } from "../components/ui/badge.js";
+import { Card, CardContent } from "../components/ui/card.js";
 
-const iconMap: Record<string, ElementType> = {
-  FileText,
-  File,
-  User,
-  Tag,
-  Package,
-};
+type ContentPageLoadInput = LoadStudioContentOverviewStateInput;
 
-export default function ContentPage() {
+function findMetricValue(
+  entry: StudioContentOverviewEntry,
+  metricId: StudioContentOverviewEntry["metrics"][number]["id"],
+): number | undefined {
+  return entry.metrics.find((metric) => metric.id === metricId)?.value;
+}
+
+function renderCard(entry: StudioContentOverviewEntry): ReactNode {
+  const totalCount = findMetricValue(entry, "documents");
+  const publishedCount = findMetricValue(entry, "published");
+  const draftCount = findMetricValue(entry, "withDrafts");
+  const card = (
+    <Card
+      data-mdcms-content-card-type={entry.type}
+      data-mdcms-content-card-disabled={entry.canNavigate ? "false" : "true"}
+      className="h-full border-border py-0 transition-all hover:border-accent/50 hover:shadow-sm"
+    >
+      <CardContent className="p-4">
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+            <FileText className="h-6 w-6 text-accent" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold">{entry.type}</h2>
+              {entry.canNavigate ? (
+                <ChevronRight className="h-4 w-4 text-foreground-muted" />
+              ) : null}
+            </div>
+            <p className="line-clamp-2 text-sm text-muted-foreground">
+              {entry.directory}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 space-y-3 border-t border-border pt-4">
+          {entry.metrics.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-4 text-sm">
+              {totalCount !== undefined ? (
+                <span
+                  data-mdcms-content-metric="documents"
+                  className="text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">
+                    {totalCount}
+                  </span>{" "}
+                  total
+                </span>
+              ) : null}
+              {publishedCount !== undefined ? (
+                <span
+                  data-mdcms-content-metric="published"
+                  className="text-muted-foreground"
+                >
+                  <span className="font-medium text-success">
+                    {publishedCount}
+                  </span>{" "}
+                  published
+                </span>
+              ) : null}
+              {draftCount !== undefined ? (
+                <span
+                  data-mdcms-content-metric="withDrafts"
+                  className="text-muted-foreground"
+                >
+                  <span className="font-medium text-warning">{draftCount}</span>{" "}
+                  drafts
+                </span>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Counts unavailable for your current permissions.
+            </p>
+          )}
+
+          {entry.localized ? (
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="gap-1">
+                <Globe className="h-3 w-3" />
+                Localized
+              </Badge>
+              {entry.locales?.length ? (
+                <span className="text-xs text-muted-foreground">
+                  {entry.locales.join(", ")}
+                </span>
+              ) : null}
+            </div>
+          ) : (
+            <Badge variant="outline" className="gap-1">
+              <GlobeOff className="h-3 w-3" />
+              Single locale
+            </Badge>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  if (!entry.canNavigate) {
+    return <div key={entry.type}>{card}</div>;
+  }
+
+  return (
+    <Link key={entry.type} href={`/admin/content/${entry.type}`}>
+      {card}
+    </Link>
+  );
+}
+
+function renderCardGrid(entries: StudioContentOverviewEntry[]) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {entries.map((entry) => renderCard(entry))}
+    </div>
+  );
+}
+
+export function createContentPageLoadInput(
+  context: StudioMountContext,
+): ContentPageLoadInput | null {
+  const route = context.documentRoute;
+
+  if (!route) {
+    return null;
+  }
+
+  return {
+    config: {
+      project: route.project,
+      environment: route.environment,
+      serverUrl: context.apiBaseUrl,
+      supportedLocales: route.supportedLocales,
+    },
+    auth: context.auth,
+  };
+}
+
+function createContentPageMissingRouteState(): StudioContentOverviewState {
+  return {
+    status: "error",
+    project: "unknown",
+    environment: "unknown",
+    message: "Content overview requires an active project and environment.",
+  };
+}
+
+export function ContentPageView({
+  state,
+}: {
+  state: StudioContentOverviewState;
+}) {
   return (
     <div className="min-h-screen">
       <PageHeader breadcrumbs={[{ label: "Content" }]} />
 
       <div className="space-y-6 p-6">
-        <div>
-          <h1 className="text-2xl font-semibold">Content</h1>
-          <p className="text-sm text-foreground-muted">
+        <div className="space-y-1">
+          <PageHeaderHeading>Content</PageHeaderHeading>
+          <PageHeaderDescription>
             Browse and manage your content by type
-          </p>
+          </PageHeaderDescription>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {mockContentTypes.map((type) => {
-            const IconComponent = iconMap[type.icon] || FileText;
-
-            return (
-              <Link key={type.id} href={`/admin/content/${type.id}`}>
-                <Card className="h-full border-border transition-all hover:border-accent/50 hover:shadow-sm">
-                  <CardContent className="p-5">
-                    <div className="flex items-start gap-4">
-                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent/10">
-                        <IconComponent className="h-6 w-6 text-accent" />
-                      </div>
-                      <div className="min-w-0 flex-1 space-y-1">
-                        <div className="flex items-center gap-2">
-                          <h3 className="text-lg font-semibold">{type.name}</h3>
-                          <ChevronRight className="h-4 w-4 text-foreground-muted" />
-                        </div>
-                        <p className="line-clamp-2 text-sm text-foreground-muted">
-                          {type.description}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="mt-4 space-y-3 border-t border-border pt-4">
-                      <div className="flex items-center gap-4 text-sm">
-                        <span className="text-foreground-muted">
-                          <span className="font-medium text-foreground">
-                            {type.documentCount}
-                          </span>{" "}
-                          total
-                        </span>
-                        <span className="text-foreground-muted">
-                          <span className="font-medium text-success">
-                            {type.publishedCount}
-                          </span>{" "}
-                          published
-                        </span>
-                        <span className="text-foreground-muted">
-                          <span className="font-medium text-warning">
-                            {type.draftCount}
-                          </span>{" "}
-                          drafts
-                        </span>
-                      </div>
-
-                      {type.localized ? (
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="gap-1">
-                            <Globe className="h-3 w-3" />
-                            Localized
-                          </Badge>
-                          <span className="text-xs text-foreground-muted">
-                            {type.locales?.join(", ")}
-                          </span>
-                        </div>
-                      ) : (
-                        <span className="text-xs text-foreground-muted">
-                          Single locale
-                        </span>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
-        </div>
+        {state.status === "loading" ? (
+          <div
+            data-mdcms-content-page-state="loading"
+            className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+          >
+            {state.message}
+          </div>
+        ) : state.status === "forbidden" ? (
+          <section
+            data-mdcms-content-page-state="forbidden"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="secondary">Forbidden</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : state.status === "error" ? (
+          <section
+            data-mdcms-content-page-state="error"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="destructive">Error</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : state.entries.length === 0 ? (
+          <section
+            data-mdcms-content-page-state="empty"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="outline">Empty</Badge>
+            <p className="text-sm text-muted-foreground">
+              No schema types were returned for this project and environment.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : state.status === "permission-constrained" ? (
+          <div
+            data-mdcms-content-page-state="permission-constrained"
+            className="space-y-4"
+          >
+            <section className="space-y-2 rounded-lg border border-dashed p-4">
+              <Badge variant="outline">Limited access</Badge>
+              <p className="text-sm text-muted-foreground">{state.message}</p>
+            </section>
+            {renderCardGrid(state.entries)}
+          </div>
+        ) : (
+          <div data-mdcms-content-page-state="ready" className="space-y-4">
+            {renderCardGrid(state.entries)}
+          </div>
+        )}
       </div>
     </div>
   );
+}
+
+export default function ContentPage({
+  context,
+  loadState = loadStudioContentOverviewState,
+}: {
+  context: StudioMountContext;
+  loadState?: typeof loadStudioContentOverviewState;
+}) {
+  const [state, setState] = useState<StudioContentOverviewState>(() =>
+    createStudioContentOverviewLoadingState(),
+  );
+
+  useEffect(() => {
+    const loadInput = createContentPageLoadInput(context);
+
+    if (!loadInput) {
+      setState(createContentPageMissingRouteState());
+      return;
+    }
+
+    let active = true;
+    setState(createStudioContentOverviewLoadingState());
+
+    void loadState(loadInput)
+      .then((nextState) => {
+        if (active) {
+          setState(nextState);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return;
+        }
+
+        setState({
+          status: "error",
+          project: loadInput.config.project,
+          environment: loadInput.config.environment,
+          message:
+            error instanceof Error && error.message.trim().length > 0
+              ? error.message
+              : "Failed to load content overview.",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    context.apiBaseUrl,
+    context.auth.mode,
+    context.auth.mode === "token" ? context.auth.token : undefined,
+    context.documentRoute?.environment,
+    context.documentRoute?.project,
+    loadState,
+  ]);
+
+  return <ContentPageView state={state} />;
 }

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../content-overview-state.js";
 import Link from "../adapters/next-link.js";
 import { ChevronRight, FileText, Globe, GlobeOff } from "lucide-react";
+import { resolveStudioHref, useBasePath } from "../navigation.js";
 import {
   PageHeader,
   PageHeaderDescription,
@@ -30,7 +31,10 @@ function findMetricValue(
   return entry.metrics.find((metric) => metric.id === metricId)?.value;
 }
 
-function renderCard(entry: StudioContentOverviewEntry): ReactNode {
+function renderCard(
+  entry: StudioContentOverviewEntry,
+  basePath: string,
+): ReactNode {
   const totalCount = findMetricValue(entry, "documents");
   const publishedCount = findMetricValue(entry, "published");
   const draftCount = findMetricValue(entry, "withDrafts");
@@ -127,16 +131,22 @@ function renderCard(entry: StudioContentOverviewEntry): ReactNode {
   }
 
   return (
-    <Link key={entry.type} href={`/admin/content/${entry.type}`}>
+    <Link
+      key={entry.type}
+      href={resolveStudioHref(basePath, `/content/${entry.type}`)}
+    >
       {card}
     </Link>
   );
 }
 
-function renderCardGrid(entries: StudioContentOverviewEntry[]) {
+function renderCardGrid(
+  entries: StudioContentOverviewEntry[],
+  basePath: string,
+) {
   return (
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-      {entries.map((entry) => renderCard(entry))}
+      {entries.map((entry) => renderCard(entry, basePath))}
     </div>
   );
 }
@@ -175,6 +185,8 @@ export function ContentPageView({
 }: {
   state: StudioContentOverviewState;
 }) {
+  const basePath = useBasePath();
+
   return (
     <div className="min-h-screen">
       <PageHeader breadcrumbs={[{ label: "Content" }]} />
@@ -238,11 +250,11 @@ export function ContentPageView({
               <Badge variant="outline">Limited access</Badge>
               <p className="text-sm text-muted-foreground">{state.message}</p>
             </section>
-            {renderCardGrid(state.entries)}
+            {renderCardGrid(state.entries, basePath)}
           </div>
         ) : (
           <div data-mdcms-content-page-state="ready" className="space-y-4">
-            {renderCardGrid(state.entries)}
+            {renderCardGrid(state.entries, basePath)}
           </div>
         )}
       </div>

--- a/packages/studio/src/lib/session-api.test.ts
+++ b/packages/studio/src/lib/session-api.test.ts
@@ -35,6 +35,13 @@ function createSessionApi(options: StudioSessionApiOptions = {}) {
   );
 }
 
+function createPrefixedSessionApi(options: StudioSessionApiOptions = {}) {
+  return createStudioSessionApi(
+    { serverUrl: "http://localhost:4000/review-api/editor" },
+    options,
+  );
+}
+
 function createSessionResponse(
   overrides: Record<string, unknown> = {},
 ): Response {
@@ -100,6 +107,29 @@ test("get attaches bearer token in token auth mode", async () => {
   );
   assert.equal(calls[0]?.init?.credentials, undefined);
   assert.equal(result.session.email, "alice@company.com");
+});
+
+test("get preserves a path-prefixed serverUrl for scenario-scoped auth/session routes", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createPrefixedSessionApi({
+    auth: { mode: "token", token: "mdcms_key_test" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return createSessionResponse();
+    },
+  });
+
+  await api.get();
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/review-api/editor/api/v1/auth/session",
+  );
+  assert.equal(
+    readHeader(calls[0]?.init, "authorization"),
+    "Bearer mdcms_key_test",
+  );
 });
 
 test("get throws UNAUTHORIZED on 401 response", async () => {
@@ -168,4 +198,30 @@ test("signOut posts to logout with CSRF token", async () => {
     "csrf-test-token",
   );
   assert.equal(calls[0]?.init?.credentials, "include");
+});
+
+test("signOut preserves a path-prefixed serverUrl for scenario-scoped auth/logout routes", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createPrefixedSessionApi({
+    auth: { mode: "cookie" },
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify({ data: { revoked: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  await api.signOut("csrf-test-token");
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/review-api/editor/api/v1/auth/logout",
+  );
+  assert.equal(
+    readHeader(calls[0]?.init, "x-mdcms-csrf-token"),
+    "csrf-test-token",
+  );
 });

--- a/packages/studio/src/lib/session-api.ts
+++ b/packages/studio/src/lib/session-api.ts
@@ -4,6 +4,7 @@ import {
   applyStudioAuthToRequestInit,
   type StudioRuntimeAuth,
 } from "./request-auth.js";
+import { resolveStudioRelativeUrl } from "./url-resolution.js";
 
 export type StudioSessionInfo = {
   id: string;
@@ -137,7 +138,10 @@ export function createStudioSessionApi(
 
   return {
     async get() {
-      const url = new URL("/api/v1/auth/session", config.serverUrl);
+      const url = resolveStudioRelativeUrl(
+        "/api/v1/auth/session",
+        config.serverUrl,
+      );
       const response = await fetcher(
         url,
         applyStudioAuthToRequestInit(options.auth, { method: "GET" }),
@@ -157,7 +161,10 @@ export function createStudioSessionApi(
     },
 
     async signOut(csrfToken: string) {
-      const url = new URL("/api/v1/auth/logout", config.serverUrl);
+      const url = resolveStudioRelativeUrl(
+        "/api/v1/auth/logout",
+        config.serverUrl,
+      );
       const response = await fetcher(
         url,
         applyStudioAuthToRequestInit(options.auth, {

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -6,6 +6,8 @@ import { test } from "bun:test";
 
 import {
   RuntimeError,
+  defineConfig,
+  defineType,
   type MdxExtractedProps,
   type HostBridgeV1,
   type StudioBootstrapManifest,
@@ -19,6 +21,14 @@ const validHostBridge: HostBridgeV1 = {
   version: "1",
   resolveComponent: () => null,
   renderMdxPreview: () => () => {},
+};
+
+const stringSchema = {
+  "~standard": {
+    version: 1 as const,
+    vendor: "test",
+    validate: (value: unknown) => ({ value }),
+  },
 };
 
 async function withTempDir<T>(
@@ -515,6 +525,152 @@ test("loadStudioRuntime carries supported locales into the document route mount 
       "de",
       "ja",
     ]);
+  });
+});
+
+test("loadStudioRuntime swallows expected config validation failures when deriving supported locales", async () => {
+  await withTempDir("studio-loader-invalid-locales-", async (directory) => {
+    const fixture = await createRuntimeFixture(directory);
+    const contexts: unknown[] = [];
+
+    await loadStudioRuntime({
+      config: defineConfig({
+        project: "marketing-site",
+        environment: "staging",
+        serverUrl: "http://localhost:4000",
+        contentDirectories: ["content/blog"],
+        types: [
+          defineType("BlogPost", {
+            directory: "content/blog",
+            localized: true,
+            fields: {
+              title: stringSchema,
+            },
+          }),
+        ],
+      }),
+      basePath: "/admin",
+      container: {},
+      fetcher: async (input) => {
+        const url = String(input);
+
+        if (url === "http://localhost:4000/api/v1/studio/bootstrap") {
+          return new Response(
+            JSON.stringify(
+              createReadyBootstrapPayload({
+                manifest: fixture.manifest,
+              }),
+            ),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          );
+        }
+
+        if (url === "http://localhost:4000" + fixture.manifest.entryUrl) {
+          return new Response(new Uint8Array(fixture.runtimeBytes), {
+            status: 200,
+            headers: {
+              "content-type": "text/javascript; charset=utf-8",
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      },
+      loadRemoteModule: async () => ({
+        mount: (_target: unknown, context: unknown) => {
+          contexts.push(context);
+          return () => {};
+        },
+      }),
+    });
+
+    const mountedContext = contexts[0] as {
+      documentRoute?: {
+        supportedLocales?: string[];
+      };
+    };
+
+    assert.equal(mountedContext.documentRoute?.supportedLocales, undefined);
+  });
+});
+
+test("loadStudioRuntime rethrows unexpected config parse failures when deriving supported locales", async () => {
+  await withTempDir("studio-loader-unexpected-config-", async (directory) => {
+    const fixture = await createRuntimeFixture(directory);
+    const validTypes = [
+      defineType("BlogPost", {
+        directory: "content/blog",
+        fields: {
+          title: stringSchema,
+        },
+      }),
+    ];
+    let typeAccessCount = 0;
+    const config = {
+      project: "marketing-site",
+      environment: "staging",
+      serverUrl: "http://localhost:4000",
+      contentDirectories: ["content/blog"],
+      get types() {
+        typeAccessCount += 1;
+
+        if (typeAccessCount === 1) {
+          return validTypes;
+        }
+
+        throw new Error("types getter exploded");
+      },
+    } as unknown as MdcmsConfig;
+
+    await assert.rejects(
+      () =>
+        loadStudioRuntime({
+          config,
+          basePath: "/admin",
+          container: {},
+          fetcher: async (input) => {
+            const url = String(input);
+
+            if (url === "http://localhost:4000/api/v1/studio/bootstrap") {
+              return new Response(
+                JSON.stringify(
+                  createReadyBootstrapPayload({
+                    manifest: fixture.manifest,
+                  }),
+                ),
+                {
+                  status: 200,
+                  headers: {
+                    "content-type": "application/json",
+                  },
+                },
+              );
+            }
+
+            if (url === "http://localhost:4000" + fixture.manifest.entryUrl) {
+              return new Response(new Uint8Array(fixture.runtimeBytes), {
+                status: 200,
+                headers: {
+                  "content-type": "text/javascript; charset=utf-8",
+                },
+              });
+            }
+
+            throw new Error(`Unexpected fetch URL: ${url}`);
+          },
+          loadRemoteModule: async () => {
+            throw new Error("loadRemoteModule should not be called");
+          },
+        }),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes("types getter exploded"),
+    );
   });
 });
 

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -439,6 +439,85 @@ test("loadStudioRuntime derives a local mdx catalog and editor resolver from con
   });
 });
 
+test("loadStudioRuntime carries supported locales into the document route mount context", async () => {
+  await withTempDir("studio-loader-locales-", async (directory) => {
+    const fixture = await createRuntimeFixture(directory);
+    const contexts: unknown[] = [];
+
+    await loadStudioRuntime({
+      config: {
+        project: "marketing-site",
+        environment: "staging",
+        serverUrl: "http://localhost:4000",
+        contentDirectories: [],
+        locales: {
+          default: "en-US",
+          supported: ["en-US", "fr", "de", "ja"],
+        },
+        environments: {
+          production: {},
+          staging: {
+            extends: "production",
+          },
+        },
+        types: [],
+      },
+      basePath: "/admin",
+      container: {},
+      hostBridge: validHostBridge,
+      fetcher: async (input) => {
+        const url = String(input);
+
+        if (url === "http://localhost:4000/api/v1/studio/bootstrap") {
+          return new Response(
+            JSON.stringify(
+              createReadyBootstrapPayload({
+                manifest: fixture.manifest,
+              }),
+            ),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          );
+        }
+
+        if (url === "http://localhost:4000" + fixture.manifest.entryUrl) {
+          return new Response(new Uint8Array(fixture.runtimeBytes), {
+            status: 200,
+            headers: {
+              "content-type": "text/javascript; charset=utf-8",
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      },
+      loadRemoteModule: async () => ({
+        mount: (_target: unknown, context: unknown) => {
+          contexts.push(context);
+          return () => {};
+        },
+      }),
+    });
+
+    const mountedContext = contexts[0] as {
+      documentRoute?: {
+        supportedLocales?: string[];
+      };
+    };
+
+    assert.deepEqual(mountedContext.documentRoute?.supportedLocales, [
+      "en-US",
+      "fr",
+      "de",
+      "ja",
+    ]);
+  });
+});
+
 test("loadStudioRuntime resolves props editors lazily and preserves loader rejections", async () => {
   await withTempDir("studio-loader-mdx-lazy-", async (directory) => {
     const fixture = await createRuntimeFixture(directory);

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -245,8 +245,12 @@ async function createDocumentRouteMountContext(
     supportedLocales = parsedConfig.locales.implicit
       ? undefined
       : [...parsedConfig.locales.supported];
-  } catch {
-    supportedLocales = undefined;
+  } catch (error) {
+    if (error instanceof RuntimeError && error.code === "INVALID_CONFIG") {
+      supportedLocales = undefined;
+    } else {
+      throw error;
+    }
   }
 
   return {

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -8,6 +8,7 @@ import {
   assertStudioBootstrapReadyResponse,
   assertStudioMountContext,
   isRuntimeErrorLike,
+  parseMdcmsConfig,
   type ErrorEnvelope,
   type HostBridgeV1,
   type MdxComponentCatalog,
@@ -237,10 +238,23 @@ async function createDocumentRouteMountContext(
   }
 
   const capability = await resolveStudioDocumentRouteSchemaCapability(config);
+  let supportedLocales: string[] | undefined;
+
+  try {
+    const parsedConfig = parseMdcmsConfig(config);
+    supportedLocales = parsedConfig.locales.implicit
+      ? undefined
+      : [...parsedConfig.locales.supported];
+  } catch {
+    supportedLocales = undefined;
+  }
 
   return {
     project,
     environment,
+    ...(supportedLocales && supportedLocales.length > 0
+      ? { supportedLocales }
+      : {}),
     write: capability.canWrite
       ? {
           canWrite: true,


### PR DESCRIPTION
## Summary
- replace the remaining `/admin/content` mock behavior with live schema-driven overview state and a dedicated metadata-only `/api/v1/content/overview` count contract
- restore the original content overview card presentation with truthful `total`, `published`, `drafts`, and locale badges, plus localized demo content to exercise that path
- persist the Studio light/dark theme in browser-local storage so the shell survives reloads and remounts without resetting

## Verification
- `bun test apps/server/src/lib/content-api.test.ts packages/studio/src/lib/content-overview-api.test.ts packages/studio/src/lib/content-overview-state.test.ts packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx packages/studio/src/lib/runtime-ui/adapters/next-themes.test.ts packages/studio/src/lib/studio-loader.test.ts packages/shared/src/lib/contracts/extensibility.test.ts packages/studio/src/lib/content-list-api.test.ts`
- `bun run format:check`
- `bun run check`

## Notes
- database-backed content API integration tests remain skipped in this environment because the test database is not available here
- unrelated local workspace dirt like `docker-compose.dev.yml` and local-only planning files is intentionally left out of the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added content overview API returning per-type counts (total, published, drafts) and client APIs to fetch them.

* **Studio**
  * New data-driven Content Overview page with locale-aware entries, permission-aware navigation, and deterministic states.

* **Demo Content**
  * Demo seed includes localized campaign samples (en/fr).

* **Theme**
  * Browser theme preference persistence with system/default fallbacks.

* **Tests**
  * Added integration and unit tests for overview API, seeding, state loading, and UI.

* **Documentation**
  * Updated specs and READMEs describing the API, Studio behavior, and locales.

* **Style**
  * Updated icon usage across UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->