### PR TITLE
CMS-65: wire Studio environment management basics

### DIFF
--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/[id]/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/[id]/route.ts
@@ -1,9 +1,6 @@
 import { RuntimeError } from "@mdcms/shared";
 
-import {
-  createReviewEnvironment,
-  listReviewEnvironments,
-} from "../../../../../../review/environments";
+import { deleteReviewEnvironment } from "../../../../../../../review/environments";
 
 function toErrorResponse(error: unknown): Response {
   if (error instanceof RuntimeError) {
@@ -35,31 +32,15 @@ function toErrorResponse(error: unknown): Response {
   );
 }
 
-export async function GET(
+export async function DELETE(
   _request: Request,
-  context: { params: Promise<{ scenario: string }> },
+  context: { params: Promise<{ scenario: string; id: string }> },
 ) {
   try {
-    const { scenario } = await context.params;
+    const { scenario, id } = await context.params;
 
     return Response.json({
-      data: listReviewEnvironments(scenario),
-    });
-  } catch (error) {
-    return toErrorResponse(error);
-  }
-}
-
-export async function POST(
-  request: Request,
-  context: { params: Promise<{ scenario: string }> },
-) {
-  try {
-    const { scenario } = await context.params;
-    const payload = (await request.json()) as { name?: string };
-
-    return Response.json({
-      data: createReviewEnvironment(scenario, payload),
+      data: deleteReviewEnvironment(scenario, id),
     });
   } catch (error) {
     return toErrorResponse(error);

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.test.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { POST } from "./route";
+
+test("environment review POST returns 400 for malformed json bodies", async () => {
+  const response = await POST(
+    new Request("http://localhost/review-api/owner/api/v1/environments", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{",
+    }),
+    {
+      params: Promise.resolve({
+        scenario: "owner",
+      }),
+    },
+  );
+
+  const payload = (await response.json()) as {
+    code?: string;
+    statusCode?: number;
+  };
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, "INVALID_INPUT");
+  assert.equal(payload.statusCode, 400);
+});

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
@@ -35,6 +35,27 @@ function toErrorResponse(error: unknown): Response {
   );
 }
 
+async function parseCreateEnvironmentRequest(
+  request: Request,
+): Promise<{ name?: string }> {
+  try {
+    return (await request.json()) as { name?: string };
+  } catch (error) {
+    if (
+      error instanceof SyntaxError ||
+      (error as Error)?.name === "SyntaxError"
+    ) {
+      throw new RuntimeError({
+        code: "INVALID_INPUT",
+        message: "Request body must be valid JSON.",
+        statusCode: 400,
+      });
+    }
+
+    throw error;
+  }
+}
+
 export async function GET(
   _request: Request,
   context: { params: Promise<{ scenario: string }> },
@@ -56,7 +77,7 @@ export async function POST(
 ) {
   try {
     const { scenario } = await context.params;
-    const payload = (await request.json()) as { name?: string };
+    const payload = await parseCreateEnvironmentRequest(request);
 
     return Response.json({
       data: createReviewEnvironment(scenario, payload),

--- a/apps/studio-review/review/environments.test.ts
+++ b/apps/studio-review/review/environments.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+
+import { beforeEach, test } from "bun:test";
+
+import {
+  createReviewEnvironment,
+  deleteReviewEnvironment,
+  listReviewEnvironments,
+  resetReviewEnvironmentStore,
+} from "./environments";
+
+beforeEach(() => {
+  resetReviewEnvironmentStore();
+});
+
+test("listReviewEnvironments allows owner scenarios and returns seeded rows", () => {
+  const environments = listReviewEnvironments("owner");
+
+  assert.equal(environments.length, 2);
+  assert.equal(environments[0]?.name, "production");
+  assert.equal(environments[1]?.name, "staging");
+});
+
+test("listReviewEnvironments forbids non-admin scenarios", () => {
+  assert.throws(
+    () => listReviewEnvironments("editor"),
+    (error: unknown) =>
+      !!error &&
+      typeof error === "object" &&
+      "statusCode" in error &&
+      error.statusCode === 403,
+  );
+});
+
+test("createReviewEnvironment persists newly created review rows", () => {
+  const created = createReviewEnvironment("owner", { name: "preview" });
+  const environments = listReviewEnvironments("owner");
+
+  assert.equal(created.name, "preview");
+  assert.equal(environments.length, 3);
+  assert.equal(environments[2]?.name, "preview");
+});
+
+test("deleteReviewEnvironment removes non-default rows and rejects deleting production", () => {
+  const deleted = deleteReviewEnvironment("owner", "env-staging");
+
+  assert.deepEqual(deleted, {
+    deleted: true,
+    id: "env-staging",
+  });
+  assert.equal(listReviewEnvironments("owner").length, 1);
+
+  assert.throws(
+    () => deleteReviewEnvironment("owner", "env-production"),
+    (error: unknown) =>
+      !!error &&
+      typeof error === "object" &&
+      "statusCode" in error &&
+      error.statusCode === 409,
+  );
+});

--- a/apps/studio-review/review/environments.test.ts
+++ b/apps/studio-review/review/environments.test.ts
@@ -41,6 +41,17 @@ test("createReviewEnvironment persists newly created review rows", () => {
   assert.equal(environments[2]?.name, "preview");
 });
 
+test("createReviewEnvironment forbids non-admin scenarios", () => {
+  assert.throws(
+    () => createReviewEnvironment("editor", { name: "preview" }),
+    (error: unknown) =>
+      !!error &&
+      typeof error === "object" &&
+      "statusCode" in error &&
+      error.statusCode === 403,
+  );
+});
+
 test("deleteReviewEnvironment removes non-default rows and rejects deleting production", () => {
   const deleted = deleteReviewEnvironment("owner", "env-staging");
 
@@ -57,5 +68,16 @@ test("deleteReviewEnvironment removes non-default rows and rejects deleting prod
       typeof error === "object" &&
       "statusCode" in error &&
       error.statusCode === 409,
+  );
+});
+
+test("deleteReviewEnvironment forbids non-admin scenarios", () => {
+  assert.throws(
+    () => deleteReviewEnvironment("editor", "env-staging"),
+    (error: unknown) =>
+      !!error &&
+      typeof error === "object" &&
+      "statusCode" in error &&
+      error.statusCode === 403,
   );
 });

--- a/apps/studio-review/review/environments.ts
+++ b/apps/studio-review/review/environments.ts
@@ -1,0 +1,169 @@
+import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
+
+import { getReviewScenario } from "./scenarios";
+
+type ReviewEnvironmentStore = Map<string, EnvironmentSummary[]>;
+
+const reviewEnvironmentSeeds: readonly EnvironmentSummary[] = [
+  {
+    id: "env-production",
+    project: "marketing-site",
+    name: "production",
+    extends: null,
+    isDefault: true,
+    createdAt: "2026-03-19T10:00:00.000Z",
+  },
+  {
+    id: "env-staging",
+    project: "marketing-site",
+    name: "staging",
+    extends: "production",
+    isDefault: false,
+    createdAt: "2026-03-20T10:00:00.000Z",
+  },
+] as const;
+
+const store: ReviewEnvironmentStore = new Map();
+
+function cloneSeedData(): EnvironmentSummary[] {
+  return reviewEnvironmentSeeds.map((environment) => ({ ...environment }));
+}
+
+function readScenarioStore(scenarioId: string): EnvironmentSummary[] {
+  const existing = store.get(scenarioId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const seeded = cloneSeedData();
+  store.set(scenarioId, seeded);
+  return seeded;
+}
+
+function canManageReviewEnvironments(scenarioId: string): boolean {
+  const scenario = getReviewScenario(scenarioId);
+
+  return (
+    scenario.capabilities.users.manage || scenario.capabilities.settings.manage
+  );
+}
+
+function createForbiddenError(): RuntimeError {
+  return new RuntimeError({
+    code: "FORBIDDEN",
+    message: "Environment management is limited to admin review scenarios.",
+    statusCode: 403,
+  });
+}
+
+function createConflictError(message: string): RuntimeError {
+  return new RuntimeError({
+    code: "CONFLICT",
+    message,
+    statusCode: 409,
+  });
+}
+
+function createNotFoundError(): RuntimeError {
+  return new RuntimeError({
+    code: "NOT_FOUND",
+    message: "Environment not found.",
+    statusCode: 404,
+  });
+}
+
+function createInvalidInputError(): RuntimeError {
+  return new RuntimeError({
+    code: "INVALID_INPUT",
+    message: 'Field "name" is required.',
+    statusCode: 400,
+  });
+}
+
+export function resetReviewEnvironmentStore(): void {
+  store.clear();
+}
+
+export function listReviewEnvironments(
+  scenarioId: string,
+): EnvironmentSummary[] {
+  if (!canManageReviewEnvironments(scenarioId)) {
+    throw createForbiddenError();
+  }
+
+  return readScenarioStore(scenarioId).map((environment) => ({
+    ...environment,
+  }));
+}
+
+export function createReviewEnvironment(
+  scenarioId: string,
+  input: { name?: string },
+): EnvironmentSummary {
+  if (!canManageReviewEnvironments(scenarioId)) {
+    throw createForbiddenError();
+  }
+
+  const name = input.name?.trim();
+
+  if (!name) {
+    throw createInvalidInputError();
+  }
+
+  const environments = readScenarioStore(scenarioId);
+
+  if (environments.some((environment) => environment.name === name)) {
+    throw createConflictError(`Environment "${name}" already exists.`);
+  }
+
+  const created: EnvironmentSummary = {
+    id: `env-${name}`,
+    project: "marketing-site",
+    name,
+    extends: name === "production" ? null : "production",
+    isDefault: name === "production",
+    createdAt: "2026-04-10T10:00:00.000Z",
+  };
+
+  environments.push(created);
+
+  return { ...created };
+}
+
+export function deleteReviewEnvironment(
+  scenarioId: string,
+  environmentId: string,
+): { deleted: true; id: string } {
+  if (!canManageReviewEnvironments(scenarioId)) {
+    throw createForbiddenError();
+  }
+
+  const environments = readScenarioStore(scenarioId);
+  const index = environments.findIndex(
+    (environment) => environment.id === environmentId,
+  );
+
+  if (index === -1) {
+    throw createNotFoundError();
+  }
+
+  const environment = environments[index];
+
+  if (!environment) {
+    throw createNotFoundError();
+  }
+
+  if (environment.isDefault) {
+    throw createConflictError(
+      'The default "production" environment cannot be deleted.',
+    );
+  }
+
+  environments.splice(index, 1);
+
+  return {
+    deleted: true,
+    id: environmentId,
+  };
+}

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -363,6 +363,66 @@ Normative behavior:
 - Environment switching does not require host bridge cooperation. The host bridge
   does not define an environment navigation callback.
 
+### Environment Management (`/admin/environments`)
+
+The `/admin/environments` route is a live project-scoped environment management
+surface for the currently mounted project. It is backed by:
+
+- `GET /api/v1/environments` for the current project environment list
+- `POST /api/v1/environments` for environment creation
+- `DELETE /api/v1/environments/:id` for environment deletion
+- `GET /api/v1/me/capabilities` for shell-level admin navigation visibility
+
+Normative behavior:
+
+- The route manages only list/create/delete behavior in MVP. Clone, promote,
+  rename, description editing, and other environment workflows are out of scope
+  for this route until their owning work is specified.
+- Environment rows are rendered from the live `EnvironmentSummary[]` contract.
+  Studio must not render mock environment metadata, synthetic document counts,
+  or fake promotion history on this route.
+- The create flow submits `{ name }` to `POST /api/v1/environments`. Studio may
+  omit `extends` and rely on the server-side config validation rules defined by
+  the environment-management contract.
+- On successful create, the creation dialog closes and the environment list
+  reloads from the live API before the new row is presented as ready.
+- The default `production` environment is rendered as the non-deletable default
+  environment. Its delete action is disabled or omitted in the ready state.
+- Deleting a non-default environment requires an explicit confirmation step and,
+  on success, reloads the live environment list before removing the row from the
+  UI.
+- The route must surface deterministic server failures truthfully:
+  - `INVALID_INPUT` (`400`) on create is shown inline on the creation form.
+  - `CONFLICT` (`409`) on create or delete is shown inline without replacing the
+    current ready view.
+  - `NOT_FOUND` (`404`) on delete is surfaced as a non-destructive row/action
+    failure and followed by a live list reload.
+- The shell navigation entry for `/admin/environments` follows the same
+  admin-owned visibility policy as other admin surfaces. Until a dedicated
+  environment-management capability exists, Studio may use the current
+  capability snapshot to hide the entry unless the caller exposes at least one
+  admin-only capability (`capabilities.users.manage` or
+  `capabilities.settings.manage`).
+- Direct navigation to `/admin/environments` remains supported even when the
+  navigation entry is hidden. Route authorization still depends on the
+  environment-management endpoints; hidden navigation is advisory UI gating, not
+  the security boundary.
+
+Deterministic states:
+
+- While the initial environment list request is pending, the route renders a
+  dedicated loading state for environment management instead of mock cards.
+- If `GET /api/v1/environments` returns `401` or `403`, the route renders a
+  forbidden state for the active project.
+- If `GET /api/v1/environments` returns a non-auth, non-forbidden failure, the
+  route renders an error state with a retry action.
+- If `GET /api/v1/environments` succeeds with zero rows, the route renders an
+  empty state for the active project. When the current caller is allowed to use
+  the route, the empty state may include the create affordance.
+- When the list request succeeds with one or more rows, the route renders a
+  ready state with per-row metadata limited to the live environment summary
+  contract (`name`, `extends`, default status, `createdAt`).
+
 ### Target-Scoped Capabilities and Schema Recovery
 
 Studio uses `GET /api/v1/me/capabilities` as the canonical source for

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -186,6 +186,24 @@ export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
   - successful `Sync Schema` runs reuse the same local config snapshot payload
     as CLI schema sync; Studio does not expose manual schema editing controls
 
+## Environment Management
+
+- Remote runtime route: `/admin/environments`
+- The route is now backed by the live environment management endpoints:
+  - `GET /api/v1/environments`
+  - `POST /api/v1/environments`
+  - `DELETE /api/v1/environments/:id`
+- The page is intentionally scoped to list/create/delete only.
+- It renders deterministic loading, empty, forbidden, error, and ready states.
+- Environment rows render only contract-backed metadata:
+  - `name`
+  - `extends`
+  - default status
+  - `createdAt`
+- The create dialog submits `{ name }`; the server remains authoritative for
+  config-defined environment validation.
+- The default `production` environment is rendered as non-deletable.
+
 ## Schema Browser
 
 - Remote runtime route: `/admin/schema`

--- a/packages/studio/src/lib/environment-api.test.ts
+++ b/packages/studio/src/lib/environment-api.test.ts
@@ -28,12 +28,19 @@ function readHeader(
   return null;
 }
 
-function createApi(options: StudioEnvironmentApiOptions = {}) {
+function createApi(
+  options: StudioEnvironmentApiOptions = {},
+  config?: {
+    project?: string;
+    environment?: string;
+    serverUrl?: string;
+  },
+) {
   return createStudioEnvironmentApi(
     {
-      project: "marketing-site",
-      environment: "production",
-      serverUrl: "http://localhost:4000",
+      project: config?.project ?? "marketing-site",
+      environment: config?.environment ?? "production",
+      serverUrl: config?.serverUrl ?? "http://localhost:4000",
     },
     options,
   );
@@ -87,6 +94,99 @@ test("list returns empty array for empty response", async () => {
   const result = await api.list();
 
   assert.deepEqual(result, []);
+});
+
+test("list resolves scenario-relative environment routes", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi(
+    {
+      fetcher: async (input, init) => {
+        calls.push({ input, init });
+        return new Response(JSON.stringify({ data: [validEnvSummary] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+    {
+      serverUrl: "http://localhost:4000/review-api/editor",
+    },
+  );
+
+  await api.list();
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/review-api/editor/api/v1/environments",
+  );
+});
+
+test("create posts the environment name with project and csrf headers", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({
+          data: {
+            ...validEnvSummary,
+            id: "env-staging",
+            name: "staging",
+            isDefault: false,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    },
+  });
+
+  const result = await api.create({ name: "staging" });
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/environments",
+  );
+  assert.equal(calls[0]?.init?.method, "POST");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-project"), "marketing-site");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-environment"), "production");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-csrf-token"), "csrf-token");
+  assert.equal(calls[0]?.init?.body, JSON.stringify({ name: "staging" }));
+  assert.equal(result.name, "staging");
+});
+
+test("delete sends the environment id with csrf protection", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({ data: { deleted: true, id: "env-staging" } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    },
+  });
+
+  await api.delete("env-staging");
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/environments/env-staging",
+  );
+  assert.equal(calls[0]?.init?.method, "DELETE");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-csrf-token"), "csrf-token");
 });
 
 test("list throws on 401 response", async () => {

--- a/packages/studio/src/lib/environment-api.test.ts
+++ b/packages/studio/src/lib/environment-api.test.ts
@@ -161,6 +161,24 @@ test("create posts the environment name with project and csrf headers", async ()
   assert.equal(result.name, "staging");
 });
 
+test("create throws MISSING_CSRF_TOKEN when cookie auth omits csrfToken", async () => {
+  let called = false;
+  const api = createApi({
+    auth: { mode: "cookie" },
+    fetcher: async () => {
+      called = true;
+      throw new Error("fetcher should not be called");
+    },
+  });
+
+  await assert.rejects(
+    () => api.create({ name: "staging" }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "MISSING_CSRF_TOKEN",
+  );
+  assert.equal(called, false);
+});
+
 test("delete sends the environment id with csrf protection", async () => {
   const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
     [];
@@ -187,6 +205,24 @@ test("delete sends the environment id with csrf protection", async () => {
   );
   assert.equal(calls[0]?.init?.method, "DELETE");
   assert.equal(readHeader(calls[0]?.init, "x-mdcms-csrf-token"), "csrf-token");
+});
+
+test("delete throws MISSING_CSRF_TOKEN when cookie auth omits csrfToken", async () => {
+  let called = false;
+  const api = createApi({
+    auth: { mode: "cookie" },
+    fetcher: async () => {
+      called = true;
+      throw new Error("fetcher should not be called");
+    },
+  });
+
+  await assert.rejects(
+    () => api.delete("env-staging"),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "MISSING_CSRF_TOKEN",
+  );
+  assert.equal(called, false);
 });
 
 test("list throws on 401 response", async () => {

--- a/packages/studio/src/lib/environment-api.ts
+++ b/packages/studio/src/lib/environment-api.ts
@@ -1,9 +1,16 @@
-import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
+import {
+  RuntimeError,
+  assertEnvironmentCreateInput,
+  assertEnvironmentSummary,
+  type EnvironmentCreateInput,
+  type EnvironmentSummary,
+} from "@mdcms/shared";
 
 import {
   applyStudioAuthToRequestInit,
   type StudioRuntimeAuth,
 } from "./request-auth.js";
+import { resolveStudioRelativeUrl } from "./url-resolution.js";
 
 export type StudioEnvironmentApiConfig = {
   project: string;
@@ -13,11 +20,14 @@ export type StudioEnvironmentApiConfig = {
 
 export type StudioEnvironmentApiOptions = {
   auth?: StudioRuntimeAuth;
+  csrfToken?: string;
   fetcher?: typeof fetch;
 };
 
 export type StudioEnvironmentApi = {
   list: () => Promise<EnvironmentSummary[]>;
+  create: (input: EnvironmentCreateInput) => Promise<EnvironmentSummary>;
+  delete: (environmentId: string) => Promise<void>;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -32,51 +42,186 @@ async function readResponsePayload(response: Response): Promise<unknown> {
   }
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toRouteFailureError(
+  response: Response,
+  payload: unknown,
+  fallbackCode: string,
+  fallbackMessage: string,
+): RuntimeError {
+  const parsed = isRecord(payload) ? payload : {};
+  const code =
+    typeof parsed.code === "string" && parsed.code.trim().length > 0
+      ? parsed.code
+      : fallbackCode;
+  const message =
+    typeof parsed.message === "string" && parsed.message.trim().length > 0
+      ? parsed.message
+      : fallbackMessage;
+
+  return new RuntimeError({
+    code,
+    message,
+    statusCode: response.status,
+    details: { status: response.status, payload },
+  });
+}
+
+function resolveRouteUrl(
+  config: StudioEnvironmentApiConfig,
+  pathname: string,
+): URL {
+  return resolveStudioRelativeUrl(pathname, config.serverUrl);
+}
+
+function requireCsrfToken(
+  csrfToken: string | undefined,
+  operation: string,
+): string {
+  if (isNonEmptyString(csrfToken)) {
+    return csrfToken;
+  }
+
+  throw new RuntimeError({
+    code: "MISSING_CSRF_TOKEN",
+    message: `${operation} requires a CSRF token.`,
+    statusCode: 400,
+  });
+}
+
+function parseEnvironmentSummaryFromPayload(
+  payload: unknown,
+  path: string,
+): EnvironmentSummary {
+  if (!isRecord(payload) || !("data" in payload)) {
+    throw new RuntimeError({
+      code: "ENVIRONMENT_RESPONSE_INVALID",
+      message: "Environment response is invalid.",
+      statusCode: 500,
+      details: { payload, path },
+    });
+  }
+
+  const data = payload.data;
+  assertEnvironmentSummary(data, path);
+  return data;
+}
+
 export function createStudioEnvironmentApi(
   config: StudioEnvironmentApiConfig,
   options: StudioEnvironmentApiOptions = {},
 ): StudioEnvironmentApi {
   const fetcher = options.fetcher ?? fetch;
+  const scopedHeaders = {
+    "x-mdcms-project": config.project,
+    "x-mdcms-environment": config.environment,
+  };
 
   return {
     async list() {
-      const url = new URL("/api/v1/environments", config.serverUrl);
+      const url = resolveRouteUrl(config, "/api/v1/environments");
       const response = await fetcher(
         url,
         applyStudioAuthToRequestInit(options.auth, {
           method: "GET",
-          headers: {
-            "x-mdcms-project": config.project,
-            "x-mdcms-environment": config.environment,
-          },
+          headers: scopedHeaders,
         }),
       );
       const payload = await readResponsePayload(response);
 
       if (!response.ok) {
-        const parsed = isRecord(payload) ? payload : {};
-        const code =
-          typeof parsed.code === "string" && parsed.code.trim().length > 0
-            ? parsed.code
-            : "ENVIRONMENT_REQUEST_FAILED";
-        const message =
-          typeof parsed.message === "string" && parsed.message.trim().length > 0
-            ? parsed.message
-            : "Environment list request failed.";
-
-        throw new RuntimeError({
-          code,
-          message,
-          statusCode: response.status,
-          details: { status: response.status, payload },
-        });
+        throw toRouteFailureError(
+          response,
+          payload,
+          "ENVIRONMENT_REQUEST_FAILED",
+          "Environment list request failed.",
+        );
       }
 
       if (!isRecord(payload) || !Array.isArray(payload.data)) {
         return [];
       }
 
-      return payload.data as EnvironmentSummary[];
+      payload.data.forEach((item, index) => {
+        assertEnvironmentSummary(item, `response.data[${index}]`);
+      });
+
+      return payload.data;
+    },
+
+    async create(input) {
+      assertEnvironmentCreateInput(input, "input");
+
+      const url = resolveRouteUrl(config, "/api/v1/environments");
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "POST",
+          headers: {
+            ...scopedHeaders,
+            "content-type": "application/json",
+            "x-mdcms-csrf-token": requireCsrfToken(
+              options.csrfToken,
+              "Environment creation",
+            ),
+          },
+          body: JSON.stringify(input),
+        }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        throw toRouteFailureError(
+          response,
+          payload,
+          "ENVIRONMENT_CREATE_FAILED",
+          "Environment creation failed.",
+        );
+      }
+
+      return parseEnvironmentSummaryFromPayload(payload, "response.data");
+    },
+
+    async delete(environmentId) {
+      if (!isNonEmptyString(environmentId)) {
+        throw new RuntimeError({
+          code: "INVALID_INPUT",
+          message: "Environment id is required.",
+          statusCode: 400,
+          details: { field: "environmentId" },
+        });
+      }
+
+      const url = resolveRouteUrl(
+        config,
+        `/api/v1/environments/${encodeURIComponent(environmentId)}`,
+      );
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "DELETE",
+          headers: {
+            ...scopedHeaders,
+            "x-mdcms-csrf-token": requireCsrfToken(
+              options.csrfToken,
+              "Environment deletion",
+            ),
+          },
+        }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        throw toRouteFailureError(
+          response,
+          payload,
+          "ENVIRONMENT_DELETE_FAILED",
+          "Environment deletion failed.",
+        );
+      }
     },
   };
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { EnvironmentSummary } from "@mdcms/shared";
+
+import {
+  EnvironmentManagementPageView,
+  type EnvironmentManagementState,
+} from "./environments-page.js";
+
+function createEnvironmentSummary(
+  overrides: Partial<EnvironmentSummary> = {},
+): EnvironmentSummary {
+  return {
+    id: "env-production",
+    project: "marketing-site",
+    name: "production",
+    extends: null,
+    isDefault: true,
+    createdAt: "2026-03-19T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderMarkup(state: EnvironmentManagementState): string {
+  return renderToStaticMarkup(
+    createElement(EnvironmentManagementPageView, {
+      state,
+    }),
+  );
+}
+
+test("EnvironmentManagementPageView renders loading and empty states deterministically", () => {
+  const loadingMarkup = renderMarkup({
+    status: "loading",
+    project: "marketing-site",
+    message: "Loading environments.",
+  });
+  const emptyMarkup = renderMarkup({
+    status: "ready",
+    project: "marketing-site",
+    environments: [],
+  });
+
+  assert.match(loadingMarkup, /data-mdcms-environments-page-state="loading"/);
+  assert.match(loadingMarkup, /Loading environments/i);
+  assert.match(emptyMarkup, /data-mdcms-environments-page-state="empty"/);
+  assert.match(emptyMarkup, /No environments were returned/i);
+  assert.match(emptyMarkup, /New Environment/);
+});
+
+test("EnvironmentManagementPageView renders live environment summaries and only allows deleting non-default environments", () => {
+  const markup = renderMarkup({
+    status: "ready",
+    project: "marketing-site",
+    environments: [
+      createEnvironmentSummary(),
+      createEnvironmentSummary({
+        id: "env-staging",
+        name: "staging",
+        extends: "production",
+        isDefault: false,
+      }),
+    ],
+  });
+
+  assert.match(markup, /data-mdcms-environments-page-state="ready"/);
+  assert.match(markup, /data-mdcms-environment-row="production"/);
+  assert.match(markup, /data-mdcms-environment-row="staging"/);
+  assert.match(markup, />Default</);
+  assert.match(markup, /Extends production/);
+  assert.match(markup, /Delete staging/);
+  assert.doesNotMatch(markup, /Delete production/);
+  assert.doesNotMatch(markup, /promot/i);
+  assert.doesNotMatch(markup, /document count/i);
+});
+
+test("EnvironmentManagementPageView renders forbidden and error states", () => {
+  const forbiddenMarkup = renderMarkup({
+    status: "forbidden",
+    project: "marketing-site",
+    message: "Forbidden.",
+  });
+  const errorMarkup = renderMarkup({
+    status: "error",
+    project: "marketing-site",
+    message: "Environment request failed.",
+  });
+
+  assert.match(
+    forbiddenMarkup,
+    /data-mdcms-environments-page-state="forbidden"/,
+  );
+  assert.match(errorMarkup, /data-mdcms-environments-page-state="error"/);
+});

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -6,6 +6,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { EnvironmentSummary } from "@mdcms/shared";
 
+import { ThemeProvider } from "../../adapters/next-themes.js";
+import { StudioMountInfoProvider } from "./mount-info-context.js";
+import { StudioSessionProvider } from "./session-context.js";
 import {
   EnvironmentManagementPageView,
   type EnvironmentManagementState,
@@ -27,9 +30,33 @@ function createEnvironmentSummary(
 
 function renderMarkup(state: EnvironmentManagementState): string {
   return renderToStaticMarkup(
-    createElement(EnvironmentManagementPageView, {
-      state,
-    }),
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(
+        StudioSessionProvider,
+        {
+          value: { status: "unauthenticated" },
+        },
+        createElement(
+          StudioMountInfoProvider,
+          {
+            value: {
+              project: "marketing-site",
+              environment: "staging",
+              setEnvironment: () => {},
+              apiBaseUrl: "http://localhost:4000",
+              auth: { mode: "cookie" },
+              environments: [],
+              hostBridge: null,
+            },
+          },
+          createElement(EnvironmentManagementPageView, {
+            state,
+          }),
+        ),
+      ),
+    ),
   );
 }
 
@@ -45,6 +72,9 @@ test("EnvironmentManagementPageView renders loading and empty states determinist
     environments: [],
   });
 
+  assert.match(loadingMarkup, /class="min-h-screen"/);
+  assert.match(loadingMarkup, /sticky top-0/);
+  assert.match(loadingMarkup, /p-6 space-y-6/);
   assert.match(loadingMarkup, /data-mdcms-environments-page-state="loading"/);
   assert.match(loadingMarkup, /Loading environments/i);
   assert.match(emptyMarkup, /data-mdcms-environments-page-state="empty"/);

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -57,12 +57,15 @@ test("EnvironmentManagementPageView renders live environment summaries and only 
     status: "ready",
     project: "marketing-site",
     environments: [
-      createEnvironmentSummary(),
+      createEnvironmentSummary({
+        createdAt: "2026-03-19T10:00:00.000Z",
+      }),
       createEnvironmentSummary({
         id: "env-staging",
         name: "staging",
         extends: "production",
         isDefault: false,
+        createdAt: "2026-03-20T11:30:45.000Z",
       }),
     ],
   });
@@ -72,6 +75,8 @@ test("EnvironmentManagementPageView renders live environment summaries and only 
   assert.match(markup, /data-mdcms-environment-row="staging"/);
   assert.match(markup, />Default</);
   assert.match(markup, /Extends production/);
+  assert.match(markup, /2026-03-19T10:00:00.000Z/);
+  assert.match(markup, /2026-03-20T11:30:45.000Z/);
   assert.match(markup, /Delete staging/);
   assert.doesNotMatch(markup, /Delete production/);
   assert.doesNotMatch(markup, /promot/i);

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -12,7 +12,6 @@ import {
   PageHeader,
   PageHeaderActions,
   PageHeaderDescription,
-  PageHeaderHeading,
 } from "../../components/layout/page-header.js";
 import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
@@ -177,194 +176,199 @@ export function EnvironmentManagementPageView({
   const canManage = state.status === "ready";
 
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader>
-        <div className="space-y-1">
-          <PageHeaderHeading>Environments</PageHeaderHeading>
-          <PageHeaderDescription>
-            Manage project environments for {state.project}.
-          </PageHeaderDescription>
-        </div>
-        {canManage ? (
-          <PageHeaderActions>
-            <Dialog
-              open={isCreateDialogOpen}
-              onOpenChange={onCreateDialogChange}
-            >
-              <DialogTrigger asChild>
-                <Button>
-                  <Plus className="mr-2 h-4 w-4" />
-                  New Environment
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Create Environment</DialogTitle>
-                  <DialogDescription>
-                    Create a new environment for this project.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="grid gap-3 py-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="environment-name">Name</Label>
-                    <Input
-                      id="environment-name"
-                      placeholder="e.g. staging"
-                      value={createName}
-                      onChange={(event) =>
-                        onCreateNameChange?.(event.target.value)
-                      }
-                    />
-                  </div>
-                  {createError ? (
-                    <p className="text-sm text-destructive">{createError}</p>
-                  ) : null}
-                </div>
-                <DialogFooter>
-                  <Button
-                    variant="outline"
-                    onClick={() => onCreateDialogChange?.(false)}
-                  >
-                    Cancel
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Environments" }]} />
+      <div className="p-6 space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Environments
+            </h1>
+            <PageHeaderDescription>
+              Manage project environments for {state.project}.
+            </PageHeaderDescription>
+          </div>
+          {canManage ? (
+            <PageHeaderActions>
+              <Dialog
+                open={isCreateDialogOpen}
+                onOpenChange={onCreateDialogChange}
+              >
+                <DialogTrigger asChild>
+                  <Button className="w-full sm:w-auto" type="button">
+                    <Plus className="mr-2 h-4 w-4" />
+                    New Environment
                   </Button>
-                  <Button
-                    disabled={pendingCreate}
-                    onClick={() => onCreateSubmit?.()}
-                  >
-                    {pendingCreate ? "Creating..." : "Create"}
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </PageHeaderActions>
-        ) : null}
-      </PageHeader>
-
-      {actionError ? (
-        <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-          {actionError}
-        </section>
-      ) : null}
-
-      {state.status === "loading" ? (
-        <section
-          data-mdcms-environments-page-state="loading"
-          className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
-        >
-          {state.message}
-        </section>
-      ) : state.status === "forbidden" ? (
-        <section
-          data-mdcms-environments-page-state="forbidden"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="secondary">Forbidden</Badge>
-          <p className="text-sm text-muted-foreground">{state.message}</p>
-          <p className="text-xs text-muted-foreground">{state.project}</p>
-        </section>
-      ) : state.status === "error" ? (
-        <section
-          data-mdcms-environments-page-state="error"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="destructive">Error</Badge>
-          <p className="text-sm text-muted-foreground">{state.message}</p>
-          <p className="text-xs text-muted-foreground">{state.project}</p>
-          {renderRetryButton(onRetry)}
-        </section>
-      ) : state.environments.length === 0 ? (
-        <section
-          data-mdcms-environments-page-state="empty"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="outline">Empty</Badge>
-          <p className="text-sm text-muted-foreground">
-            No environments were returned for this project yet.
-          </p>
-          <p className="text-xs text-muted-foreground">{state.project}</p>
-        </section>
-      ) : (
-        <section
-          data-mdcms-environments-page-state="ready"
-          className="grid gap-4"
-        >
-          {state.environments.map((environment) => (
-            <article
-              key={environment.id}
-              data-mdcms-environment-row={environment.name}
-              className="space-y-4 rounded-lg border p-4"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="space-y-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="text-lg font-semibold tracking-tight">
-                      {environment.name}
-                    </h2>
-                    {environment.isDefault ? (
-                      <Badge variant="secondary">Default</Badge>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Create Environment</DialogTitle>
+                    <DialogDescription>
+                      Create a new environment for this project.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="grid gap-3 py-4">
+                    <div className="grid gap-2">
+                      <Label htmlFor="environment-name">Name</Label>
+                      <Input
+                        id="environment-name"
+                        placeholder="e.g. staging"
+                        value={createName}
+                        onChange={(event) =>
+                          onCreateNameChange?.(event.target.value)
+                        }
+                      />
+                    </div>
+                    {createError ? (
+                      <p className="text-sm text-destructive">{createError}</p>
                     ) : null}
                   </div>
-                  <p className="text-sm text-muted-foreground">
-                    {environment.extends
-                      ? `Extends ${environment.extends}`
-                      : "No parent environment"}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Created {formatCreatedAt(environment.createdAt)}
-                  </p>
-                </div>
-                {!environment.isDefault ? (
-                  <Button
-                    variant="outline"
-                    disabled={pendingDeleteId === environment.id}
-                    onClick={() => onRequestDelete?.(environment)}
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    {pendingDeleteId === environment.id
-                      ? `Deleting ${environment.name}...`
-                      : `Delete ${environment.name}`}
-                  </Button>
-                ) : null}
-              </div>
-            </article>
-          ))}
-        </section>
-      )}
+                  <DialogFooter>
+                    <Button
+                      variant="outline"
+                      onClick={() => onCreateDialogChange?.(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      disabled={pendingCreate}
+                      onClick={() => onCreateSubmit?.()}
+                    >
+                      {pendingCreate ? "Creating..." : "Create"}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </PageHeaderActions>
+          ) : null}
+        </div>
 
-      <Dialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => onDeleteDialogChange?.(open)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Environment</DialogTitle>
-            <DialogDescription>
-              {isEnvironmentSummary(deleteTarget)
-                ? `Delete ${deleteTarget.name} from ${state.project}?`
-                : "Delete this environment?"}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => onDeleteDialogChange?.(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={!deleteTarget || pendingDeleteId === deleteTarget.id}
-              onClick={() => onDeleteConfirm?.()}
-            >
-              {deleteTarget && pendingDeleteId === deleteTarget.id
-                ? `Deleting ${deleteTarget.name}...`
-                : deleteTarget
-                  ? `Delete ${deleteTarget.name}`
-                  : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        {actionError ? (
+          <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+            {actionError}
+          </section>
+        ) : null}
+
+        {state.status === "loading" ? (
+          <section
+            data-mdcms-environments-page-state="loading"
+            className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+          >
+            {state.message}
+          </section>
+        ) : state.status === "forbidden" ? (
+          <section
+            data-mdcms-environments-page-state="forbidden"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="secondary">Forbidden</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">{state.project}</p>
+          </section>
+        ) : state.status === "error" ? (
+          <section
+            data-mdcms-environments-page-state="error"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="destructive">Error</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">{state.project}</p>
+            {renderRetryButton(onRetry)}
+          </section>
+        ) : state.environments.length === 0 ? (
+          <section
+            data-mdcms-environments-page-state="empty"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="outline">Empty</Badge>
+            <p className="text-sm text-muted-foreground">
+              No environments were returned for this project yet.
+            </p>
+            <p className="text-xs text-muted-foreground">{state.project}</p>
+          </section>
+        ) : (
+          <section
+            data-mdcms-environments-page-state="ready"
+            className="grid gap-4"
+          >
+            {state.environments.map((environment) => (
+              <article
+                key={environment.id}
+                data-mdcms-environment-row={environment.name}
+                className="space-y-4 rounded-lg border p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-semibold tracking-tight">
+                        {environment.name}
+                      </h2>
+                      {environment.isDefault ? (
+                        <Badge variant="secondary">Default</Badge>
+                      ) : null}
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {environment.extends
+                        ? `Extends ${environment.extends}`
+                        : "No parent environment"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Created {formatCreatedAt(environment.createdAt)}
+                    </p>
+                  </div>
+                  {!environment.isDefault ? (
+                    <Button
+                      variant="outline"
+                      disabled={pendingDeleteId === environment.id}
+                      onClick={() => onRequestDelete?.(environment)}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      {pendingDeleteId === environment.id
+                        ? `Deleting ${environment.name}...`
+                        : `Delete ${environment.name}`}
+                    </Button>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
+
+        <Dialog
+          open={deleteTarget !== null}
+          onOpenChange={(open) => onDeleteDialogChange?.(open)}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete Environment</DialogTitle>
+              <DialogDescription>
+                {isEnvironmentSummary(deleteTarget)
+                  ? `Delete ${deleteTarget.name} from ${state.project}?`
+                  : "Delete this environment?"}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onDeleteDialogChange?.(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={!deleteTarget || pendingDeleteId === deleteTarget.id}
+                onClick={() => onDeleteConfirm?.()}
+              >
+                {deleteTarget && pendingDeleteId === deleteTarget.id
+                  ? `Deleting ${deleteTarget.name}...`
+                  : deleteTarget
+                    ? `Delete ${deleteTarget.name}`
+                    : "Delete"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -130,7 +130,7 @@ function formatCreatedAt(value: string): string {
     return value;
   }
 
-  return date.toLocaleString();
+  return date.toISOString();
 }
 
 function sortEnvironments(

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -1,37 +1,21 @@
 "use client";
 
-import { useState } from "react";
-import {
-  Globe,
-  Check,
-  ChevronRight,
-  Plus,
-  MoreHorizontal,
-  Trash2,
-  Settings2,
-} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import type { EnvironmentSummary } from "@mdcms/shared";
+import { Plus, Trash2 } from "lucide-react";
+
+import { createStudioEnvironmentApi } from "../../../environment-api.js";
+import { useStudioSession } from "./session-context.js";
+import { useStudioMountInfo } from "./mount-info-context.js";
 import {
   PageHeader,
-  PageHeaderHeading,
-  PageHeaderDescription,
   PageHeaderActions,
+  PageHeaderDescription,
+  PageHeaderHeading,
 } from "../../components/layout/page-header.js";
-import { Button } from "../../components/ui/button.js";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "../../components/ui/card.js";
 import { Badge } from "../../components/ui/badge.js";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu.js";
+import { Button } from "../../components/ui/button.js";
 import {
   Dialog,
   DialogContent,
@@ -43,255 +27,540 @@ import {
 } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Textarea } from "../../components/ui/textarea.js";
-import { mockEnvironments } from "../../lib/mock-data.js";
 
-type EnvironmentCard = {
-  id: string;
-  name: string;
-  slug: string;
-  description: string;
-  isProduction: boolean;
-  color: string;
-  documentCount: number;
-  lastPublished: Date | null;
-};
-
-const environmentColorMap = {
-  green: "#22c55e",
-  yellow: "#eab308",
-  blue: "#3b82f6",
-  gray: "#6b7280",
-} as const;
-
-const initialEnvironments: EnvironmentCard[] = mockEnvironments.map(
-  (environment) => ({
-    id: environment.id,
-    name: environment.name,
-    slug: environment.id,
-    description: environment.description ?? "",
-    isProduction: environment.isProduction ?? false,
-    color: environmentColorMap[environment.color],
-    documentCount: environment.documentCount,
-    lastPublished: null,
-  }),
-);
-
-export default function EnvironmentsPage() {
-  const [environments, setEnvironments] =
-    useState<EnvironmentCard[]>(initialEnvironments);
-  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [newEnv, setNewEnv] = useState({ name: "", slug: "", description: "" });
-
-  const handleCreateEnvironment = () => {
-    if (!newEnv.name || !newEnv.slug) return;
-
-    const env: EnvironmentCard = {
-      id: `env-${Date.now()}`,
-      name: newEnv.name,
-      slug: newEnv.slug,
-      description: newEnv.description,
-      isProduction: false,
-      color: "#6b7280",
-      documentCount: 0,
-      lastPublished: null,
+export type EnvironmentManagementState =
+  | {
+      status: "loading";
+      project: string;
+      message: string;
+    }
+  | {
+      status: "forbidden";
+      project: string;
+      message: string;
+    }
+  | {
+      status: "error";
+      project: string;
+      message: string;
+    }
+  | {
+      status: "ready";
+      project: string;
+      environments: EnvironmentSummary[];
     };
 
-    setEnvironments([...environments, env]);
-    setNewEnv({ name: "", slug: "", description: "" });
-    setIsCreateDialogOpen(false);
+type EnvironmentManagementPageViewProps = {
+  state: EnvironmentManagementState;
+  createName?: string;
+  createError?: string | null;
+  actionError?: string | null;
+  pendingCreate?: boolean;
+  pendingDeleteId?: string | null;
+  deleteTarget?: EnvironmentSummary | null;
+  isCreateDialogOpen?: boolean;
+  onCreateDialogChange?: (open: boolean) => void;
+  onCreateNameChange?: (value: string) => void;
+  onCreateSubmit?: () => void;
+  onDeleteDialogChange?: (open: boolean) => void;
+  onRequestDelete?: (environment: EnvironmentSummary) => void;
+  onDeleteConfirm?: () => void;
+  onRetry?: () => void;
+};
+
+function createLoadingState(project: string): EnvironmentManagementState {
+  return {
+    status: "loading",
+    project,
+    message: "Loading environments.",
   };
+}
+
+function createMissingRouteState(): EnvironmentManagementState {
+  return {
+    status: "error",
+    project: "unknown",
+    message:
+      "Environment management requires an active project and environment.",
+  };
+}
+
+function isEnvironmentSummary(value: unknown): value is EnvironmentSummary {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    "name" in value &&
+    typeof value.name === "string"
+  );
+}
+
+function readRuntimeErrorMessage(error: unknown, fallback: string): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.trim().length > 0
+  ) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function readRuntimeErrorStatus(error: unknown): number | null {
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+
+  return null;
+}
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+function sortEnvironments(
+  environments: readonly EnvironmentSummary[],
+): EnvironmentSummary[] {
+  return [...environments].sort((left, right) => {
+    if (left.isDefault !== right.isDefault) {
+      return left.isDefault ? -1 : 1;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function renderRetryButton(onRetry?: () => void) {
+  if (!onRetry) {
+    return null;
+  }
+
+  return (
+    <Button variant="outline" onClick={onRetry}>
+      Retry
+    </Button>
+  );
+}
+
+export function EnvironmentManagementPageView({
+  state,
+  createName = "",
+  createError = null,
+  actionError = null,
+  pendingCreate = false,
+  pendingDeleteId = null,
+  deleteTarget = null,
+  isCreateDialogOpen = false,
+  onCreateDialogChange,
+  onCreateNameChange,
+  onCreateSubmit,
+  onDeleteDialogChange,
+  onRequestDelete,
+  onDeleteConfirm,
+  onRetry,
+}: EnvironmentManagementPageViewProps) {
+  const canManage = state.status === "ready";
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader>
-        <div>
+        <div className="space-y-1">
           <PageHeaderHeading>Environments</PageHeaderHeading>
           <PageHeaderDescription>
-            Manage content publishing environments and promotion workflows
+            Manage project environments for {state.project}.
           </PageHeaderDescription>
         </div>
-        <PageHeaderActions>
-          <Dialog
-            open={isCreateDialogOpen}
-            onOpenChange={setIsCreateDialogOpen}
-          >
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="mr-2 h-4 w-4" />
-                New Environment
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Create Environment</DialogTitle>
-                <DialogDescription>
-                  Add a new environment for content staging and publishing.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="name">Name</Label>
-                  <Input
-                    id="name"
-                    placeholder="e.g., QA, Preview"
-                    value={newEnv.name}
-                    onChange={(e) =>
-                      setNewEnv({ ...newEnv, name: e.target.value })
-                    }
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="slug">Slug</Label>
-                  <Input
-                    id="slug"
-                    placeholder="e.g., qa, preview"
-                    value={newEnv.slug}
-                    onChange={(e) =>
-                      setNewEnv({ ...newEnv, slug: e.target.value })
-                    }
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="description">Description</Label>
-                  <Textarea
-                    id="description"
-                    placeholder="Describe this environment's purpose..."
-                    value={newEnv.description}
-                    onChange={(e) =>
-                      setNewEnv({ ...newEnv, description: e.target.value })
-                    }
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setIsCreateDialogOpen(false)}
-                >
-                  Cancel
+        {canManage ? (
+          <PageHeaderActions>
+            <Dialog
+              open={isCreateDialogOpen}
+              onOpenChange={onCreateDialogChange}
+            >
+              <DialogTrigger asChild>
+                <Button>
+                  <Plus className="mr-2 h-4 w-4" />
+                  New Environment
                 </Button>
-                <Button onClick={handleCreateEnvironment}>Create</Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </PageHeaderActions>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Create Environment</DialogTitle>
+                  <DialogDescription>
+                    Create a new environment for this project.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-3 py-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor="environment-name">Name</Label>
+                    <Input
+                      id="environment-name"
+                      placeholder="e.g. staging"
+                      value={createName}
+                      onChange={(event) =>
+                        onCreateNameChange?.(event.target.value)
+                      }
+                    />
+                  </div>
+                  {createError ? (
+                    <p className="text-sm text-destructive">{createError}</p>
+                  ) : null}
+                </div>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => onCreateDialogChange?.(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    disabled={pendingCreate}
+                    onClick={() => onCreateSubmit?.()}
+                  >
+                    {pendingCreate ? "Creating..." : "Create"}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </PageHeaderActions>
+        ) : null}
       </PageHeader>
 
-      {/* Environment Pipeline */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Publishing Pipeline</CardTitle>
-          <CardDescription>
-            Content flows from Development through Staging to Production
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center gap-2">
-            {environments.map((env, index) => (
-              <div key={env.id} className="flex items-center">
-                <div
-                  className="flex items-center gap-2 rounded-lg border px-4 py-3"
-                  style={{ borderColor: env.color }}
-                >
-                  <div
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: env.color }}
-                  />
-                  <span className="font-medium">{env.name}</span>
-                  {env.isProduction && (
-                    <Badge variant="secondary" className="ml-1">
-                      <Check className="mr-1 h-3 w-3" />
-                      Live
-                    </Badge>
-                  )}
-                </div>
-                {index < environments.length - 1 && (
-                  <ChevronRight className="mx-2 h-4 w-4 text-muted-foreground" />
-                )}
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      {actionError ? (
+        <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          {actionError}
+        </section>
+      ) : null}
 
-      {/* Environment Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {environments.map((env) => (
-          <Card key={env.id} className="relative">
-            <CardHeader className="pb-3">
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-3">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-lg"
-                    style={{ backgroundColor: `${env.color}20` }}
+      {state.status === "loading" ? (
+        <section
+          data-mdcms-environments-page-state="loading"
+          className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+        >
+          {state.message}
+        </section>
+      ) : state.status === "forbidden" ? (
+        <section
+          data-mdcms-environments-page-state="forbidden"
+          className="space-y-3 rounded-lg border border-dashed p-6"
+        >
+          <Badge variant="secondary">Forbidden</Badge>
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+          <p className="text-xs text-muted-foreground">{state.project}</p>
+        </section>
+      ) : state.status === "error" ? (
+        <section
+          data-mdcms-environments-page-state="error"
+          className="space-y-3 rounded-lg border border-dashed p-6"
+        >
+          <Badge variant="destructive">Error</Badge>
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+          <p className="text-xs text-muted-foreground">{state.project}</p>
+          {renderRetryButton(onRetry)}
+        </section>
+      ) : state.environments.length === 0 ? (
+        <section
+          data-mdcms-environments-page-state="empty"
+          className="space-y-3 rounded-lg border border-dashed p-6"
+        >
+          <Badge variant="outline">Empty</Badge>
+          <p className="text-sm text-muted-foreground">
+            No environments were returned for this project yet.
+          </p>
+          <p className="text-xs text-muted-foreground">{state.project}</p>
+        </section>
+      ) : (
+        <section
+          data-mdcms-environments-page-state="ready"
+          className="grid gap-4"
+        >
+          {state.environments.map((environment) => (
+            <article
+              key={environment.id}
+              data-mdcms-environment-row={environment.name}
+              className="space-y-4 rounded-lg border p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-semibold tracking-tight">
+                      {environment.name}
+                    </h2>
+                    {environment.isDefault ? (
+                      <Badge variant="secondary">Default</Badge>
+                    ) : null}
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {environment.extends
+                      ? `Extends ${environment.extends}`
+                      : "No parent environment"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Created {formatCreatedAt(environment.createdAt)}
+                  </p>
+                </div>
+                {!environment.isDefault ? (
+                  <Button
+                    variant="outline"
+                    disabled={pendingDeleteId === environment.id}
+                    onClick={() => onRequestDelete?.(environment)}
                   >
-                    <Globe className="h-5 w-5" style={{ color: env.color }} />
-                  </div>
-                  <div>
-                    <CardTitle className="text-base">{env.name}</CardTitle>
-                    <CardDescription className="text-xs">
-                      /{env.slug}
-                    </CardDescription>
-                  </div>
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon" className="h-8 w-8">
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem>
-                      <Settings2 className="mr-2 h-4 w-4" />
-                      Settings
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      disabled={env.isProduction}
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <p className="mb-4 text-sm text-muted-foreground">
-                {env.description}
-              </p>
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div>
-                  <p className="text-muted-foreground">Documents</p>
-                  <p className="font-medium">
-                    {env.documentCount.toLocaleString()}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-muted-foreground">Last Published</p>
-                  <p className="font-medium">
-                    {env.lastPublished
-                      ? env.lastPublished.toLocaleDateString()
-                      : "Never"}
-                  </p>
-                </div>
-              </div>
-              <div className="mt-4 flex gap-2">
-                <Button variant="outline" size="sm" className="flex-1">
-                  View Content
-                </Button>
-                {!env.isProduction && (
-                  <Button size="sm" className="flex-1">
-                    Promote
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    {pendingDeleteId === environment.id
+                      ? `Deleting ${environment.name}...`
+                      : `Delete ${environment.name}`}
                   </Button>
-                )}
+                ) : null}
               </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => onDeleteDialogChange?.(open)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Environment</DialogTitle>
+            <DialogDescription>
+              {isEnvironmentSummary(deleteTarget)
+                ? `Delete ${deleteTarget.name} from ${state.project}?`
+                : "Delete this environment?"}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onDeleteDialogChange?.(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={!deleteTarget || pendingDeleteId === deleteTarget.id}
+              onClick={() => onDeleteConfirm?.()}
+            >
+              {deleteTarget && pendingDeleteId === deleteTarget.id
+                ? `Deleting ${deleteTarget.name}...`
+                : deleteTarget
+                  ? `Delete ${deleteTarget.name}`
+                  : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
+  );
+}
+
+export default function EnvironmentsPage() {
+  const { project, environment, apiBaseUrl, auth } = useStudioMountInfo();
+  const sessionState = useStudioSession();
+  const [state, setState] = useState<EnvironmentManagementState>(() =>
+    project ? createLoadingState(project) : createMissingRouteState(),
+  );
+  const [reloadVersion, setReloadVersion] = useState(0);
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingCreate, setPendingCreate] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<EnvironmentSummary | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!project || !environment) {
+      setState(createMissingRouteState());
+      return;
+    }
+
+    let cancelled = false;
+    setState(createLoadingState(project));
+
+    const environmentApi = createStudioEnvironmentApi(
+      {
+        project,
+        environment,
+        serverUrl: apiBaseUrl,
+      },
+      { auth },
+    );
+
+    void environmentApi
+      .list()
+      .then((environments) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          status: "ready",
+          project,
+          environments: sortEnvironments(environments),
+        });
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+
+        const message = readRuntimeErrorMessage(
+          error,
+          "Environment request failed.",
+        );
+        const statusCode = readRuntimeErrorStatus(error);
+
+        setState(
+          statusCode === 401 || statusCode === 403
+            ? {
+                status: "forbidden",
+                project,
+                message,
+              }
+            : {
+                status: "error",
+                project,
+                message,
+              },
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, auth.mode, auth.token, environment, project, reloadVersion]);
+
+  async function handleCreateSubmit() {
+    if (!project || !environment) {
+      setCreateError("Environment management requires an active project.");
+      return;
+    }
+
+    if (sessionState.status !== "authenticated") {
+      setCreateError("Session could not be verified.");
+      return;
+    }
+
+    setPendingCreate(true);
+    setCreateError(null);
+    setActionError(null);
+
+    try {
+      const environmentApi = createStudioEnvironmentApi(
+        {
+          project,
+          environment,
+          serverUrl: apiBaseUrl,
+        },
+        {
+          auth,
+          csrfToken: sessionState.csrfToken,
+        },
+      );
+
+      await environmentApi.create({ name: createName });
+      setCreateName("");
+      setIsCreateDialogOpen(false);
+      setReloadVersion((current) => current + 1);
+    } catch (error) {
+      setCreateError(
+        readRuntimeErrorMessage(error, "Environment creation failed."),
+      );
+    } finally {
+      setPendingCreate(false);
+    }
+  }
+
+  async function handleDeleteConfirm() {
+    if (!project || !environment || !deleteTarget) {
+      setActionError("Environment deletion requires an active target.");
+      return;
+    }
+
+    if (sessionState.status !== "authenticated") {
+      setActionError("Session could not be verified.");
+      return;
+    }
+
+    setPendingDeleteId(deleteTarget.id);
+    setActionError(null);
+
+    try {
+      const environmentApi = createStudioEnvironmentApi(
+        {
+          project,
+          environment,
+          serverUrl: apiBaseUrl,
+        },
+        {
+          auth,
+          csrfToken: sessionState.csrfToken,
+        },
+      );
+
+      await environmentApi.delete(deleteTarget.id);
+      setDeleteTarget(null);
+      setReloadVersion((current) => current + 1);
+    } catch (error) {
+      setActionError(
+        readRuntimeErrorMessage(error, "Environment deletion failed."),
+      );
+    } finally {
+      setPendingDeleteId(null);
+    }
+  }
+
+  return (
+    <EnvironmentManagementPageView
+      state={state}
+      createName={createName}
+      createError={createError}
+      actionError={actionError}
+      pendingCreate={pendingCreate}
+      pendingDeleteId={pendingDeleteId}
+      deleteTarget={deleteTarget}
+      isCreateDialogOpen={isCreateDialogOpen}
+      onCreateDialogChange={(open) => {
+        setIsCreateDialogOpen(open);
+        if (!open) {
+          setCreateError(null);
+          setCreateName("");
+        }
+      }}
+      onCreateNameChange={setCreateName}
+      onCreateSubmit={handleCreateSubmit}
+      onDeleteDialogChange={(open) => {
+        if (!open) {
+          setDeleteTarget(null);
+        }
+      }}
+      onRequestDelete={(environment) => {
+        setActionError(null);
+        setDeleteTarget(environment);
+      }}
+      onDeleteConfirm={handleDeleteConfirm}
+      onRetry={() => {
+        setActionError(null);
+        setReloadVersion((current) => current + 1);
+      }}
+    />
   );
 }

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
@@ -97,6 +97,26 @@ test("AppSidebar shows Users route when users.manage is allowed", () => {
   assert.match(markup, /href="\/admin\/users"/);
 });
 
+test("AppSidebar hides Environments route when admin-only capabilities are unavailable", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: false,
+    canManageSettings: false,
+  });
+
+  assert.doesNotMatch(markup, /href="\/admin\/environments"/);
+});
+
+test("AppSidebar shows Environments route when admin-only capabilities are available", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: true,
+    canManageSettings: false,
+  });
+
+  assert.match(markup, /href="\/admin\/environments"/);
+});
+
 test("AppSidebar hides Users route when users.manage is not allowed", () => {
   const markup = renderSidebarWithCapabilities({
     canReadSchema: true,

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx
@@ -117,6 +117,16 @@ test("AppSidebar shows Environments route when admin-only capabilities are avail
   assert.match(markup, /href="\/admin\/environments"/);
 });
 
+test("AppSidebar shows Environments route when only settings.manage is allowed", () => {
+  const markup = renderSidebarWithCapabilities({
+    canReadSchema: true,
+    canManageUsers: false,
+    canManageSettings: true,
+  });
+
+  assert.match(markup, /href="\/admin\/environments"/);
+});
+
 test("AppSidebar hides Users route when users.manage is not allowed", () => {
   const markup = renderSidebarWithCapabilities({
     canReadSchema: true,

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -56,7 +56,11 @@ function getMainNavItems(filters: {
   canManageUsers: boolean;
   canManageSettings: boolean;
 }) {
+  const canManageAdminSurfaces =
+    filters.canManageUsers || filters.canManageSettings;
+
   return mainNavItems.filter((item) => {
+    if (item.href === "/admin/environments") return canManageAdminSurfaces;
     if (item.href === "/admin/schema") return filters.canReadSchema;
     if (item.href === "/admin/users") return filters.canManageUsers;
     if (item.href === "/admin/settings") return filters.canManageSettings;


### PR DESCRIPTION
## Summary
- define the `/admin/environments` Studio route contract in `SPEC-006` and document the live environment management surface
- replace the mock environments page with a live list/create/delete UI backed by the existing environment endpoints and admin-gated navigation
- align `apps/studio-review` environment fixtures and routes with the real contract, including admin-only access and delete handling

## Verification
- `bun test packages/studio/src/lib/environment-api.test.ts packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx apps/server/src/lib/environments-api.route.test.ts apps/studio-review/review/environments.test.ts`
- `bun run format:check`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment management UI at /admin/environments with live list/create/delete flows, confirmation for deletions, and non-deletable default environment; sidebar nav entry now respects admin capabilities.
  * Client API extended to support create and delete operations with CSRF enforcement and improved error handling.

* **Tests**
  * Added server and client tests covering listing, creation, deletion, authorization, CSRF, and error cases.

* **Documentation**
  * Added spec and README describing routes, UI behaviors, and expected error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->