### PR TITLE
refactor: replace TipTap prop-driven content sync with imperative ref API

### DIFF
--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -346,6 +346,11 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             emitUpdate: false,
           });
           lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
+
+          // Refresh derived UI state that onUpdate would normally handle,
+          // since we suppressed the update event above.
+          publishSelectedMdxComponent(editor);
+          syncSlashTrigger(editor);
         },
       }),
       [editor],

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -338,7 +338,13 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             return;
           }
 
-          editor.commands.setContent(markdown, { contentType: "markdown" });
+          // Suppress onUpdate so programmatic syncs (version preview,
+          // back-to-draft, post-save rehydration) don't trigger onChange
+          // and accidentally mark the draft as unsaved / arm autosave.
+          editor.commands.setContent(markdown, {
+            contentType: "markdown",
+            emitUpdate: false,
+          });
           lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
         },
       }),

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import {
+  forwardRef,
   useEffect,
   useEffectEvent,
+  useImperativeHandle,
   useRef,
   useState,
   type ReactNode,
@@ -63,8 +65,12 @@ import { Button } from "../ui/button.js";
 import { Separator } from "../ui/separator.js";
 import { cn } from "../../lib/utils.js";
 
+export interface TipTapEditorHandle {
+  setContent: (markdown: string) => void;
+}
+
 interface TipTapEditorProps {
-  content?: string;
+  initialContent?: string;
   onChange?: (content: string) => void;
   placeholder?: string;
   context?: StudioMountContext;
@@ -141,502 +147,509 @@ export function createTipTapEditorDependencies(input: {
   return [input.placeholder, input.hostBridge, input.readOnly, input.forbidden];
 }
 
-export function TipTapEditor({
-  content = defaultContent,
-  onChange,
-  placeholder = "Start writing, or press / for commands...",
-  context,
-  readOnly = false,
-  forbidden = false,
-  onActiveMdxComponentChange,
-}: TipTapEditorProps) {
-  const toolbar = createEditorToolbarLayout();
-  const catalogComponents = context?.mdx?.catalog.components ?? [];
-  const isEditorReadOnly = readOnly || forbidden;
-  const [pickerSource, setPickerSource] = useState<"toolbar" | "slash" | null>(
-    null,
-  );
-  const [slashTrigger, setSlashTrigger] =
-    useState<MdxComponentSlashTrigger | null>(null);
-  const lastPublishedSelectionRef =
-    useRef<PublishedMdxComponentSelectionSnapshot | null>(null);
-  const lastEmittedMarkdownRef = useRef<string | null>(null);
-  const externalSyncTokenRef = useRef(0);
-  const handleEditorUpdate = useEffectEvent(
-    (nextEditor: TipTapEditorInstance) => {
-      if (externalSyncTokenRef.current > 0) {
-        return;
-      }
-
-      const nextMarkdown = extractMarkdownFromEditor(nextEditor);
-
-      if (nextMarkdown === lastEmittedMarkdownRef.current) {
-        return;
-      }
-
-      lastEmittedMarkdownRef.current = nextMarkdown;
-      onChange?.(nextMarkdown);
+export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
+  function TipTapEditor(
+    {
+      initialContent = defaultContent,
+      onChange,
+      placeholder = "Start writing, or press / for commands...",
+      context,
+      readOnly = false,
+      forbidden = false,
+      onActiveMdxComponentChange,
     },
-  );
-  const syncSlashTrigger = useEffectEvent(
-    (nextEditor: TipTapEditorInstance) => {
-      const nextTrigger = getMdxComponentSlashTrigger(nextEditor);
+    ref,
+  ) {
+    const toolbar = createEditorToolbarLayout();
+    const catalogComponents = context?.mdx?.catalog.components ?? [];
+    const isEditorReadOnly = readOnly || forbidden;
+    const [pickerSource, setPickerSource] = useState<
+      "toolbar" | "slash" | null
+    >(null);
+    const [slashTrigger, setSlashTrigger] =
+      useState<MdxComponentSlashTrigger | null>(null);
+    const lastPublishedSelectionRef =
+      useRef<PublishedMdxComponentSelectionSnapshot | null>(null);
+    const lastEmittedMarkdownRef = useRef<string | null>(null);
+    const handleEditorUpdate = useEffectEvent(
+      (nextEditor: TipTapEditorInstance) => {
+        const nextMarkdown = extractMarkdownFromEditor(nextEditor);
 
-      setSlashTrigger(nextTrigger);
-      setPickerSource((currentSource) => {
-        if (currentSource === "toolbar") {
-          return currentSource;
-        }
-
-        if (nextTrigger) {
-          return "slash";
-        }
-
-        return currentSource === "slash" ? null : currentSource;
-      });
-    },
-  );
-  const publishSelectedMdxComponent = useEffectEvent(
-    (nextEditor: TipTapEditorInstance) => {
-      if (!onActiveMdxComponentChange) {
-        lastPublishedSelectionRef.current = null;
-        return;
-      }
-
-      const selected = getSelectedMdxComponent(nextEditor, catalogComponents);
-
-      if (!selected) {
-        if (lastPublishedSelectionRef.current === null) {
+        if (nextMarkdown === lastEmittedMarkdownRef.current) {
           return;
         }
 
-        lastPublishedSelectionRef.current = null;
-        onActiveMdxComponentChange(null);
-        return;
-      }
+        lastEmittedMarkdownRef.current = nextMarkdown;
+        onChange?.(nextMarkdown);
+      },
+    );
+    const syncSlashTrigger = useEffectEvent(
+      (nextEditor: TipTapEditorInstance) => {
+        const nextTrigger = getMdxComponentSlashTrigger(nextEditor);
 
-      const nextSnapshot = createPublishedMdxComponentSelectionSnapshot({
-        selected,
-        readOnly,
-        forbidden,
-      });
-
-      if (
-        !hasPublishedMdxComponentSelectionChanged(
-          lastPublishedSelectionRef.current,
-          nextSnapshot,
-        )
-      ) {
-        return;
-      }
-
-      lastPublishedSelectionRef.current = nextSnapshot;
-
-      onActiveMdxComponentChange({
-        ...selected,
-        readOnly,
-        forbidden,
-        onPropsChange: (patch) => {
-          if (
-            updateSelectedMdxComponentProps(
-              nextEditor,
-              catalogComponents,
-              patch,
-              {
-                readOnly,
-                forbidden,
-              },
-            )
-          ) {
-            publishSelectedMdxComponent(nextEditor);
-            handleEditorUpdate(nextEditor);
+        setSlashTrigger(nextTrigger);
+        setPickerSource((currentSource) => {
+          if (currentSource === "toolbar") {
+            return currentSource;
           }
+
+          if (nextTrigger) {
+            return "slash";
+          }
+
+          return currentSource === "slash" ? null : currentSource;
+        });
+      },
+    );
+    const publishSelectedMdxComponent = useEffectEvent(
+      (nextEditor: TipTapEditorInstance) => {
+        if (!onActiveMdxComponentChange) {
+          lastPublishedSelectionRef.current = null;
+          return;
+        }
+
+        const selected = getSelectedMdxComponent(nextEditor, catalogComponents);
+
+        if (!selected) {
+          if (lastPublishedSelectionRef.current === null) {
+            return;
+          }
+
+          lastPublishedSelectionRef.current = null;
+          onActiveMdxComponentChange(null);
+          return;
+        }
+
+        const nextSnapshot = createPublishedMdxComponentSelectionSnapshot({
+          selected,
+          readOnly,
+          forbidden,
+        });
+
+        if (
+          !hasPublishedMdxComponentSelectionChanged(
+            lastPublishedSelectionRef.current,
+            nextSnapshot,
+          )
+        ) {
+          return;
+        }
+
+        lastPublishedSelectionRef.current = nextSnapshot;
+
+        onActiveMdxComponentChange({
+          ...selected,
+          readOnly,
+          forbidden,
+          onPropsChange: (patch) => {
+            if (
+              updateSelectedMdxComponentProps(
+                nextEditor,
+                catalogComponents,
+                patch,
+                {
+                  readOnly,
+                  forbidden,
+                },
+              )
+            ) {
+              publishSelectedMdxComponent(nextEditor);
+              handleEditorUpdate(nextEditor);
+            }
+          },
+        });
+      },
+    );
+    const editor = useEditor(
+      {
+        content: initialContent,
+        contentType: "markdown",
+        editable: !isEditorReadOnly,
+        immediatelyRender: false,
+        extensions: createEditorExtensions({
+          mdxComponent: MdxComponentExtension.extend({
+            addNodeView() {
+              const NodeView = (props: ReactNodeViewProps) => (
+                <MdxComponentNodeView
+                  {...props}
+                  context={context}
+                  readOnly={readOnly}
+                  forbidden={forbidden}
+                />
+              );
+
+              return ReactNodeViewRenderer(NodeView);
+            },
+          }),
+        }),
+        editorProps: {
+          attributes: {
+            class:
+              "prose prose-sm max-w-none min-h-[480px] px-4 py-4 focus:outline-none",
+            "data-placeholder": placeholder,
+          },
         },
-      });
-    },
-  );
-  const editor = useEditor(
-    {
-      content,
-      contentType: "markdown",
-      editable: !isEditorReadOnly,
-      immediatelyRender: false,
-      extensions: createEditorExtensions({
-        mdxComponent: MdxComponentExtension.extend({
-          addNodeView() {
-            const NodeView = (props: ReactNodeViewProps) => (
-              <MdxComponentNodeView
-                {...props}
-                context={context}
-                readOnly={readOnly}
-                forbidden={forbidden}
-              />
+        onUpdate({ editor }) {
+          handleEditorUpdate(editor);
+          publishSelectedMdxComponent(editor);
+          syncSlashTrigger(editor);
+        },
+        onSelectionUpdate({ editor }) {
+          publishSelectedMdxComponent(editor);
+          syncSlashTrigger(editor);
+        },
+      },
+      createTipTapEditorDependencies({
+        placeholder,
+        hostBridge: context?.hostBridge,
+        readOnly,
+        forbidden,
+      }),
+    );
+
+    // Seed the emitted markdown ref once the editor initializes so the
+    // first focus/click does not produce a spurious onChange.
+    useEffect(() => {
+      if (!editor) {
+        return;
+      }
+
+      if (lastEmittedMarkdownRef.current === null) {
+        lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
+      }
+    }, [editor]);
+
+    // Imperative content setter — callers use ref.current.setContent()
+    // instead of changing a content prop. This avoids the flushSync
+    // lifecycle conflict entirely because setContent runs from event
+    // handlers, not from effects.
+    useImperativeHandle(
+      ref,
+      () => ({
+        setContent(markdown: string) {
+          if (!editor || editor.isDestroyed) {
+            return;
+          }
+
+          const currentMarkdown = extractMarkdownFromEditor(editor);
+
+          if (currentMarkdown === markdown) {
+            lastEmittedMarkdownRef.current = currentMarkdown;
+            return;
+          }
+
+          editor.commands.setContent(markdown, { contentType: "markdown" });
+          lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
+        },
+      }),
+      [editor],
+    );
+
+    useEffect(() => {
+      if (!editor) {
+        return;
+      }
+
+      editor.setEditable(!isEditorReadOnly);
+      publishSelectedMdxComponent(editor);
+      syncSlashTrigger(editor);
+    }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
+
+    const isActive = (name: string, attributes?: Record<string, unknown>) =>
+      editor?.isActive(name, attributes) ?? false;
+
+    const run = (command: () => boolean) => {
+      command();
+    };
+
+    const iconClassName = "h-4 w-4";
+
+    const renderToolbarItem = (itemId: string) => {
+      switch (itemId) {
+        case "undo":
+          return <Undo className={iconClassName} />;
+        case "redo":
+          return <Redo className={iconClassName} />;
+        case "bold":
+          return <Bold className={iconClassName} />;
+        case "italic":
+          return <Italic className={iconClassName} />;
+        case "underline":
+          return <UnderlineIcon className={iconClassName} />;
+        case "strike":
+          return <Strikethrough className={iconClassName} />;
+        case "code":
+          return <Code className={iconClassName} />;
+        case "highlight":
+          return <Highlighter className={iconClassName} />;
+        case "heading1":
+          return <span className="text-sm font-semibold">H1</span>;
+        case "heading2":
+          return <span className="text-sm font-semibold">H2</span>;
+        case "bulletList":
+          return <List className={iconClassName} />;
+        case "orderedList":
+          return <ListOrdered className={iconClassName} />;
+        case "taskList":
+          return <ListTodo className={iconClassName} />;
+        case "blockquote":
+          return <Quote className={iconClassName} />;
+        case "codeBlock":
+          return <FileCode className={iconClassName} />;
+        case "horizontalRule":
+          return <Minus className={iconClassName} />;
+        case "image":
+          return <ImageIcon className={iconClassName} />;
+        case "link":
+          return <LinkIcon className={iconClassName} />;
+        case "table":
+          return <Table2 className={iconClassName} />;
+        case "insertComponent":
+          return (
+            <>
+              <Puzzle className={iconClassName} />
+              <span>Insert Component</span>
+            </>
+          );
+        default:
+          return null;
+      }
+    };
+
+    const triggerToolbarItem = (itemId: string) => {
+      switch (itemId) {
+        case "undo":
+          return run(() => editor?.chain().focus().undo().run() ?? false);
+        case "redo":
+          return run(() => editor?.chain().focus().redo().run() ?? false);
+        case "bold":
+          return run(() => editor?.chain().focus().toggleBold().run() ?? false);
+        case "italic":
+          return run(
+            () => editor?.chain().focus().toggleItalic().run() ?? false,
+          );
+        case "underline":
+          return;
+        case "strike":
+          return run(
+            () => editor?.chain().focus().toggleStrike().run() ?? false,
+          );
+        case "code":
+          return run(() => editor?.chain().focus().toggleCode().run() ?? false);
+        case "highlight":
+          return;
+        case "heading1":
+          return run(
+            () =>
+              editor?.chain().focus().toggleHeading({ level: 1 }).run() ??
+              false,
+          );
+        case "heading2":
+          return run(
+            () =>
+              editor?.chain().focus().toggleHeading({ level: 2 }).run() ??
+              false,
+          );
+        case "bulletList":
+          return run(
+            () => editor?.chain().focus().toggleBulletList().run() ?? false,
+          );
+        case "orderedList":
+          return run(
+            () => editor?.chain().focus().toggleOrderedList().run() ?? false,
+          );
+        case "taskList":
+          return run(
+            () => editor?.chain().focus().toggleTaskList().run() ?? false,
+          );
+        case "blockquote":
+          return run(
+            () => editor?.chain().focus().toggleBlockquote().run() ?? false,
+          );
+        case "codeBlock":
+          return run(
+            () => editor?.chain().focus().toggleCodeBlock().run() ?? false,
+          );
+        case "horizontalRule":
+          return run(
+            () => editor?.chain().focus().setHorizontalRule().run() ?? false,
+          );
+        case "insertComponent":
+          setPickerSource((currentSource) =>
+            currentSource === "toolbar" ? null : "toolbar",
+          );
+          return;
+        default:
+          return;
+      }
+    };
+
+    const isToolbarItemActive = (itemId: string) => {
+      switch (itemId) {
+        case "bold":
+          return isActive("bold");
+        case "italic":
+          return isActive("italic");
+        case "strike":
+          return isActive("strike");
+        case "code":
+          return isActive("code");
+        case "heading1":
+          return isActive("heading", { level: 1 });
+        case "heading2":
+          return isActive("heading", { level: 2 });
+        case "bulletList":
+          return isActive("bulletList");
+        case "orderedList":
+          return isActive("orderedList");
+        case "taskList":
+          return isActive("taskList");
+        case "blockquote":
+          return isActive("blockquote");
+        case "codeBlock":
+          return isActive("codeBlock");
+        default:
+          return false;
+      }
+    };
+
+    const insertSelectedComponent = (
+      component: (typeof catalogComponents)[number],
+    ) => {
+      if (!editor) {
+        return;
+      }
+
+      const didInsert =
+        pickerSource === "slash" && slashTrigger
+          ? replaceSlashTriggerWithMdxComponent(editor, slashTrigger, component)
+          : editor.commands.insertContent(
+              createMdxComponentInsertContent(component),
             );
 
-            return ReactNodeViewRenderer(NodeView);
-          },
-        }),
-      }),
-      editorProps: {
-        attributes: {
-          class:
-            "prose prose-sm max-w-none min-h-[480px] px-4 py-4 focus:outline-none",
-          "data-placeholder": placeholder,
-        },
-      },
-      onUpdate({ editor }) {
-        handleEditorUpdate(editor);
-        publishSelectedMdxComponent(editor);
-        syncSlashTrigger(editor);
-      },
-      onSelectionUpdate({ editor }) {
-        publishSelectedMdxComponent(editor);
-        syncSlashTrigger(editor);
-      },
-    },
-    createTipTapEditorDependencies({
-      placeholder,
-      hostBridge: context?.hostBridge,
-      readOnly,
-      forbidden,
-    }),
-  );
-
-  useEffect(() => {
-    if (!editor) {
-      return;
-    }
-
-    // Seed the ref with TipTap's normalized output so the first focus/click
-    // does not produce a spurious onChange from parse normalization.
-    if (lastEmittedMarkdownRef.current === null) {
-      lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
-    }
-
-    const currentMarkdown = extractMarkdownFromEditor(editor);
-
-    if (currentMarkdown === content) {
-      lastEmittedMarkdownRef.current = currentMarkdown;
-      return;
-    }
-
-    // Defer setContent out of the React lifecycle to avoid the
-    // "flushSync was called from inside a lifecycle method" warning.
-    // TipTap's ProseMirror internals call flushSync during setContent.
-    const pendingContent = content;
-    const syncToken = ++externalSyncTokenRef.current;
-    queueMicrotask(() => {
-      try {
-        if (!editor.isDestroyed) {
-          editor.commands.setContent(pendingContent, {
-            contentType: "markdown",
-          });
-          lastEmittedMarkdownRef.current = extractMarkdownFromEditor(editor);
-        }
-      } finally {
-        // Only clear the guard if no newer sync was queued
-        if (externalSyncTokenRef.current === syncToken) {
-          externalSyncTokenRef.current = 0;
-        }
+      if (!didInsert) {
+        return;
       }
-    });
-  }, [content, editor]);
 
-  useEffect(() => {
-    if (!editor) {
-      return;
-    }
+      if (!getSelectedMdxComponent(editor, catalogComponents)) {
+        selectAdjacentMdxComponent(editor);
+      }
 
-    editor.setEditable(!isEditorReadOnly);
-    publishSelectedMdxComponent(editor);
-    syncSlashTrigger(editor);
-  }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
+      setSlashTrigger(null);
+      setPickerSource(null);
+      publishSelectedMdxComponent(editor);
+      handleEditorUpdate(editor);
+      syncSlashTrigger(editor);
+    };
 
-  const isActive = (name: string, attributes?: Record<string, unknown>) =>
-    editor?.isActive(name, attributes) ?? false;
+    const isPickerOpen =
+      pickerSource === "toolbar" ||
+      (pickerSource === "slash" && slashTrigger !== null);
 
-  const run = (command: () => boolean) => {
-    command();
-  };
+    return (
+      <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background">
+        <div className="border-b border-border bg-background-subtle">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2">
+            {toolbar.primaryGroups.map((group, groupIndex) => (
+              <div key={group.id} className="flex items-center gap-1.5">
+                {groupIndex > 0 ? (
+                  <Separator orientation="vertical" className="mr-1 h-6" />
+                ) : null}
+                {group.items.map((item) => (
+                  <div
+                    key={item.id}
+                    onClick={() => {
+                      if (
+                        item.availability === "enabled" &&
+                        !isEditorReadOnly
+                      ) {
+                        triggerToolbarItem(item.id);
+                      }
+                    }}
+                  >
+                    <ToolbarButton
+                      disabled={
+                        item.availability !== "enabled" || isEditorReadOnly
+                      }
+                      label={
+                        item.availability === "visual-only"
+                          ? `${item.label} (planned)`
+                          : isEditorReadOnly
+                            ? `${item.label} (unavailable in read-only mode)`
+                            : item.label
+                      }
+                      active={isToolbarItemActive(item.id)}
+                      className={cn(
+                        item.id === "heading1" || item.id === "heading2"
+                          ? "min-w-10 px-3"
+                          : "w-8 px-0",
+                        item.availability === "visual-only" &&
+                          "text-foreground-muted",
+                      )}
+                    >
+                      {renderToolbarItem(item.id)}
+                    </ToolbarButton>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
 
-  const iconClassName = "h-4 w-4";
-
-  const renderToolbarItem = (itemId: string) => {
-    switch (itemId) {
-      case "undo":
-        return <Undo className={iconClassName} />;
-      case "redo":
-        return <Redo className={iconClassName} />;
-      case "bold":
-        return <Bold className={iconClassName} />;
-      case "italic":
-        return <Italic className={iconClassName} />;
-      case "underline":
-        return <UnderlineIcon className={iconClassName} />;
-      case "strike":
-        return <Strikethrough className={iconClassName} />;
-      case "code":
-        return <Code className={iconClassName} />;
-      case "highlight":
-        return <Highlighter className={iconClassName} />;
-      case "heading1":
-        return <span className="text-sm font-semibold">H1</span>;
-      case "heading2":
-        return <span className="text-sm font-semibold">H2</span>;
-      case "bulletList":
-        return <List className={iconClassName} />;
-      case "orderedList":
-        return <ListOrdered className={iconClassName} />;
-      case "taskList":
-        return <ListTodo className={iconClassName} />;
-      case "blockquote":
-        return <Quote className={iconClassName} />;
-      case "codeBlock":
-        return <FileCode className={iconClassName} />;
-      case "horizontalRule":
-        return <Minus className={iconClassName} />;
-      case "image":
-        return <ImageIcon className={iconClassName} />;
-      case "link":
-        return <LinkIcon className={iconClassName} />;
-      case "table":
-        return <Table2 className={iconClassName} />;
-      case "insertComponent":
-        return (
-          <>
-            <Puzzle className={iconClassName} />
-            <span>Insert Component</span>
-          </>
-        );
-      default:
-        return null;
-    }
-  };
-
-  const triggerToolbarItem = (itemId: string) => {
-    switch (itemId) {
-      case "undo":
-        return run(() => editor?.chain().focus().undo().run() ?? false);
-      case "redo":
-        return run(() => editor?.chain().focus().redo().run() ?? false);
-      case "bold":
-        return run(() => editor?.chain().focus().toggleBold().run() ?? false);
-      case "italic":
-        return run(() => editor?.chain().focus().toggleItalic().run() ?? false);
-      case "underline":
-        return;
-      case "strike":
-        return run(() => editor?.chain().focus().toggleStrike().run() ?? false);
-      case "code":
-        return run(() => editor?.chain().focus().toggleCode().run() ?? false);
-      case "highlight":
-        return;
-      case "heading1":
-        return run(
-          () =>
-            editor?.chain().focus().toggleHeading({ level: 1 }).run() ?? false,
-        );
-      case "heading2":
-        return run(
-          () =>
-            editor?.chain().focus().toggleHeading({ level: 2 }).run() ?? false,
-        );
-      case "bulletList":
-        return run(
-          () => editor?.chain().focus().toggleBulletList().run() ?? false,
-        );
-      case "orderedList":
-        return run(
-          () => editor?.chain().focus().toggleOrderedList().run() ?? false,
-        );
-      case "taskList":
-        return run(
-          () => editor?.chain().focus().toggleTaskList().run() ?? false,
-        );
-      case "blockquote":
-        return run(
-          () => editor?.chain().focus().toggleBlockquote().run() ?? false,
-        );
-      case "codeBlock":
-        return run(
-          () => editor?.chain().focus().toggleCodeBlock().run() ?? false,
-        );
-      case "horizontalRule":
-        return run(
-          () => editor?.chain().focus().setHorizontalRule().run() ?? false,
-        );
-      case "insertComponent":
-        setPickerSource((currentSource) =>
-          currentSource === "toolbar" ? null : "toolbar",
-        );
-        return;
-      default:
-        return;
-    }
-  };
-
-  const isToolbarItemActive = (itemId: string) => {
-    switch (itemId) {
-      case "bold":
-        return isActive("bold");
-      case "italic":
-        return isActive("italic");
-      case "strike":
-        return isActive("strike");
-      case "code":
-        return isActive("code");
-      case "heading1":
-        return isActive("heading", { level: 1 });
-      case "heading2":
-        return isActive("heading", { level: 2 });
-      case "bulletList":
-        return isActive("bulletList");
-      case "orderedList":
-        return isActive("orderedList");
-      case "taskList":
-        return isActive("taskList");
-      case "blockquote":
-        return isActive("blockquote");
-      case "codeBlock":
-        return isActive("codeBlock");
-      default:
-        return false;
-    }
-  };
-
-  const insertSelectedComponent = (
-    component: (typeof catalogComponents)[number],
-  ) => {
-    if (!editor) {
-      return;
-    }
-
-    const didInsert =
-      pickerSource === "slash" && slashTrigger
-        ? replaceSlashTriggerWithMdxComponent(editor, slashTrigger, component)
-        : editor.commands.insertContent(
-            createMdxComponentInsertContent(component),
-          );
-
-    if (!didInsert) {
-      return;
-    }
-
-    if (!getSelectedMdxComponent(editor, catalogComponents)) {
-      selectAdjacentMdxComponent(editor);
-    }
-
-    setSlashTrigger(null);
-    setPickerSource(null);
-    publishSelectedMdxComponent(editor);
-    handleEditorUpdate(editor);
-    syncSlashTrigger(editor);
-  };
-
-  const isPickerOpen =
-    pickerSource === "toolbar" ||
-    (pickerSource === "slash" && slashTrigger !== null);
-
-  return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background">
-      <div className="border-b border-border bg-background-subtle">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2">
-          {toolbar.primaryGroups.map((group, groupIndex) => (
-            <div key={group.id} className="flex items-center gap-1.5">
-              {groupIndex > 0 ? (
-                <Separator orientation="vertical" className="mr-1 h-6" />
-              ) : null}
-              {group.items.map((item) => (
-                <div
+          {toolbar.secondaryItems.length > 0 ? (
+            <div className="flex items-center gap-2 border-t border-border px-3 py-2">
+              {toolbar.secondaryItems.map((item) => (
+                <Button
                   key={item.id}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={item.availability !== "enabled" || isEditorReadOnly}
                   onClick={() => {
                     if (item.availability === "enabled" && !isEditorReadOnly) {
                       triggerToolbarItem(item.id);
                     }
                   }}
+                  title={
+                    item.availability !== "enabled"
+                      ? `${item.label} (planned)`
+                      : isEditorReadOnly
+                        ? `${item.label} (unavailable in read-only mode)`
+                        : item.label
+                  }
+                  className="border-accent text-accent hover:bg-accent-subtle hover:text-accent"
                 >
-                  <ToolbarButton
-                    disabled={
-                      item.availability !== "enabled" || isEditorReadOnly
-                    }
-                    label={
-                      item.availability === "visual-only"
-                        ? `${item.label} (planned)`
-                        : isEditorReadOnly
-                          ? `${item.label} (unavailable in read-only mode)`
-                          : item.label
-                    }
-                    active={isToolbarItemActive(item.id)}
-                    className={cn(
-                      item.id === "heading1" || item.id === "heading2"
-                        ? "min-w-10 px-3"
-                        : "w-8 px-0",
-                      item.availability === "visual-only" &&
-                        "text-foreground-muted",
-                    )}
-                  >
-                    {renderToolbarItem(item.id)}
-                  </ToolbarButton>
-                </div>
+                  {renderToolbarItem(item.id)}
+                </Button>
               ))}
             </div>
-          ))}
+          ) : null}
+
+          {isPickerOpen ? (
+            <div
+              data-mdcms-mdx-picker-source={pickerSource ?? "toolbar"}
+              className="border-t border-border px-3 py-3"
+            >
+              {pickerSource === "slash" && slashTrigger ? (
+                <p className="mb-2 text-xs text-foreground-muted">
+                  Slash filter: /{slashTrigger.query}
+                </p>
+              ) : null}
+              <MdxComponentPicker
+                components={catalogComponents}
+                query={
+                  pickerSource === "slash" ? (slashTrigger?.query ?? "") : ""
+                }
+                forbidden={isEditorReadOnly}
+                onSelect={insertSelectedComponent}
+              />
+            </div>
+          ) : null}
         </div>
 
-        {toolbar.secondaryItems.length > 0 ? (
-          <div className="flex items-center gap-2 border-t border-border px-3 py-2">
-            {toolbar.secondaryItems.map((item) => (
-              <Button
-                key={item.id}
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={item.availability !== "enabled" || isEditorReadOnly}
-                onClick={() => {
-                  if (item.availability === "enabled" && !isEditorReadOnly) {
-                    triggerToolbarItem(item.id);
-                  }
-                }}
-                title={
-                  item.availability !== "enabled"
-                    ? `${item.label} (planned)`
-                    : isEditorReadOnly
-                      ? `${item.label} (unavailable in read-only mode)`
-                      : item.label
-                }
-                className="border-accent text-accent hover:bg-accent-subtle hover:text-accent"
-              >
-                {renderToolbarItem(item.id)}
-              </Button>
-            ))}
-          </div>
-        ) : null}
-
-        {isPickerOpen ? (
-          <div
-            data-mdcms-mdx-picker-source={pickerSource ?? "toolbar"}
-            className="border-t border-border px-3 py-3"
-          >
-            {pickerSource === "slash" && slashTrigger ? (
-              <p className="mb-2 text-xs text-foreground-muted">
-                Slash filter: /{slashTrigger.query}
-              </p>
-            ) : null}
-            <MdxComponentPicker
-              components={catalogComponents}
-              query={
-                pickerSource === "slash" ? (slashTrigger?.query ?? "") : ""
-              }
-              forbidden={isEditorReadOnly}
-              onSelect={insertSelectedComponent}
-            />
-          </div>
-        ) : null}
+        <div className="min-h-[480px] bg-transparent">
+          <EditorContent editor={editor} />
+        </div>
       </div>
-
-      <div className="min-h-[480px] bg-transparent">
-        <EditorContent editor={editor} />
-      </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2424,6 +2424,16 @@ export default function ContentDocumentPage({
 
       const versionBody = versionDoc.body ?? "";
 
+      // Only update the editor if this version is still the one the UI expects.
+      // A newer version click may have fired while this fetch was in-flight.
+      const afterFetch = stateRef.current;
+      if (
+        afterFetch.status !== "ready" ||
+        afterFetch.viewingVersion?.version !== version
+      ) {
+        return;
+      }
+
       editorRef.current?.setContent(versionBody);
 
       setState((current) =>

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2079,6 +2079,7 @@ export default function ContentDocumentPage({
       if (
         publishedBody !== currentState.draftBody &&
         latestAfterPublish.status === "ready" &&
+        latestAfterPublish.documentId === currentState.documentId &&
         latestAfterPublish.draftBody === currentState.draftBody &&
         !latestAfterPublish.viewingVersion
       ) {
@@ -2247,6 +2248,7 @@ export default function ContentDocumentPage({
     if (
       persistedBody !== requestBody &&
       latestAfterSave.status === "ready" &&
+      latestAfterSave.documentId === currentState.documentId &&
       latestAfterSave.draftBody === requestBody &&
       !latestAfterSave.viewingVersion
     ) {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2225,12 +2225,19 @@ export default function ContentDocumentPage({
       return false;
     }
 
+    // If the server normalized the body (whitespace, etc.), rehydrate the
+    // editor so it matches the canonical persisted draft.
+    const persistedBody = nextState.document.body;
+    if (persistedBody !== requestBody) {
+      editorRef.current?.setContent(persistedBody);
+    }
+
     setState((current) =>
       current.status === "ready"
         ? applySuccessfulDraftSaveToReadyState({
             state: current,
             requestBody,
-            persistedBody: nextState.document.body,
+            persistedBody,
             updatedAt: nextState.document.updatedAt,
           })
         : current,

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -4,6 +4,7 @@ import {
   type ChangeEvent,
   useEffect,
   useEffectEvent,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -1942,10 +1943,13 @@ export default function ContentDocumentPage({
   const stateRef = useRef(state);
   const loadRequestIdRef = useRef(0);
 
-  // Sync ref immediately so event handlers and async callbacks always
-  // see the latest committed state — not deferred to a useEffect which
-  // can lag behind when promises resolve between commit and effect.
-  stateRef.current = state;
+  // Sync ref after commit so event handlers and async callbacks always
+  // see the latest committed state. useLayoutEffect runs synchronously
+  // after commit but before paint, avoiding the stale-ref gap of useEffect
+  // while respecting React's rule against mutating refs during render.
+  useLayoutEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   function createRouteApi(): StudioDocumentRouteApi | undefined {
     if (!context || !route) {
@@ -2169,7 +2173,6 @@ export default function ContentDocumentPage({
     }
 
     setState(nextState);
-    stateRef.current = nextState;
   });
 
   const saveDraft = useEffectEvent(async (): Promise<boolean> => {
@@ -2256,7 +2259,8 @@ export default function ContentDocumentPage({
     }
 
     setState((current) =>
-      current.status === "ready"
+      current.status === "ready" &&
+      current.documentId === currentState.documentId
         ? applySuccessfulDraftSaveToReadyState({
             state: current,
             requestBody,
@@ -2459,6 +2463,7 @@ export default function ContentDocumentPage({
       const afterFetch = stateRef.current;
       if (
         afterFetch.status !== "ready" ||
+        afterFetch.documentId !== currentState.documentId ||
         afterFetch.viewingVersion?.version !== version
       ) {
         return;

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2071,9 +2071,15 @@ export default function ContentDocumentPage({
         return;
       }
 
-      // If publish normalized the body, rehydrate the editor.
+      // If publish normalized the body, rehydrate the editor — but only
+      // if the user hasn't typed newer edits during the in-flight publish.
       const publishedBody = nextState.document.body;
-      if (publishedBody !== currentState.draftBody) {
+      const latestAfterPublish = stateRef.current;
+      if (
+        publishedBody !== currentState.draftBody &&
+        latestAfterPublish.status === "ready" &&
+        latestAfterPublish.draftBody === currentState.draftBody
+      ) {
         editorRef.current?.setContent(publishedBody);
       }
 
@@ -2232,9 +2238,15 @@ export default function ContentDocumentPage({
     }
 
     // If the server normalized the body (whitespace, etc.), rehydrate the
-    // editor so it matches the canonical persisted draft.
+    // editor — but only if the user hasn't typed newer edits during the
+    // in-flight save. The reducer already preserves newer drafts in state.
     const persistedBody = nextState.document.body;
-    if (persistedBody !== requestBody) {
+    const latestAfterSave = stateRef.current;
+    if (
+      persistedBody !== requestBody &&
+      latestAfterSave.status === "ready" &&
+      latestAfterSave.draftBody === requestBody
+    ) {
       editorRef.current?.setContent(persistedBody);
     }
 

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2071,6 +2071,12 @@ export default function ContentDocumentPage({
         return;
       }
 
+      // If publish normalized the body, rehydrate the editor.
+      const publishedBody = nextState.document.body;
+      if (publishedBody !== currentState.draftBody) {
+        editorRef.current?.setContent(publishedBody);
+      }
+
       setState((current) =>
         current.status === "ready" &&
         current.documentId === currentState.documentId

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1942,9 +1942,10 @@ export default function ContentDocumentPage({
   const stateRef = useRef(state);
   const loadRequestIdRef = useRef(0);
 
-  useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
+  // Sync ref immediately so event handlers and async callbacks always
+  // see the latest committed state — not deferred to a useEffect which
+  // can lag behind when promises resolve between commit and effect.
+  stateRef.current = state;
 
   function createRouteApi(): StudioDocumentRouteApi | undefined {
     if (!context || !route) {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2079,7 +2079,8 @@ export default function ContentDocumentPage({
       if (
         publishedBody !== currentState.draftBody &&
         latestAfterPublish.status === "ready" &&
-        latestAfterPublish.draftBody === currentState.draftBody
+        latestAfterPublish.draftBody === currentState.draftBody &&
+        !latestAfterPublish.viewingVersion
       ) {
         editorRef.current?.setContent(publishedBody);
       }
@@ -2246,7 +2247,8 @@ export default function ContentDocumentPage({
     if (
       persistedBody !== requestBody &&
       latestAfterSave.status === "ready" &&
-      latestAfterSave.draftBody === requestBody
+      latestAfterSave.draftBody === requestBody &&
+      !latestAfterSave.viewingVersion
     ) {
       editorRef.current?.setContent(persistedBody);
     }

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -36,7 +36,10 @@ import {
 } from "../../document-version-diff.js";
 import { useParams, useRouter } from "../adapters/next-navigation.js";
 import { type MdxPropsPanelSelection } from "../components/editor/mdx-props-panel.js";
-import { TipTapEditor } from "../components/editor/tiptap-editor.js";
+import {
+  TipTapEditor,
+  type TipTapEditorHandle,
+} from "../components/editor/tiptap-editor.js";
 import { BreadcrumbTrail } from "../components/layout/page-header.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
@@ -234,6 +237,7 @@ type ContentDocumentPageViewProps = {
     side: "left" | "right",
     version?: number,
   ) => void;
+  editorRef?: React.Ref<TipTapEditorHandle>;
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
   onLocaleSwitch?: (locale: string) => void;
@@ -1563,6 +1567,7 @@ export function ContentDocumentPageView({
   onPublishSubmit,
   onSchemaSync,
   onSelectComparisonVersion,
+  editorRef,
   onViewVersion,
   onBackToDraft,
   onLocaleSwitch,
@@ -1819,11 +1824,8 @@ export function ContentDocumentPageView({
                   ) : null}
 
                   <TipTapEditor
-                    content={
-                      state.viewingVersion?.status === "ready"
-                        ? state.viewingVersion.body
-                        : state.draftBody
-                    }
+                    ref={editorRef}
+                    initialContent={state.draftBody}
                     context={context}
                     onChange={onDraftChange}
                     onActiveMdxComponentChange={onActiveMdxComponentChange}
@@ -1934,6 +1936,7 @@ export default function ContentDocumentPage({
         }),
   );
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const editorRef = useRef<TipTapEditorHandle>(null);
   const [activeMdxComponent, setActiveMdxComponent] =
     useState<MdxPropsPanelSelection | null>(null);
   const stateRef = useRef(state);
@@ -2419,6 +2422,10 @@ export default function ContentDocumentPage({
         version,
       });
 
+      const versionBody = versionDoc.body ?? "";
+
+      editorRef.current?.setContent(versionBody);
+
       setState((current) =>
         current.status === "ready" &&
         current.viewingVersion?.version === version
@@ -2426,7 +2433,7 @@ export default function ContentDocumentPage({
               ...current,
               viewingVersion: {
                 version,
-                body: versionDoc.body ?? "",
+                body: versionBody,
                 status: "ready",
               },
             }
@@ -2454,6 +2461,12 @@ export default function ContentDocumentPage({
   });
 
   const handleBackToDraft = useEffectEvent(() => {
+    const currentState = stateRef.current;
+
+    if (currentState.status === "ready") {
+      editorRef.current?.setContent(currentState.draftBody);
+    }
+
     setState((current) =>
       current.status === "ready"
         ? { ...current, viewingVersion: undefined }
@@ -2622,6 +2635,7 @@ export default function ContentDocumentPage({
         void handleCreateVariant(prefill);
       }}
       onCancelVariantCreation={handleCancelVariantCreation}
+      editorRef={editorRef}
       onViewVersion={(version) => {
         void handleViewVersion(version);
       }}


### PR DESCRIPTION
## Summary

- Replace `content` prop + `useEffect` sync with an imperative `ref.setContent(markdown)` API on `TipTapEditor`
- Eliminates the `flushSync` lifecycle warning entirely — `setContent` now runs from event handlers, not effects
- Removes `queueMicrotask`, `externalSyncTokenRef`, and all sync guard machinery that existed solely to work around the prop-driven approach

## Test plan

- [x] Typecheck passes
- [x] 319 Studio tests pass
- [x] Version preview (click version → view in editor → back to draft) works without `flushSync` warning
- [x] Normal editing flow unchanged — `onChange` fires on user edits, autosave works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor exposes a programmatic setContent API and uses initialContent for one-time seeding.
  * Pages now drive the editor via a ref so published versions, saved drafts, and viewed versions are applied immediately.

* **Bug Fixes**
  * Fewer duplicate change events; selection and slash-trigger state consistently sync after programmatic updates.
  * Editor rehydrates when server-saved content changes, when switching versions, or when returning to draft.

* **Refactor**
  * Initialization and update flow streamlined with committed-phase state observation for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->