### PR TITLE
feat: add content list translation status indicators

### DIFF
--- a/apps/studio-example/app/admin/studio-config.test.ts
+++ b/apps/studio-example/app/admin/studio-config.test.ts
@@ -70,3 +70,12 @@ test("createClientStudioConfig merges prepared extracted props onto authored com
     },
   });
 });
+
+test("createClientStudioConfig preserves explicit locale metadata", () => {
+  const config = createClientStudioConfig([]);
+
+  assert.deepEqual(config.locales, {
+    default: "en",
+    supported: ["en", "fr"],
+  });
+});

--- a/apps/studio-example/app/admin/studio-config.ts
+++ b/apps/studio-example/app/admin/studio-config.ts
@@ -2,6 +2,7 @@ import type { MdcmsConfig } from "@mdcms/studio";
 import { prepareStudioConfig } from "@mdcms/studio/runtime";
 import {
   studioExampleEnvironment,
+  studioExampleLocales,
   studioExampleMdxComponents,
   studioExampleProject,
   studioExampleServerUrl,
@@ -46,6 +47,7 @@ export function createClientStudioConfig(
     project: studioExampleProject,
     environment: studioExampleEnvironment,
     serverUrl: studioExampleServerUrl,
+    locales: studioExampleLocales,
     // Pre-computed schema hash from the server component where the full
     // config (with Zod types/environments) is available for derivation.
     ...(schemaHash ? { _schemaHash: schemaHash } : {}),

--- a/apps/studio-example/lib/studio-example-studio-config.ts
+++ b/apps/studio-example/lib/studio-example-studio-config.ts
@@ -1,6 +1,10 @@
 export const studioExampleProject = "marketing-site";
 export const studioExampleEnvironment = "staging";
 export const studioExampleServerUrl = "http://localhost:4000";
+export const studioExampleLocales = {
+  default: "en",
+  supported: ["en", "fr"],
+} as const;
 
 export const studioExampleMdxComponents = [
   {

--- a/apps/studio-example/mdcms.config.ts
+++ b/apps/studio-example/mdcms.config.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   studioExampleEnvironment,
+  studioExampleLocales,
   studioExampleMdxComponents,
   studioExampleProject,
   studioExampleServerUrl,
@@ -46,10 +47,7 @@ export default defineConfig({
   environment: studioExampleEnvironment,
   serverUrl: studioExampleServerUrl,
   contentDirectories: ["content"],
-  locales: {
-    default: "en",
-    supported: ["en", "fr"],
-  },
+  locales: studioExampleLocales,
   environments: {
     production: {},
     staging: {

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TranslationCoverageSummary } from "./page.js";
+
+test("TranslationCoverageSummary renders the loading state deterministically", () => {
+  const markup = renderToStaticMarkup(
+    createElement(TranslationCoverageSummary, {
+      status: "loading",
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-translation-coverage-state="loading"/);
+  assert.match(markup, /Loading locale coverage/i);
+});
+
+test("TranslationCoverageSummary renders the translated locale count", () => {
+  const markup = renderToStaticMarkup(
+    createElement(TranslationCoverageSummary, {
+      status: "ready",
+      coverage: {
+        translatedLocales: 2,
+        totalLocales: 4,
+      },
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-translation-coverage-state="ready"/);
+  assert.match(markup, /2\/4 locales translated/);
+});
+
+test("TranslationCoverageSummary renders an error fallback when coverage is unavailable", () => {
+  const markup = renderToStaticMarkup(
+    createElement(TranslationCoverageSummary, {
+      status: "error",
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-translation-coverage-state="error"/);
+  assert.match(markup, /Translation status unavailable/i);
+});

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
@@ -6,6 +6,19 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { TranslationCoverageSummary } from "./page.js";
 
+test("TranslationCoverageSummary renders nothing for the idle state", () => {
+  const markup = renderToStaticMarkup(
+    createElement(TranslationCoverageSummary, {
+      status: "idle",
+    }),
+  );
+
+  assert.equal(markup, "");
+  assert.doesNotMatch(markup, /data-mdcms-translation-coverage-state/);
+  assert.doesNotMatch(markup, /Loading/i);
+  assert.doesNotMatch(markup, /Translation status unavailable/i);
+});
+
 test("TranslationCoverageSummary renders the loading state deterministically", () => {
   const markup = renderToStaticMarkup(
     createElement(TranslationCoverageSummary, {

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
@@ -4,7 +4,10 @@ import { test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { TranslationCoverageSummary } from "./page.js";
+import {
+  getContentTypeTableColumns,
+  TranslationCoverageSummary,
+} from "./page.js";
 
 test("TranslationCoverageSummary renders nothing for the idle state", () => {
   const markup = renderToStaticMarkup(
@@ -54,4 +57,18 @@ test("TranslationCoverageSummary renders an error fallback when coverage is unav
 
   assert.match(markup, /data-mdcms-translation-coverage-state="error"/);
   assert.match(markup, /Translation status unavailable/i);
+});
+
+test("content type table adds a dedicated Translations column for localized lists", () => {
+  assert.deepEqual(
+    getContentTypeTableColumns(true).map((column) => column.label),
+    ["Title / Path", "Translations", "Status", "Updated", "Author", ""],
+  );
+});
+
+test("content type table keeps the original columns for non-localized lists", () => {
+  assert.deepEqual(
+    getContentTypeTableColumns(false).map((column) => column.label),
+    ["Title / Path", "Status", "Updated", "Author", ""],
+  );
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -58,6 +58,7 @@ import { useStudioMountInfo } from "../../mount-info-context.js";
 import {
   useContentTypeList,
   PAGE_SIZE,
+  type ContentTypeTranslationCoverageStatus,
   type MappedContentDocument,
   type ContentTypeListFilters,
 } from "../../../../hooks/use-content-type-list.js";
@@ -66,6 +67,11 @@ import { CreateDocumentDialog } from "../../../../components/create-document-dia
 import { createStudioSchemaRouteApi } from "../../../../../schema-route-api.js";
 import { createStudioDocumentRouteApi } from "../../../../../document-route-api.js";
 import { useToast } from "../../../../components/toast.js";
+import {
+  CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+  formatContentTranslationCoverageLabel,
+  type ContentTranslationCoverage,
+} from "../../../../lib/content-translation-coverage.js";
 
 const statusConfig = {
   published: {
@@ -81,6 +87,51 @@ const statusConfig = {
     className: "bg-warning/10 text-warning border-warning/20",
   },
 };
+
+type TranslationCoverageSummaryProps = {
+  status: ContentTypeTranslationCoverageStatus;
+  coverage?: ContentTranslationCoverage;
+};
+
+export function TranslationCoverageSummary({
+  status,
+  coverage,
+}: TranslationCoverageSummaryProps) {
+  if (status === "idle") {
+    return null;
+  }
+
+  if (status === "loading") {
+    return (
+      <p
+        data-mdcms-translation-coverage-state="loading"
+        className="mt-1 text-xs text-foreground-muted"
+      >
+        Loading locale coverage...
+      </p>
+    );
+  }
+
+  if (status === "error" || !coverage) {
+    return (
+      <p
+        data-mdcms-translation-coverage-state="error"
+        className="mt-1 text-xs text-destructive"
+      >
+        Translation status unavailable.
+      </p>
+    );
+  }
+
+  return (
+    <p
+      data-mdcms-translation-coverage-state="ready"
+      className="mt-1 text-xs text-foreground-muted"
+    >
+      {formatContentTranslationCoverageLabel(coverage)}
+    </p>
+  );
+}
 
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
@@ -208,14 +259,7 @@ export default function ContentTypePage() {
       return documentApi.publish({ documentId });
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: [
-          "content-list",
-          mountInfo.project,
-          mountInfo.environment,
-          typeId,
-        ],
-      });
+      invalidateContentListQueries();
     },
     onError: onRowActionError,
   });
@@ -227,14 +271,7 @@ export default function ContentTypePage() {
       return documentApi.unpublish({ documentId });
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: [
-          "content-list",
-          mountInfo.project,
-          mountInfo.environment,
-          typeId,
-        ],
-      });
+      invalidateContentListQueries();
     },
     onError: onRowActionError,
   });
@@ -246,14 +283,7 @@ export default function ContentTypePage() {
       return documentApi.duplicate({ documentId });
     },
     onSuccess: (data) => {
-      void queryClient.invalidateQueries({
-        queryKey: [
-          "content-list",
-          mountInfo.project,
-          mountInfo.environment,
-          typeId,
-        ],
-      });
+      invalidateContentListQueries();
       router.push(`/admin/content/${typeId}/${data.documentId}`);
     },
     onError: onRowActionError,
@@ -266,14 +296,7 @@ export default function ContentTypePage() {
       return documentApi.softDelete({ documentId });
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: [
-          "content-list",
-          mountInfo.project,
-          mountInfo.environment,
-          typeId,
-        ],
-      });
+      invalidateContentListQueries();
       toast.success(
         "Document moved to trash. It can be restored from the Trash page.",
       );
@@ -294,6 +317,28 @@ export default function ContentTypePage() {
   const currentPage = list.pagination
     ? Math.floor(list.pagination.offset / PAGE_SIZE) + 1
     : 1;
+  const showTranslationCoverage =
+    schemaEntry?.localized === true &&
+    (mountInfo.supportedLocales?.length ?? 0) > 0;
+
+  const invalidateContentListQueries = () => {
+    void queryClient.invalidateQueries({
+      queryKey: [
+        "content-list",
+        mountInfo.project,
+        mountInfo.environment,
+        typeId,
+      ],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: [
+        CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+        mountInfo.project,
+        mountInfo.environment,
+        typeId,
+      ],
+    });
+  };
 
   function renderRowActions(doc: MappedContentDocument) {
     return (
@@ -547,6 +592,16 @@ export default function ContentTypePage() {
                             <p className="text-xs text-foreground-muted font-mono">
                               {doc.path}
                             </p>
+                            {showTranslationCoverage ? (
+                              <TranslationCoverageSummary
+                                status={list.translationCoverageStatus}
+                                coverage={
+                                  list.translationCoverageByGroup[
+                                    doc.translationGroupId
+                                  ]
+                                }
+                              />
+                            ) : null}
                           </div>
                         </TableCell>
                         <TableCell>

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -56,6 +56,7 @@ import { cn } from "../../../../lib/utils.js";
 import { useAdminCapabilities } from "../../capabilities-context.js";
 import { useStudioMountInfo } from "../../mount-info-context.js";
 import {
+  getContentTypeListQueryKey,
   useContentTypeList,
   PAGE_SIZE,
   type ContentTypeTranslationCoverageStatus,
@@ -68,8 +69,8 @@ import { createStudioSchemaRouteApi } from "../../../../../schema-route-api.js";
 import { createStudioDocumentRouteApi } from "../../../../../document-route-api.js";
 import { useToast } from "../../../../components/toast.js";
 import {
-  CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
   formatContentTranslationCoverageLabel,
+  getContentTranslationCoverageQueryKey,
   type ContentTranslationCoverage,
 } from "../../../../lib/content-translation-coverage.js";
 
@@ -174,27 +175,6 @@ export default function ContentTypePage() {
   const [rowActionError, setRowActionError] = useState<string | null>(null);
   const [showLoading, setShowLoading] = useState(false);
 
-  const list = useContentTypeList(typeId);
-  const create = useCreateDocument(typeId);
-
-  // Debounce loading skeleton by 200ms
-  useEffect(() => {
-    if (list.status !== "loading") {
-      setShowLoading(false);
-      return;
-    }
-    const timer = setTimeout(() => setShowLoading(true), 200);
-    return () => clearTimeout(timer);
-  }, [list.status]);
-
-  // Debounced search
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      list.setFilters({ q: searchInput || undefined });
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchInput, list.setFilters]);
-
   // Schema query for type metadata (localized, locales, directory)
   const schemaApi = useMemo(() => {
     if (!mountInfo.project || !mountInfo.environment || !mountInfo.apiBaseUrl)
@@ -228,6 +208,29 @@ export default function ContentTypePage() {
   }, [schemaQuery.data, typeId]);
 
   const typeName = schemaEntry?.type ?? typeId;
+  const enableTranslationCoverage = schemaEntry?.localized === true;
+  const list = useContentTypeList(typeId, {
+    enableTranslationCoverage,
+  });
+  const create = useCreateDocument(typeId);
+
+  // Debounce loading skeleton by 200ms
+  useEffect(() => {
+    if (list.status !== "loading") {
+      setShowLoading(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowLoading(true), 200);
+    return () => clearTimeout(timer);
+  }, [list.status]);
+
+  // Debounced search
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      list.setFilters({ q: searchInput || undefined });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput, list.setFilters]);
 
   // Document route API for row actions
   const documentApi = useMemo(() => {
@@ -318,25 +321,22 @@ export default function ContentTypePage() {
     ? Math.floor(list.pagination.offset / PAGE_SIZE) + 1
     : 1;
   const showTranslationCoverage =
-    schemaEntry?.localized === true &&
-    (mountInfo.supportedLocales?.length ?? 0) > 0;
+    enableTranslationCoverage && (mountInfo.supportedLocales?.length ?? 0) > 0;
 
   const invalidateContentListQueries = () => {
     void queryClient.invalidateQueries({
-      queryKey: [
-        "content-list",
+      queryKey: getContentTypeListQueryKey(
         mountInfo.project,
         mountInfo.environment,
         typeId,
-      ],
+      ),
     });
     void queryClient.invalidateQueries({
-      queryKey: [
-        CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+      queryKey: getContentTranslationCoverageQueryKey(
         mountInfo.project,
         mountInfo.environment,
         typeId,
-      ],
+      ),
     });
   };
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -94,6 +94,33 @@ type TranslationCoverageSummaryProps = {
   coverage?: ContentTranslationCoverage;
 };
 
+type ContentTypeTableColumn = {
+  key: "title" | "translations" | "status" | "updated" | "author" | "actions";
+  label: string;
+  className?: string;
+};
+
+export function getContentTypeTableColumns(
+  showTranslationCoverage: boolean,
+): ContentTypeTableColumn[] {
+  return [
+    { key: "title", label: "Title / Path" },
+    ...(showTranslationCoverage
+      ? ([
+          {
+            key: "translations",
+            label: "Translations",
+            className: "w-40",
+          },
+        ] satisfies ContentTypeTableColumn[])
+      : []),
+    { key: "status", label: "Status", className: "w-28" },
+    { key: "updated", label: "Updated", className: "w-32" },
+    { key: "author", label: "Author", className: "w-28" },
+    { key: "actions", label: "", className: "w-14" },
+  ];
+}
+
 export function TranslationCoverageSummary({
   status,
   coverage,
@@ -106,7 +133,7 @@ export function TranslationCoverageSummary({
     return (
       <p
         data-mdcms-translation-coverage-state="loading"
-        className="mt-1 text-xs text-foreground-muted"
+        className="text-xs text-foreground-muted"
       >
         Loading locale coverage...
       </p>
@@ -117,7 +144,7 @@ export function TranslationCoverageSummary({
     return (
       <p
         data-mdcms-translation-coverage-state="error"
-        className="mt-1 text-xs text-destructive"
+        className="text-xs text-destructive"
       >
         Translation status unavailable.
       </p>
@@ -127,7 +154,7 @@ export function TranslationCoverageSummary({
   return (
     <p
       data-mdcms-translation-coverage-state="ready"
-      className="mt-1 text-xs text-foreground-muted"
+      className="text-xs text-foreground-muted"
     >
       {formatContentTranslationCoverageLabel(coverage)}
     </p>
@@ -322,6 +349,10 @@ export default function ContentTypePage() {
     : 1;
   const showTranslationCoverage =
     enableTranslationCoverage && (mountInfo.supportedLocales?.length ?? 0) > 0;
+  const tableColumns = useMemo(
+    () => getContentTypeTableColumns(showTranslationCoverage),
+    [showTranslationCoverage],
+  );
 
   const invalidateContentListQueries = () => {
     void queryClient.invalidateQueries({
@@ -568,11 +599,14 @@ export default function ContentTypePage() {
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Title / Path</TableHead>
-                      <TableHead className="w-28">Status</TableHead>
-                      <TableHead className="w-32">Updated</TableHead>
-                      <TableHead className="w-28">Author</TableHead>
-                      <TableHead className="w-14"></TableHead>
+                      {tableColumns.map((column) => (
+                        <TableHead
+                          key={column.key}
+                          className={column.className}
+                        >
+                          {column.label}
+                        </TableHead>
+                      ))}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -592,18 +626,20 @@ export default function ContentTypePage() {
                             <p className="text-xs text-foreground-muted font-mono">
                               {doc.path}
                             </p>
-                            {showTranslationCoverage ? (
-                              <TranslationCoverageSummary
-                                status={list.translationCoverageStatus}
-                                coverage={
-                                  list.translationCoverageByGroup[
-                                    doc.translationGroupId
-                                  ]
-                                }
-                              />
-                            ) : null}
                           </div>
                         </TableCell>
+                        {showTranslationCoverage ? (
+                          <TableCell>
+                            <TranslationCoverageSummary
+                              status={list.translationCoverageStatus}
+                              coverage={
+                                list.translationCoverageByGroup[
+                                  doc.translationGroupId
+                                ]
+                              }
+                            />
+                          </TableCell>
+                        ) : null}
                         <TableCell>
                           <Badge
                             variant="outline"

--- a/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
@@ -54,6 +54,7 @@ import {
   type MappedTrashDocument,
   type TrashListSort,
 } from "../../hooks/use-trash-list.js";
+import { CONTENT_TRANSLATION_COVERAGE_QUERY_KEY } from "../../lib/content-translation-coverage.js";
 import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioDocumentRouteApi } from "../../../document-route-api.js";
 import { useToast } from "../../components/toast.js";
@@ -162,6 +163,13 @@ export default function TrashPage() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["trash-list"] });
+      void queryClient.invalidateQueries({
+        queryKey: [
+          CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+          mountInfo.project,
+          mountInfo.environment,
+        ],
+      });
       toast.success("Document restored. It is now available as a draft.");
     },
     onError: (error: Error) => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
@@ -54,7 +54,7 @@ import {
   type MappedTrashDocument,
   type TrashListSort,
 } from "../../hooks/use-trash-list.js";
-import { CONTENT_TRANSLATION_COVERAGE_QUERY_KEY } from "../../lib/content-translation-coverage.js";
+import { getContentTranslationCoverageQueryKey } from "../../lib/content-translation-coverage.js";
 import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { createStudioDocumentRouteApi } from "../../../document-route-api.js";
 import { useToast } from "../../components/toast.js";
@@ -164,11 +164,10 @@ export default function TrashPage() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["trash-list"] });
       void queryClient.invalidateQueries({
-        queryKey: [
-          CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+        queryKey: getContentTranslationCoverageQueryKey(
           mountInfo.project,
           mountInfo.environment,
-        ],
+        ),
       });
       toast.success("Document restored. It is now available as a draft.");
     },

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
@@ -9,6 +9,7 @@ import {
   extractDocumentTitle,
   mapFiltersToQuery,
   getContentTypeListQueryKey,
+  getTranslationCoverageStatus,
   PAGE_SIZE,
   shouldEnableTranslationCoverage,
 } from "./use-content-type-list.js";
@@ -143,6 +144,18 @@ test("shouldEnableTranslationCoverage requires both a localized type and support
       supportedLocaleCount: 0,
     }),
     false,
+  );
+});
+
+test("getTranslationCoverageStatus reports loading during background coverage refetches", () => {
+  assert.equal(
+    getTranslationCoverageStatus({
+      enableTranslationCoverage: true,
+      isLoading: false,
+      isFetching: true,
+      hasError: false,
+    }),
+    "loading",
   );
 });
 

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
@@ -8,7 +8,9 @@ import {
   deriveDocumentStatus,
   extractDocumentTitle,
   mapFiltersToQuery,
+  getContentTypeListQueryKey,
   PAGE_SIZE,
+  shouldEnableTranslationCoverage,
 } from "./use-content-type-list.js";
 
 const baseDoc: ContentDocumentResponse = {
@@ -111,6 +113,37 @@ test("mapFiltersToQuery maps sort values to API params", () => {
 test("mapFiltersToQuery includes q when present", () => {
   const result = mapFiltersToQuery({ q: "hello" });
   assert.equal(result.q, "hello");
+});
+
+test("getContentTypeListQueryKey returns the canonical type-scoped query prefix", () => {
+  assert.deepEqual(
+    getContentTypeListQueryKey("marketing-site", "production", "BlogPost"),
+    ["content-list", "marketing-site", "production", "BlogPost"],
+  );
+});
+
+test("shouldEnableTranslationCoverage requires both a localized type and supported locales", () => {
+  assert.equal(
+    shouldEnableTranslationCoverage({
+      enableTranslationCoverage: true,
+      supportedLocaleCount: 2,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldEnableTranslationCoverage({
+      enableTranslationCoverage: false,
+      supportedLocaleCount: 2,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldEnableTranslationCoverage({
+      enableTranslationCoverage: true,
+      supportedLocaleCount: 0,
+    }),
+    false,
+  );
 });
 
 test("PAGE_SIZE is 20", () => {

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
@@ -65,6 +65,7 @@ test("extractDocumentTitle falls back to last path segment", () => {
 test("mapContentDocument transforms API response to view model", () => {
   const mapped = mapContentDocument(baseDoc);
   assert.equal(mapped.documentId, "doc-1");
+  assert.equal(mapped.translationGroupId, "tg-1");
   assert.equal(mapped.title, "Hello World");
   assert.equal(mapped.path, "blog/hello-world");
   assert.equal(mapped.locale, "en");

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -166,6 +166,18 @@ export function shouldEnableTranslationCoverage(input: {
   return input.enableTranslationCoverage && input.supportedLocaleCount > 0;
 }
 
+export function getTranslationCoverageStatus(input: {
+  enableTranslationCoverage: boolean;
+  isLoading: boolean;
+  isFetching: boolean;
+  hasError: boolean;
+}): ContentTypeTranslationCoverageStatus {
+  if (!input.enableTranslationCoverage) return "idle";
+  if (input.isLoading || input.isFetching) return "loading";
+  if (input.hasError) return "error";
+  return "ready";
+}
+
 export function useContentTypeList(
   typeId: string,
   options: ContentTypeListOptions = {},
@@ -250,13 +262,16 @@ export function useContentTypeList(
     translationCoverageQuery.data ?? {};
   const translationCoverageStatus: ContentTypeTranslationCoverageStatus =
     useMemo(() => {
-      if (!enableTranslationCoverage) return "idle";
-      if (translationCoverageQuery.isLoading) return "loading";
-      if (translationCoverageQuery.error) return "error";
-      return "ready";
+      return getTranslationCoverageStatus({
+        enableTranslationCoverage,
+        isLoading: translationCoverageQuery.isLoading,
+        isFetching: translationCoverageQuery.isFetching,
+        hasError: translationCoverageQuery.error != null,
+      });
     }, [
       enableTranslationCoverage,
       translationCoverageQuery.isLoading,
+      translationCoverageQuery.isFetching,
       translationCoverageQuery.error,
     ]);
 

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -13,12 +13,18 @@ import {
   createStudioContentListApi,
   type StudioContentListQuery,
 } from "../../content-list-api.js";
+import {
+  getContentTranslationCoverageQueryKey,
+  loadContentTranslationCoverageMap,
+  type ContentTranslationCoverageMap,
+} from "../lib/content-translation-coverage.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 
 export type DocumentStatus = "published" | "draft" | "changed";
 
 export type MappedContentDocument = {
   documentId: string;
+  translationGroupId: string;
   title: string;
   path: string;
   locale: string;
@@ -26,6 +32,12 @@ export type MappedContentDocument = {
   updatedAt: string;
   createdBy: string;
 };
+
+export type ContentTypeTranslationCoverageStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "error";
 
 export type ContentTypeListFilters = {
   q?: string;
@@ -68,6 +80,7 @@ export function mapContentDocument(
 ): MappedContentDocument {
   return {
     documentId: doc.documentId,
+    translationGroupId: doc.translationGroupId,
     title: extractDocumentTitle(doc.frontmatter, doc.path),
     path: doc.path,
     locale: doc.locale,
@@ -138,6 +151,7 @@ export function useContentTypeList(typeId: string) {
   const mountInfo = useStudioMountInfo();
   const [filters, setFiltersState] = useState<ContentTypeListFilters>({});
   const [offset, setOffset] = useState(0);
+  const supportedLocaleCount = mountInfo.supportedLocales?.length ?? 0;
 
   const api = useMemo(() => {
     if (!mountInfo.project || !mountInfo.environment || !mountInfo.apiBaseUrl) {
@@ -183,6 +197,21 @@ export function useContentTypeList(typeId: string) {
     enabled: api !== null,
   });
 
+  const translationCoverageQuery = useQuery({
+    queryKey: getContentTranslationCoverageQueryKey(
+      mountInfo.project,
+      mountInfo.environment,
+      typeId,
+    ),
+    queryFn: () =>
+      loadContentTranslationCoverageMap(api!, {
+        type: typeId,
+        totalLocales: supportedLocaleCount,
+      }),
+    enabled: api !== null && supportedLocaleCount > 0,
+    staleTime: 60_000,
+  });
+
   const documents = useMemo(
     () => (query.data?.data ?? []).map(mapContentDocument),
     [query.data?.data],
@@ -190,6 +219,19 @@ export function useContentTypeList(typeId: string) {
 
   const pagination: PaginationMetadata | null = query.data?.pagination ?? null;
   const users: Record<string, ContentUserSummary> = query.data?.users ?? {};
+  const translationCoverageByGroup: ContentTranslationCoverageMap =
+    translationCoverageQuery.data ?? {};
+  const translationCoverageStatus: ContentTypeTranslationCoverageStatus =
+    useMemo(() => {
+      if (supportedLocaleCount === 0) return "idle";
+      if (translationCoverageQuery.isLoading) return "loading";
+      if (translationCoverageQuery.error) return "error";
+      return "ready";
+    }, [
+      supportedLocaleCount,
+      translationCoverageQuery.isLoading,
+      translationCoverageQuery.error,
+    ]);
 
   const status: ContentTypeListStatus = useMemo(() => {
     if (query.isLoading) return "loading";
@@ -224,13 +266,18 @@ export function useContentTypeList(typeId: string) {
 
   const refresh = useCallback(() => {
     query.refetch();
-  }, [query.refetch]);
+    if (supportedLocaleCount > 0) {
+      translationCoverageQuery.refetch();
+    }
+  }, [query.refetch, supportedLocaleCount, translationCoverageQuery.refetch]);
 
   return {
     status,
     documents,
     pagination,
     users,
+    translationCoverageStatus,
+    translationCoverageByGroup,
     filters,
     errorMessage,
     setFilters,

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -54,6 +54,10 @@ export type ContentTypeListStatus =
 
 export const PAGE_SIZE = 20;
 
+export type ContentTypeListOptions = {
+  enableTranslationCoverage?: boolean;
+};
+
 export function deriveDocumentStatus(
   publishedVersion: number | null,
   hasUnpublishedChanges: boolean,
@@ -147,11 +151,33 @@ function hasActiveFilters(filters: ContentTypeListFilters): boolean {
   return Boolean(filters.q || (filters.status && filters.status !== "all"));
 }
 
-export function useContentTypeList(typeId: string) {
+export function getContentTypeListQueryKey(
+  project: string | null | undefined,
+  environment: string | null | undefined,
+  typeId: string,
+) {
+  return ["content-list", project, environment, typeId] as const;
+}
+
+export function shouldEnableTranslationCoverage(input: {
+  enableTranslationCoverage: boolean;
+  supportedLocaleCount: number;
+}): boolean {
+  return input.enableTranslationCoverage && input.supportedLocaleCount > 0;
+}
+
+export function useContentTypeList(
+  typeId: string,
+  options: ContentTypeListOptions = {},
+) {
   const mountInfo = useStudioMountInfo();
   const [filters, setFiltersState] = useState<ContentTypeListFilters>({});
   const [offset, setOffset] = useState(0);
   const supportedLocaleCount = mountInfo.supportedLocales?.length ?? 0;
+  const enableTranslationCoverage = shouldEnableTranslationCoverage({
+    enableTranslationCoverage: options.enableTranslationCoverage === true,
+    supportedLocaleCount,
+  });
 
   const api = useMemo(() => {
     if (!mountInfo.project || !mountInfo.environment || !mountInfo.apiBaseUrl) {
@@ -176,10 +202,11 @@ export function useContentTypeList(typeId: string) {
 
   const query = useQuery({
     queryKey: [
-      "content-list",
-      mountInfo.project,
-      mountInfo.environment,
-      typeId,
+      ...getContentTypeListQueryKey(
+        mountInfo.project,
+        mountInfo.environment,
+        typeId,
+      ),
       queryParams,
       offset,
     ],
@@ -208,7 +235,7 @@ export function useContentTypeList(typeId: string) {
         type: typeId,
         totalLocales: supportedLocaleCount,
       }),
-    enabled: api !== null && supportedLocaleCount > 0,
+    enabled: api !== null && enableTranslationCoverage,
     staleTime: 60_000,
   });
 
@@ -223,12 +250,12 @@ export function useContentTypeList(typeId: string) {
     translationCoverageQuery.data ?? {};
   const translationCoverageStatus: ContentTypeTranslationCoverageStatus =
     useMemo(() => {
-      if (supportedLocaleCount === 0) return "idle";
+      if (!enableTranslationCoverage) return "idle";
       if (translationCoverageQuery.isLoading) return "loading";
       if (translationCoverageQuery.error) return "error";
       return "ready";
     }, [
-      supportedLocaleCount,
+      enableTranslationCoverage,
       translationCoverageQuery.isLoading,
       translationCoverageQuery.error,
     ]);
@@ -266,10 +293,14 @@ export function useContentTypeList(typeId: string) {
 
   const refresh = useCallback(() => {
     query.refetch();
-    if (supportedLocaleCount > 0) {
+    if (enableTranslationCoverage) {
       translationCoverageQuery.refetch();
     }
-  }, [query.refetch, supportedLocaleCount, translationCoverageQuery.refetch]);
+  }, [
+    enableTranslationCoverage,
+    query.refetch,
+    translationCoverageQuery.refetch,
+  ]);
 
   return {
     status,

--- a/packages/studio/src/lib/runtime-ui/hooks/use-create-document.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-create-document.ts
@@ -5,7 +5,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { IMPLICIT_DEFAULT_LOCALE } from "@mdcms/shared";
 import { createStudioDocumentRouteApi } from "../../document-route-api.js";
-import { CONTENT_TRANSLATION_COVERAGE_QUERY_KEY } from "../lib/content-translation-coverage.js";
+import { getContentTranslationCoverageQueryKey } from "../lib/content-translation-coverage.js";
+import { getContentTypeListQueryKey } from "./use-content-type-list.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import { useRouter } from "../navigation.js";
 
@@ -67,20 +68,18 @@ export function useCreateDocument(typeId: string) {
     },
     onSuccess: (data) => {
       void queryClient.invalidateQueries({
-        queryKey: [
-          "content-list",
+        queryKey: getContentTypeListQueryKey(
           mountInfo.project,
           mountInfo.environment,
           typeId,
-        ],
+        ),
       });
       void queryClient.invalidateQueries({
-        queryKey: [
-          CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+        queryKey: getContentTranslationCoverageQueryKey(
           mountInfo.project,
           mountInfo.environment,
           typeId,
-        ],
+        ),
       });
       setIsOpen(false);
       router.push(`/admin/content/${typeId}/${data.documentId}`);

--- a/packages/studio/src/lib/runtime-ui/hooks/use-create-document.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-create-document.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { IMPLICIT_DEFAULT_LOCALE } from "@mdcms/shared";
 import { createStudioDocumentRouteApi } from "../../document-route-api.js";
+import { CONTENT_TRANSLATION_COVERAGE_QUERY_KEY } from "../lib/content-translation-coverage.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import { useRouter } from "../navigation.js";
 
@@ -68,6 +69,14 @@ export function useCreateDocument(typeId: string) {
       void queryClient.invalidateQueries({
         queryKey: [
           "content-list",
+          mountInfo.project,
+          mountInfo.environment,
+          typeId,
+        ],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [
+          CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
           mountInfo.project,
           mountInfo.environment,
           typeId,

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
@@ -158,3 +158,62 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
     },
   ]);
 });
+
+test("loadContentTranslationCoverageMap stops after the configured maxPages guard", async () => {
+  let calls = 0;
+  const api: StudioContentListApi = {
+    list: async () => {
+      calls += 1;
+
+      if (calls > 3) {
+        throw new Error("pagination guard did not stop further requests");
+      }
+
+      return {
+        data: [
+          {
+            documentId: `doc-${calls}`,
+            translationGroupId: "tg-1",
+            project: "marketing-site",
+            environment: "production",
+            path: `blog/post-${calls}`,
+            type: "BlogPost",
+            locale: `locale-${calls}`,
+            format: "md",
+            isDeleted: false,
+            hasUnpublishedChanges: false,
+            version: 1,
+            publishedVersion: 1,
+            draftRevision: 0,
+            frontmatter: { title: `Post ${calls}` },
+            body: "# Post",
+            createdBy: "user-1",
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedBy: "user-1",
+            updatedAt: "2026-03-20T00:00:00.000Z",
+          },
+        ],
+        pagination: {
+          total: 1,
+          limit: 1,
+          offset: calls - 1,
+          hasMore: true,
+        },
+      };
+    },
+  };
+
+  const coverage = await loadContentTranslationCoverageMap(api, {
+    type: "BlogPost",
+    totalLocales: 5,
+    maxPages: 3,
+  } as never);
+
+  assert.equal(calls, 3);
+  assert.deepEqual(coverage, {
+    "tg-1": {
+      translatedLocales: 3,
+      totalLocales: 5,
+    },
+  });
+});

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import type { StudioContentListApi } from "../../content-list-api.js";
+
+import {
+  buildContentTranslationCoverageMap,
+  formatContentTranslationCoverageLabel,
+  loadContentTranslationCoverageMap,
+} from "./content-translation-coverage.js";
+
+test("buildContentTranslationCoverageMap counts unique locales per translation group", () => {
+  const coverage = buildContentTranslationCoverageMap(
+    [
+      { translationGroupId: "tg-1", locale: "en" },
+      { translationGroupId: "tg-1", locale: "fr" },
+      { translationGroupId: "tg-1", locale: "fr" },
+      { translationGroupId: "tg-2", locale: "en" },
+    ],
+    4,
+  );
+
+  assert.deepEqual(coverage, {
+    "tg-1": { translatedLocales: 2, totalLocales: 4 },
+    "tg-2": { translatedLocales: 1, totalLocales: 4 },
+  });
+});
+
+test("formatContentTranslationCoverageLabel renders the translated locale count", () => {
+  assert.equal(
+    formatContentTranslationCoverageLabel({
+      translatedLocales: 2,
+      totalLocales: 4,
+    }),
+    "2/4 locales translated",
+  );
+});
+
+test("loadContentTranslationCoverageMap paginates through the full type list", async () => {
+  const calls: Array<Record<string, unknown> | undefined> = [];
+  const api: StudioContentListApi = {
+    list: async (query = {}) => {
+      calls.push(query);
+
+      if ((query.offset ?? 0) === 0) {
+        return {
+          data: [
+            {
+              documentId: "doc-1",
+              translationGroupId: "tg-1",
+              project: "marketing-site",
+              environment: "production",
+              path: "blog/hello-world",
+              type: "BlogPost",
+              locale: "en",
+              format: "md",
+              isDeleted: false,
+              hasUnpublishedChanges: false,
+              version: 1,
+              publishedVersion: 1,
+              draftRevision: 0,
+              frontmatter: { title: "Hello World" },
+              body: "# Hello",
+              createdBy: "user-1",
+              createdAt: "2026-03-01T00:00:00.000Z",
+              updatedBy: "user-1",
+              updatedAt: "2026-03-20T00:00:00.000Z",
+            },
+            {
+              documentId: "doc-2",
+              translationGroupId: "tg-1",
+              project: "marketing-site",
+              environment: "production",
+              path: "blog/bonjour",
+              type: "BlogPost",
+              locale: "fr",
+              format: "md",
+              isDeleted: false,
+              hasUnpublishedChanges: false,
+              version: 1,
+              publishedVersion: 1,
+              draftRevision: 0,
+              frontmatter: { title: "Bonjour" },
+              body: "# Bonjour",
+              createdBy: "user-1",
+              createdAt: "2026-03-01T00:00:00.000Z",
+              updatedBy: "user-1",
+              updatedAt: "2026-03-20T00:00:00.000Z",
+            },
+          ],
+          pagination: {
+            total: 3,
+            limit: 2,
+            offset: 0,
+            hasMore: true,
+          },
+        };
+      }
+
+      return {
+        data: [
+          {
+            documentId: "doc-3",
+            translationGroupId: "tg-2",
+            project: "marketing-site",
+            environment: "production",
+            path: "blog/hallo",
+            type: "BlogPost",
+            locale: "de",
+            format: "md",
+            isDeleted: false,
+            hasUnpublishedChanges: false,
+            version: 1,
+            publishedVersion: 1,
+            draftRevision: 0,
+            frontmatter: { title: "Hallo" },
+            body: "# Hallo",
+            createdBy: "user-1",
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedBy: "user-1",
+            updatedAt: "2026-03-20T00:00:00.000Z",
+          },
+        ],
+        pagination: {
+          total: 3,
+          limit: 2,
+          offset: 2,
+          hasMore: false,
+        },
+      };
+    },
+  };
+
+  const coverage = await loadContentTranslationCoverageMap(api, {
+    type: "BlogPost",
+    totalLocales: 4,
+  });
+
+  assert.deepEqual(coverage, {
+    "tg-1": { translatedLocales: 2, totalLocales: 4 },
+    "tg-2": { translatedLocales: 1, totalLocales: 4 },
+  });
+  assert.deepEqual(calls, [
+    {
+      type: "BlogPost",
+      draft: true,
+      isDeleted: false,
+      limit: 100,
+      offset: 0,
+    },
+    {
+      type: "BlogPost",
+      draft: true,
+      isDeleted: false,
+      limit: 100,
+      offset: 2,
+    },
+  ]);
+});

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
@@ -1,0 +1,109 @@
+import type { ContentDocumentResponse } from "@mdcms/shared";
+
+import type { StudioContentListApi } from "../../content-list-api.js";
+
+export const CONTENT_TRANSLATION_COVERAGE_QUERY_KEY =
+  "content-translation-coverage";
+export const CONTENT_TRANSLATION_COVERAGE_PAGE_SIZE = 100;
+
+export type ContentTranslationCoverage = {
+  translatedLocales: number;
+  totalLocales: number;
+};
+
+export type ContentTranslationCoverageMap = Record<
+  string,
+  ContentTranslationCoverage
+>;
+
+type TranslationCoverageDocument = Pick<
+  ContentDocumentResponse,
+  "translationGroupId" | "locale"
+>;
+
+export function getContentTranslationCoverageQueryKey(
+  project: string | null | undefined,
+  environment: string | null | undefined,
+  type: string,
+) {
+  return [
+    CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
+    project,
+    environment,
+    type,
+  ] as const;
+}
+
+export function buildContentTranslationCoverageMap(
+  documents: TranslationCoverageDocument[],
+  totalLocales: number,
+): ContentTranslationCoverageMap {
+  if (totalLocales <= 0) {
+    return {};
+  }
+
+  const localesByGroup = new Map<string, Set<string>>();
+
+  for (const document of documents) {
+    const locales =
+      localesByGroup.get(document.translationGroupId) ?? new Set();
+    locales.add(document.locale);
+    localesByGroup.set(document.translationGroupId, locales);
+  }
+
+  return Object.fromEntries(
+    [...localesByGroup.entries()].map(([translationGroupId, locales]) => [
+      translationGroupId,
+      {
+        translatedLocales: locales.size,
+        totalLocales,
+      },
+    ]),
+  );
+}
+
+export function formatContentTranslationCoverageLabel(
+  coverage: ContentTranslationCoverage,
+): string {
+  return `${coverage.translatedLocales}/${coverage.totalLocales} locales translated`;
+}
+
+export async function loadContentTranslationCoverageMap(
+  api: StudioContentListApi,
+  input: {
+    type: string;
+    totalLocales: number;
+  },
+): Promise<ContentTranslationCoverageMap> {
+  if (input.totalLocales <= 0) {
+    return {};
+  }
+
+  const documents: TranslationCoverageDocument[] = [];
+  let offset = 0;
+
+  while (true) {
+    const response = await api.list({
+      type: input.type,
+      draft: true,
+      isDeleted: false,
+      limit: CONTENT_TRANSLATION_COVERAGE_PAGE_SIZE,
+      offset,
+    });
+
+    documents.push(
+      ...response.data.map((document) => ({
+        translationGroupId: document.translationGroupId,
+        locale: document.locale,
+      })),
+    );
+
+    if (!response.pagination.hasMore || response.data.length === 0) {
+      break;
+    }
+
+    offset += Math.max(response.pagination.limit, response.data.length, 1);
+  }
+
+  return buildContentTranslationCoverageMap(documents, input.totalLocales);
+}

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
@@ -5,6 +5,7 @@ import type { StudioContentListApi } from "../../content-list-api.js";
 export const CONTENT_TRANSLATION_COVERAGE_QUERY_KEY =
   "content-translation-coverage";
 export const CONTENT_TRANSLATION_COVERAGE_PAGE_SIZE = 100;
+export const MAX_CONTENT_TRANSLATION_COVERAGE_PAGES = 1000;
 
 export type ContentTranslationCoverage = {
   translatedLocales: number;
@@ -24,13 +25,13 @@ type TranslationCoverageDocument = Pick<
 export function getContentTranslationCoverageQueryKey(
   project: string | null | undefined,
   environment: string | null | undefined,
-  type: string,
+  type?: string,
 ) {
   return [
     CONTENT_TRANSLATION_COVERAGE_QUERY_KEY,
     project,
     environment,
-    type,
+    ...(type ? [type] : []),
   ] as const;
 }
 
@@ -73,6 +74,7 @@ export async function loadContentTranslationCoverageMap(
   input: {
     type: string;
     totalLocales: number;
+    maxPages?: number;
   },
 ): Promise<ContentTranslationCoverageMap> {
   if (input.totalLocales <= 0) {
@@ -81,8 +83,13 @@ export async function loadContentTranslationCoverageMap(
 
   const documents: TranslationCoverageDocument[] = [];
   let offset = 0;
+  let pageCount = 0;
+  const maxPages = Math.max(
+    1,
+    input.maxPages ?? MAX_CONTENT_TRANSLATION_COVERAGE_PAGES,
+  );
 
-  while (true) {
+  while (pageCount < maxPages) {
     const response = await api.list({
       type: input.type,
       draft: true,
@@ -90,6 +97,7 @@ export async function loadContentTranslationCoverageMap(
       limit: CONTENT_TRANSLATION_COVERAGE_PAGE_SIZE,
       offset,
     });
+    pageCount += 1;
 
     documents.push(
       ...response.data.map((document) => ({
@@ -102,7 +110,14 @@ export async function loadContentTranslationCoverageMap(
       break;
     }
 
-    offset += Math.max(response.pagination.limit, response.data.length, 1);
+    const nextOffset =
+      offset + Math.max(response.pagination.limit, response.data.length, 1);
+
+    if (nextOffset <= offset) {
+      break;
+    }
+
+    offset = nextOffset;
   }
 
   return buildContentTranslationCoverageMap(documents, input.totalLocales);


### PR DESCRIPTION
## Summary
- implement translation coverage aggregation for localized Studio content lists using existing content list reads
- render per-row translation status indicators with deterministic loading and error fallbacks
- invalidate translation coverage caches after create, delete, duplicate, and restore flows, and cover the behavior with focused tests

## Testing
- bun --cwd packages/studio test
- bun run format:check
- bun run check

CMS-64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation coverage indicator showing "X/Y locales translated" with idle, loading, ready and error states; shown only for localized types with locales.
  * Content table gains an optional "Translations" column to surface per-item coverage.
  * Example project centralizes locale configuration used by the studio.

* **Bug Fixes**
  * Cache invalidation improved so translation coverage refreshes after creating or restoring content.

* **Tests**
  * Added unit and UI tests for coverage calculation, pagination, query keys, hook behavior and all coverage UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->