### PR TITLE
feat(cms-135,136,137,138,144): Studio MVP truthfulness audit fixes

### DIFF
--- a/apps/server/src/bin/demo-seed-api-key.ts
+++ b/apps/server/src/bin/demo-seed-api-key.ts
@@ -303,18 +303,31 @@ async function ensureDemoApiKey(input: {
   });
 
   if (existing) {
+    const currentAllowlist = Array.isArray(existing.contextAllowlist)
+      ? (existing.contextAllowlist as Array<{
+          project: string;
+          environment: string;
+        }>)
+      : [];
+    const alreadyPresent = currentAllowlist.some(
+      (entry) =>
+        entry.project === input.project &&
+        entry.environment === input.environment,
+    );
+    const mergedAllowlist = alreadyPresent
+      ? currentAllowlist
+      : [
+          ...currentAllowlist,
+          { project: input.project, environment: input.environment },
+        ];
+
     await input.db
       .update(apiKeys)
       .set({
         label: DEMO_KEY_LABEL,
         keyPrefix: toKeyPrefix(input.apiKey),
         scopes: [...DEMO_KEY_SCOPES],
-        contextAllowlist: [
-          {
-            project: input.project,
-            environment: input.environment,
-          },
-        ],
+        contextAllowlist: mergedAllowlist,
         expiresAt: null,
         revokedAt: null,
         createdByUserId: input.userId,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
       [
         "sh",
         "-lc",
-        "bun install --frozen-lockfile && bun run --cwd apps/server db:migrate && bun run --cwd apps/server demo:seed && MDCMS_DEMO_ENVIRONMENT=production bun run --cwd apps/server demo:seed",
+        "bun install --frozen-lockfile && bun run --cwd apps/server db:migrate && MDCMS_DEMO_ENVIRONMENT=staging bun run --cwd apps/server demo:seed && MDCMS_DEMO_ENVIRONMENT=production bun run --cwd apps/server demo:seed",
       ]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://mdcms:mdcms@postgres:5432/mdcms}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
       [
         "sh",
         "-lc",
-        "bun install --frozen-lockfile && bun run --cwd apps/server db:migrate && bun run --cwd apps/server demo:seed",
+        "bun install --frozen-lockfile && bun run --cwd apps/server db:migrate && bun run --cwd apps/server demo:seed && MDCMS_DEMO_ENVIRONMENT=production bun run --cwd apps/server demo:seed",
       ]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://mdcms:mdcms@postgres:5432/mdcms}

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -344,6 +344,25 @@ Each embedded Studio instance is configured with a specific project through `mdc
 
 For users who manage multiple projects, the Studio header provides a project switcher that links to the other Studio instances they are allowed to access.
 
+### Environment Scope and Switching
+
+The active environment is Studio-owned state. The host app provides the initial
+environment through `documentRoute.environment` at mount time. Once mounted,
+Studio owns the active environment and can switch it through an in-shell
+environment selector without host involvement or page reload.
+
+Normative behavior:
+
+- The shell header displays an environment selector when the environment list API
+  returns more than one environment for the current project.
+- Selecting a different environment updates Studio-internal state. All
+  environment-scoped API queries (capabilities, schema, content, trash) re-fetch
+  against the new environment automatically.
+- When only one environment exists, the header shows a read-only environment
+  badge instead of a selector.
+- Environment switching does not require host bridge cooperation. The host bridge
+  does not define an environment navigation callback.
+
 ### Target-Scoped Capabilities and Schema Recovery
 
 Studio uses `GET /api/v1/me/capabilities` as the canonical source for

--- a/packages/shared/src/lib/contracts/extensibility.test.ts
+++ b/packages/shared/src/lib/contracts/extensibility.test.ts
@@ -751,23 +751,12 @@ test("assertStudioMountContext rejects invalid extracted mdx prop shapes", () =>
   );
 });
 
-test("assertHostBridgeV1 accepts a bridge with onNavigate callback", () => {
-  assert.doesNotThrow(() =>
+test("assertHostBridgeV1 rejects a bridge with unknown extra keys", () => {
+  assert.throws(() =>
     assertHostBridgeV1({
       ...validHostBridge,
       onNavigate: () => {},
     }),
-  );
-});
-
-test("assertHostBridgeV1 rejects a bridge with non-function onNavigate", () => {
-  assert.throws(
-    () =>
-      assertHostBridgeV1({
-        ...validHostBridge,
-        onNavigate: "not-a-function",
-      }),
-    /onNavigate/,
   );
 });
 

--- a/packages/shared/src/lib/contracts/extensibility.test.ts
+++ b/packages/shared/src/lib/contracts/extensibility.test.ts
@@ -374,7 +374,7 @@ test("runtime contract validators cover positive and negative shapes", () => {
       hostBridge: validHostBridge,
       documentRoute: {
         project: "marketing-site",
-        environment: "staging",
+        initialEnvironment: "staging",
         supportedLocales: ["en-US", "fr"],
         write: {
           canWrite: true,
@@ -441,7 +441,7 @@ test("runtime contract validators cover positive and negative shapes", () => {
         hostBridge: validHostBridge,
         documentRoute: {
           project: "marketing-site",
-          environment: "staging",
+          initialEnvironment: "staging",
           write: {
             canWrite: true,
           },

--- a/packages/shared/src/lib/contracts/extensibility.ts
+++ b/packages/shared/src/lib/contracts/extensibility.ts
@@ -128,7 +128,6 @@ export type HostBridgeV1 = {
     props: Record<string, unknown>;
     key: string;
   }) => () => void;
-  onNavigate?: (target: { environment: string }) => void;
 };
 
 export type StudioDocumentRouteWriteContext =
@@ -372,7 +371,6 @@ const hostBridgeV1Schema = z
     ),
     resolveComponent: functionSchema,
     renderMdxPreview: functionSchema,
-    onNavigate: functionSchema.optional(),
   })
   .strict();
 

--- a/packages/shared/src/lib/contracts/extensibility.ts
+++ b/packages/shared/src/lib/contracts/extensibility.ts
@@ -142,7 +142,10 @@ export type StudioDocumentRouteWriteContext =
 
 export type StudioDocumentRouteMountContext = {
   project: string;
-  environment: string;
+  /** Initial environment provided by the host app. Studio owns the active
+   *  environment after mount — use `useStudioMountInfo().environment` for the
+   *  current value at runtime. */
+  initialEnvironment: string;
   supportedLocales?: string[];
   write: StudioDocumentRouteWriteContext;
 };
@@ -543,7 +546,7 @@ const studioDocumentRouteWriteSchema = z.discriminatedUnion("canWrite", [
 const studioDocumentRouteContextSchema = z
   .object({
     project: nonEmptyStringSchema,
-    environment: nonEmptyStringSchema,
+    initialEnvironment: nonEmptyStringSchema,
     supportedLocales: z.array(nonEmptyStringSchema).optional(),
     write: studioDocumentRouteWriteSchema,
   })

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -353,8 +353,5 @@ test("recent documents include frontmatter and hasUnpublishedChanges", async () 
   if (result.status !== "loaded") return;
   assert.equal(result.data.recentDocuments.length, 1);
   assert.equal(result.data.recentDocuments[0]?.hasUnpublishedChanges, true);
-  assert.equal(
-    result.data.recentDocuments[0]?.frontmatter.title,
-    "Draft Post",
-  );
+  assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Draft Post");
 });

--- a/packages/studio/src/lib/dashboard-data.test.ts
+++ b/packages/studio/src/lib/dashboard-data.test.ts
@@ -6,6 +6,7 @@ import { test } from "bun:test";
 import { loadDashboardData } from "./dashboard-data.js";
 import type { StudioSchemaRouteApi } from "./schema-route-api.js";
 import type { StudioContentListApi } from "./content-list-api.js";
+import type { StudioContentOverviewApi } from "./content-overview-api.js";
 
 function paginatedResponse(
   total: number,
@@ -63,6 +64,22 @@ const emptySyncResult = {
   affectedTypes: [] as string[],
 };
 
+function makeOverviewApi(
+  counts: Record<string, { total: number; published: number; drafts: number }>,
+): StudioContentOverviewApi {
+  return {
+    get: async (input) =>
+      input.types.map((type) => ({
+        type,
+        total: counts[type]?.total ?? 0,
+        published: counts[type]?.published ?? 0,
+        drafts: counts[type]?.drafts ?? 0,
+      })),
+  };
+}
+
+const emptyOverviewApi = makeOverviewApi({});
+
 test("returns loaded state with real data", async () => {
   const schemaApi: StudioSchemaRouteApi = {
     list: async () => [
@@ -74,27 +91,21 @@ test("returns loaded state with real data", async () => {
 
   const contentApi: StudioContentListApi = {
     list: async (query = {}) => {
-      if (!query.type && !query.published && !query.sort)
-        return paginatedResponse(42);
-      if (!query.type && query.published === true) return paginatedResponse(30);
       if (query.sort === "updatedAt")
         return paginatedResponse(42, [
           makeDoc(),
           makeDoc({ documentId: "doc-2", path: "blog/world" }),
         ]);
-      if (query.type === "BlogPost" && !query.published)
-        return paginatedResponse(20);
-      if (query.type === "BlogPost" && query.published === true)
-        return paginatedResponse(15);
-      if (query.type === "Page" && !query.published)
-        return paginatedResponse(22);
-      if (query.type === "Page" && query.published === true)
-        return paginatedResponse(15);
       return paginatedResponse(0);
     },
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const overviewApi = makeOverviewApi({
+    BlogPost: { total: 20, published: 15, drafts: 5 },
+    Page: { total: 22, published: 15, drafts: 7 },
+  });
+
+  const result = await loadDashboardData(schemaApi, contentApi, overviewApi);
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
@@ -121,7 +132,11 @@ test("zero documents returns loaded with 0 counts, not a special empty state", a
     list: async () => paginatedResponse(0),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
@@ -142,7 +157,11 @@ test("schema types with zero documents returns loaded with type stats", async ()
     list: async () => paginatedResponse(0),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const overviewApi = makeOverviewApi({
+    BlogPost: { total: 0, published: 0, drafts: 0 },
+  });
+
+  const result = await loadDashboardData(schemaApi, contentApi, overviewApi);
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
@@ -168,7 +187,11 @@ test("returns forbidden on schema 403", async () => {
     list: async () => paginatedResponse(10),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
   assert.equal(result.status, "forbidden");
 });
 
@@ -188,7 +211,11 @@ test("returns forbidden on content 403", async () => {
     },
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
   assert.equal(result.status, "forbidden");
 });
 
@@ -208,7 +235,11 @@ test("returns forbidden on 401", async () => {
     list: async () => paginatedResponse(0),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
   assert.equal(result.status, "forbidden");
 });
 
@@ -228,7 +259,11 @@ test("returns error on 500", async () => {
     list: async () => paginatedResponse(10),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
   assert.equal(result.status, "error");
   if (result.status !== "error") return;
   assert.equal(result.message, "Schema service down");
@@ -246,7 +281,11 @@ test("returns error on network failure", async () => {
     list: async () => paginatedResponse(10),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const result = await loadDashboardData(
+    schemaApi,
+    contentApi,
+    emptyOverviewApi,
+  );
   assert.equal(result.status, "error");
   if (result.status !== "error") return;
   assert.equal(result.message, "fetch failed");
@@ -266,7 +305,16 @@ test("caps content types at 5", async () => {
     list: async () => paginatedResponse(100),
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const counts: Record<
+    string,
+    { total: number; published: number; drafts: number }
+  > = {};
+  for (let i = 0; i < 8; i++) {
+    counts[`Type${i}`] = { total: 100, published: 80, drafts: 20 };
+  }
+  const overviewApi = makeOverviewApi(counts);
+
+  const result = await loadDashboardData(schemaApi, contentApi, overviewApi);
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
@@ -295,11 +343,18 @@ test("recent documents include frontmatter and hasUnpublishedChanges", async () 
     },
   };
 
-  const result = await loadDashboardData(schemaApi, contentApi);
+  const overviewApi = makeOverviewApi({
+    BlogPost: { total: 1, published: 0, drafts: 1 },
+  });
+
+  const result = await loadDashboardData(schemaApi, contentApi, overviewApi);
 
   assert.equal(result.status, "loaded");
   if (result.status !== "loaded") return;
   assert.equal(result.data.recentDocuments.length, 1);
   assert.equal(result.data.recentDocuments[0]?.hasUnpublishedChanges, true);
-  assert.equal(result.data.recentDocuments[0]?.frontmatter.title, "Draft Post");
+  assert.equal(
+    result.data.recentDocuments[0]?.frontmatter.title,
+    "Draft Post",
+  );
 });

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -2,6 +2,7 @@ import type { SchemaRegistryEntry } from "@mdcms/shared";
 
 import type { StudioSchemaRouteApi } from "./schema-route-api.js";
 import type { StudioContentListApi } from "./content-list-api.js";
+import type { StudioContentOverviewApi } from "./content-overview-api.js";
 
 export type ContentTypeStat = {
   type: string;
@@ -35,33 +36,38 @@ export type DashboardLoadResult =
 export async function loadDashboardData(
   schemaApi: StudioSchemaRouteApi,
   contentApi: StudioContentListApi,
+  overviewApi: StudioContentOverviewApi,
 ): Promise<DashboardLoadResult> {
   try {
-    const [schemaTypes, totalResult, publishedResult, recentResult] =
-      await Promise.all([
-        schemaApi.list(),
-        contentApi.list({ draft: true, limit: 1 }),
-        contentApi.list({ published: true, limit: 1 }),
-        contentApi.list({ draft: true, sort: "updatedAt", order: "desc", limit: 5 }),
-      ]);
-
-    const totalDocuments = totalResult.pagination.total;
-    const publishedDocuments = publishedResult.pagination.total;
-    const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
+    const [schemaTypes, recentResult] = await Promise.all([
+      schemaApi.list(),
+      contentApi.list({
+        draft: true,
+        sort: "updatedAt",
+        order: "desc",
+        limit: 5,
+      }),
+    ]);
 
     const typesToShow = schemaTypes.slice(0, 5);
-    const typeStats = await Promise.all(
-      typesToShow.map(async (entry: SchemaRegistryEntry) => {
-        const [typeTotal, typePublished] = await Promise.all([
-          contentApi.list({ draft: true, type: entry.type, limit: 1 }),
-          contentApi.list({ type: entry.type, published: true, limit: 1 }),
-        ]);
+    const overviewCounts =
+      typesToShow.length > 0
+        ? await overviewApi.get({
+            types: typesToShow.map((entry) => entry.type),
+          })
+        : [];
 
-        const totalCount = typeTotal.pagination.total;
-        const publishedCount = Math.min(
-          typePublished.pagination.total,
-          totalCount,
-        );
+    let totalDocuments = 0;
+    let publishedDocuments = 0;
+
+    const typeStats: ContentTypeStat[] = typesToShow.map(
+      (entry: SchemaRegistryEntry, index: number) => {
+        const counts = overviewCounts[index];
+        const totalCount = counts?.total ?? 0;
+        const publishedCount = counts?.published ?? 0;
+
+        totalDocuments += totalCount;
+        publishedDocuments += publishedCount;
 
         return {
           type: entry.type,
@@ -70,8 +76,10 @@ export async function loadDashboardData(
           totalCount,
           publishedCount,
         };
-      }),
+      },
     );
+
+    const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
 
     return {
       status: "loaded",

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -59,6 +59,7 @@ export async function loadDashboardData(
 
     let totalDocuments = 0;
     let publishedDocuments = 0;
+    let draftDocuments = 0;
 
     const typeStats: ContentTypeStat[] = typesToShow.map(
       (entry: SchemaRegistryEntry, index: number) => {
@@ -68,6 +69,7 @@ export async function loadDashboardData(
 
         totalDocuments += totalCount;
         publishedDocuments += publishedCount;
+        draftDocuments += counts?.drafts ?? 0;
 
         return {
           type: entry.type,
@@ -78,8 +80,6 @@ export async function loadDashboardData(
         };
       },
     );
-
-    const draftDocuments = Math.max(0, totalDocuments - publishedDocuments);
 
     return {
       status: "loaded",

--- a/packages/studio/src/lib/dashboard-data.ts
+++ b/packages/studio/src/lib/dashboard-data.ts
@@ -40,9 +40,9 @@ export async function loadDashboardData(
     const [schemaTypes, totalResult, publishedResult, recentResult] =
       await Promise.all([
         schemaApi.list(),
-        contentApi.list({ limit: 1 }),
+        contentApi.list({ draft: true, limit: 1 }),
         contentApi.list({ published: true, limit: 1 }),
-        contentApi.list({ sort: "updatedAt", order: "desc", limit: 5 }),
+        contentApi.list({ draft: true, sort: "updatedAt", order: "desc", limit: 5 }),
       ]);
 
     const totalDocuments = totalResult.pagination.total;
@@ -53,7 +53,7 @@ export async function loadDashboardData(
     const typeStats = await Promise.all(
       typesToShow.map(async (entry: SchemaRegistryEntry) => {
         const [typeTotal, typePublished] = await Promise.all([
-          contentApi.list({ type: entry.type, limit: 1 }),
+          contentApi.list({ draft: true, type: entry.type, limit: 1 }),
           contentApi.list({ type: entry.type, published: true, limit: 1 }),
         ]);
 

--- a/packages/studio/src/lib/remote-studio-app.test.ts
+++ b/packages/studio/src/lib/remote-studio-app.test.ts
@@ -150,7 +150,7 @@ test("RemoteStudioApp renders only the filtered action catalog on the document r
     },
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -254,7 +254,7 @@ test("RemoteStudioApp keeps the editor route chrome truthful and width-constrain
     },
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -291,7 +291,7 @@ test("RemoteStudioApp renders the expanded admin route surfaces", () => {
     },
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: false,
         message: "Schema sync required before Studio can write drafts.",

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -521,7 +521,7 @@ export function RemoteStudioApp({
               <StudioMountInfoProvider
                 value={{
                   project: context.documentRoute?.project ?? null,
-                  environment: context.documentRoute?.environment ?? null,
+                  environment: context.documentRoute?.initialEnvironment ?? null,
                   setEnvironment: () => {},
                   apiBaseUrl: context.apiBaseUrl,
                   auth: context.auth,

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -530,7 +530,8 @@ export function RemoteStudioApp({
               <StudioMountInfoProvider
                 value={{
                   project: context.documentRoute?.project ?? null,
-                  environment: context.documentRoute?.initialEnvironment ?? null,
+                  environment:
+                    context.documentRoute?.initialEnvironment ?? null,
                   setEnvironment: () => {},
                   apiBaseUrl: context.apiBaseUrl,
                   auth: context.auth,

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -522,6 +522,7 @@ export function RemoteStudioApp({
                 value={{
                   project: context.documentRoute?.project ?? null,
                   environment: context.documentRoute?.environment ?? null,
+                  setEnvironment: () => {},
                   apiBaseUrl: context.apiBaseUrl,
                   auth: context.auth,
                   environments: [],

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -489,7 +489,9 @@ export function RemoteStudioApp({
     let resolvedHref = href;
     if (currentEnv) {
       const url = new URL(href, window.location.origin);
-      url.searchParams.set("env", currentEnv);
+      if (!url.searchParams.has("env")) {
+        url.searchParams.set("env", currentEnv);
+      }
       resolvedHref = url.pathname + url.search + url.hash;
     }
 

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -487,10 +487,10 @@ export function RemoteStudioApp({
     // Preserve the active environment query param across navigations
     const currentEnv = new URLSearchParams(window.location.search).get("env");
     let resolvedHref = href;
-    if (currentEnv && !href.includes("?")) {
-      resolvedHref = `${href}?env=${encodeURIComponent(currentEnv)}`;
-    } else if (currentEnv && href.includes("?") && !href.includes("env=")) {
-      resolvedHref = `${href}&env=${encodeURIComponent(currentEnv)}`;
+    if (currentEnv) {
+      const url = new URL(href, window.location.origin);
+      url.searchParams.set("env", currentEnv);
+      resolvedHref = url.pathname + url.search + url.hash;
     }
 
     if (mode === "replace") {

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -484,10 +484,19 @@ export function RemoteStudioApp({
       return;
     }
 
+    // Preserve the active environment query param across navigations
+    const currentEnv = new URLSearchParams(window.location.search).get("env");
+    let resolvedHref = href;
+    if (currentEnv && !href.includes("?")) {
+      resolvedHref = `${href}?env=${encodeURIComponent(currentEnv)}`;
+    } else if (currentEnv && href.includes("?") && !href.includes("env=")) {
+      resolvedHref = `${href}&env=${encodeURIComponent(currentEnv)}`;
+    }
+
     if (mode === "replace") {
-      window.history.replaceState(null, "", href);
+      window.history.replaceState(null, "", resolvedHref);
     } else {
-      window.history.pushState(null, "", href);
+      window.history.pushState(null, "", resolvedHref);
     }
 
     setPathname(window.location.pathname);

--- a/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
@@ -1,27 +1,18 @@
 import { Terminal } from "lucide-react";
 import { ComingSoon } from "../../components/coming-soon.js";
-import {
-  PageHeader,
-  PageHeaderHeading,
-  PageHeaderDescription,
-} from "../../components/layout/page-header.js";
+import { PageHeader } from "../../components/layout/page-header.js";
 
 export default function ApiPlaygroundPage() {
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader>
-        <div>
-          <PageHeaderHeading>API Playground</PageHeaderHeading>
-          <PageHeaderDescription>
-            Explore your content API
-          </PageHeaderDescription>
-        </div>
-      </PageHeader>
-      <ComingSoon
-        icon={Terminal}
-        title="API Playground"
-        description="An interactive environment for testing and exploring your content API endpoints."
-      />
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "API" }]} />
+      <div className="p-6">
+        <ComingSoon
+          icon={Terminal}
+          title="API Playground"
+          description="An interactive environment for testing and exploring your content API endpoints."
+        />
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/api-page.tsx
@@ -13,21 +13,14 @@ export default function ApiPlaygroundPage() {
         <div>
           <PageHeaderHeading>API Playground</PageHeaderHeading>
           <PageHeaderDescription>
-            Explore and test your content API endpoints
+            Explore your content API
           </PageHeaderDescription>
         </div>
       </PageHeader>
       <ComingSoon
         icon={Terminal}
         title="API Playground"
-        description="Test and explore your content API with an interactive playground. Generate queries, preview responses, and create code snippets for your applications."
-        features={[
-          "Interactive GraphQL and REST explorer",
-          "Auto-generated query builder",
-          "Response previews with syntax highlighting",
-          "Code generation for popular frameworks",
-          "API key management and testing",
-        ]}
+        description="An interactive environment for testing and exploring your content API endpoints."
       />
     </div>
   );

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -12,7 +12,6 @@ import {
   Trash2,
   Send,
   FileText,
-  Loader2,
   AlertCircle,
   ShieldAlert,
   ArrowUpFromLine,
@@ -52,6 +51,7 @@ import {
   PaginationPrevious,
 } from "../../../../components/ui/pagination.js";
 import { PageHeader } from "../../../../components/layout/page-header.js";
+import { Skeleton } from "../../../../components/ui/skeleton.js";
 import { cn } from "../../../../lib/utils.js";
 import { useAdminCapabilities } from "../../capabilities-context.js";
 import { useStudioMountInfo } from "../../mount-info-context.js";
@@ -121,9 +121,20 @@ export default function ContentTypePage() {
   const toast = useToast();
   const [searchInput, setSearchInput] = useState("");
   const [rowActionError, setRowActionError] = useState<string | null>(null);
+  const [showLoading, setShowLoading] = useState(false);
 
   const list = useContentTypeList(typeId);
   const create = useCreateDocument(typeId);
+
+  // Debounce loading skeleton by 200ms
+  useEffect(() => {
+    if (list.status !== "loading") {
+      setShowLoading(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowLoading(true), 200);
+    return () => clearTimeout(timer);
+  }, [list.status]);
 
   // Debounced search
   useEffect(() => {
@@ -434,9 +445,28 @@ export default function ContentTypePage() {
         )}
 
         {/* Content area */}
-        {list.status === "loading" && (
-          <div className="flex items-center justify-center py-16">
-            <Loader2 className="h-6 w-6 animate-spin text-foreground-muted" />
+        {list.status === "loading" && showLoading && (
+          <div className="rounded-lg border border-border">
+            <div className="border-b border-border px-4 py-3 flex gap-4">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-16 ml-auto" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 border-b border-border px-4 py-3 last:border-b-0"
+              >
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+                <Skeleton className="h-5 w-16 rounded-full" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-6 w-6 rounded-full" />
+              </div>
+            ))}
           </div>
         )}
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
@@ -20,7 +20,7 @@ function createContext(): StudioMountContext {
     },
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -78,6 +78,9 @@ export default function AdminLayout({
   const [canDeleteContent, setCanDeleteContent] = useState(false);
   const [canManageUsers, setCanManageUsers] = useState(false);
   const [canManageSettings, setCanManageSettings] = useState(false);
+  const [activeEnvironment, setActiveEnvironment] = useState<string | null>(
+    context.documentRoute?.environment ?? null,
+  );
   const [sessionState, setSessionState] = useState<StudioSessionState>({
     status: "loading",
   });
@@ -93,7 +96,18 @@ export default function AdminLayout({
 
   // Fetch capabilities
   useEffect(() => {
-    const loadInput = createAdminLayoutCapabilitiesLoadInput(context);
+    const project = context.documentRoute?.project;
+    const loadInput =
+      project && activeEnvironment
+        ? {
+            config: {
+              project,
+              environment: activeEnvironment,
+              serverUrl: context.apiBaseUrl,
+            },
+            auth: context.auth,
+          }
+        : null;
 
     if (!loadInput) {
       setCanReadSchema(false);
@@ -144,7 +158,7 @@ export default function AdminLayout({
     context.apiBaseUrl,
     context.auth.mode,
     context.auth.token,
-    context.documentRoute?.environment,
+    activeEnvironment,
     context.documentRoute?.project,
   ]);
 
@@ -196,17 +210,21 @@ export default function AdminLayout({
 
   // Fetch environments
   useEffect(() => {
-    const capLoadInput = createAdminLayoutCapabilitiesLoadInput(context);
-
-    if (!capLoadInput) {
+    const project = context.documentRoute?.project;
+    if (!project || !activeEnvironment) {
       setEnvironments([]);
       return;
     }
 
     let cancelled = false;
-    const envApi = createStudioEnvironmentApi(capLoadInput.config, {
-      auth: capLoadInput.auth,
-    });
+    const envApi = createStudioEnvironmentApi(
+      {
+        project,
+        environment: activeEnvironment,
+        serverUrl: context.apiBaseUrl,
+      },
+      { auth: context.auth },
+    );
 
     void envApi
       .list()
@@ -228,7 +246,7 @@ export default function AdminLayout({
     context.apiBaseUrl,
     context.auth.mode,
     context.auth.token,
-    context.documentRoute?.environment,
+    activeEnvironment,
     context.documentRoute?.project,
   ]);
 
@@ -282,7 +300,8 @@ export default function AdminLayout({
 
   const mountInfo = {
     project: context.documentRoute?.project ?? null,
-    environment: context.documentRoute?.environment ?? null,
+    environment: activeEnvironment,
+    setEnvironment: setActiveEnvironment,
     apiBaseUrl: context.apiBaseUrl,
     auth: context.auth,
     environments,

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -46,7 +46,7 @@ export function createAdminLayoutCapabilitiesLoadInput(
   return {
     config: {
       project: route.project,
-      environment: route.environment,
+      environment: route.initialEnvironment,
       serverUrl: context.apiBaseUrl,
     },
     auth: context.auth,
@@ -86,7 +86,7 @@ export default function AdminLayout({
         );
         if (fromQuery) return fromQuery;
       }
-      return context.documentRoute?.environment ?? null;
+      return context.documentRoute?.initialEnvironment ?? null;
     },
   );
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { StudioMountContext, EnvironmentSummary } from "@mdcms/shared";
 
@@ -78,9 +78,26 @@ export default function AdminLayout({
   const [canDeleteContent, setCanDeleteContent] = useState(false);
   const [canManageUsers, setCanManageUsers] = useState(false);
   const [canManageSettings, setCanManageSettings] = useState(false);
-  const [activeEnvironment, setActiveEnvironment] = useState<string | null>(
-    context.documentRoute?.environment ?? null,
+  const [activeEnvironment, setActiveEnvironmentRaw] = useState<string | null>(
+    () => {
+      if (typeof window !== "undefined") {
+        const fromQuery = new URLSearchParams(window.location.search).get(
+          "env",
+        );
+        if (fromQuery) return fromQuery;
+      }
+      return context.documentRoute?.environment ?? null;
+    },
   );
+
+  const setActiveEnvironment = useCallback((env: string) => {
+    setActiveEnvironmentRaw(env);
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      url.searchParams.set("env", env);
+      window.history.replaceState(null, "", url.toString());
+    }
+  }, []);
   const [sessionState, setSessionState] = useState<StudioSessionState>({
     status: "loading",
   });

--- a/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
@@ -1,157 +1,29 @@
 "use client";
 
+import { Image } from "lucide-react";
+import { ComingSoon } from "../../components/coming-soon.js";
 import {
-  Image,
-  Folder,
-  Search,
-  Upload,
-  FileImage,
-  FileVideo,
-  FileAudio,
-  File,
-} from "lucide-react";
-import { Badge } from "../../components/ui/badge.js";
-import { PageHeader } from "../../components/layout/page-header.js";
-
-// Mock media items for the ghosted preview
-const mockMediaItems = [
-  { id: "1", type: "image", name: "hero-banner.jpg" },
-  { id: "2", type: "image", name: "team-photo.png" },
-  { id: "3", type: "video", name: "product-demo.mp4" },
-  { id: "4", type: "image", name: "logo-dark.svg" },
-  { id: "5", type: "image", name: "blog-cover.jpg" },
-  { id: "6", type: "audio", name: "podcast-ep1.mp3" },
-  { id: "7", type: "image", name: "avatar-1.png" },
-  { id: "8", type: "image", name: "avatar-2.png" },
-  { id: "9", type: "document", name: "guide.pdf" },
-  { id: "10", type: "image", name: "feature-1.jpg" },
-  { id: "11", type: "image", name: "feature-2.jpg" },
-  { id: "12", type: "image", name: "feature-3.jpg" },
-];
-
-const mockFolders = [
-  { id: "1", name: "Images", count: 156 },
-  { id: "2", name: "Videos", count: 23 },
-  { id: "3", name: "Documents", count: 45 },
-  { id: "4", name: "Audio", count: 12 },
-];
-
-const getFileIcon = (type: string) => {
-  switch (type) {
-    case "image":
-      return FileImage;
-    case "video":
-      return FileVideo;
-    case "audio":
-      return FileAudio;
-    default:
-      return File;
-  }
-};
+  PageHeader,
+  PageHeaderHeading,
+  PageHeaderDescription,
+} from "../../components/layout/page-header.js";
 
 export default function MediaPage() {
   return (
-    <div className="min-h-screen">
-      <PageHeader breadcrumbs={[{ label: "Media" }]} />
-
-      <div className="flex flex-col items-center justify-center px-6 py-16">
-        {/* Coming Soon Content */}
-        <div className="text-center max-w-lg mx-auto mb-12">
-          <div className="mb-6 flex justify-center">
-            <div className="rounded-full bg-accent/10 p-4">
-              <Image className="h-16 w-16 text-foreground-muted" />
-            </div>
-          </div>
-
-          <div className="flex items-center justify-center gap-3 mb-4">
-            <h1 className="text-2xl font-semibold">Media Library</h1>
-            <Badge variant="outline" className="border-accent text-accent">
-              Coming Soon
-            </Badge>
-          </div>
-
-          <p className="text-sm text-foreground-muted leading-relaxed">
-            Browse, search, tag, and organize all your media files in one place.
-            Reuse assets across documents with a powerful media management
-            system.
-          </p>
+    <div className="flex flex-col gap-6">
+      <PageHeader>
+        <div>
+          <PageHeaderHeading>Media</PageHeaderHeading>
+          <PageHeaderDescription>
+            Media management for your content
+          </PageHeaderDescription>
         </div>
-
-        {/* Ghosted Preview Mockup */}
-        <div className="w-full max-w-5xl relative">
-          {/* Blur overlay */}
-          <div className="absolute inset-0 bg-background/60 backdrop-blur-sm z-10 rounded-lg" />
-
-          {/* Mockup content */}
-          <div className="rounded-lg border border-border overflow-hidden opacity-40">
-            {/* Toolbar */}
-            <div className="flex items-center justify-between border-b border-border bg-background-subtle p-3">
-              <div className="flex items-center gap-3">
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-muted" />
-                  <div className="h-9 w-64 rounded-md border border-border bg-background pl-9" />
-                </div>
-              </div>
-              <div className="flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-white text-sm">
-                <Upload className="h-4 w-4" />
-                Upload
-              </div>
-            </div>
-
-            {/* Main content */}
-            <div className="flex">
-              {/* Folder sidebar */}
-              <div className="w-48 border-r border-border bg-background p-3 space-y-1">
-                {mockFolders.map((folder) => (
-                  <div
-                    key={folder.id}
-                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-                  >
-                    <Folder className="h-4 w-4 text-foreground-muted" />
-                    <span className="flex-1">{folder.name}</span>
-                    <span className="text-xs text-foreground-muted">
-                      {folder.count}
-                    </span>
-                  </div>
-                ))}
-              </div>
-
-              {/* Media grid */}
-              <div className="flex-1 p-4">
-                <div className="grid grid-cols-4 gap-4">
-                  {mockMediaItems.map((item) => {
-                    const IconComponent = getFileIcon(item.type);
-                    return (
-                      <div
-                        key={item.id}
-                        className="aspect-square rounded-lg border border-border bg-background-subtle flex flex-col items-center justify-center p-4"
-                      >
-                        <IconComponent className="h-8 w-8 text-foreground-muted mb-2" />
-                        <span className="text-xs text-foreground-muted truncate w-full text-center">
-                          {item.name}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* GitHub link */}
-        <p className="mt-8 text-sm text-foreground-muted">
-          Want to help build this?{" "}
-          <a
-            href="https://github.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:underline inline-flex items-center gap-1"
-          >
-            Contribute on GitHub
-          </a>
-        </p>
-      </div>
+      </PageHeader>
+      <ComingSoon
+        icon={Image}
+        title="Media Library"
+        description="A dedicated space for managing images, files, and other media assets used across your content."
+      />
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/media-page.tsx
@@ -2,28 +2,19 @@
 
 import { Image } from "lucide-react";
 import { ComingSoon } from "../../components/coming-soon.js";
-import {
-  PageHeader,
-  PageHeaderHeading,
-  PageHeaderDescription,
-} from "../../components/layout/page-header.js";
+import { PageHeader } from "../../components/layout/page-header.js";
 
 export default function MediaPage() {
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader>
-        <div>
-          <PageHeaderHeading>Media</PageHeaderHeading>
-          <PageHeaderDescription>
-            Media management for your content
-          </PageHeaderDescription>
-        </div>
-      </PageHeader>
-      <ComingSoon
-        icon={Image}
-        title="Media Library"
-        description="A dedicated space for managing images, files, and other media assets used across your content."
-      />
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Media" }]} />
+      <div className="p-6">
+        <ComingSoon
+          icon={Image}
+          title="Media Library"
+          description="A dedicated space for managing images, files, and other media assets used across your content."
+        />
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -46,3 +46,20 @@ export function StudioMountInfoProvider({
 export function useStudioMountInfo(): StudioMountInfo {
   return useContext(StudioMountInfoContext);
 }
+
+export type StudioApiConfig = {
+  config: { project: string; environment: string; serverUrl: string };
+  authOptions: { auth: StudioMountContext["auth"] };
+};
+
+/** Centralized API config derived from the active environment. All
+ *  environment-scoped API calls should use this instead of constructing
+ *  config objects manually, so the active environment is never stale. */
+export function useStudioApiConfig(): StudioApiConfig | null {
+  const { project, environment, apiBaseUrl, auth } = useStudioMountInfo();
+  if (!project || !environment) return null;
+  return {
+    config: { project, environment, serverUrl: apiBaseUrl },
+    authOptions: { auth },
+  };
+}

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { createContext, useContext, type PropsWithChildren } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type PropsWithChildren,
+} from "react";
 
 import type {
   EnvironmentSummary,
@@ -57,9 +62,11 @@ export type StudioApiConfig = {
  *  config objects manually, so the active environment is never stale. */
 export function useStudioApiConfig(): StudioApiConfig | null {
   const { project, environment, apiBaseUrl, auth } = useStudioMountInfo();
-  if (!project || !environment) return null;
-  return {
-    config: { project, environment, serverUrl: apiBaseUrl },
-    authOptions: { auth },
-  };
+  return useMemo(() => {
+    if (!project || !environment) return null;
+    return {
+      config: { project, environment, serverUrl: apiBaseUrl },
+      authOptions: { auth },
+    };
+  }, [project, environment, apiBaseUrl, auth]);
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/mount-info-context.tsx
@@ -11,6 +11,7 @@ import type {
 export type StudioMountInfo = {
   project: string | null;
   environment: string | null;
+  setEnvironment: (environment: string) => void;
   apiBaseUrl: string;
   auth: StudioMountContext["auth"];
   environments: EnvironmentSummary[];
@@ -21,6 +22,7 @@ export type StudioMountInfo = {
 const DEFAULT_MOUNT_INFO: StudioMountInfo = {
   project: null,
   environment: null,
+  setEnvironment: () => {},
   apiBaseUrl: "",
   auth: { mode: "cookie" },
   environments: [],

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -33,7 +33,10 @@ import {
   type DashboardLoadResult,
 } from "../../../dashboard-data.js";
 
-type DashboardState = { status: "loading" } | DashboardLoadResult;
+type DashboardState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | DashboardLoadResult;
 
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
@@ -65,7 +68,7 @@ export default function DashboardPage() {
   const session = useStudioSession();
   const mountInfo = useStudioMountInfo();
   const { canCreateContent } = useAdminCapabilities();
-  const [state, setState] = useState<DashboardState>({ status: "loading" });
+  const [state, setState] = useState<DashboardState>({ status: "idle" });
 
   useEffect(() => {
     const { project, environment, apiBaseUrl, auth } = mountInfo;
@@ -125,6 +128,14 @@ export default function DashboardPage() {
     session.status === "authenticated"
       ? deriveUserLabel(session.session.email)
       : null;
+
+  if (state.status === "idle") {
+    return (
+      <div className="min-h-screen">
+        <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
+      </div>
+    );
+  }
 
   if (state.status === "loading") {
     return (

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -9,7 +9,6 @@ import {
   Plus,
   ChevronRight,
   Clock,
-  Loader2,
   AlertCircle,
   ShieldAlert,
 } from "lucide-react";
@@ -21,6 +20,7 @@ import {
   CardTitle,
 } from "../../components/ui/card.js";
 import { Badge } from "../../components/ui/badge.js";
+import { Skeleton } from "../../components/ui/skeleton.js";
 import { PageHeader } from "../../components/layout/page-header.js";
 import { useStudioSession } from "./session-context.js";
 import { useStudioMountInfo } from "./mount-info-context.js";
@@ -122,8 +122,58 @@ export default function DashboardPage() {
     return (
       <div className="min-h-screen">
         <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
-        <div className="flex items-center justify-center p-24">
-          <Loader2 className="h-6 w-6 animate-spin text-foreground-muted" />
+        <div className="p-6 space-y-6">
+          <div>
+            <Skeleton className="h-8 w-40" />
+            <Skeleton className="mt-2 h-4 w-56" />
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Card key={i} className="border-border py-0 gap-0">
+                <CardContent className="p-4">
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-8 w-16" />
+                    <Skeleton className="h-3 w-28" />
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card className="border-border">
+              <CardHeader className="pb-2">
+                <Skeleton className="h-5 w-24" />
+              </CardHeader>
+              <CardContent className="space-y-1">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-4 p-3">
+                    <Skeleton className="h-10 w-10 rounded-md" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-28" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+            <Card className="border-border">
+              <CardHeader className="pb-2">
+                <Skeleton className="h-5 w-32" />
+              </CardHeader>
+              <CardContent className="space-y-1">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-start gap-3 p-2">
+                    <Skeleton className="h-8 w-8 rounded-md" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-36" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </div>
     );

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -75,9 +75,14 @@ export default function DashboardPage() {
       return;
     }
 
-    setState({ status: "loading" });
-
     let cancelled = false;
+
+    // Delay showing the skeleton by 200ms — if data arrives faster the
+    // user never sees a loading flash.
+    const loadingTimer = setTimeout(() => {
+      if (!cancelled) setState({ status: "loading" });
+    }, 200);
+
     const config = { project, environment, serverUrl: apiBaseUrl };
     const authOpts = { auth };
 
@@ -88,11 +93,13 @@ export default function DashboardPage() {
     loadDashboardData(schemaApi, contentApi, overviewApi)
       .then((result) => {
         if (!cancelled) {
+          clearTimeout(loadingTimer);
           setState(result);
         }
       })
       .catch((err) => {
         if (!cancelled) {
+          clearTimeout(loadingTimer);
           setState({
             status: "error",
             message:
@@ -105,6 +112,7 @@ export default function DashboardPage() {
 
     return () => {
       cancelled = true;
+      clearTimeout(loadingTimer);
     };
   }, [
     mountInfo.project,

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -338,11 +338,12 @@ export default function DashboardPage() {
                   No documents yet.
                 </p>
               ) : (
-                <div className="space-y-4">
+                <div className="space-y-1">
                   {data.recentDocuments.map((doc) => (
-                    <div
+                    <Link
                       key={doc.documentId}
-                      className="flex items-start gap-3"
+                      href={`/admin/content/${doc.type}/${doc.documentId}`}
+                      className="flex items-start gap-3 rounded-lg p-2 transition-colors hover:bg-background-subtle"
                     >
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent/10">
                         <FileText className="h-4 w-4 text-accent" />
@@ -369,7 +370,7 @@ export default function DashboardPage() {
                         <Clock className="h-3 w-3" />
                         {formatRelativeTime(doc.updatedAt)}
                       </span>
-                    </div>
+                    </Link>
                   ))}
                 </div>
               )}

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -27,6 +27,7 @@ import { useStudioMountInfo } from "./mount-info-context.js";
 import { useAdminCapabilities } from "./capabilities-context.js";
 import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioContentListApi } from "../../../content-list-api.js";
+import { createStudioContentOverviewApi } from "../../../content-overview-api.js";
 import {
   loadDashboardData,
   type DashboardLoadResult,
@@ -82,8 +83,9 @@ export default function DashboardPage() {
 
     const schemaApi = createStudioSchemaRouteApi(config, authOpts);
     const contentApi = createStudioContentListApi(config, authOpts);
+    const overviewApi = createStudioContentOverviewApi(config, authOpts);
 
-    loadDashboardData(schemaApi, contentApi)
+    loadDashboardData(schemaApi, contentApi, overviewApi)
       .then((result) => {
         if (!cancelled) {
           setState(result);

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -248,11 +248,11 @@ export default function DashboardPage() {
 
         {/* Content Types & Recent Documents */}
         <div className="grid gap-6 lg:grid-cols-2">
-          {/* Content Types */}
+          {/* Content */}
           <Card className="border-border">
-            <CardHeader className="flex flex-row items-center justify-between pb-4">
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
               <CardTitle className="text-lg font-semibold">
-                Content Types
+                Content
               </CardTitle>
               <Link
                 href="/admin/content"
@@ -261,7 +261,7 @@ export default function DashboardPage() {
                 View all <ChevronRight className="h-4 w-4" />
               </Link>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-1">
               {data.contentTypes.length === 0 ? (
                 <p className="text-sm text-foreground-muted py-4 text-center">
                   No schema types synced yet.
@@ -323,7 +323,7 @@ export default function DashboardPage() {
           <Card className="border-border">
             <CardHeader className="flex flex-row items-center justify-between pb-4">
               <CardTitle className="text-lg font-semibold">
-                Recently Updated
+                Recently updated
               </CardTitle>
               <Link
                 href="/admin/content"

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -74,7 +74,6 @@ export default function DashboardPage() {
     const { project, environment, apiBaseUrl, auth } = mountInfo;
 
     if (!project || !environment || !apiBaseUrl) {
-      setState({ status: "loading" });
       return;
     }
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -319,11 +319,11 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          {/* Recent Documents */}
+          {/* Recently Updated */}
           <Card className="border-border">
             <CardHeader className="flex flex-row items-center justify-between pb-4">
               <CardTitle className="text-lg font-semibold">
-                Recent Documents
+                Recently Updated
               </CardTitle>
               <Link
                 href="/admin/content"

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -309,9 +309,7 @@ export default function DashboardPage() {
           {/* Content */}
           <Card className="border-border">
             <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-lg font-semibold">
-                Content
-              </CardTitle>
+              <CardTitle className="text-lg font-semibold">Content</CardTitle>
               <Link
                 href="/admin/content"
                 className="text-sm text-foreground-muted hover:text-accent flex items-center gap-1"

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.test.tsx
@@ -55,7 +55,7 @@ test("createSchemaPageLoadInput maps the mounted project and environment", () =>
     },
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: false,
         message: "Schema sync required before Studio can write drafts.",

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
@@ -101,6 +101,7 @@ function renderConstraintSummary(field: SchemaFieldSnapshot): ReactNode {
   );
 }
 
+/** Maps a StudioMountContext to a schema load input. Exported for tests. */
 export function createSchemaPageLoadInput(
   context: StudioMountContext,
 ): SchemaPageLoadInput | null {

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
@@ -113,7 +113,7 @@ export function createSchemaPageLoadInput(
   return {
     config: {
       project: route.project,
-      environment: route.environment,
+      environment: route.initialEnvironment,
       serverUrl: context.apiBaseUrl,
     },
     auth: context.auth,

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import type { SchemaRegistryEntry, StudioMountContext } from "@mdcms/shared";
 
+import { useStudioMountInfo } from "./mount-info-context.js";
 import {
   createStudioSchemaLoadingState,
   loadStudioSchemaState,
@@ -290,17 +291,25 @@ export default function SchemaPage({
 }: {
   context: StudioMountContext;
 }) {
+  const mountInfo = useStudioMountInfo();
   const [state, setState] = useState<StudioSchemaState>(() =>
     createSchemaPageLoadingState(),
   );
 
   useEffect(() => {
-    const loadInput = createSchemaPageLoadInput(context);
-
-    if (!loadInput) {
+    if (!mountInfo.project || !mountInfo.environment) {
       setState(createSchemaPageMissingRouteState());
       return;
     }
+
+    const loadInput: SchemaPageLoadInput = {
+      config: {
+        project: mountInfo.project,
+        environment: mountInfo.environment,
+        serverUrl: mountInfo.apiBaseUrl,
+      },
+      auth: mountInfo.auth,
+    };
 
     let active = true;
     setState(createSchemaPageLoadingState());
@@ -331,10 +340,10 @@ export default function SchemaPage({
       active = false;
     };
   }, [
-    context.apiBaseUrl,
-    context.auth,
-    context.documentRoute?.environment,
-    context.documentRoute?.project,
+    mountInfo.apiBaseUrl,
+    mountInfo.auth,
+    mountInfo.environment,
+    mountInfo.project,
   ]);
 
   return <SchemaPageView state={state} />;

--- a/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
@@ -1,27 +1,18 @@
 import { GitBranch } from "lucide-react";
 import { ComingSoon } from "../../components/coming-soon.js";
-import {
-  PageHeader,
-  PageHeaderHeading,
-  PageHeaderDescription,
-} from "../../components/layout/page-header.js";
+import { PageHeader } from "../../components/layout/page-header.js";
 
 export default function WorkflowsPage() {
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader>
-        <div>
-          <PageHeaderHeading>Workflows</PageHeaderHeading>
-          <PageHeaderDescription>
-            Content review and publishing workflows
-          </PageHeaderDescription>
-        </div>
-      </PageHeader>
-      <ComingSoon
-        icon={GitBranch}
-        title="Workflows"
-        description="Define review and approval steps for your content before it gets published."
-      />
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Workflows" }]} />
+      <div className="p-6">
+        <ComingSoon
+          icon={GitBranch}
+          title="Workflows"
+          description="Define review and approval steps for your content before it gets published."
+        />
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/workflows-page.tsx
@@ -13,21 +13,14 @@ export default function WorkflowsPage() {
         <div>
           <PageHeaderHeading>Workflows</PageHeaderHeading>
           <PageHeaderDescription>
-            Automate content review and publishing processes
+            Content review and publishing workflows
           </PageHeaderDescription>
         </div>
       </PageHeader>
       <ComingSoon
         icon={GitBranch}
         title="Workflows"
-        description="Create automated content workflows with approval chains, scheduled publishing, and custom triggers to streamline your editorial process."
-        features={[
-          "Multi-step approval workflows",
-          "Role-based review assignments",
-          "Scheduled content publishing",
-          "Webhook triggers and notifications",
-          "Audit trail and compliance tracking",
-        ]}
+        description="Define review and approval steps for your content before it gets published."
       />
     </div>
   );

--- a/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { LucideIcon } from "lucide-react";
-import { Card, CardContent } from "./ui/card.js";
 import { Badge } from "./ui/badge.js";
 
 interface ComingSoonProps {
@@ -12,32 +11,37 @@ interface ComingSoonProps {
 
 export function ComingSoon({ icon: Icon, title, description }: ComingSoonProps) {
   return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <Card className="max-w-lg border-dashed">
-        <CardContent className="flex flex-col items-center py-12 text-center">
-          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-            <Icon className="h-8 w-8 text-muted-foreground" />
-          </div>
-          <Badge variant="secondary" className="mb-4">
-            Coming Soon
-          </Badge>
-          <h2 className="mb-2 text-2xl font-semibold tracking-tight">
-            {title}
-          </h2>
-          <p className="mb-6 max-w-sm text-muted-foreground">{description}</p>
-          <p className="text-sm text-muted-foreground">
-            Want to help build this?{" "}
-            <a
-              href="https://github.com/blazity/mdcms"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:underline"
-            >
-              Contribute on GitHub
-            </a>
-          </p>
-        </CardContent>
-      </Card>
+    <div className="relative flex flex-col items-center justify-center py-24">
+      {/* Large watermark icon */}
+      <Icon className="absolute h-64 w-64 text-foreground/[0.02] pointer-events-none" />
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col items-center text-center max-w-md">
+        <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-lg bg-accent/10">
+          <Icon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+        <Badge
+          variant="outline"
+          className="mt-4 font-normal text-muted-foreground"
+        >
+          Coming soon
+        </Badge>
+        <p className="mt-6 text-xs text-muted-foreground/60">
+          Want to help build this?{" "}
+          <a
+            href="https://github.com/blazity/mdcms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent/70 hover:text-accent hover:underline"
+          >
+            Contribute on GitHub
+          </a>
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
@@ -9,7 +9,11 @@ interface ComingSoonProps {
   description: string;
 }
 
-export function ComingSoon({ icon: Icon, title, description }: ComingSoonProps) {
+export function ComingSoon({
+  icon: Icon,
+  title,
+  description,
+}: ComingSoonProps) {
   return (
     <div className="relative flex flex-col items-center justify-center py-24">
       {/* Large watermark icon */}

--- a/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/coming-soon.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { LucideIcon } from "lucide-react";
-import { Button } from "./ui/button.js";
 import { Card, CardContent } from "./ui/card.js";
 import { Badge } from "./ui/badge.js";
 
@@ -9,15 +8,9 @@ interface ComingSoonProps {
   icon: LucideIcon;
   title: string;
   description: string;
-  features?: string[];
 }
 
-export function ComingSoon({
-  icon: Icon,
-  title,
-  description,
-  features,
-}: ComingSoonProps) {
+export function ComingSoon({ icon: Icon, title, description }: ComingSoonProps) {
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
       <Card className="max-w-lg border-dashed">
@@ -32,22 +25,17 @@ export function ComingSoon({
             {title}
           </h2>
           <p className="mb-6 max-w-sm text-muted-foreground">{description}</p>
-          {features && features.length > 0 && (
-            <div className="mb-6 text-left">
-              <p className="mb-2 text-sm font-medium">Planned features:</p>
-              <ul className="space-y-1 text-sm text-muted-foreground">
-                {features.map((feature, index) => (
-                  <li key={index} className="flex items-center gap-2">
-                    <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                    {feature}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          <Button variant="outline" disabled>
-            Notify Me When Available
-          </Button>
+          <p className="text-sm text-muted-foreground">
+            Want to help build this?{" "}
+            <a
+              href="https://github.com/blazity/mdcms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              Contribute on GitHub
+            </a>
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -141,7 +141,6 @@ export function AppSidebar({
               );
             })}
           </ul>
-
         </nav>
 
         {/* Bottom Section */}

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -16,30 +16,19 @@ import {
   Settings,
   Trash2,
   FolderInput,
-  Sparkles,
-  Calendar,
-  Shield,
-  Search,
+  Terminal,
   ChevronsLeft,
   ChevronsRight,
-  ChevronDown,
 } from "lucide-react";
 import { cn } from "../../lib/utils.js";
 import { Button } from "../ui/button.js";
-import { Badge } from "../ui/badge.js";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip.js";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "../ui/collapsible.js";
 import { MDCMSLogo } from "../mdcms-logo.js";
-import { useState } from "react";
 
 interface AppSidebarProps {
   canReadSchema?: boolean;
@@ -57,8 +46,8 @@ const mainNavItems = [
   { icon: FolderInput, label: "Schema", href: "/admin/schema" },
   { icon: Users, label: "Users", href: "/admin/users" },
   { icon: Settings, label: "Settings", href: "/admin/settings" },
-  { icon: Sparkles, label: "Workflows", href: "/admin/workflows" },
-  { icon: Search, label: "API", href: "/admin/api" },
+  { icon: GitBranch, label: "Workflows", href: "/admin/workflows" },
+  { icon: Terminal, label: "API", href: "/admin/api" },
   { icon: Trash2, label: "Trash", href: "/admin/trash" },
 ];
 
@@ -75,12 +64,6 @@ function getMainNavItems(filters: {
   });
 }
 
-const comingSoonItems = [
-  { icon: Calendar, label: "Scheduled" },
-  { icon: Shield, label: "Audit Log" },
-  { icon: Search, label: "SEO Analysis" },
-];
-
 export function AppSidebar({
   canReadSchema,
   canManageUsers,
@@ -94,8 +77,6 @@ export function AppSidebar({
   const effectiveCanReadSchema = canReadSchema ?? contextCanReadSchema;
   const effectiveCanManageUsers = canManageUsers ?? false;
   const effectiveCanManageSettings = canManageSettings ?? false;
-  const [comingSoonOpen, setComingSoonOpen] = useState(false);
-
   return (
     <TooltipProvider delayDuration={0}>
       <aside
@@ -161,68 +142,6 @@ export function AppSidebar({
             })}
           </ul>
 
-          {/* Separator */}
-          <div className="my-4 h-px bg-border" />
-
-          {/* Coming Soon Section */}
-          {collapsed ? (
-            <ul className="space-y-1">
-              {comingSoonItems.map((item) => (
-                <li key={item.label}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Link
-                        href="#"
-                        className="flex h-10 items-center justify-center rounded-md text-foreground-muted/60 hover:bg-background-subtle hover:text-foreground-muted"
-                        onClick={(event) => event.preventDefault()}
-                      >
-                        <item.icon className="h-5 w-5" />
-                      </Link>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">
-                      {item.label} (Coming soon)
-                    </TooltipContent>
-                  </Tooltip>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <Collapsible open={comingSoonOpen} onOpenChange={setComingSoonOpen}>
-              <CollapsibleTrigger asChild>
-                <button className="flex w-full items-center justify-between px-3 py-2 text-xs font-medium uppercase tracking-wider text-foreground-muted hover:text-foreground">
-                  <span>Coming Soon</span>
-                  <ChevronDown
-                    className={cn(
-                      "h-4 w-4 transition-transform",
-                      comingSoonOpen && "rotate-180",
-                    )}
-                  />
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <ul className="space-y-1 pt-1">
-                  {comingSoonItems.map((item) => (
-                    <li key={item.label}>
-                      <Link
-                        href="#"
-                        className="flex h-10 items-center gap-3 rounded-md px-3 text-sm text-foreground-muted/60 hover:bg-background-subtle hover:text-foreground-muted"
-                        onClick={(event) => event.preventDefault()}
-                      >
-                        <item.icon className="h-5 w-5 shrink-0" />
-                        <span className="flex-1">{item.label}</span>
-                        <Badge
-                          variant="outline"
-                          className="h-5 px-1.5 text-[10px] font-normal"
-                        >
-                          Soon
-                        </Badge>
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CollapsibleContent>
-            </Collapsible>
-          )}
         </nav>
 
         {/* Bottom Section */}

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useTheme } from "../../adapters/next-themes.js";
 import Link from "../../adapters/next-link.js";
-import { Sun, Moon, ChevronRight, LogOut, User, Settings } from "lucide-react";
+import { Sun, Moon, ChevronRight, LogOut } from "lucide-react";
 import { Button } from "../ui/button.js";
 import { Avatar, AvatarFallback } from "../ui/avatar.js";
 import {
@@ -245,17 +245,8 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                   </div>
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem>
-                  <User className="mr-2 h-4 w-4" />
-                  Profile
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Settings className="mr-2 h-4 w-4" />
-                  Preferences
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  className="text-destructive focus:text-destructive"
+                  className="text-destructive focus:bg-destructive/10 focus:text-destructive"
                   onClick={handleSignOut}
                 >
                   <LogOut className="mr-2 h-4 w-4" />

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -245,10 +245,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                   </div>
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  variant="destructive"
-                  onClick={handleSignOut}
-                >
+                <DropdownMenuItem variant="destructive" onClick={handleSignOut}>
                   <LogOut className="mr-2 h-4 w-4" />
                   Sign out
                 </DropdownMenuItem>

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -246,7 +246,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+                  variant="destructive"
                   onClick={handleSignOut}
                 >
                   <LogOut className="mr-2 h-4 w-4" />

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -166,7 +166,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
   };
 
   const handleEnvironmentChange = (environmentName: string) => {
-    mountInfo.hostBridge?.onNavigate?.({ environment: environmentName });
+    mountInfo.setEnvironment(environmentName);
   };
 
   return (
@@ -178,7 +178,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
         {/* Right side - Controls */}
         <div className="flex items-center gap-3">
           {/* Environment selector */}
-          {mountInfo.environments.length > 0 ? (
+          {mountInfo.environments.length > 1 ? (
             <Select
               value={mountInfo.environment ?? undefined}
               onValueChange={handleEnvironmentChange}

--- a/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent/10 focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent/10 focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent/10 focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent/10 focus:text-accent-foreground data-[state=open]:bg-accent/10 data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/select.tsx
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent/10 focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/packages/studio/src/lib/runtime-ui/components/ui/skeleton.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import { cn } from "../../lib/utils.js";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-foreground/5", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/packages/studio/src/lib/runtime-ui/components/ui/skeleton.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/skeleton.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { cn } from "../../lib/utils.js";
 
 function Skeleton({

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -173,6 +173,7 @@ export function useContentTypeList(typeId: string) {
       const result = await api!.list({
         type: typeId,
         ...queryParams,
+        draft: true,
         isDeleted: false,
         limit: PAGE_SIZE,
         offset,

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -95,7 +95,7 @@ function createReadyState() {
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -146,7 +146,7 @@ function createReadySchemaState(
 function createRouteContext(canWrite = true) {
   return {
     project: "marketing-site",
-    environment: "staging",
+    initialEnvironment: "staging",
     write: canWrite
       ? {
           canWrite: true as const,
@@ -247,7 +247,7 @@ test("createContentDocumentPageState maps shell loading and error states into vi
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -259,7 +259,7 @@ test("createContentDocumentPageState maps shell loading and error states into vi
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -271,7 +271,7 @@ test("createContentDocumentPageState maps shell loading and error states into vi
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -283,7 +283,7 @@ test("createContentDocumentPageState maps shell loading and error states into vi
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: true,
         schemaHash: "schema-hash",
@@ -309,7 +309,7 @@ test("ContentDocumentPageView renders document route loading and failure states"
       typeLabel: "Blog post",
       documentRoute: {
         project: "marketing-site",
-        environment: "staging",
+        initialEnvironment: "staging",
         write: {
           canWrite: true,
           schemaHash: "schema-hash",
@@ -323,7 +323,7 @@ test("ContentDocumentPageView renders document route loading and failure states"
       typeLabel: "Blog post",
       documentRoute: {
         project: "marketing-site",
-        environment: "staging",
+        initialEnvironment: "staging",
         write: {
           canWrite: true,
           schemaHash: "schema-hash",
@@ -337,7 +337,7 @@ test("ContentDocumentPageView renders document route loading and failure states"
       typeLabel: "Blog post",
       documentRoute: {
         project: "marketing-site",
-        environment: "staging",
+        initialEnvironment: "staging",
         write: {
           canWrite: true,
           schemaHash: "schema-hash",
@@ -351,7 +351,7 @@ test("ContentDocumentPageView renders document route loading and failure states"
       typeLabel: "Blog post",
       documentRoute: {
         project: "marketing-site",
-        environment: "staging",
+        initialEnvironment: "staging",
         write: {
           canWrite: true,
           schemaHash: "schema-hash",
@@ -1314,7 +1314,7 @@ test("ContentDocumentPageView blocks writes when the local schema hash capabilit
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: false,
         message: "Schema sync required before Studio can write drafts.",

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -572,7 +572,7 @@ export function createContentDocumentRouteApi(input: {
   return createStudioDocumentRouteApi(
     {
       project: input.route.project,
-      environment: input.route.environment,
+      environment: input.route.initialEnvironment,
       serverUrl: input.context.apiBaseUrl,
     },
     {
@@ -723,7 +723,7 @@ export async function loadContentDocumentPageState(input: {
   const shell = await loadDocumentShell(
     {
       project: route.project,
-      environment: route.environment,
+      environment: route.initialEnvironment,
       serverUrl: input.context.apiBaseUrl,
     },
     {
@@ -749,7 +749,7 @@ export async function loadContentDocumentPageState(input: {
   const schemaState = await loadSchemaState({
     config: {
       project: route.project,
-      environment: route.environment,
+      environment: route.initialEnvironment,
       serverUrl: input.context.apiBaseUrl,
     },
     auth: input.context.auth,

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
@@ -58,6 +58,7 @@ function renderMarkup(
             value: {
               project: "marketing-site",
               environment: "staging",
+              setEnvironment: () => {},
               apiBaseUrl: "http://localhost:4000",
               auth: { mode: "cookie" },
               environments: [],

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.test.tsx
@@ -95,7 +95,7 @@ test("ContentPageView renders loading and empty states deterministically", () =>
   assert.match(loadingMarkup, /class="min-h-screen"/);
   assert.match(loadingMarkup, />Content</);
   assert.match(loadingMarkup, /data-mdcms-content-page-state="loading"/);
-  assert.match(loadingMarkup, /Loading content overview\./);
+  assert.match(loadingMarkup, /data-slot="skeleton"/);
   assert.match(emptyMarkup, /data-mdcms-content-page-state="empty"/);
   assert.match(emptyMarkup, /No schema types were returned/);
 });

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -164,7 +164,7 @@ export function createContentPageLoadInput(
   return {
     config: {
       project: route.project,
-      environment: route.environment,
+      environment: route.initialEnvironment,
       serverUrl: context.apiBaseUrl,
       supportedLocales: route.supportedLocales,
     },

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -11,6 +11,7 @@ import {
   type StudioContentOverviewEntry,
   type StudioContentOverviewState,
 } from "../../content-overview-state.js";
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import Link from "../adapters/next-link.js";
 import { ChevronRight, FileText, Globe, GlobeOff } from "lucide-react";
 import { resolveStudioHref, useBasePath } from "../navigation.js";
@@ -269,17 +270,26 @@ export default function ContentPage({
   context: StudioMountContext;
   loadState?: typeof loadStudioContentOverviewState;
 }) {
+  const mountInfo = useStudioMountInfo();
   const [state, setState] = useState<StudioContentOverviewState>(() =>
     createStudioContentOverviewLoadingState(),
   );
 
   useEffect(() => {
-    const loadInput = createContentPageLoadInput(context);
-
-    if (!loadInput) {
+    if (!mountInfo.project || !mountInfo.environment) {
       setState(createContentPageMissingRouteState());
       return;
     }
+
+    const loadInput: ContentPageLoadInput = {
+      config: {
+        project: mountInfo.project,
+        environment: mountInfo.environment,
+        serverUrl: mountInfo.apiBaseUrl,
+        supportedLocales: mountInfo.supportedLocales,
+      },
+      auth: mountInfo.auth,
+    };
 
     let active = true;
     setState(createStudioContentOverviewLoadingState());
@@ -310,11 +320,11 @@ export default function ContentPage({
       active = false;
     };
   }, [
-    context.apiBaseUrl,
-    context.auth.mode,
-    context.auth.mode === "token" ? context.auth.token : undefined,
-    context.documentRoute?.environment,
-    context.documentRoute?.project,
+    mountInfo.apiBaseUrl,
+    mountInfo.auth,
+    mountInfo.environment,
+    mountInfo.project,
+    mountInfo.supportedLocales,
     loadState,
   ]);
 

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -14,6 +14,7 @@ import {
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import Link from "../adapters/next-link.js";
 import { ChevronRight, FileText, Globe, GlobeOff } from "lucide-react";
+import { Skeleton } from "../components/ui/skeleton.js";
 import { resolveStudioHref, useBasePath } from "../navigation.js";
 import {
   PageHeader,
@@ -203,9 +204,27 @@ export function ContentPageView({
         {state.status === "loading" ? (
           <div
             data-mdcms-content-page-state="loading"
-            className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+            className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
           >
-            {state.message}
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="rounded-lg border border-border p-4">
+                <div className="flex items-start gap-4">
+                  <Skeleton className="h-12 w-12 rounded-lg" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-5 w-28" />
+                    <Skeleton className="h-4 w-36" />
+                  </div>
+                </div>
+                <div className="mt-4 space-y-3 border-t border-border pt-4">
+                  <div className="flex gap-4">
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-16" />
+                  </div>
+                  <Skeleton className="h-5 w-24 rounded-full" />
+                </div>
+              </div>
+            ))}
           </div>
         ) : state.status === "forbidden" ? (
           <section
@@ -292,11 +311,15 @@ export default function ContentPage({
     };
 
     let active = true;
-    setState(createStudioContentOverviewLoadingState());
+
+    const loadingTimer = setTimeout(() => {
+      if (active) setState(createStudioContentOverviewLoadingState());
+    }, 200);
 
     void loadState(loadInput)
       .then((nextState) => {
         if (active) {
+          clearTimeout(loadingTimer);
           setState(nextState);
         }
       })
@@ -305,6 +328,7 @@ export default function ContentPage({
           return;
         }
 
+        clearTimeout(loadingTimer);
         setState({
           status: "error",
           project: loadInput.config.project,
@@ -318,6 +342,7 @@ export default function ContentPage({
 
     return () => {
       active = false;
+      clearTimeout(loadingTimer);
     };
   }, [
     mountInfo.apiBaseUrl,

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -228,7 +228,7 @@ test("loadStudioRuntime fetches bootstrap, verifies runtime, and mounts the remo
       hostBridge: HostBridgeV1;
       documentRoute?: {
         project: string;
-        environment: string;
+        initialEnvironment: string;
         write:
           | {
               canWrite: true;
@@ -247,7 +247,7 @@ test("loadStudioRuntime fetches bootstrap, verifies runtime, and mounts the remo
     assert.equal(mountedContext.hostBridge, validHostBridge);
     assert.deepEqual(mountedContext.documentRoute, {
       project: "marketing-site",
-      environment: "staging",
+      initialEnvironment: "staging",
       write: {
         canWrite: false,
         message:

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -255,7 +255,7 @@ async function createDocumentRouteMountContext(
 
   return {
     project,
-    environment,
+    initialEnvironment: environment,
     ...(supportedLocales && supportedLocales.length > 0
       ? { supportedLocales }
       : {}),


### PR DESCRIPTION
## Summary

- **CMS-135 (shell):** Remove "Coming Soon" sidebar section (roadmap leakage), dead Profile/Preferences menu items, fix nav icon mismatches, fix accent contrast on select/dropdown hover states, make environment switching Studio-owned with URL query param persistence, rename `documentRoute.environment` to `initialEnvironment`, add `useStudioApiConfig()` hook
- **CMS-136 (dashboard):** Include drafts in counts, replace wasteful list calls with content overview API, rename labels ("Content", "Recently updated"), make recent documents clickable, add skeleton loading with 200ms debounce
- **CMS-137 (content overview):** Use reactive mount info for environment, replace loading text with debounced skeleton cards
- **CMS-138 (content type list):** Include drafts in document list, replace loading spinner with debounced skeleton table
- **CMS-144 (placeholder pages):** Rework media/workflows/API pages with consistent breadcrumb layout and MVP-safe copy, redesign ComingSoon component (no card/dashed border, watermark icon), remove feature lists and "Notify Me" button, fix GitHub link to blazity/mdcms

Also: seed both staging and production in docker-compose, add Skeleton UI component.

## Test plan

- [ ] `bun run format:check` passes
- [ ] `bun run check` (build + typecheck) passes
- [ ] `bun run unit` passes (738 tests, 0 failures)
- [ ] Studio embed smoke check passes
- [ ] Visual review: sidebar has no Coming Soon section, user menu has only Sign out, environment selector works and persists across navigations
- [ ] Visual review: dashboard skeleton loading on env switch, clickable recent documents, correct counts including drafts
- [ ] Visual review: placeholder pages show consistent ComingSoon design with breadcrumb header
- [ ] Visual review: select/dropdown hover states use subtle accent tint, not solid orange

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-shell environment selector (shown only for multiple environments) with switching that refreshes environment-scoped data; selection persists to the URL.

* **Improvements**
  * Recent documents on the dashboard are now clickable and navigate to detail pages.
  * Replaced spinners with skeleton placeholders and added a short debounce for loading states.
  * More accurate dashboard content statistics via overview data.
  * Simplified page layouts and consolidated “Coming Soon” presentations (Media/Workflows/API).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->