### PR TITLE
CMS-67: Wire environment-specific field badges in editor UI

### DIFF
--- a/apps/studio-example/app/admin/[[...path]]/page.tsx
+++ b/apps/studio-example/app/admin/[[...path]]/page.tsx
@@ -19,6 +19,11 @@ export default async function AdminCatchAllPage() {
       preparedComponents={extractPreparedStudioComponentMetadata(
         preparedConfig,
       )}
+      documentRouteMetadata={
+        "_documentRouteMetadata" in preparedConfig
+          ? preparedConfig._documentRouteMetadata
+          : undefined
+      }
       schemaHash={
         "_schemaHash" in preparedConfig
           ? (preparedConfig._schemaHash as string)

--- a/apps/studio-example/app/admin/admin-studio-client.tsx
+++ b/apps/studio-example/app/admin/admin-studio-client.tsx
@@ -6,14 +6,17 @@ import {
   createClientStudioConfig,
   type PreparedStudioComponentMetadata,
 } from "./studio-config";
+import type { MdcmsConfig } from "@mdcms/studio";
 
 export function AdminStudioClient(props: {
   preparedComponents: PreparedStudioComponentMetadata[];
   schemaHash?: string;
+  documentRouteMetadata?: MdcmsConfig["_documentRouteMetadata"];
 }) {
   const config = createClientStudioConfig(
     props.preparedComponents,
     props.schemaHash,
+    props.documentRouteMetadata ?? undefined,
   );
 
   return <Studio config={config} basePath="/admin" />;

--- a/apps/studio-example/app/admin/studio-config.ts
+++ b/apps/studio-example/app/admin/studio-config.ts
@@ -10,6 +10,9 @@ import {
 
 type PreparedStudioConfig = Awaited<ReturnType<typeof prepareStudioConfig>>;
 type PreparedStudioComponent = NonNullable<MdcmsConfig["components"]>[number];
+type PreparedDocumentRouteMetadata = NonNullable<
+  MdcmsConfig["_documentRouteMetadata"]
+>;
 
 export type PreparedStudioComponentMetadata = Pick<
   PreparedStudioComponent,
@@ -32,6 +35,7 @@ export function extractPreparedStudioComponentMetadata(
 export function createClientStudioConfig(
   preparedComponents: PreparedStudioComponentMetadata[],
   schemaHash?: string,
+  documentRouteMetadata?: PreparedDocumentRouteMetadata,
 ): MdcmsConfig {
   const extractedPropsByName = new Map(
     preparedComponents.map((component) => [
@@ -51,6 +55,9 @@ export function createClientStudioConfig(
     // Pre-computed schema hash from the server component where the full
     // config (with Zod types/environments) is available for derivation.
     ...(schemaHash ? { _schemaHash: schemaHash } : {}),
+    ...(documentRouteMetadata
+      ? { _documentRouteMetadata: documentRouteMetadata }
+      : {}),
     components: clientComponents.map((component) => {
       const extractedProps = extractedPropsByName.get(component.name);
 

--- a/apps/studio-example/mdcms.config.test.ts
+++ b/apps/studio-example/mdcms.config.test.ts
@@ -3,9 +3,12 @@ import { test } from "node:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { prepareStudioConfig } from "@mdcms/studio/runtime";
+
 import { Callout } from "./components/mdx/Callout";
 import { Chart } from "./components/mdx/Chart";
 import { PricingTable } from "./components/mdx/PricingTable";
+import { resolveStudioExampleAppRoot } from "./app/admin/resolve-studio-example-app-root";
 import config from "./mdcms.config";
 
 test("studio-example registers the expected demo MDX components", async () => {
@@ -50,6 +53,22 @@ test("studio-example config includes a localized demo type with explicit locales
   assert.ok(campaignType);
   assert.equal(campaignType?.localized, true);
   assert.equal(campaignType?.directory, "content/campaigns");
+});
+
+test("studio-example config exposes environment-specific demo fields", async () => {
+  const preparedConfig = await prepareStudioConfig(config, {
+    cwd: resolveStudioExampleAppRoot(),
+  });
+
+  assert.deepEqual(
+    preparedConfig._documentRouteMetadata?.environmentFieldTargets,
+    {
+      post: {
+        abTestVariant: ["staging"],
+        featured: ["staging"],
+      },
+    },
+  );
 });
 
 test("demo MDX components tolerate empty preview props during insertion", () => {

--- a/apps/studio-example/mdcms.config.ts
+++ b/apps/studio-example/mdcms.config.ts
@@ -14,6 +14,8 @@ const post = defineType("post", {
   fields: {
     title: z.string().min(1),
     slug: z.string().min(1),
+    featured: z.boolean().default(false).env("staging"),
+    abTestVariant: z.string().min(1).optional().env("staging"),
     author: reference("author").optional(),
   },
 });

--- a/apps/studio-review/app/review/[scenario]/admin/[[...path]]/page.tsx
+++ b/apps/studio-review/app/review/[scenario]/admin/[[...path]]/page.tsx
@@ -37,6 +37,11 @@ export default async function AdminReviewPage(props: {
       scenario={scenario}
       basePath={`/review/${scenario}/admin`}
       serverUrl={createReviewScenarioServerUrl({ scenario, origin })}
+      documentRouteMetadata={
+        "_documentRouteMetadata" in preparedConfig
+          ? preparedConfig._documentRouteMetadata
+          : undefined
+      }
       preparedComponents={extractPreparedStudioComponentMetadata(
         preparedConfig,
       )}

--- a/apps/studio-review/app/review/[scenario]/admin/admin-studio-client.tsx
+++ b/apps/studio-review/app/review/[scenario]/admin/admin-studio-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Studio } from "@mdcms/studio";
+import { Studio, type MdcmsConfig } from "@mdcms/studio";
 
 import {
   createClientStudioConfig,
@@ -12,11 +12,13 @@ export function AdminStudioClient(props: {
   basePath: string;
   serverUrl: string;
   preparedComponents: PreparedStudioComponentMetadata[];
+  documentRouteMetadata?: MdcmsConfig["_documentRouteMetadata"];
 }) {
   const config = createClientStudioConfig({
     scenario: props.scenario,
     serverUrl: props.serverUrl,
     preparedComponents: props.preparedComponents,
+    documentRouteMetadata: props.documentRouteMetadata ?? undefined,
   });
 
   return (

--- a/apps/studio-review/app/review/[scenario]/admin/studio-config.ts
+++ b/apps/studio-review/app/review/[scenario]/admin/studio-config.ts
@@ -10,6 +10,9 @@ import {
 
 type PreparedStudioConfig = Awaited<ReturnType<typeof prepareStudioConfig>>;
 type PreparedStudioComponent = NonNullable<MdcmsConfig["components"]>[number];
+type PreparedDocumentRouteMetadata = NonNullable<
+  MdcmsConfig["_documentRouteMetadata"]
+>;
 
 export type PreparedStudioComponentMetadata = Pick<
   PreparedStudioComponent,
@@ -70,6 +73,7 @@ export function createClientStudioConfig(input: {
   scenario: string;
   serverUrl: string;
   preparedComponents: PreparedStudioComponentMetadata[];
+  documentRouteMetadata?: PreparedDocumentRouteMetadata;
 }): MdcmsConfig {
   const extractedPropsByName = new Map(
     input.preparedComponents.map((component) => [
@@ -85,6 +89,9 @@ export function createClientStudioConfig(input: {
     project: studioReviewProject,
     environment: studioReviewEnvironment,
     serverUrl: input.serverUrl,
+    ...(input.documentRouteMetadata
+      ? { _documentRouteMetadata: input.documentRouteMetadata }
+      : {}),
     components: clientComponents.map((component) => {
       const extractedProps = extractedPropsByName.get(component.name);
 

--- a/apps/studio-review/mdcms.config.ts
+++ b/apps/studio-review/mdcms.config.ts
@@ -13,6 +13,7 @@ const post = defineType("post", {
   fields: {
     title: z.string().min(1),
     slug: z.string().min(1),
+    featured: z.boolean().default(false).env("staging"),
     author: reference("author").optional(),
   },
 });

--- a/apps/studio-review/review/scenarios.test.ts
+++ b/apps/studio-review/review/scenarios.test.ts
@@ -11,3 +11,17 @@ test("review scenarios expose deterministic capability sets", () => {
   assert.equal(editor.capabilities.settings.manage, false);
   assert.equal(editor.document.documentId.length > 0, true);
 });
+
+test("review owner scenario exposes staging-only editor fields in the schema fixture", () => {
+  const owner = getReviewScenario("owner");
+  const postSchema = owner.schema.entries.find(
+    (entry) => entry.type === "post",
+  );
+
+  assert.ok(postSchema, "expected post schema entry");
+  assert.deepEqual(Object.keys(postSchema.resolvedSchema.fields).sort(), [
+    "featured",
+    "slug",
+    "title",
+  ]);
+});

--- a/apps/studio-review/review/scenarios.ts
+++ b/apps/studio-review/review/scenarios.ts
@@ -97,6 +97,11 @@ function createSchemaEntries() {
         directory: "content/posts",
         localized: false,
         fields: {
+          featured: {
+            kind: "boolean",
+            required: true,
+            nullable: false,
+          },
           title: {
             kind: "string",
             required: true,

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -349,13 +349,17 @@ Normative behavior:
   to that mutable head snapshot.
 - The primary canvas edits the document `body` through the editor engine owned
   by SPEC-007.
-- The right sidebar exposes two tabs:
-  - `Properties` for document metadata and schema-driven frontmatter editing
+- The right sidebar exposes three tabs:
+  - `Properties` for schema-driven frontmatter editing
+  - `Info` for document system metadata
   - `History` for publish history and version comparison
-- The `Properties` tab shows the existing system metadata (`status`,
-  `publishedVersion`, `locale`, `updatedAt`, `path`) and, below it, the
-  schema-derived frontmatter fields for the current type in the active
-  environment.
+- `Properties` is dedicated to schema-derived frontmatter fields for the
+  current type in the active environment.
+- `Properties` does not render document system metadata such as `status`,
+  `publishedVersion`, `locale`, `updatedAt`, or `path`.
+- `Info` shows the existing read-only document metadata (`status`,
+  `publishedVersion`, `locale`, `updatedAt`, `path`).
+- The default selected sidebar tab is `Properties`.
 - Frontmatter controls are derived from the live resolved schema. Studio must
   not ship hard-coded per-type property forms for routed document editing.
 - MVP editable field support is intentionally narrow:

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -327,6 +327,10 @@ single document head in the active `(project, environment)` target. It is
 backed by:
 
 - `GET /api/v1/content/:documentId?draft=true` for the current draft snapshot
+  (`draft=true` is an authorization/read-model switch that returns the mutable
+  head content snapshot for the addressed document when the caller is
+  authorized; it is not a server-side status filter for "draft-only" or
+  "show unpublished" documents)
 - `PUT /api/v1/content/:documentId` for draft persistence
 - `POST /api/v1/content/:documentId/publish` for publish
 - `GET /api/v1/content/:documentId/versions` and
@@ -340,6 +344,9 @@ Normative behavior:
 - The editor route is keyed by the routed `type`, `documentId`, and active
   environment. Studio must reject stale async results when the active
   environment or routed document changes.
+- `GET /api/v1/content/:documentId?draft=true` reads the mutable head snapshot
+  for that single document in the active target. Authorization controls access
+  to that mutable head snapshot.
 - The primary canvas edits the document `body` through the editor engine owned
   by SPEC-007.
 - The right sidebar exposes two tabs:

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -362,6 +362,8 @@ Normative behavior:
 - The default selected sidebar tab is `Properties`.
 - Frontmatter controls are derived from the live resolved schema. Studio must
   not ship hard-coded per-type property forms for routed document editing.
+- Every property row shows an always-visible compact type label derived from
+  the resolved schema for the active environment.
 - MVP editable field support is intentionally narrow:
   - `string` fields render as single-line text inputs
   - `number` fields render as numeric inputs

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -349,9 +349,9 @@ Normative behavior:
   to that mutable head snapshot.
 - The primary canvas edits the document `body` through the editor engine owned
   by SPEC-007.
-- The right sidebar exposes three tabs:
-  - `Properties` for schema-driven frontmatter editing
+- The right sidebar exposes three tabs in this order:
   - `Info` for document system metadata
+  - `Properties` for schema-driven frontmatter editing
   - `History` for publish history and version comparison
 - `Properties` is dedicated to schema-derived frontmatter fields for the
   current type in the active environment.
@@ -359,7 +359,8 @@ Normative behavior:
   `publishedVersion`, `locale`, `updatedAt`, or `path`.
 - `Info` shows the existing read-only document metadata (`status`,
   `publishedVersion`, `locale`, `updatedAt`, `path`).
-- The default selected sidebar tab is `Properties`.
+- The default selected sidebar tab is `Properties` even though `Info` appears
+  first in the tab strip.
 - Frontmatter controls are derived from the live resolved schema. Studio must
   not ship hard-coded per-type property forms for routed document editing.
 - Every property row shows an always-visible compact type label derived from

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-04-06
+last_updated: 2026-04-10
 ---
 
 # SPEC-006 Studio Runtime and UI
@@ -319,6 +319,71 @@ Row-level actions:
 
 - Row action failures are surfaced inline with a dismissible error banner.
 - The `content.list.row.actions` extensibility slot applies to these actions.
+
+### Document Editor (`/admin/content/:type/:documentId`)
+
+The `/admin/content/:type/:documentId` route is the live document editor for a
+single document head in the active `(project, environment)` target. It is
+backed by:
+
+- `GET /api/v1/content/:documentId?draft=true` for the current draft snapshot
+- `PUT /api/v1/content/:documentId` for draft persistence
+- `POST /api/v1/content/:documentId/publish` for publish
+- `GET /api/v1/content/:documentId/versions` and
+  `GET /api/v1/content/:documentId/versions/:version` for history and diff
+- `GET /api/v1/content/:documentId/variants` for locale variant discovery
+- `GET /api/v1/schema` for live type and field metadata
+- `GET /api/v1/me/capabilities` for write/publish gating
+
+Normative behavior:
+
+- The editor route is keyed by the routed `type`, `documentId`, and active
+  environment. Studio must reject stale async results when the active
+  environment or routed document changes.
+- The primary canvas edits the document `body` through the editor engine owned
+  by SPEC-007.
+- The right sidebar exposes two tabs:
+  - `Properties` for document metadata and schema-driven frontmatter editing
+  - `History` for publish history and version comparison
+- The `Properties` tab shows the existing system metadata (`status`,
+  `publishedVersion`, `locale`, `updatedAt`, `path`) and, below it, the
+  schema-derived frontmatter fields for the current type in the active
+  environment.
+- Frontmatter controls are derived from the live resolved schema. Studio must
+  not ship hard-coded per-type property forms for routed document editing.
+- MVP editable field support is intentionally narrow:
+  - `string` fields render as single-line text inputs
+  - `number` fields render as numeric inputs
+  - `boolean` fields render as switches
+  - enum-like fields render as selects when the resolved schema exposes a
+    closed value set
+  - optional wrappers of supported kinds reuse the same control and allow an
+    empty/unset value
+- Unsupported field shapes render deterministically as read-only property rows
+  with a type label and a “Not editable in Studio yet” message. Unsupported
+  shapes include reference fields, arrays, objects, tuples, unions, executable
+  custom schemas, and any unrecognized field kind.
+- Unsupported frontmatter values must be preserved in the local draft state and
+  in subsequent `PUT /api/v1/content/:documentId` writes. Studio must not drop
+  a field solely because the current UI cannot edit it.
+- Property field order follows the resolved schema order for the current type.
+- Fields that only exist in specific environments remain first-class controls
+  when they are present in the active environment. Their environment badge is
+  shown inline with the field label/control (for example `staging only`); a
+  summary-only list without an editable control does not satisfy this contract.
+- Fields omitted from the resolved schema for the active environment are not
+  rendered as editable controls in that environment.
+- Frontmatter edits participate in the same unsaved/saving/saved indicator model
+  as body edits. Changing only a property field is sufficient to mark the draft
+  unsaved and trigger draft persistence.
+- Existing write-blocking states continue to apply to both body and property
+  editing. When Studio is read-only because of RBAC, schema mismatch, or other
+  guarded write conditions, the properties editor is disabled consistently with
+  the main editor canvas.
+- Validation failures returned by `PUT /api/v1/content/:documentId` should be
+  anchored to the corresponding property control when the failure can be mapped
+  to a named frontmatter field; otherwise Studio falls back to the route-level
+  mutation error banner.
 
 ### Theme Preference Persistence
 

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-03-26
+last_updated: 2026-04-10
 ---
 
 # SPEC-007 Editor, MDX, and Collaboration
@@ -95,15 +95,19 @@ There are two distinct save operations:
 **Auto-save (draft):**
 
 - Debounced: triggers ~5 seconds after the last change, or on editor blur/disconnect.
-- Serializes the current TipTap document state to markdown + frontmatter.
+- Serializes the current TipTap document state to markdown together with the
+  current frontmatter draft state from the schema-driven `Properties` tab.
 - `UPDATE`s the `documents` row in place, sets `has_unpublished_changes = TRUE`, and increments `draft_revision`. No version history is created.
 - Silent — no UI indication beyond a subtle "Saved" indicator.
 - Does not depend on Redis, WebSocket sessions, or webhook fan-out in MVP.
+- Frontmatter-only edits and body-only edits use the same draft-save pipeline
+  and the same unsaved/saving/saved state machine.
 
 **Publish (versioned):**
 
 - Explicit user action (Publish button).
-- Copies the current draft content into a new immutable row in `document_versions`.
+- Copies the current draft body and frontmatter into a new immutable row in
+  `document_versions`.
 - Optionally includes a change summary entered by the user.
 - This is the only action that creates version history.
 

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -106,8 +106,12 @@ There are two distinct save operations:
 **Publish (versioned):**
 
 - Explicit user action (Publish button).
-- Copies the current draft body and frontmatter into a new immutable row in
-  `document_versions`.
+- The client invokes the publish endpoint with the document identity and the
+  optional change summary; it does not upload the body/frontmatter snapshot as
+  part of the publish request in MVP.
+- The server copies the current mutable draft body and frontmatter from the
+  `documents` head row into a new immutable row in `document_versions` at the
+  moment publish succeeds.
 - Optionally includes a change summary entered by the user.
 - This is the only action that creates version history.
 

--- a/packages/shared/src/lib/contracts/extensibility.test.ts
+++ b/packages/shared/src/lib/contracts/extensibility.test.ts
@@ -376,6 +376,21 @@ test("runtime contract validators cover positive and negative shapes", () => {
         project: "marketing-site",
         initialEnvironment: "staging",
         supportedLocales: ["en-US", "fr"],
+        writeByEnvironment: {
+          production: {
+            canWrite: true,
+            schemaHash: "production-schema-hash",
+          },
+          staging: {
+            canWrite: true,
+            schemaHash: "staging-schema-hash",
+          },
+        },
+        environmentFieldTargets: {
+          BlogPost: {
+            featured: ["staging"],
+          },
+        },
         write: {
           canWrite: true,
           schemaHash: "schema-hash",

--- a/packages/shared/src/lib/contracts/extensibility.ts
+++ b/packages/shared/src/lib/contracts/extensibility.ts
@@ -148,6 +148,8 @@ export type StudioDocumentRouteMountContext = {
   initialEnvironment: string;
   supportedLocales?: string[];
   defaultLocale?: string;
+  writeByEnvironment?: Record<string, StudioDocumentRouteWriteContext>;
+  environmentFieldTargets?: Record<string, Record<string, string[]>>;
   write: StudioDocumentRouteWriteContext;
 };
 
@@ -550,6 +552,15 @@ const studioDocumentRouteContextSchema = z
     initialEnvironment: nonEmptyStringSchema,
     supportedLocales: z.array(nonEmptyStringSchema).optional(),
     defaultLocale: nonEmptyStringSchema.optional(),
+    writeByEnvironment: z
+      .record(nonEmptyStringSchema, studioDocumentRouteWriteSchema)
+      .optional(),
+    environmentFieldTargets: z
+      .record(
+        nonEmptyStringSchema,
+        z.record(nonEmptyStringSchema, z.array(nonEmptyStringSchema)),
+      )
+      .optional(),
     write: studioDocumentRouteWriteSchema,
   })
   .strict()

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -152,6 +152,12 @@ export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
   - `write.canWrite`
   - `write.schemaHash` when draft writes are allowed, or `write.message` when
     the route must stay read-only
+  - optional `writeByEnvironment` metadata for environment-switched editor
+    routes so Studio can use the correct local schema hash after the active
+    environment changes in-shell
+  - optional `environmentFieldTargets` metadata keyed by `type -> field ->
+environments[]` so the document sidebar can label environment-specific
+    fields such as `staging only`
 - `loadStudioRuntimeFromBootstrap(...)` derives `documentRoute.write` from the
   local authored config. Write-enabled routes require enough local config data
   to deterministically derive the active environment schema hash.

--- a/packages/studio/src/lib/document-route-schema.test.ts
+++ b/packages/studio/src/lib/document-route-schema.test.ts
@@ -6,6 +6,7 @@ import { createStudioEmbedConfig } from "./studio.js";
 import {
   resolveStudioDocumentRouteSchemaDetails,
   resolveStudioDocumentRouteSchemaCapability,
+  resolveStudioDocumentRoutePreparedMetadata,
   type StudioDocumentRouteSchemaCapability,
 } from "./document-route-schema.js";
 import { defineConfig, defineType, reference } from "@mdcms/shared";
@@ -126,6 +127,24 @@ test("derived schema details expose the local sync payload pieces", async () => 
     "Author",
   ]);
   assert.match(details.syncPayload.schemaHash, /^[a-f0-9]{64}$/);
+});
+
+test("prepared document route metadata includes per-environment hashes and field targets", async () => {
+  const metadata = await resolveStudioDocumentRoutePreparedMetadata(
+    createAuthoredConfig(),
+  );
+
+  assert.deepEqual(Object.keys(metadata.schemaHashesByEnvironment).sort(), [
+    "production",
+    "staging",
+  ]);
+  assert.match(metadata.schemaHashesByEnvironment.production, /^[a-f0-9]{64}$/);
+  assert.match(metadata.schemaHashesByEnvironment.staging, /^[a-f0-9]{64}$/);
+  assert.deepEqual(metadata.environmentFieldTargets, {
+    Article: {
+      summary: ["staging"],
+    },
+  });
 });
 
 test("equivalent authored config data yields the same schema hash", async () => {

--- a/packages/studio/src/lib/document-route-schema.ts
+++ b/packages/studio/src/lib/document-route-schema.ts
@@ -35,6 +35,11 @@ export type StudioDocumentRouteSchemaDetails =
       message: string;
     };
 
+export type StudioDocumentRoutePreparedMetadata = {
+  schemaHashesByEnvironment: Record<string, string>;
+  environmentFieldTargets: Record<string, Record<string, string[]>>;
+};
+
 function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
   return {
     project: config.project,
@@ -107,6 +112,122 @@ function hasResolvedEnvironment(
   );
 }
 
+function listResolvedEnvironments(config: ParsedMdcmsConfig): string[] {
+  return Object.keys(config.resolvedEnvironments).sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function resolveEnvironmentFieldTargets(
+  config: ParsedMdcmsConfig,
+): Record<string, Record<string, string[]>> {
+  const environmentNames = listResolvedEnvironments(config);
+
+  if (environmentNames.length <= 1) {
+    return {};
+  }
+
+  const fieldTargets = new Map<string, Map<string, Set<string>>>();
+
+  for (const environmentName of environmentNames) {
+    const resolvedEnvironment = config.resolvedEnvironments[environmentName];
+
+    if (!resolvedEnvironment) {
+      continue;
+    }
+
+    for (const [typeName, typeDefinition] of Object.entries(
+      resolvedEnvironment.types,
+    )) {
+      const typeFieldTargets =
+        fieldTargets.get(typeName) ?? new Map<string, Set<string>>();
+
+      for (const fieldName of Object.keys(typeDefinition.fields)) {
+        const targets = typeFieldTargets.get(fieldName) ?? new Set<string>();
+        targets.add(environmentName);
+        typeFieldTargets.set(fieldName, targets);
+      }
+
+      fieldTargets.set(typeName, typeFieldTargets);
+    }
+  }
+
+  const result = Object.fromEntries(
+    Array.from(fieldTargets.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([typeName, typeFieldTargets]) => {
+        const scopedFields = Object.fromEntries(
+          Array.from(typeFieldTargets.entries())
+            .sort(([left], [right]) => left.localeCompare(right))
+            .flatMap(([fieldName, targets]) => {
+              const sortedTargets = Array.from(targets).sort((left, right) =>
+                left.localeCompare(right),
+              );
+
+              return sortedTargets.length === environmentNames.length
+                ? []
+                : [[fieldName, sortedTargets] as const];
+            }),
+        );
+
+        return [typeName, scopedFields] as const;
+      })
+      .filter(([, scopedFields]) => Object.keys(scopedFields).length > 0),
+  );
+
+  return result;
+}
+
+async function resolveSchemaHashesByEnvironment(
+  config: ParsedMdcmsConfig,
+): Promise<Record<string, string>> {
+  const rawConfigSnapshot = toRawConfigSnapshot(config);
+  const entries = await Promise.all(
+    listResolvedEnvironments(config).map(async (environment) => {
+      const resolvedSchema = serializeResolvedEnvironmentSchema(
+        config,
+        environment,
+      );
+      const schemaHash = await sha256Hex(
+        JSON.stringify({
+          environment,
+          rawConfigSnapshot,
+          resolvedSchema,
+        }),
+      );
+
+      return [environment, schemaHash] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries);
+}
+
+export async function resolveStudioDocumentRoutePreparedMetadata(
+  config: SharedMdcmsConfig,
+): Promise<StudioDocumentRoutePreparedMetadata> {
+  const parsedConfig = parseMdcmsConfig(config);
+  const environment = parsedConfig.environment?.trim();
+
+  if (!environment) {
+    throw new Error(
+      "Studio writes require an active environment in the local Studio config.",
+    );
+  }
+
+  if (!hasResolvedEnvironment(parsedConfig, environment)) {
+    throw new Error(
+      `Studio writes require a resolved schema for environment "${environment}".`,
+    );
+  }
+
+  return {
+    schemaHashesByEnvironment:
+      await resolveSchemaHashesByEnvironment(parsedConfig),
+    environmentFieldTargets: resolveEnvironmentFieldTargets(parsedConfig),
+  };
+}
+
 export async function resolveStudioDocumentRouteSchemaCapability(
   config: SharedMdcmsConfig,
 ): Promise<StudioDocumentRouteSchemaCapability> {
@@ -161,13 +282,15 @@ export async function resolveStudioDocumentRouteSchemaDetails(
       parsedConfig,
       environment,
     );
-    const schemaHash = await sha256Hex(
-      JSON.stringify({
-        environment,
-        rawConfigSnapshot,
-        resolvedSchema,
-      }),
-    );
+    const schemaHash = (await resolveSchemaHashesByEnvironment(parsedConfig))[
+      environment
+    ];
+
+    if (!schemaHash) {
+      throw new Error(
+        `Studio writes require a resolved schema for environment "${environment}".`,
+      );
+    }
 
     return {
       canWrite: true,

--- a/packages/studio/src/lib/document-shell.test.ts
+++ b/packages/studio/src/lib/document-shell.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { loadStudioDocumentShell } from "./document-shell.js";
+
+const validDocumentResponse = {
+  data: {
+    documentId: "11111111-1111-4111-8111-111111111111",
+    translationGroupId: "22222222-2222-4222-8222-222222222222",
+    project: "marketing-site",
+    environment: "staging",
+    path: "blog/launch-notes",
+    type: "BlogPost",
+    locale: "en",
+    format: "mdx" as const,
+    isDeleted: false,
+    hasUnpublishedChanges: true,
+    version: 5,
+    publishedVersion: 5,
+    draftRevision: 8,
+    frontmatter: {
+      title: "Launch Notes",
+      featured: true,
+    },
+    body: "# Launch Notes",
+    createdBy: "33333333-3333-4333-8333-333333333331",
+    createdAt: "2026-03-27T10:00:00.000Z",
+    updatedBy: "33333333-3333-4333-8333-333333333331",
+    updatedAt: "2026-03-27T12:00:00.000Z",
+  },
+};
+
+test("loadStudioDocumentShell keeps draft frontmatter and format for the document page", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+
+  const shell = await loadStudioDocumentShell(
+    {
+      project: "marketing-site",
+      environment: "staging",
+      serverUrl: "http://localhost:4000",
+    },
+    {
+      type: "BlogPost",
+      documentId: "11111111-1111-4111-8111-111111111111",
+      locale: "en",
+    },
+    {
+      auth: { mode: "cookie" },
+      fetcher: async (input, init) => {
+        calls.push({ input, init });
+
+        return new Response(JSON.stringify(validDocumentResponse), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      },
+    },
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(shell.state, "ready");
+  if (shell.state !== "ready") {
+    throw new Error("expected ready shell state");
+  }
+
+  assert.equal(shell.data?.format, "mdx");
+  assert.deepEqual(shell.data?.frontmatter, {
+    title: "Launch Notes",
+    featured: true,
+  });
+  assert.equal(shell.data?.body, "# Launch Notes");
+});

--- a/packages/studio/src/lib/document-shell.ts
+++ b/packages/studio/src/lib/document-shell.ts
@@ -19,6 +19,8 @@ export type StudioDocumentShellData = {
   type: string;
   locale: string;
   path: string;
+  format: "md" | "mdx";
+  frontmatter: Record<string, unknown>;
   body: string;
   updatedAt: string;
   hasUnpublishedChanges: boolean;
@@ -142,6 +144,8 @@ export async function loadStudioDocumentShell(
         type: document.type ?? input.type,
         locale: document.locale ?? locale,
         path: document.path,
+        format: document.format ?? "mdx",
+        frontmatter: document.frontmatter ?? {},
         body: document.body ?? "",
         updatedAt: document.updatedAt ?? "",
         hasUnpublishedChanges: document.hasUnpublishedChanges,

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -1568,15 +1568,14 @@ test("ContentDocumentPageView renders environment-specific field badges inline w
 
   const markup = renderPageMarkup(state);
 
-  assert.match(markup, /Frontmatter/);
   assert.match(markup, /data-mdcms-property-field="featured"/);
   assert.match(markup, /data-mdcms-property-type="boolean"/);
   assert.match(markup, />featured</);
-  assert.match(markup, /staging only/);
+  assert.match(markup, /staging/);
   assert.match(markup, /data-mdcms-property-field="abTestVariant"/);
   assert.match(markup, /data-mdcms-property-type="string"/);
   assert.match(markup, />abTestVariant</);
-  assert.match(markup, /preview, staging only/);
+  assert.match(markup, /preview, staging/);
 });
 
 test("ContentDocumentPageView renders schema-driven property controls and unsupported fallback rows", () => {
@@ -1660,9 +1659,9 @@ test("ContentDocumentPageView renders schema-driven property controls and unsupp
   assert.match(markup, /data-mdcms-property-editor="select"/);
   assert.match(markup, /data-mdcms-property-field="metadata"/);
   assert.match(markup, /data-mdcms-property-type="object"/);
-  assert.match(markup, /Not editable in Studio yet/);
+  assert.match(markup, /Not editable yet/);
   assert.match(markup, /data-mdcms-property-field="featured"/);
-  assert.match(markup, /staging only/);
+  assert.match(markup, /staging/);
   assert.match(markup, />string</);
   assert.match(markup, />number</);
   assert.match(markup, />boolean</);

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -23,6 +23,7 @@ import {
   parseSelectedComparisonVersionValue,
   publishContentDocumentReadyState,
   reloadSchemaStateForGuard,
+  resolveActiveDocumentRouteContext,
   reduceContentDocumentPageReadyState,
   saveContentDocumentReadyState,
   syncSchemaStateForGuard,
@@ -1289,6 +1290,48 @@ test("ContentDocumentPageView blocks writes when the local schema hash capabilit
   assert.equal(state.canWrite, false);
   assert.match(markup, /data-mdcms-document-write-state="blocked"/);
   assert.match(markup, /Schema sync required before Studio can write drafts\./);
+});
+
+test("ContentDocumentPageView renders environment-specific field badges for the active environment", () => {
+  const state = createReadyState();
+  state.route.environmentFieldTargets = {
+    [state.typeId]: {
+      featured: ["staging"],
+      abTestVariant: ["preview", "staging"],
+    },
+  };
+
+  const markup = renderPageMarkup(state);
+
+  assert.match(markup, /Environment-specific fields/);
+  assert.match(markup, />featured</);
+  assert.match(markup, /staging only/);
+  assert.match(markup, />abTestVariant</);
+  assert.match(markup, /preview, staging only/);
+});
+
+test("resolveActiveDocumentRouteContext switches write metadata with the selected environment", () => {
+  const route = {
+    ...createRouteContext(true),
+    writeByEnvironment: {
+      production: {
+        canWrite: true as const,
+        schemaHash: "production-schema-hash",
+      },
+      staging: {
+        canWrite: true as const,
+        schemaHash: "staging-schema-hash",
+      },
+    },
+  };
+
+  const activeRoute = resolveActiveDocumentRouteContext(route, "production");
+
+  assert.equal(activeRoute.initialEnvironment, "production");
+  assert.deepEqual(activeRoute.write, {
+    canWrite: true,
+    schemaHash: "production-schema-hash",
+  });
 });
 
 test("locale switcher renders for localized type with supportedLocales", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -1559,9 +1559,11 @@ test("ContentDocumentPageView renders environment-specific field badges inline w
 
   assert.match(markup, /Frontmatter/);
   assert.match(markup, /data-mdcms-property-field="featured"/);
+  assert.match(markup, /data-mdcms-property-type="boolean"/);
   assert.match(markup, />featured</);
   assert.match(markup, /staging only/);
   assert.match(markup, /data-mdcms-property-field="abTestVariant"/);
+  assert.match(markup, /data-mdcms-property-type="string"/);
   assert.match(markup, />abTestVariant</);
   assert.match(markup, /preview, staging only/);
 });
@@ -1634,17 +1636,27 @@ test("ContentDocumentPageView renders schema-driven property controls and unsupp
   const markup = renderPageMarkup(state);
 
   assert.match(markup, /data-mdcms-property-field="title"/);
+  assert.match(markup, /data-mdcms-property-type="string"/);
   assert.match(markup, /data-mdcms-property-editor="string"/);
   assert.match(markup, /data-mdcms-property-field="views"/);
+  assert.match(markup, /data-mdcms-property-type="number"/);
   assert.match(markup, /data-mdcms-property-editor="number"/);
   assert.match(markup, /data-mdcms-property-field="published"/);
+  assert.match(markup, /data-mdcms-property-type="boolean"/);
   assert.match(markup, /data-mdcms-property-editor="boolean"/);
   assert.match(markup, /data-mdcms-property-field="status"/);
+  assert.match(markup, /data-mdcms-property-type="enum"/);
   assert.match(markup, /data-mdcms-property-editor="select"/);
   assert.match(markup, /data-mdcms-property-field="metadata"/);
+  assert.match(markup, /data-mdcms-property-type="object"/);
   assert.match(markup, /Not editable in Studio yet/);
   assert.match(markup, /data-mdcms-property-field="featured"/);
   assert.match(markup, /staging only/);
+  assert.match(markup, />string</);
+  assert.match(markup, />number</);
+  assert.match(markup, />boolean</);
+  assert.match(markup, />enum</);
+  assert.match(markup, />object</);
 });
 
 test("resolveActiveDocumentRouteContext switches write metadata with the selected environment", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -16,10 +16,12 @@ import {
   applySuccessfulDraftSaveToReadyState,
   applySchemaStateToReadyState,
   ContentDocumentPageView,
+  createContentDocumentRouteRequestToken,
   createContentDocumentPageState,
   filterLocaleOptions,
   loadContentDocumentPageState,
   loadContentDocumentVersionDiff,
+  matchesContentDocumentRouteRequestToken,
   parseSelectedComparisonVersionValue,
   publishContentDocumentReadyState,
   reloadSchemaStateForGuard,
@@ -1332,6 +1334,44 @@ test("resolveActiveDocumentRouteContext switches write metadata with the selecte
     canWrite: true,
     schemaHash: "production-schema-hash",
   });
+});
+
+test("document route request tokens reject stale async results after an environment switch", () => {
+  const requestToken = createContentDocumentRouteRequestToken({
+    documentId: "11111111-1111-4111-8111-111111111111",
+    route: createRouteContext(true),
+  });
+  const switchedRoute = resolveActiveDocumentRouteContext(
+    {
+      ...createRouteContext(true),
+      writeByEnvironment: {
+        production: {
+          canWrite: true as const,
+          schemaHash: "production-schema-hash",
+        },
+        staging: {
+          canWrite: true as const,
+          schemaHash: "staging-schema-hash",
+        },
+      },
+    },
+    "production",
+  );
+
+  assert.equal(
+    matchesContentDocumentRouteRequestToken(requestToken, {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      route: createRouteContext(true),
+    }),
+    true,
+  );
+  assert.equal(
+    matchesContentDocumentRouteRequestToken(requestToken, {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      route: switchedRoute,
+    }),
+    false,
+  );
 });
 
 test("locale switcher renders for localized type with supportedLocales", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -1362,7 +1362,7 @@ test("loadContentDocumentPageState seeds arbitrary version comparison and diff s
   assert.equal(diff.rightVersion, 3);
 });
 
-test("ContentDocumentPageView renders tabbed sidebar with properties, info, and history", () => {
+test("ContentDocumentPageView renders tabbed sidebar in info, properties, history order", () => {
   const ready = createReadyState();
   const readyMarkup = renderPageMarkup({
     ...ready,
@@ -1429,6 +1429,17 @@ test("ContentDocumentPageView renders tabbed sidebar with properties, info, and 
   // The sidebar defaults to the Properties tab. Version history content
   // is in the History tab and version diff is in a modal, so they are
   // not present in the default SSR render. System metadata moved to Info.
+  const infoIndex = readyMarkup.indexOf(">Info<");
+  const propertiesIndex = readyMarkup.indexOf(">Properties<");
+  const historyIndex = readyMarkup.indexOf(">History<");
+
+  assert.ok(infoIndex >= 0, "expected Info tab label");
+  assert.ok(propertiesIndex >= 0, "expected Properties tab label");
+  assert.ok(historyIndex >= 0, "expected History tab label");
+  assert.ok(
+    infoIndex < propertiesIndex && propertiesIndex < historyIndex,
+    "expected Info, Properties, History tab order",
+  );
   assert.match(readyMarkup, /Properties/);
   assert.match(readyMarkup, /Info/);
   assert.match(readyMarkup, /History/);

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -29,6 +29,7 @@ import {
   resolveActiveDocumentRouteContext,
   reduceContentDocumentPageReadyState,
   saveContentDocumentReadyState,
+  SidebarInfoTab,
   syncSchemaStateForGuard,
 } from "./content-document-page.js";
 
@@ -96,6 +97,12 @@ function renderPageMarkup(
       }),
     ),
   );
+}
+
+function renderInfoTabMarkup(
+  state: ReturnType<typeof createReadyState>,
+): string {
+  return renderToStaticMarkup(createElement(SidebarInfoTab, { state }));
 }
 
 function createReadyState(
@@ -1355,7 +1362,7 @@ test("loadContentDocumentPageState seeds arbitrary version comparison and diff s
   assert.equal(diff.rightVersion, 3);
 });
 
-test("ContentDocumentPageView renders tabbed sidebar with properties and history", () => {
+test("ContentDocumentPageView renders tabbed sidebar with properties, info, and history", () => {
   const ready = createReadyState();
   const readyMarkup = renderPageMarkup({
     ...ready,
@@ -1421,10 +1428,15 @@ test("ContentDocumentPageView renders tabbed sidebar with properties and history
 
   // The sidebar defaults to the Properties tab. Version history content
   // is in the History tab and version diff is in a modal, so they are
-  // not present in the default SSR render.
+  // not present in the default SSR render. System metadata moved to Info.
   assert.match(readyMarkup, /Properties/);
+  assert.match(readyMarkup, /Info/);
   assert.match(readyMarkup, /History/);
   assert.match(readyMarkup, /Publish document/);
+  assert.doesNotMatch(readyMarkup, /Status/);
+  assert.doesNotMatch(readyMarkup, /Published version/);
+  assert.doesNotMatch(readyMarkup, /Last edited/);
+  assert.doesNotMatch(readyMarkup, /Path/);
   // Old sidebar content should be gone
   assert.doesNotMatch(readyMarkup, /Document workflow/);
   assert.doesNotMatch(readyMarkup, /This page loads the routed draft/);
@@ -1432,6 +1444,31 @@ test("ContentDocumentPageView renders tabbed sidebar with properties and history
   assert.doesNotMatch(readyMarkup, /Move \/ Rename/);
   assert.doesNotMatch(readyMarkup, /View published version/);
   assert.doesNotMatch(readyMarkup, /Route status/);
+});
+
+test("SidebarInfoTab renders the document system metadata outside Properties", () => {
+  const state = createReadyState({
+    document: {
+      ...createReadyState().document,
+      hasUnpublishedChanges: false,
+      publishedVersion: 1,
+      path: "content/posts/hello-mdcms",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    },
+  });
+
+  const markup = renderInfoTabMarkup(state);
+
+  assert.match(markup, /Status/);
+  assert.match(markup, />Published</);
+  assert.match(markup, /Published version/);
+  assert.match(markup, />v1</);
+  assert.match(markup, /Locale/);
+  assert.match(markup, />en</);
+  assert.match(markup, /Last edited/);
+  assert.match(markup, /Path/);
+  assert.match(markup, /content\/posts\/hello-mdcms/);
+  assert.doesNotMatch(markup, /data-mdcms-property-field=/);
 });
 
 test("ContentDocumentPageView derives truthful document badges from live document state", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "bun:test";
 import {
   RuntimeError,
+  type SchemaRegistryEntry,
   createEmptyCurrentPrincipalCapabilities,
 } from "@mdcms/shared";
 import { createElement } from "react";
@@ -44,6 +45,10 @@ function createReadyShell(
       type: "BlogPost",
       locale: "en",
       path: "blog/launch-notes",
+      format: "mdx",
+      frontmatter: {
+        title: "Launch Notes",
+      },
       body: "# Launch Notes",
       updatedAt: "2026-03-27T12:00:00.000Z",
       hasUnpublishedChanges: true,
@@ -93,9 +98,17 @@ function renderPageMarkup(
   );
 }
 
-function createReadyState() {
+function createReadyState(
+  overrides: Partial<
+    Extract<
+      ReturnType<typeof createContentDocumentPageState>,
+      { status: "ready" }
+    >
+  > = {},
+) {
   const state = createContentDocumentPageState({
     shell: createReadyShell(),
+    typeId: "BlogPost",
     typeLabel: "Blog post",
     documentRoute: {
       project: "marketing-site",
@@ -111,7 +124,10 @@ function createReadyState() {
     throw new Error("expected ready state");
   }
 
-  return state;
+  return {
+    ...state,
+    ...overrides,
+  };
 }
 
 type ReadySchemaState = Extract<
@@ -144,6 +160,24 @@ function createReadySchemaState(
     sync: async (): Promise<ReadySchemaState> =>
       createReadySchemaState(overrides),
     ...overrides,
+  };
+}
+
+function createSchemaEntry(
+  fields: SchemaRegistryEntry["resolvedSchema"]["fields"],
+): SchemaRegistryEntry {
+  return {
+    type: "BlogPost",
+    directory: "content/blog",
+    localized: true,
+    schemaHash: "local-hash",
+    syncedAt: "2026-03-27T12:00:00.000Z",
+    resolvedSchema: {
+      type: "BlogPost",
+      directory: "content/blog",
+      localized: true,
+      fields,
+    },
   };
 }
 
@@ -541,6 +575,59 @@ test("reduceContentDocumentPageReadyState moves draft edits through unsaved, sav
   assert.equal(saved.draftBody, "# Launch Notes\nUpdated");
 });
 
+test("createContentDocumentPageState keeps routed frontmatter and format in ready state", () => {
+  const state = createContentDocumentPageState({
+    shell: createReadyShell({
+      format: "md",
+      frontmatter: {
+        title: "Launch Notes",
+        seo: {
+          slug: "launch-notes",
+        },
+      },
+    }),
+    typeLabel: "Blog post",
+    documentRoute: createRouteContext(),
+  });
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") {
+    throw new Error("expected ready state");
+  }
+
+  assert.equal(state.document.format, "md");
+  assert.deepEqual(state.document.frontmatter, {
+    title: "Launch Notes",
+    seo: {
+      slug: "launch-notes",
+    },
+  });
+  assert.deepEqual(state.draftFrontmatter, {
+    title: "Launch Notes",
+    seo: {
+      slug: "launch-notes",
+    },
+  });
+});
+
+test("reduceContentDocumentPageReadyState marks frontmatter edits as unsaved and updates the draft frontmatter", () => {
+  const initial = createReadyState();
+
+  const next = reduceContentDocumentPageReadyState(initial, {
+    type: "frontmatterFieldChanged",
+    fieldName: "title",
+    value: "Updated Launch Notes",
+  });
+
+  assert.equal(next.saveState, "unsaved");
+  assert.deepEqual(next.draftFrontmatter, {
+    title: "Updated Launch Notes",
+  });
+  assert.deepEqual(initial.document.frontmatter, {
+    title: "Launch Notes",
+  });
+});
+
 test("reduceContentDocumentPageReadyState keeps the unsaved draft body and surfaces mutation feedback on save failure", () => {
   const initial = createReadyState();
 
@@ -676,10 +763,83 @@ test("saveContentDocumentReadyState persists routed draft updates through the co
   assert.equal(calls[0]?.schemaHash, "schema-hash");
   assert.deepEqual(calls[0]?.payload, {
     body: "# Launch Notes\nUpdated",
+    frontmatter: {
+      title: "Launch Notes",
+    },
   });
   assert.equal(next.saveState, "saved");
   assert.equal(next.document.body, "# Launch Notes\nUpdated");
   assert.equal(next.document.updatedAt, "2026-03-27T12:05:00.000Z");
+});
+
+test("saveContentDocumentReadyState persists draft frontmatter changes and preserves unsupported values", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const initial = reduceContentDocumentPageReadyState(
+    createReadyState({
+      document: {
+        ...createReadyState().document,
+        frontmatter: {
+          title: "Launch Notes",
+          seo: {
+            slug: "launch-notes",
+          },
+        },
+      },
+      draftFrontmatter: {
+        title: "Launch Notes",
+        seo: {
+          slug: "launch-notes",
+        },
+      },
+    }),
+    {
+      type: "frontmatterFieldChanged",
+      fieldName: "title",
+      value: "Updated Launch Notes",
+    },
+  );
+
+  const next = await saveContentDocumentReadyState({
+    api: {
+      updateDraft: async (input) => {
+        calls.push(input as Record<string, unknown>);
+
+        return createDocumentResponse({
+          frontmatter: {
+            title: "Updated Launch Notes",
+            seo: {
+              slug: "launch-notes",
+            },
+          },
+          updatedAt: "2026-03-27T12:05:00.000Z",
+        });
+      },
+    },
+    route: createRouteContext(),
+    state: initial,
+  });
+
+  assert.deepEqual(calls[0]?.payload, {
+    body: "# Launch Notes",
+    frontmatter: {
+      title: "Updated Launch Notes",
+      seo: {
+        slug: "launch-notes",
+      },
+    },
+  });
+  assert.deepEqual(next.document.frontmatter, {
+    title: "Updated Launch Notes",
+    seo: {
+      slug: "launch-notes",
+    },
+  });
+  assert.deepEqual(next.draftFrontmatter, {
+    title: "Updated Launch Notes",
+    seo: {
+      slug: "launch-notes",
+    },
+  });
 });
 
 test("saveContentDocumentReadyState applies the normalized body returned by the server", async () => {
@@ -730,6 +890,38 @@ test("saveContentDocumentReadyState keeps the unsaved draft when the routed upda
   assert.equal(next.draftBody, "# Launch Notes\nInvalid");
   assert.equal(next.document.body, "# Launch Notes");
   assert.equal(next.mutationError, "Path must be unique.");
+});
+
+test("saveContentDocumentReadyState anchors mapped frontmatter validation failures to the field state", async () => {
+  const initial = reduceContentDocumentPageReadyState(createReadyState(), {
+    type: "frontmatterFieldChanged",
+    fieldName: "author",
+    value: "not-a-valid-reference",
+  });
+
+  const next = await saveContentDocumentReadyState({
+    api: {
+      updateDraft: async () => {
+        throw new RuntimeError({
+          code: "INVALID_INPUT",
+          message:
+            'Field "frontmatter.author" must reference an "Author" document.',
+          statusCode: 400,
+          details: {
+            field: "frontmatter.author",
+          },
+        });
+      },
+    },
+    route: createRouteContext(),
+    state: initial,
+  });
+
+  assert.equal(next.mutationError, undefined);
+  assert.deepEqual(next.fieldErrors, {
+    author: 'Field "frontmatter.author" must reference an "Author" document.',
+  });
+  assert.equal(next.saveState, "unsaved");
 });
 
 test("saveContentDocumentReadyState surfaces forbidden routed draft updates without pretending the draft persisted", async () => {
@@ -1294,8 +1486,31 @@ test("ContentDocumentPageView blocks writes when the local schema hash capabilit
   assert.match(markup, /Schema sync required before Studio can write drafts\./);
 });
 
-test("ContentDocumentPageView renders environment-specific field badges for the active environment", () => {
+test("ContentDocumentPageView renders environment-specific field badges inline with editable fields", () => {
   const state = createReadyState();
+  state.schemaState = createReadySchemaState({
+    entries: [
+      createSchemaEntry({
+        featured: {
+          kind: "boolean",
+          required: true,
+          nullable: false,
+        },
+        abTestVariant: {
+          kind: "string",
+          required: false,
+          nullable: false,
+        },
+      }),
+    ],
+  });
+  state.document.frontmatter = {
+    featured: false,
+    abTestVariant: "variant-a",
+  };
+  state.draftFrontmatter = {
+    ...state.document.frontmatter,
+  };
   state.route.environmentFieldTargets = {
     [state.typeId]: {
       featured: ["staging"],
@@ -1305,11 +1520,94 @@ test("ContentDocumentPageView renders environment-specific field badges for the 
 
   const markup = renderPageMarkup(state);
 
-  assert.match(markup, /Environment-specific fields/);
+  assert.match(markup, /Frontmatter/);
+  assert.match(markup, /data-mdcms-property-field="featured"/);
   assert.match(markup, />featured</);
   assert.match(markup, /staging only/);
+  assert.match(markup, /data-mdcms-property-field="abTestVariant"/);
   assert.match(markup, />abTestVariant</);
   assert.match(markup, /preview, staging only/);
+});
+
+test("ContentDocumentPageView renders schema-driven property controls and unsupported fallback rows", () => {
+  const state = createReadyState();
+  state.schemaState = createReadySchemaState({
+    entries: [
+      createSchemaEntry({
+        title: {
+          kind: "string",
+          required: true,
+          nullable: false,
+        },
+        views: {
+          kind: "number",
+          required: false,
+          nullable: false,
+        },
+        published: {
+          kind: "boolean",
+          required: true,
+          nullable: false,
+        },
+        status: {
+          kind: "enum",
+          required: true,
+          nullable: false,
+          options: ["draft", "published"],
+        },
+        metadata: {
+          kind: "object",
+          required: false,
+          nullable: false,
+          fields: {
+            slug: {
+              kind: "string",
+              required: true,
+              nullable: false,
+            },
+          },
+        },
+        featured: {
+          kind: "boolean",
+          required: true,
+          nullable: false,
+        },
+      }),
+    ],
+  });
+  state.route.environmentFieldTargets = {
+    [state.typeId]: {
+      featured: ["staging"],
+    },
+  };
+  state.document.frontmatter = {
+    title: "Launch Notes",
+    views: 42,
+    published: true,
+    status: "draft",
+    metadata: {
+      slug: "launch-notes",
+    },
+    featured: false,
+  };
+  state.draftFrontmatter = {
+    ...state.document.frontmatter,
+  };
+
+  const markup = renderPageMarkup(state);
+
+  assert.match(markup, /data-mdcms-property-field="title"/);
+  assert.match(markup, /data-mdcms-property-editor="string"/);
+  assert.match(markup, /data-mdcms-property-field="views"/);
+  assert.match(markup, /data-mdcms-property-editor="number"/);
+  assert.match(markup, /data-mdcms-property-field="published"/);
+  assert.match(markup, /data-mdcms-property-editor="boolean"/);
+  assert.match(markup, /data-mdcms-property-field="status"/);
+  assert.match(markup, /data-mdcms-property-editor="select"/);
+  assert.match(markup, /data-mdcms-property-field="metadata"/);
+  assert.match(markup, /Not editable in Studio yet/);
+  assert.match(markup, /data-mdcms-property-field="featured"/);
+  assert.match(markup, /staging only/);
 });
 
 test("resolveActiveDocumentRouteContext switches write metadata with the selected environment", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useEffectEvent,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -35,6 +36,7 @@ import {
   diffDocumentVersions,
   type DocumentVersionDiff,
 } from "../../document-version-diff.js";
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import { useParams, useRouter } from "../adapters/next-navigation.js";
 import { type MdxPropsPanelSelection } from "../components/editor/mdx-props-panel.js";
 import {
@@ -1326,6 +1328,9 @@ function getStatusBadge(state: ContentDocumentPageReadyState): {
 
 function SidebarPropertiesTab(props: { state: ContentDocumentPageReadyState }) {
   const status = getStatusBadge(props.state);
+  const environmentSpecificFieldBadges = getEnvironmentSpecificFieldBadges(
+    props.state,
+  );
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -1377,6 +1382,27 @@ function SidebarPropertiesTab(props: { state: ContentDocumentPageReadyState }) {
           {props.state.document.path}
         </span>
       </div>
+
+      {environmentSpecificFieldBadges.length > 0 ? (
+        <div>
+          <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted">
+            Environment-specific fields
+          </div>
+          <div className="flex flex-col gap-2">
+            {environmentSpecificFieldBadges.map(({ fieldName, label }) => (
+              <div
+                key={fieldName}
+                className="flex items-center justify-between gap-3 rounded-md border border-border bg-background-subtle px-2.5 py-2"
+              >
+                <code className="text-xs text-foreground">{fieldName}</code>
+                <Badge variant="outline" className="shrink-0 text-[10px]">
+                  {label}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -1552,6 +1578,44 @@ export function filterLocaleOptions(input: {
       (item) =>
         item.hasVariant || (input.canWrite && !input.variantsFetchFailed),
     );
+}
+
+export function resolveActiveDocumentRouteContext(
+  route: StudioDocumentRouteMountContext,
+  environment: string | null | undefined,
+): StudioDocumentRouteMountContext {
+  const nextEnvironment = environment?.trim();
+
+  if (!nextEnvironment || nextEnvironment === route.initialEnvironment) {
+    return route;
+  }
+
+  return {
+    ...route,
+    initialEnvironment: nextEnvironment,
+    write: route.writeByEnvironment?.[nextEnvironment] ?? {
+      canWrite: false,
+      message: `Studio writes require a resolved schema for environment "${nextEnvironment}".`,
+    },
+  };
+}
+
+function getEnvironmentSpecificFieldBadges(
+  state: ContentDocumentPageReadyState,
+): Array<{ fieldName: string; label: string }> {
+  const typeFieldTargets = state.route.environmentFieldTargets?.[state.typeId];
+
+  if (!typeFieldTargets) {
+    return [];
+  }
+
+  return Object.entries(typeFieldTargets)
+    .filter(([, targets]) => targets.includes(state.route.initialEnvironment))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([fieldName, targets]) => ({
+      fieldName,
+      label: `${targets.join(", ")} only`,
+    }));
 }
 
 export function ContentDocumentPageView({
@@ -1913,12 +1977,32 @@ export default function ContentDocumentPage({
 }: {
   context?: StudioMountContext;
 }) {
+  const mountInfo = useStudioMountInfo();
   const params = useParams();
   const router = useRouter();
   const typeId = (params.type as string) || "content";
   const documentId = (params.documentId as string) || "";
   const typeLabel = typeId;
-  const route = context?.documentRoute;
+  const route = useMemo(
+    () =>
+      context?.documentRoute
+        ? resolveActiveDocumentRouteContext(
+            context.documentRoute,
+            mountInfo.environment,
+          )
+        : undefined,
+    [context?.documentRoute, mountInfo.environment],
+  );
+  const activeContext = useMemo(
+    () =>
+      context && route
+        ? {
+            ...context,
+            documentRoute: route,
+          }
+        : context,
+    [context, route],
+  );
 
   const [state, setState] = useState<ContentDocumentPageState>(() =>
     route
@@ -1952,12 +2036,12 @@ export default function ContentDocumentPage({
   }, [state]);
 
   function createRouteApi(): StudioDocumentRouteApi | undefined {
-    if (!context || !route) {
+    if (!activeContext || !route) {
       return undefined;
     }
 
     return createContentDocumentRouteApi({
-      context,
+      context: activeContext,
       route,
     });
   }
@@ -2162,7 +2246,7 @@ export default function ContentDocumentPage({
     );
 
     const nextState = await loadContentDocumentPageState({
-      context,
+      context: activeContext,
       typeId,
       typeLabel,
       documentId,
@@ -2521,7 +2605,7 @@ export default function ContentDocumentPage({
 
   useEffect(() => {
     void loadDocument();
-  }, [context, documentId, route, typeId, typeLabel]);
+  }, [activeContext, documentId, route, typeId, typeLabel]);
 
   const readyDraftBody = state.status === "ready" ? state.draftBody : undefined;
   const readyDocumentBody =
@@ -2614,7 +2698,7 @@ export default function ContentDocumentPage({
   return (
     <ContentDocumentPageView
       state={state}
-      context={context}
+      context={activeContext}
       sidebarOpen={sidebarOpen}
       activeMdxComponent={activeMdxComponent}
       onDraftChange={(body) => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1882,14 +1882,10 @@ function formatPropertyOptionLabel(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function SidebarPropertiesTab(props: {
+export function SidebarInfoTab(props: {
   state: ContentDocumentPageReadyState;
-  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
 }) {
   const status = getStatusBadge(props.state);
-  const propertyDescriptors = getPropertyDescriptors(props.state);
-  const propertiesReadOnly =
-    !props.state.canWrite || !!props.state.viewingVersion;
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -1941,7 +1937,20 @@ function SidebarPropertiesTab(props: {
           {props.state.document.path}
         </span>
       </div>
+    </div>
+  );
+}
 
+function SidebarPropertiesTab(props: {
+  state: ContentDocumentPageReadyState;
+  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
+}) {
+  const propertyDescriptors = getPropertyDescriptors(props.state);
+  const propertiesReadOnly =
+    !props.state.canWrite || !!props.state.viewingVersion;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
       {propertyDescriptors.length > 0 ? (
         <div>
           <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted">
@@ -2254,7 +2263,7 @@ function ContentDocumentPageSidebar(props: {
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState<"properties" | "history">(
+  const [activeTab, setActiveTab] = useState<"properties" | "info" | "history">(
     "properties",
   );
 
@@ -2281,6 +2290,18 @@ function ContentDocumentPageSidebar(props: {
           type="button"
           className={cn(
             "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
+            activeTab === "info"
+              ? "border-b-2 border-accent text-accent"
+              : "text-foreground-muted hover:text-foreground",
+          )}
+          onClick={() => setActiveTab("info")}
+        >
+          Info
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
             activeTab === "history"
               ? "border-b-2 border-accent text-accent"
               : "text-foreground-muted hover:text-foreground",
@@ -2298,6 +2319,8 @@ function ContentDocumentPageSidebar(props: {
             state={props.state}
             onFrontmatterFieldChange={props.onFrontmatterFieldChange}
           />
+        ) : activeTab === "info" ? (
+          <SidebarInfoTab state={props.state} />
         ) : (
           <SidebarHistoryTab
             state={props.state}

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -441,9 +441,11 @@ function mapErrorToFrontmatterField(error: unknown): string | undefined {
     return undefined;
   }
 
-  const normalized = candidate.startsWith("frontmatter.")
-    ? candidate.slice("frontmatter.".length)
-    : candidate;
+  if (!candidate.startsWith("frontmatter.")) {
+    return undefined;
+  }
+
+  const normalized = candidate.slice("frontmatter.".length);
   const [fieldName] = normalized.split(/[.[\]]/, 1);
 
   return fieldName?.trim().length ? fieldName : undefined;

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -195,6 +195,11 @@ export type ContentDocumentPageState =
     }
   | ContentDocumentPageReadyState;
 
+export type ContentDocumentRouteRequestToken = {
+  documentId: string;
+  initialEnvironment: string;
+};
+
 type ContentDocumentPageStateInput = {
   shell: StudioDocumentShell;
   typeLabel: string;
@@ -247,6 +252,30 @@ type ContentDocumentPageViewProps = {
   onCreateVariant?: (prefill: boolean) => void;
   onCancelVariantCreation?: () => void;
 };
+
+/** Captures the routed document identity used to reject stale async results. */
+export function createContentDocumentRouteRequestToken(input: {
+  documentId: string;
+  route: Pick<StudioDocumentRouteMountContext, "initialEnvironment">;
+}): ContentDocumentRouteRequestToken {
+  return {
+    documentId: input.documentId,
+    initialEnvironment: input.route.initialEnvironment,
+  };
+}
+
+export function matchesContentDocumentRouteRequestToken(
+  token: ContentDocumentRouteRequestToken,
+  input: {
+    documentId: string;
+    route?: Pick<StudioDocumentRouteMountContext, "initialEnvironment">;
+  },
+): boolean {
+  return (
+    input.documentId === token.documentId &&
+    input.route?.initialEnvironment === token.initialEnvironment
+  );
+}
 
 type CreateContentDocumentPageHistoryApi = (input: {
   context: StudioMountContext;
@@ -2035,23 +2064,35 @@ export default function ContentDocumentPage({
     stateRef.current = state;
   }, [state]);
 
-  function createRouteApi(): StudioDocumentRouteApi | undefined {
-    if (!activeContext || !route) {
+  function createRouteApi(input?: {
+    context?: StudioMountContext;
+    route?: StudioDocumentRouteMountContext;
+  }): StudioDocumentRouteApi | undefined {
+    const nextContext = input?.context ?? activeContext;
+    const nextRoute = input?.route ?? route;
+
+    if (!nextContext || !nextRoute) {
       return undefined;
     }
 
     return createContentDocumentRouteApi({
-      context: activeContext,
-      route,
+      context: nextContext,
+      route: nextRoute,
     });
   }
 
   const loadSelectedVersionDiff = useEffectEvent(async () => {
     const currentState = stateRef.current;
-    const api = createRouteApi();
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
 
     if (
       !api ||
+      !requestRoute ||
       currentState.status !== "ready" ||
       !currentState.selectedComparison.leftVersion ||
       !currentState.selectedComparison.rightVersion
@@ -2059,6 +2100,10 @@ export default function ContentDocumentPage({
       return;
     }
 
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
     const leftVersion = currentState.selectedComparison.leftVersion;
     const rightVersion = currentState.selectedComparison.rightVersion;
 
@@ -2086,6 +2131,7 @@ export default function ContentDocumentPage({
 
       setState((current) =>
         current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current) &&
         current.selectedComparison.leftVersion === leftVersion &&
         current.selectedComparison.rightVersion === rightVersion
           ? {
@@ -2105,6 +2151,7 @@ export default function ContentDocumentPage({
 
       setState((current) =>
         current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current) &&
         current.selectedComparison.leftVersion === leftVersion &&
         current.selectedComparison.rightVersion === rightVersion
           ? {
@@ -2123,12 +2170,26 @@ export default function ContentDocumentPage({
 
   const publishDocument = useEffectEvent(async () => {
     const currentState = stateRef.current;
-    const api = createRouteApi();
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
 
-    if (!api || currentState.status !== "ready" || !currentState.canWrite) {
+    if (
+      !api ||
+      !requestRoute ||
+      currentState.status !== "ready" ||
+      !currentState.canWrite
+    ) {
       return;
     }
 
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
     setState((current) =>
       current.status === "ready"
         ? {
@@ -2150,7 +2211,8 @@ export default function ContentDocumentPage({
 
       if (hasSchemaRecoveryMismatch(recoveredSchemaState)) {
         setState((current) =>
-          current.status === "ready"
+          current.status === "ready" &&
+          matchesContentDocumentRouteRequestToken(requestToken, current)
             ? applyGuardedPublishFailureToReadyState({
                 state: current,
                 schemaState: recoveredSchemaState,
@@ -2167,7 +2229,10 @@ export default function ContentDocumentPage({
       if (
         publishedBody !== currentState.draftBody &&
         latestAfterPublish.status === "ready" &&
-        latestAfterPublish.documentId === currentState.documentId &&
+        matchesContentDocumentRouteRequestToken(
+          requestToken,
+          latestAfterPublish,
+        ) &&
         latestAfterPublish.draftBody === currentState.draftBody &&
         !latestAfterPublish.viewingVersion
       ) {
@@ -2176,7 +2241,7 @@ export default function ContentDocumentPage({
 
       setState((current) =>
         current.status === "ready" &&
-        current.documentId === currentState.documentId
+        matchesContentDocumentRouteRequestToken(requestToken, current)
           ? applySuccessfulPublishToReadyState({
               state: current,
               requestBody: currentState.draftBody,
@@ -2188,7 +2253,8 @@ export default function ContentDocumentPage({
       const message = toRouteErrorMessage(error, "Failed to publish document.");
 
       setState((current) =>
-        current.status === "ready"
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current)
           ? {
               ...current,
               publishState: "idle",
@@ -2261,14 +2327,19 @@ export default function ContentDocumentPage({
 
   const saveDraft = useEffectEvent(async (): Promise<boolean> => {
     const currentState = stateRef.current;
-    const api = createRouteApi();
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
 
     if (
       !api ||
       // Fail closed when the embedded host cannot derive the local schema hash
       // required by guarded draft-write routes.
-      !route ||
-      !route.write.canWrite ||
+      !requestRoute ||
+      !requestRoute.write.canWrite ||
       currentState.status !== "ready"
     ) {
       return false;
@@ -2284,6 +2355,10 @@ export default function ContentDocumentPage({
     }
 
     const requestBody = currentState.draftBody;
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
 
     setState((current) =>
       current.status === "ready"
@@ -2295,7 +2370,7 @@ export default function ContentDocumentPage({
 
     const nextState = await saveContentDocumentReadyState({
       api,
-      route,
+      route: requestRoute,
       state: currentState,
     });
 
@@ -2303,7 +2378,8 @@ export default function ContentDocumentPage({
 
     if (hasSchemaRecoveryMismatch(recoveredSchemaState)) {
       setState((current) =>
-        current.status === "ready"
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current)
           ? applyGuardedDraftSaveFailureToReadyState({
               state: current,
               schemaState: recoveredSchemaState,
@@ -2316,7 +2392,8 @@ export default function ContentDocumentPage({
     const mutationError = nextState.mutationError;
     if (mutationError) {
       setState((current) =>
-        current.status === "ready"
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current)
           ? applyFailedDraftSaveToReadyState({
               state: current,
               requestBody,
@@ -2335,7 +2412,7 @@ export default function ContentDocumentPage({
     if (
       persistedBody !== requestBody &&
       latestAfterSave.status === "ready" &&
-      latestAfterSave.documentId === currentState.documentId &&
+      matchesContentDocumentRouteRequestToken(requestToken, latestAfterSave) &&
       latestAfterSave.draftBody === requestBody &&
       !latestAfterSave.viewingVersion
     ) {
@@ -2344,7 +2421,7 @@ export default function ContentDocumentPage({
 
     setState((current) =>
       current.status === "ready" &&
-      current.documentId === currentState.documentId
+      matchesContentDocumentRouteRequestToken(requestToken, current)
         ? applySuccessfulDraftSaveToReadyState({
             state: current,
             requestBody,
@@ -2520,9 +2597,19 @@ export default function ContentDocumentPage({
 
   const handleViewVersion = useEffectEvent(async (version: number) => {
     const currentState = stateRef.current;
-    const api = createRouteApi();
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
 
-    if (!api || currentState.status !== "ready") return;
+    if (!api || !requestRoute || currentState.status !== "ready") return;
+
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
 
     setState((current) =>
       current.status === "ready"
@@ -2547,7 +2634,7 @@ export default function ContentDocumentPage({
       const afterFetch = stateRef.current;
       if (
         afterFetch.status !== "ready" ||
-        afterFetch.documentId !== currentState.documentId ||
+        !matchesContentDocumentRouteRequestToken(requestToken, afterFetch) ||
         afterFetch.viewingVersion?.version !== version
       ) {
         return;
@@ -2557,6 +2644,7 @@ export default function ContentDocumentPage({
 
       setState((current) =>
         current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current) &&
         current.viewingVersion?.version === version
           ? {
               ...current,
@@ -2574,6 +2662,7 @@ export default function ContentDocumentPage({
 
       setState((current) =>
         current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current) &&
         current.viewingVersion?.version === version
           ? {
               ...current,

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -13,6 +13,8 @@ import {
 import {
   type ContentDocumentResponse,
   type ContentVersionSummaryResponse,
+  type SchemaRegistryEntry,
+  type SchemaRegistryFieldSnapshot,
   RuntimeError,
   type StudioDocumentRouteMountContext,
   type StudioMountContext,
@@ -54,6 +56,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../components/ui/dialog.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
 import { Textarea } from "../components/ui/textarea.js";
 import {
   Tooltip,
@@ -77,6 +81,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select.js";
+import { Switch } from "../components/ui/switch.js";
 
 const DOCUMENT_SAVE_DEBOUNCE_MS = 5000;
 const SCHEMA_MISMATCH_WRITE_MESSAGE =
@@ -151,9 +156,12 @@ export type ContentDocumentPageReadyState = {
   schemaState?: StudioSchemaState;
   document: StudioDocumentShellData;
   draftBody: string;
+  draftFrontmatter: Record<string, unknown>;
   saveState: "saved" | "saving" | "unsaved";
   mutationError?: string;
+  fieldErrors?: Record<string, string>;
   saveRequestBody?: string;
+  saveRequestFrontmatter?: Record<string, unknown>;
   canWrite: boolean;
   writeMessage?: string;
   publishDialogOpen: boolean;
@@ -214,16 +222,23 @@ type ContentDocumentPageReadyEvent =
       body: string;
     }
   | {
+      type: "frontmatterFieldChanged";
+      fieldName: string;
+      value: unknown;
+    }
+  | {
       type: "saveStarted";
     }
   | {
       type: "saveSucceeded";
       updatedAt: string;
       body?: string;
+      frontmatter?: Record<string, unknown>;
     }
   | {
       type: "saveFailed";
       message: string;
+      fieldName?: string;
     };
 
 type ContentDocumentPageViewProps = {
@@ -232,6 +247,7 @@ type ContentDocumentPageViewProps = {
   sidebarOpen?: boolean;
   activeMdxComponent?: MdxPropsPanelSelection | null;
   onDraftChange?: (body: string) => void;
+  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
   onActiveMdxComponentChange?: (
     selection: MdxPropsPanelSelection | null,
   ) => void;
@@ -281,6 +297,389 @@ type CreateContentDocumentPageHistoryApi = (input: {
   context: StudioMountContext;
   route: StudioDocumentRouteMountContext;
 }) => Pick<StudioDocumentRouteApi, "listVersions" | "listVariants">;
+
+type ContentDocumentPropertyControl =
+  | {
+      kind: "string";
+      value: string;
+      canUnset: boolean;
+    }
+  | {
+      kind: "number";
+      value: number | undefined;
+      canUnset: boolean;
+    }
+  | {
+      kind: "boolean";
+      value: boolean;
+      canUnset: boolean;
+      isUnset: boolean;
+    }
+  | {
+      kind: "select";
+      value: unknown;
+      options: unknown[];
+      canUnset: boolean;
+    };
+
+type ContentDocumentPropertyDescriptor = {
+  fieldName: string;
+  field: SchemaRegistryFieldSnapshot;
+  badgeLabel?: string;
+  error?: string;
+} & (
+  | {
+      status: "editable";
+      control: ContentDocumentPropertyControl;
+    }
+  | {
+      status: "unsupported";
+      typeLabel: string;
+    }
+);
+
+const PROPERTY_SELECT_UNSET_VALUE = "__mdcms_unset__";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneFrontmatter(
+  frontmatter: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return { ...(frontmatter ?? {}) };
+}
+
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === null || right === null) {
+    return left === right;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return false;
+    }
+
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    return left.every((entry, index) =>
+      areJsonValuesEqual(entry, right[index]),
+    );
+  }
+
+  if (isRecord(left) || isRecord(right)) {
+    if (!isRecord(left) || !isRecord(right)) {
+      return false;
+    }
+
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+
+    if (leftKeys.length !== rightKeys.length) {
+      return false;
+    }
+
+    return leftKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(right, key) &&
+        areJsonValuesEqual(left[key], right[key]),
+    );
+  }
+
+  return false;
+}
+
+function isDraftPersisted(state: ContentDocumentPageReadyState): boolean {
+  return (
+    state.draftBody === state.document.body &&
+    areJsonValuesEqual(state.draftFrontmatter, state.document.frontmatter)
+  );
+}
+
+function hasDifferentSaveRequestSnapshot(input: {
+  state: ContentDocumentPageReadyState;
+  requestBody: string;
+  requestFrontmatter: Record<string, unknown>;
+}): boolean {
+  return (
+    input.state.saveRequestBody !== undefined &&
+    (input.state.saveRequestBody !== input.requestBody ||
+      !areJsonValuesEqual(
+        input.state.saveRequestFrontmatter ?? {},
+        input.requestFrontmatter,
+      ))
+  );
+}
+
+function clearFieldError(
+  fieldErrors: Record<string, string> | undefined,
+  fieldName: string,
+): Record<string, string> | undefined {
+  if (!fieldErrors?.[fieldName]) {
+    return fieldErrors;
+  }
+
+  const nextErrors = { ...fieldErrors };
+  delete nextErrors[fieldName];
+
+  return Object.keys(nextErrors).length > 0 ? nextErrors : undefined;
+}
+
+function mapErrorToFrontmatterField(error: unknown): string | undefined {
+  if (!(error instanceof RuntimeError) || !isRecord(error.details)) {
+    return undefined;
+  }
+
+  const candidate = error.details.field;
+
+  if (typeof candidate !== "string" || candidate.trim().length === 0) {
+    return undefined;
+  }
+
+  const normalized = candidate.startsWith("frontmatter.")
+    ? candidate.slice("frontmatter.".length)
+    : candidate;
+  const [fieldName] = normalized.split(/[.[\]]/, 1);
+
+  return fieldName?.trim().length ? fieldName : undefined;
+}
+
+function isUnsettableField(field: SchemaRegistryFieldSnapshot): boolean {
+  return !field.required || field.nullable;
+}
+
+function unsetFieldValue(field: SchemaRegistryFieldSnapshot): undefined | null {
+  return field.nullable ? null : undefined;
+}
+
+function updateDraftFrontmatter(input: {
+  frontmatter: Record<string, unknown>;
+  fieldName: string;
+  value: unknown;
+}): Record<string, unknown> {
+  const nextFrontmatter = { ...input.frontmatter };
+
+  if (input.value === undefined) {
+    delete nextFrontmatter[input.fieldName];
+    return nextFrontmatter;
+  }
+
+  nextFrontmatter[input.fieldName] = input.value;
+  return nextFrontmatter;
+}
+
+function getSchemaEntryForReadyState(
+  state: ContentDocumentPageReadyState,
+): SchemaRegistryEntry | undefined {
+  if (state.schemaState?.status !== "ready") {
+    return undefined;
+  }
+
+  return state.schemaState.entries.find((entry) => entry.type === state.typeId);
+}
+
+function getEnvironmentSpecificFieldLabel(
+  state: ContentDocumentPageReadyState,
+  fieldName: string,
+): string | undefined {
+  const targets =
+    state.route.environmentFieldTargets?.[state.typeId]?.[fieldName];
+
+  if (!targets?.includes(state.route.initialEnvironment)) {
+    return undefined;
+  }
+
+  return `${targets.join(", ")} only`;
+}
+
+function canEditStringField(
+  value: unknown,
+): value is string | undefined | null {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function canEditNumberField(
+  value: unknown,
+): value is number | undefined | null {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function canEditBooleanField(
+  value: unknown,
+): value is boolean | undefined | null {
+  return value === undefined || value === null || typeof value === "boolean";
+}
+
+function canEditSelectField(
+  field: SchemaRegistryFieldSnapshot,
+  value: unknown,
+): boolean {
+  const options = field.options;
+
+  if (!options || options.length === 0) {
+    return false;
+  }
+
+  const supportsOptions = options.every(
+    (option) =>
+      option === null ||
+      typeof option === "string" ||
+      typeof option === "number" ||
+      typeof option === "boolean",
+  );
+
+  if (!supportsOptions) {
+    return false;
+  }
+
+  return (
+    value === undefined ||
+    value === null ||
+    options.some((option) => areJsonValuesEqual(option, value))
+  );
+}
+
+function describeUnsupportedFieldType(
+  field: SchemaRegistryFieldSnapshot,
+): string {
+  if (field.reference) {
+    return `reference:${field.reference.targetType}`;
+  }
+
+  return field.kind;
+}
+
+function resolvePropertyDescriptor(input: {
+  state: ContentDocumentPageReadyState;
+  fieldName: string;
+  field: SchemaRegistryFieldSnapshot;
+}): ContentDocumentPropertyDescriptor {
+  const badgeLabel = getEnvironmentSpecificFieldLabel(
+    input.state,
+    input.fieldName,
+  );
+  const error = input.state.fieldErrors?.[input.fieldName];
+  const currentValue = input.state.draftFrontmatter[input.fieldName];
+
+  if (
+    currentValue === undefined &&
+    input.field.options &&
+    canEditSelectField(input.field, currentValue)
+  ) {
+    return {
+      fieldName: input.fieldName,
+      field: input.field,
+      badgeLabel,
+      error,
+      status: "editable",
+      control: {
+        kind: "select",
+        value: currentValue,
+        options: input.field.options,
+        canUnset: isUnsettableField(input.field),
+      },
+    };
+  }
+
+  if (input.field.options && canEditSelectField(input.field, currentValue)) {
+    return {
+      fieldName: input.fieldName,
+      field: input.field,
+      badgeLabel,
+      error,
+      status: "editable",
+      control: {
+        kind: "select",
+        value: currentValue,
+        options: input.field.options,
+        canUnset: isUnsettableField(input.field),
+      },
+    };
+  }
+
+  if (input.field.kind === "string" && canEditStringField(currentValue)) {
+    return {
+      fieldName: input.fieldName,
+      field: input.field,
+      badgeLabel,
+      error,
+      status: "editable",
+      control: {
+        kind: "string",
+        value: typeof currentValue === "string" ? currentValue : "",
+        canUnset: isUnsettableField(input.field),
+      },
+    };
+  }
+
+  if (input.field.kind === "number" && canEditNumberField(currentValue)) {
+    return {
+      fieldName: input.fieldName,
+      field: input.field,
+      badgeLabel,
+      error,
+      status: "editable",
+      control: {
+        kind: "number",
+        value: typeof currentValue === "number" ? currentValue : undefined,
+        canUnset: isUnsettableField(input.field),
+      },
+    };
+  }
+
+  if (input.field.kind === "boolean" && canEditBooleanField(currentValue)) {
+    return {
+      fieldName: input.fieldName,
+      field: input.field,
+      badgeLabel,
+      error,
+      status: "editable",
+      control: {
+        kind: "boolean",
+        value: currentValue === true,
+        canUnset: isUnsettableField(input.field),
+        isUnset: currentValue === undefined || currentValue === null,
+      },
+    };
+  }
+
+  return {
+    fieldName: input.fieldName,
+    field: input.field,
+    badgeLabel,
+    error,
+    status: "unsupported",
+    typeLabel: describeUnsupportedFieldType(input.field),
+  };
+}
+
+function getPropertyDescriptors(
+  state: ContentDocumentPageReadyState,
+): ContentDocumentPropertyDescriptor[] {
+  const entry = getSchemaEntryForReadyState(state);
+
+  if (!entry) {
+    return [];
+  }
+
+  return Object.entries(entry.resolvedSchema.fields).map(([fieldName, field]) =>
+    resolvePropertyDescriptor({
+      state,
+      fieldName,
+      field,
+    }),
+  );
+}
 
 function createLoadingState(input: {
   typeId: string;
@@ -387,6 +786,7 @@ function createReadyState(input: {
     ...(input.schemaState ? { schemaState: input.schemaState } : {}),
     document,
     draftBody: document.body ?? "",
+    draftFrontmatter: cloneFrontmatter(document.frontmatter),
     saveState: "saved",
     canWrite: writeAccess.canWrite,
     publishDialogOpen: false,
@@ -532,10 +932,11 @@ function applyGuardedDraftSaveFailureToReadyState(input: {
 
   return {
     ...nextState,
-    saveState:
-      input.state.draftBody === input.state.document.body ? "saved" : "unsaved",
+    saveState: isDraftPersisted(input.state) ? "saved" : "unsaved",
     mutationError: undefined,
+    fieldErrors: undefined,
     saveRequestBody: undefined,
+    saveRequestFrontmatter: undefined,
   };
 }
 
@@ -627,9 +1028,12 @@ function applyDocumentResponseToReadyState(
     locale: document.locale,
     document,
     draftBody: document.body ?? "",
+    draftFrontmatter: cloneFrontmatter(document.frontmatter),
     saveState: "saved",
     mutationError: undefined,
+    fieldErrors: undefined,
     saveRequestBody: undefined,
+    saveRequestFrontmatter: undefined,
   };
 }
 
@@ -723,21 +1127,35 @@ export async function publishContentDocumentReadyState(input: {
 export function applySuccessfulPublishToReadyState(input: {
   state: ContentDocumentPageReadyState;
   requestBody: string;
+  requestFrontmatter?: Record<string, unknown>;
   publishedState: ContentDocumentPageReadyState;
 }): ContentDocumentPageReadyState {
-  if (input.state.draftBody === input.requestBody) {
+  const requestFrontmatter =
+    input.requestFrontmatter ?? input.state.draftFrontmatter;
+
+  if (
+    input.state.draftBody === input.requestBody &&
+    areJsonValuesEqual(input.state.draftFrontmatter, requestFrontmatter)
+  ) {
     return input.publishedState;
   }
 
   return {
     ...input.publishedState,
     draftBody: input.state.draftBody,
+    draftFrontmatter: input.state.draftFrontmatter,
     saveState:
-      input.state.draftBody === input.publishedState.document.body
+      input.state.draftBody === input.publishedState.document.body &&
+      areJsonValuesEqual(
+        input.state.draftFrontmatter,
+        input.publishedState.document.frontmatter,
+      )
         ? "saved"
         : "unsaved",
     mutationError: input.state.mutationError,
+    fieldErrors: input.state.fieldErrors,
     saveRequestBody: input.state.saveRequestBody,
+    saveRequestFrontmatter: input.state.saveRequestFrontmatter,
   };
 }
 
@@ -922,8 +1340,12 @@ export async function saveContentDocumentReadyState(input: {
     !input.route.write.canWrite ||
     !input.state.canWrite ||
     input.state.saveState !== "unsaved" ||
-    input.state.draftBody === input.state.document.body ||
-    input.state.saveRequestBody === input.state.draftBody
+    isDraftPersisted(input.state) ||
+    (input.state.saveRequestBody === input.state.draftBody &&
+      areJsonValuesEqual(
+        input.state.saveRequestFrontmatter ?? {},
+        input.state.draftFrontmatter,
+      ))
   ) {
     return input.state;
   }
@@ -938,6 +1360,7 @@ export async function saveContentDocumentReadyState(input: {
       locale: input.state.document.locale,
       payload: {
         body: input.state.draftBody,
+        frontmatter: input.state.draftFrontmatter,
       },
       schemaHash: input.route.write.schemaHash,
     });
@@ -945,6 +1368,7 @@ export async function saveContentDocumentReadyState(input: {
     return reduceContentDocumentPageReadyState(savingState, {
       type: "saveSucceeded",
       body: result.body ?? input.state.draftBody,
+      frontmatter: result.frontmatter ?? input.state.draftFrontmatter,
       updatedAt: result.updatedAt ?? input.state.document.updatedAt,
     });
   } catch (error) {
@@ -966,6 +1390,7 @@ export async function saveContentDocumentReadyState(input: {
     return reduceContentDocumentPageReadyState(savingState, {
       type: "saveFailed",
       message: toRouteErrorMessage(error, "Failed to save draft."),
+      fieldName: mapErrorToFrontmatterField(error),
     });
   }
 }
@@ -1077,7 +1502,9 @@ export function reduceContentDocumentPageReadyState(
 ): ContentDocumentPageReadyState {
   switch (event.type) {
     case "draftChanged": {
-      const isPersisted = event.body === state.document.body;
+      const isPersisted =
+        event.body === state.document.body &&
+        areJsonValuesEqual(state.draftFrontmatter, state.document.frontmatter);
 
       return {
         ...state,
@@ -1085,10 +1512,31 @@ export function reduceContentDocumentPageReadyState(
         saveState: isPersisted ? "saved" : "unsaved",
         mutationError: undefined,
         saveRequestBody: undefined,
+        saveRequestFrontmatter: undefined,
+      };
+    }
+    case "frontmatterFieldChanged": {
+      const draftFrontmatter = updateDraftFrontmatter({
+        frontmatter: state.draftFrontmatter,
+        fieldName: event.fieldName,
+        value: event.value,
+      });
+      const isPersisted =
+        state.draftBody === state.document.body &&
+        areJsonValuesEqual(draftFrontmatter, state.document.frontmatter);
+
+      return {
+        ...state,
+        draftFrontmatter,
+        saveState: isPersisted ? "saved" : "unsaved",
+        mutationError: undefined,
+        fieldErrors: clearFieldError(state.fieldErrors, event.fieldName),
+        saveRequestBody: undefined,
+        saveRequestFrontmatter: undefined,
       };
     }
     case "saveStarted": {
-      if (!state.canWrite || state.draftBody === state.document.body) {
+      if (!state.canWrite || isDraftPersisted(state)) {
         return state;
       }
 
@@ -1096,36 +1544,62 @@ export function reduceContentDocumentPageReadyState(
         ...state,
         saveState: "saving",
         mutationError: undefined,
+        fieldErrors: undefined,
         saveRequestBody: state.draftBody,
+        saveRequestFrontmatter: state.draftFrontmatter,
       };
     }
     case "saveSucceeded": {
       const requestBody = state.saveRequestBody ?? state.draftBody;
+      const requestFrontmatter =
+        state.saveRequestFrontmatter ?? state.draftFrontmatter;
       const savedBody = event.body ?? requestBody;
+      const savedFrontmatter = event.frontmatter ?? requestFrontmatter;
       const draftBody =
         state.draftBody === requestBody ? savedBody : state.draftBody;
+      const draftFrontmatter = areJsonValuesEqual(
+        state.draftFrontmatter,
+        requestFrontmatter,
+      )
+        ? cloneFrontmatter(savedFrontmatter)
+        : state.draftFrontmatter;
 
       return {
         ...state,
         document: {
           ...state.document,
+          frontmatter: cloneFrontmatter(savedFrontmatter),
           body: savedBody,
           hasUnpublishedChanges: true,
           updatedAt: event.updatedAt,
         },
         draftBody,
-        saveState: draftBody === savedBody ? "saved" : "unsaved",
+        draftFrontmatter,
+        saveState:
+          draftBody === savedBody &&
+          areJsonValuesEqual(draftFrontmatter, savedFrontmatter)
+            ? "saved"
+            : "unsaved",
         mutationError: undefined,
+        fieldErrors: undefined,
         saveRequestBody: undefined,
+        saveRequestFrontmatter: undefined,
       };
     }
     case "saveFailed": {
+      const fieldErrors = event.fieldName
+        ? {
+            [event.fieldName]: event.message,
+          }
+        : undefined;
+
       return {
         ...state,
-        saveState:
-          state.draftBody === state.document.body ? "saved" : "unsaved",
-        mutationError: event.message,
+        saveState: isDraftPersisted(state) ? "saved" : "unsaved",
+        mutationError: event.fieldName ? undefined : event.message,
+        fieldErrors,
         saveRequestBody: undefined,
+        saveRequestFrontmatter: undefined,
       };
     }
   }
@@ -1134,34 +1608,56 @@ export function reduceContentDocumentPageReadyState(
 export function applySuccessfulDraftSaveToReadyState(input: {
   state: ContentDocumentPageReadyState;
   requestBody: string;
+  requestFrontmatter?: Record<string, unknown>;
   persistedBody?: string;
+  persistedFrontmatter?: Record<string, unknown>;
   updatedAt: string;
 }): ContentDocumentPageReadyState {
-  const hasNewerSaveInFlight =
-    input.state.saveRequestBody !== undefined &&
-    input.state.saveRequestBody !== input.requestBody;
+  const requestFrontmatter =
+    input.requestFrontmatter ??
+    input.state.saveRequestFrontmatter ??
+    input.state.draftFrontmatter;
+  const hasNewerSaveInFlight = hasDifferentSaveRequestSnapshot({
+    state: input.state,
+    requestBody: input.requestBody,
+    requestFrontmatter,
+  });
   const persistedBody = input.persistedBody ?? input.requestBody;
+  const persistedFrontmatter = input.persistedFrontmatter ?? requestFrontmatter;
   const draftBody =
     input.state.draftBody === input.requestBody
       ? persistedBody
       : input.state.draftBody;
+  const draftFrontmatter = areJsonValuesEqual(
+    input.state.draftFrontmatter,
+    requestFrontmatter,
+  )
+    ? cloneFrontmatter(persistedFrontmatter)
+    : input.state.draftFrontmatter;
 
   return {
     ...input.state,
     document: {
       ...input.state.document,
+      frontmatter: cloneFrontmatter(persistedFrontmatter),
       body: persistedBody,
       hasUnpublishedChanges: true,
       updatedAt: input.updatedAt,
     },
     draftBody,
+    draftFrontmatter,
     mutationError: undefined,
+    fieldErrors: undefined,
     saveRequestBody: hasNewerSaveInFlight
       ? input.state.saveRequestBody
       : undefined,
+    saveRequestFrontmatter: hasNewerSaveInFlight
+      ? input.state.saveRequestFrontmatter
+      : undefined,
     saveState: hasNewerSaveInFlight
       ? input.state.saveState
-      : draftBody === persistedBody
+      : draftBody === persistedBody &&
+          areJsonValuesEqual(draftFrontmatter, persistedFrontmatter)
         ? "saved"
         : "unsaved",
   };
@@ -1170,21 +1666,36 @@ export function applySuccessfulDraftSaveToReadyState(input: {
 export function applyFailedDraftSaveToReadyState(input: {
   state: ContentDocumentPageReadyState;
   requestBody: string;
+  requestFrontmatter?: Record<string, unknown>;
   message: string;
+  fieldName?: string;
 }): ContentDocumentPageReadyState {
+  const requestFrontmatter =
+    input.requestFrontmatter ??
+    input.state.saveRequestFrontmatter ??
+    input.state.draftFrontmatter;
+
   if (
-    input.state.saveRequestBody !== undefined &&
-    input.state.saveRequestBody !== input.requestBody
+    hasDifferentSaveRequestSnapshot({
+      state: input.state,
+      requestBody: input.requestBody,
+      requestFrontmatter,
+    })
   ) {
     return input.state;
   }
 
   return {
     ...input.state,
-    saveState:
-      input.state.draftBody === input.state.document.body ? "saved" : "unsaved",
-    mutationError: input.message,
+    saveState: isDraftPersisted(input.state) ? "saved" : "unsaved",
+    mutationError: input.fieldName ? undefined : input.message,
+    fieldErrors: input.fieldName
+      ? {
+          [input.fieldName]: input.message,
+        }
+      : undefined,
     saveRequestBody: undefined,
+    saveRequestFrontmatter: undefined,
   };
 }
 
@@ -1355,11 +1866,30 @@ function getStatusBadge(state: ContentDocumentPageReadyState): {
     : { label: "Published", color: "#22c55e" };
 }
 
-function SidebarPropertiesTab(props: { state: ContentDocumentPageReadyState }) {
+function formatPropertyOptionLabel(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+function SidebarPropertiesTab(props: {
+  state: ContentDocumentPageReadyState;
+  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
+}) {
   const status = getStatusBadge(props.state);
-  const environmentSpecificFieldBadges = getEnvironmentSpecificFieldBadges(
-    props.state,
-  );
+  const propertyDescriptors = getPropertyDescriptors(props.state);
+  const propertiesReadOnly =
+    !props.state.canWrite || !!props.state.viewingVersion;
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -1412,23 +1942,207 @@ function SidebarPropertiesTab(props: { state: ContentDocumentPageReadyState }) {
         </span>
       </div>
 
-      {environmentSpecificFieldBadges.length > 0 ? (
+      {propertyDescriptors.length > 0 ? (
         <div>
           <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted">
-            Environment-specific fields
+            Frontmatter
           </div>
           <div className="flex flex-col gap-2">
-            {environmentSpecificFieldBadges.map(({ fieldName, label }) => (
-              <div
-                key={fieldName}
-                className="flex items-center justify-between gap-3 rounded-md border border-border bg-background-subtle px-2.5 py-2"
-              >
-                <code className="text-xs text-foreground">{fieldName}</code>
-                <Badge variant="outline" className="shrink-0 text-[10px]">
-                  {label}
-                </Badge>
-              </div>
-            ))}
+            {propertyDescriptors.map((descriptor) => {
+              const inputId = `document-property-${descriptor.fieldName}`;
+
+              return (
+                <div
+                  key={descriptor.fieldName}
+                  data-mdcms-property-field={descriptor.fieldName}
+                  data-mdcms-property-editor={
+                    descriptor.status === "editable"
+                      ? descriptor.control.kind
+                      : "unsupported"
+                  }
+                  className="rounded-md border border-border bg-background-subtle px-3 py-3"
+                >
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Label
+                        htmlFor={inputId}
+                        className="font-mono text-xs text-foreground"
+                      >
+                        {descriptor.fieldName}
+                      </Label>
+                      {descriptor.badgeLabel ? (
+                        <Badge
+                          variant="outline"
+                          className="shrink-0 text-[10px]"
+                        >
+                          {descriptor.badgeLabel}
+                        </Badge>
+                      ) : null}
+                      {!descriptor.field.required ? (
+                        <Badge
+                          variant="outline"
+                          className="shrink-0 text-[10px]"
+                        >
+                          Optional
+                        </Badge>
+                      ) : null}
+                    </div>
+
+                    {descriptor.status === "editable" ? (
+                      <>
+                        {descriptor.control.kind === "string" ? (
+                          <Input
+                            id={inputId}
+                            type="text"
+                            value={descriptor.control.value}
+                            disabled={propertiesReadOnly}
+                            onChange={(event) =>
+                              props.onFrontmatterFieldChange?.(
+                                descriptor.fieldName,
+                                event.currentTarget.value.length === 0 &&
+                                  descriptor.control.canUnset
+                                  ? unsetFieldValue(descriptor.field)
+                                  : event.currentTarget.value,
+                              )
+                            }
+                          />
+                        ) : null}
+
+                        {descriptor.control.kind === "number" ? (
+                          <Input
+                            id={inputId}
+                            type="number"
+                            inputMode="decimal"
+                            value={descriptor.control.value ?? ""}
+                            disabled={propertiesReadOnly}
+                            onChange={(event) => {
+                              const rawValue = event.currentTarget.value.trim();
+
+                              if (rawValue.length === 0) {
+                                if (descriptor.control.canUnset) {
+                                  props.onFrontmatterFieldChange?.(
+                                    descriptor.fieldName,
+                                    unsetFieldValue(descriptor.field),
+                                  );
+                                }
+                                return;
+                              }
+
+                              const nextValue = Number(rawValue);
+
+                              if (Number.isFinite(nextValue)) {
+                                props.onFrontmatterFieldChange?.(
+                                  descriptor.fieldName,
+                                  nextValue,
+                                );
+                              }
+                            }}
+                          />
+                        ) : null}
+
+                        {descriptor.control.kind === "boolean" ? (
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="text-xs text-foreground-muted">
+                              {descriptor.control.isUnset
+                                ? "Unset"
+                                : descriptor.control.value
+                                  ? "Enabled"
+                                  : "Disabled"}
+                            </div>
+                            <div className="flex items-center gap-2">
+                              {descriptor.control.canUnset &&
+                              !descriptor.control.isUnset ? (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={propertiesReadOnly}
+                                  onClick={() =>
+                                    props.onFrontmatterFieldChange?.(
+                                      descriptor.fieldName,
+                                      unsetFieldValue(descriptor.field),
+                                    )
+                                  }
+                                >
+                                  Unset
+                                </Button>
+                              ) : null}
+                              <Switch
+                                id={inputId}
+                                checked={descriptor.control.value}
+                                disabled={propertiesReadOnly}
+                                aria-label={descriptor.fieldName}
+                                onCheckedChange={(checked) =>
+                                  props.onFrontmatterFieldChange?.(
+                                    descriptor.fieldName,
+                                    checked,
+                                  )
+                                }
+                              />
+                            </div>
+                          </div>
+                        ) : null}
+
+                        {descriptor.control.kind === "select" ? (
+                          <Select
+                            value={
+                              descriptor.control.value === undefined ||
+                              descriptor.control.value === null
+                                ? PROPERTY_SELECT_UNSET_VALUE
+                                : JSON.stringify(descriptor.control.value)
+                            }
+                            disabled={propertiesReadOnly}
+                            onValueChange={(value) =>
+                              props.onFrontmatterFieldChange?.(
+                                descriptor.fieldName,
+                                value === PROPERTY_SELECT_UNSET_VALUE
+                                  ? unsetFieldValue(descriptor.field)
+                                  : JSON.parse(value),
+                              )
+                            }
+                          >
+                            <SelectTrigger id={inputId} className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {descriptor.control.canUnset ? (
+                                <SelectItem value={PROPERTY_SELECT_UNSET_VALUE}>
+                                  Unset
+                                </SelectItem>
+                              ) : null}
+                              {descriptor.control.options.map((option) => (
+                                <SelectItem
+                                  key={JSON.stringify(option)}
+                                  value={JSON.stringify(option)}
+                                >
+                                  {formatPropertyOptionLabel(option)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : null}
+                      </>
+                    ) : (
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-foreground-muted">
+                        <Badge variant="outline" className="text-[10px]">
+                          {descriptor.typeLabel}
+                        </Badge>
+                        <span>Not editable in Studio yet</span>
+                      </div>
+                    )}
+
+                    {descriptor.error ? (
+                      <p
+                        data-mdcms-property-error={descriptor.fieldName}
+                        className="text-xs text-destructive"
+                      >
+                        {descriptor.error}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
       ) : null}
@@ -1536,6 +2250,7 @@ function SidebarHistoryTab(props: {
 
 function ContentDocumentPageSidebar(props: {
   state: ContentDocumentPageReadyState;
+  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
 }) {
@@ -1579,7 +2294,10 @@ function ContentDocumentPageSidebar(props: {
       {/* Tab content */}
       <div className="flex-1 overflow-y-auto">
         {activeTab === "properties" ? (
-          <SidebarPropertiesTab state={props.state} />
+          <SidebarPropertiesTab
+            state={props.state}
+            onFrontmatterFieldChange={props.onFrontmatterFieldChange}
+          />
         ) : (
           <SidebarHistoryTab
             state={props.state}
@@ -1629,30 +2347,13 @@ export function resolveActiveDocumentRouteContext(
   };
 }
 
-function getEnvironmentSpecificFieldBadges(
-  state: ContentDocumentPageReadyState,
-): Array<{ fieldName: string; label: string }> {
-  const typeFieldTargets = state.route.environmentFieldTargets?.[state.typeId];
-
-  if (!typeFieldTargets) {
-    return [];
-  }
-
-  return Object.entries(typeFieldTargets)
-    .filter(([, targets]) => targets.includes(state.route.initialEnvironment))
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([fieldName, targets]) => ({
-      fieldName,
-      label: `${targets.join(", ")} only`,
-    }));
-}
-
 export function ContentDocumentPageView({
   state,
   context,
   sidebarOpen = true,
   activeMdxComponent = null,
   onDraftChange,
+  onFrontmatterFieldChange,
   onActiveMdxComponentChange,
   onToggleSidebar,
   onGoBack,
@@ -1934,6 +2635,7 @@ export function ContentDocumentPageView({
           {state.status === "ready" && sidebarOpen ? (
             <ContentDocumentPageSidebar
               state={state}
+              onFrontmatterFieldChange={onFrontmatterFieldChange}
               onViewVersion={onViewVersion}
               onBackToDraft={onBackToDraft}
             />
@@ -2245,6 +2947,7 @@ export default function ContentDocumentPage({
           ? applySuccessfulPublishToReadyState({
               state: current,
               requestBody: currentState.draftBody,
+              requestFrontmatter: currentState.draftFrontmatter,
               publishedState: nextState,
             })
           : current,
@@ -2358,13 +3061,18 @@ export default function ContentDocumentPage({
     if (
       !currentState.canWrite ||
       currentState.saveState !== "unsaved" ||
-      currentState.draftBody === currentState.document.body ||
-      currentState.saveRequestBody === currentState.draftBody
+      isDraftPersisted(currentState) ||
+      (currentState.saveRequestBody === currentState.draftBody &&
+        areJsonValuesEqual(
+          currentState.saveRequestFrontmatter ?? {},
+          currentState.draftFrontmatter,
+        ))
     ) {
       return false;
     }
 
     const requestBody = currentState.draftBody;
+    const requestFrontmatter = currentState.draftFrontmatter;
     const requestToken = createContentDocumentRouteRequestToken({
       documentId: currentState.documentId,
       route: requestRoute,
@@ -2399,7 +3107,13 @@ export default function ContentDocumentPage({
       return false;
     }
 
-    const mutationError = nextState.mutationError;
+    const failedFieldName = nextState.fieldErrors
+      ? Object.keys(nextState.fieldErrors)[0]
+      : undefined;
+    const mutationError =
+      nextState.mutationError ??
+      (failedFieldName ? nextState.fieldErrors?.[failedFieldName] : undefined);
+
     if (mutationError) {
       setState((current) =>
         current.status === "ready" &&
@@ -2407,7 +3121,9 @@ export default function ContentDocumentPage({
           ? applyFailedDraftSaveToReadyState({
               state: current,
               requestBody,
+              requestFrontmatter,
               message: mutationError,
+              fieldName: failedFieldName,
             })
           : current,
       );
@@ -2435,7 +3151,9 @@ export default function ContentDocumentPage({
         ? applySuccessfulDraftSaveToReadyState({
             state: current,
             requestBody,
+            requestFrontmatter,
             persistedBody,
+            persistedFrontmatter: nextState.document.frontmatter,
             updatedAt: nextState.document.updatedAt,
           })
         : current,
@@ -2457,7 +3175,7 @@ export default function ContentDocumentPage({
     if (
       currentState.saveState !== "saved" &&
       currentState.canWrite &&
-      currentState.draftBody !== currentState.document.body
+      !isDraftPersisted(currentState)
     ) {
       const saved = await saveDraft();
 
@@ -2558,9 +3276,8 @@ export default function ContentDocumentPage({
     );
 
     try {
-      // Always fetch the source document via loadDraft for prefill.
-      // StudioDocumentShellData does not carry frontmatter or format,
-      // so reading from local state would lose metadata.
+      // Always fetch the source document via loadDraft for prefill because the
+      // source variant may differ from the currently loaded document.
       let sourceBody = "";
       let sourceFrontmatter: Record<string, unknown> = {};
       let sourceFormat: "md" | "mdx" = "mdx";
@@ -2754,9 +3471,15 @@ export default function ContentDocumentPage({
   const readyDraftBody = state.status === "ready" ? state.draftBody : undefined;
   const readyDocumentBody =
     state.status === "ready" ? state.document.body : undefined;
+  const readyDraftFrontmatter =
+    state.status === "ready" ? state.draftFrontmatter : undefined;
+  const readyDocumentFrontmatter =
+    state.status === "ready" ? state.document.frontmatter : undefined;
   const readyCanWrite = state.status === "ready" ? state.canWrite : false;
   const readySaveRequestBody =
     state.status === "ready" ? state.saveRequestBody : undefined;
+  const readySaveRequestFrontmatter =
+    state.status === "ready" ? state.saveRequestFrontmatter : undefined;
   const readySaveState = state.status === "ready" ? state.saveState : undefined;
   const readyLeftComparisonVersion =
     state.status === "ready" ? state.selectedComparison.leftVersion : undefined;
@@ -2770,8 +3493,12 @@ export default function ContentDocumentPage({
       state.status !== "ready" ||
       !state.canWrite ||
       state.saveState !== "unsaved" ||
-      state.draftBody === state.document.body ||
-      state.saveRequestBody === state.draftBody
+      isDraftPersisted(state) ||
+      (state.saveRequestBody === state.draftBody &&
+        areJsonValuesEqual(
+          state.saveRequestFrontmatter ?? {},
+          state.draftFrontmatter,
+        ))
     ) {
       return;
     }
@@ -2786,8 +3513,11 @@ export default function ContentDocumentPage({
   }, [
     readyCanWrite,
     readyDocumentBody,
+    readyDocumentFrontmatter,
     readyDraftBody,
+    readyDraftFrontmatter,
     readySaveRequestBody,
+    readySaveRequestFrontmatter,
     readySaveState,
     state.status,
   ]);
@@ -2851,6 +3581,17 @@ export default function ContentDocumentPage({
             ? reduceContentDocumentPageReadyState(current, {
                 type: "draftChanged",
                 body,
+              })
+            : current,
+        );
+      }}
+      onFrontmatterFieldChange={(fieldName, value) => {
+        setState((current) =>
+          current.status === "ready"
+            ? reduceContentDocumentPageReadyState(current, {
+                type: "frontmatterFieldChanged",
+                fieldName,
+                value,
               })
             : current,
         );

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2283,18 +2283,6 @@ function ContentDocumentPageSidebar(props: {
           type="button"
           className={cn(
             "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
-            activeTab === "properties"
-              ? "border-b-2 border-accent text-accent"
-              : "text-foreground-muted hover:text-foreground",
-          )}
-          onClick={() => setActiveTab("properties")}
-        >
-          Properties
-        </button>
-        <button
-          type="button"
-          className={cn(
-            "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
             activeTab === "info"
               ? "border-b-2 border-accent text-accent"
               : "text-foreground-muted hover:text-foreground",
@@ -2302,6 +2290,18 @@ function ContentDocumentPageSidebar(props: {
           onClick={() => setActiveTab("info")}
         >
           Info
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
+            activeTab === "properties"
+              ? "border-b-2 border-accent text-accent"
+              : "text-foreground-muted hover:text-foreground",
+          )}
+          onClick={() => setActiveTab("properties")}
+        >
+          Properties
         </button>
         <button
           type="button"

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -2277,19 +2277,29 @@ export default function ContentDocumentPage({
       return;
     }
 
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: currentState.route,
+    });
+
     // Sync Schema forwards the authored config snapshot through the schema
     // registry contract; Studio does not edit schema definitions here.
     const nextSchemaState = await syncSchemaStateForGuard(
       currentState.schemaState,
     );
 
-    if (!nextSchemaState) {
+    const latestAfterSync = stateRef.current;
+    if (
+      !nextSchemaState ||
+      latestAfterSync.status !== "ready" ||
+      !matchesContentDocumentRouteRequestToken(requestToken, latestAfterSync)
+    ) {
       return;
     }
 
     setState((current) =>
       current.status === "ready" &&
-      current.documentId === currentState.documentId
+      matchesContentDocumentRouteRequestToken(requestToken, current)
         ? applySchemaStateToReadyState({
             state: current,
             schemaState: nextSchemaState,
@@ -2511,10 +2521,16 @@ export default function ContentDocumentPage({
 
   const handleCreateVariant = useEffectEvent(async (prefill: boolean) => {
     const currentState = stateRef.current;
-    const api = createRouteApi();
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
 
     if (
       !api ||
+      !requestRoute ||
       currentState.status !== "ready" ||
       !currentState.variantCreation ||
       !currentState.canWrite
@@ -2522,6 +2538,10 @@ export default function ContentDocumentPage({
       return;
     }
 
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
     const { targetLocale, sourceDocumentId } = currentState.variantCreation;
 
     setState((current) =>
@@ -2551,6 +2571,18 @@ export default function ContentDocumentPage({
           type: currentState.typeId,
           locale: currentState.variantCreation.sourceLocale,
         });
+
+        const latestAfterSourceLoad = stateRef.current;
+        if (
+          latestAfterSourceLoad.status !== "ready" ||
+          !matchesContentDocumentRouteRequestToken(
+            requestToken,
+            latestAfterSourceLoad,
+          )
+        ) {
+          return;
+        }
+
         sourceBody = sourceDoc.body ?? "";
         sourceFrontmatter = sourceDoc.frontmatter ?? {};
         sourceFormat = sourceDoc.format ?? "mdx";
@@ -2564,16 +2596,39 @@ export default function ContentDocumentPage({
         frontmatter: prefill ? sourceFrontmatter : {},
         body: prefill ? sourceBody : "",
         sourceDocumentId,
-        schemaHash: route?.write.canWrite ? route.write.schemaHash : undefined,
+        schemaHash: requestRoute.write.canWrite
+          ? requestRoute.write.schemaHash
+          : undefined,
       });
+
+      const latestAfterCreate = stateRef.current;
+      if (
+        latestAfterCreate.status !== "ready" ||
+        !matchesContentDocumentRouteRequestToken(
+          requestToken,
+          latestAfterCreate,
+        )
+      ) {
+        return;
+      }
 
       router.push(`/admin/content/${currentState.typeId}/${result.documentId}`);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to create variant.";
 
+      const latestAfterError = stateRef.current;
+      if (
+        latestAfterError.status !== "ready" ||
+        !matchesContentDocumentRouteRequestToken(requestToken, latestAfterError)
+      ) {
+        return;
+      }
+
       setState((current) =>
-        current.status === "ready" && current.variantCreation
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current) &&
+        current.variantCreation
           ? {
               ...current,
               variantCreation: {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -325,6 +325,7 @@ type ContentDocumentPropertyControl =
 type ContentDocumentPropertyDescriptor = {
   fieldName: string;
   field: SchemaRegistryFieldSnapshot;
+  typeLabel: string;
   badgeLabel?: string;
   error?: string;
 } & (
@@ -334,7 +335,6 @@ type ContentDocumentPropertyDescriptor = {
     }
   | {
       status: "unsupported";
-      typeLabel: string;
     }
 );
 
@@ -549,9 +549,7 @@ function canEditSelectField(
   );
 }
 
-function describeUnsupportedFieldType(
-  field: SchemaRegistryFieldSnapshot,
-): string {
+function describePropertyFieldType(field: SchemaRegistryFieldSnapshot): string {
   if (field.reference) {
     return `reference:${field.reference.targetType}`;
   }
@@ -570,6 +568,7 @@ function resolvePropertyDescriptor(input: {
   );
   const error = input.state.fieldErrors?.[input.fieldName];
   const currentValue = input.state.draftFrontmatter[input.fieldName];
+  const typeLabel = describePropertyFieldType(input.field);
 
   if (
     currentValue === undefined &&
@@ -579,6 +578,7 @@ function resolvePropertyDescriptor(input: {
     return {
       fieldName: input.fieldName,
       field: input.field,
+      typeLabel,
       badgeLabel,
       error,
       status: "editable",
@@ -595,6 +595,7 @@ function resolvePropertyDescriptor(input: {
     return {
       fieldName: input.fieldName,
       field: input.field,
+      typeLabel,
       badgeLabel,
       error,
       status: "editable",
@@ -611,6 +612,7 @@ function resolvePropertyDescriptor(input: {
     return {
       fieldName: input.fieldName,
       field: input.field,
+      typeLabel,
       badgeLabel,
       error,
       status: "editable",
@@ -626,6 +628,7 @@ function resolvePropertyDescriptor(input: {
     return {
       fieldName: input.fieldName,
       field: input.field,
+      typeLabel,
       badgeLabel,
       error,
       status: "editable",
@@ -641,6 +644,7 @@ function resolvePropertyDescriptor(input: {
     return {
       fieldName: input.fieldName,
       field: input.field,
+      typeLabel,
       badgeLabel,
       error,
       status: "editable",
@@ -656,10 +660,10 @@ function resolvePropertyDescriptor(input: {
   return {
     fieldName: input.fieldName,
     field: input.field,
+    typeLabel,
     badgeLabel,
     error,
     status: "unsupported",
-    typeLabel: describeUnsupportedFieldType(input.field),
   };
 }
 
@@ -1964,6 +1968,7 @@ function SidebarPropertiesTab(props: {
                 <div
                   key={descriptor.fieldName}
                   data-mdcms-property-field={descriptor.fieldName}
+                  data-mdcms-property-type={descriptor.typeLabel}
                   data-mdcms-property-editor={
                     descriptor.status === "editable"
                       ? descriptor.control.kind
@@ -1979,6 +1984,9 @@ function SidebarPropertiesTab(props: {
                       >
                         {descriptor.fieldName}
                       </Label>
+                      <Badge variant="outline" className="shrink-0 text-[10px]">
+                        {descriptor.typeLabel}
+                      </Badge>
                       {descriptor.badgeLabel ? (
                         <Badge
                           variant="outline"
@@ -2133,9 +2141,6 @@ function SidebarPropertiesTab(props: {
                       </>
                     ) : (
                       <div className="flex flex-wrap items-center gap-2 text-xs text-foreground-muted">
-                        <Badge variant="outline" className="text-[10px]">
-                          {descriptor.typeLabel}
-                        </Badge>
                         <span>Not editable in Studio yet</span>
                       </div>
                     )}

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -57,7 +57,6 @@ import {
   DialogTitle,
 } from "../components/ui/dialog.js";
 import { Input } from "../components/ui/input.js";
-import { Label } from "../components/ui/label.js";
 import { Textarea } from "../components/ui/textarea.js";
 import {
   Tooltip,
@@ -1954,210 +1953,230 @@ function SidebarPropertiesTab(props: {
     !props.state.canWrite || !!props.state.viewingVersion;
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="p-4">
       {propertyDescriptors.length > 0 ? (
-        <div>
-          <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted">
-            Frontmatter
-          </div>
-          <div className="flex flex-col gap-2">
-            {propertyDescriptors.map((descriptor) => {
-              const inputId = `document-property-${descriptor.fieldName}`;
+        <div className="flex flex-col">
+          {propertyDescriptors.map((descriptor) => {
+            const inputId = `document-property-${descriptor.fieldName}`;
+            const envLabel = descriptor.badgeLabel?.replace(/ only$/, "");
 
+            if (
+              descriptor.status === "editable" &&
+              descriptor.control.kind === "boolean"
+            ) {
               return (
                 <div
                   key={descriptor.fieldName}
                   data-mdcms-property-field={descriptor.fieldName}
                   data-mdcms-property-type={descriptor.typeLabel}
-                  data-mdcms-property-editor={
-                    descriptor.status === "editable"
-                      ? descriptor.control.kind
-                      : "unsupported"
-                  }
-                  className="rounded-md border border-border bg-background-subtle px-3 py-3"
+                  data-mdcms-property-editor="boolean"
+                  className="flex items-center justify-between border-b border-border py-2.5 last:border-b-0"
                 >
-                  <div className="flex flex-col gap-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Label
-                        htmlFor={inputId}
-                        className="font-mono text-xs text-foreground"
-                      >
-                        {descriptor.fieldName}
-                      </Label>
-                      <Badge variant="outline" className="shrink-0 text-[10px]">
-                        {descriptor.typeLabel}
-                      </Badge>
-                      {descriptor.badgeLabel ? (
-                        <Badge
-                          variant="outline"
-                          className="shrink-0 text-[10px]"
-                        >
-                          {descriptor.badgeLabel}
-                        </Badge>
+                  <div className="flex items-baseline gap-1.5">
+                    <label
+                      htmlFor={inputId}
+                      className="text-xs font-medium text-foreground"
+                    >
+                      {descriptor.fieldName}
+                      {descriptor.field.required ? (
+                        <span className="text-destructive"> *</span>
                       ) : null}
-                      {!descriptor.field.required ? (
-                        <Badge
-                          variant="outline"
-                          className="shrink-0 text-[10px]"
-                        >
-                          Optional
-                        </Badge>
-                      ) : null}
-                    </div>
-
-                    {descriptor.status === "editable" ? (
-                      <>
-                        {descriptor.control.kind === "string" ? (
-                          <Input
-                            id={inputId}
-                            type="text"
-                            value={descriptor.control.value}
-                            disabled={propertiesReadOnly}
-                            onChange={(event) =>
-                              props.onFrontmatterFieldChange?.(
-                                descriptor.fieldName,
-                                event.currentTarget.value.length === 0 &&
-                                  descriptor.control.canUnset
-                                  ? unsetFieldValue(descriptor.field)
-                                  : event.currentTarget.value,
-                              )
-                            }
-                          />
-                        ) : null}
-
-                        {descriptor.control.kind === "number" ? (
-                          <Input
-                            id={inputId}
-                            type="number"
-                            inputMode="decimal"
-                            value={descriptor.control.value ?? ""}
-                            disabled={propertiesReadOnly}
-                            onChange={(event) => {
-                              const rawValue = event.currentTarget.value.trim();
-
-                              if (rawValue.length === 0) {
-                                if (descriptor.control.canUnset) {
-                                  props.onFrontmatterFieldChange?.(
-                                    descriptor.fieldName,
-                                    unsetFieldValue(descriptor.field),
-                                  );
-                                }
-                                return;
-                              }
-
-                              const nextValue = Number(rawValue);
-
-                              if (Number.isFinite(nextValue)) {
-                                props.onFrontmatterFieldChange?.(
-                                  descriptor.fieldName,
-                                  nextValue,
-                                );
-                              }
-                            }}
-                          />
-                        ) : null}
-
-                        {descriptor.control.kind === "boolean" ? (
-                          <div className="flex items-center justify-between gap-3">
-                            <div className="text-xs text-foreground-muted">
-                              {descriptor.control.isUnset
-                                ? "Unset"
-                                : descriptor.control.value
-                                  ? "Enabled"
-                                  : "Disabled"}
-                            </div>
-                            <div className="flex items-center gap-2">
-                              {descriptor.control.canUnset &&
-                              !descriptor.control.isUnset ? (
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  disabled={propertiesReadOnly}
-                                  onClick={() =>
-                                    props.onFrontmatterFieldChange?.(
-                                      descriptor.fieldName,
-                                      unsetFieldValue(descriptor.field),
-                                    )
-                                  }
-                                >
-                                  Unset
-                                </Button>
-                              ) : null}
-                              <Switch
-                                id={inputId}
-                                checked={descriptor.control.value}
-                                disabled={propertiesReadOnly}
-                                aria-label={descriptor.fieldName}
-                                onCheckedChange={(checked) =>
-                                  props.onFrontmatterFieldChange?.(
-                                    descriptor.fieldName,
-                                    checked,
-                                  )
-                                }
-                              />
-                            </div>
-                          </div>
-                        ) : null}
-
-                        {descriptor.control.kind === "select" ? (
-                          <Select
-                            value={
-                              descriptor.control.value === undefined ||
-                              descriptor.control.value === null
-                                ? PROPERTY_SELECT_UNSET_VALUE
-                                : JSON.stringify(descriptor.control.value)
-                            }
-                            disabled={propertiesReadOnly}
-                            onValueChange={(value) =>
-                              props.onFrontmatterFieldChange?.(
-                                descriptor.fieldName,
-                                value === PROPERTY_SELECT_UNSET_VALUE
-                                  ? unsetFieldValue(descriptor.field)
-                                  : JSON.parse(value),
-                              )
-                            }
-                          >
-                            <SelectTrigger id={inputId} className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {descriptor.control.canUnset ? (
-                                <SelectItem value={PROPERTY_SELECT_UNSET_VALUE}>
-                                  Unset
-                                </SelectItem>
-                              ) : null}
-                              {descriptor.control.options.map((option) => (
-                                <SelectItem
-                                  key={JSON.stringify(option)}
-                                  value={JSON.stringify(option)}
-                                >
-                                  {formatPropertyOptionLabel(option)}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        ) : null}
-                      </>
-                    ) : (
-                      <div className="flex flex-wrap items-center gap-2 text-xs text-foreground-muted">
-                        <span>Not editable in Studio yet</span>
-                      </div>
-                    )}
-
-                    {descriptor.error ? (
-                      <p
-                        data-mdcms-property-error={descriptor.fieldName}
-                        className="text-xs text-destructive"
-                      >
-                        {descriptor.error}
-                      </p>
+                    </label>
+                    {envLabel ? (
+                      <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-500">
+                        {envLabel}
+                      </span>
                     ) : null}
+                    <span className="font-mono text-[10px] text-foreground-muted">
+                      {descriptor.typeLabel}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-foreground-muted">
+                      {descriptor.control.isUnset
+                        ? "Unset"
+                        : descriptor.control.value
+                          ? "On"
+                          : "Off"}
+                    </span>
+                    {descriptor.control.canUnset &&
+                    !descriptor.control.isUnset ? (
+                      <button
+                        type="button"
+                        disabled={propertiesReadOnly}
+                        className="text-[11px] text-foreground-muted hover:text-foreground disabled:opacity-50"
+                        onClick={() =>
+                          props.onFrontmatterFieldChange?.(
+                            descriptor.fieldName,
+                            unsetFieldValue(descriptor.field),
+                          )
+                        }
+                      >
+                        Unset
+                      </button>
+                    ) : null}
+                    <Switch
+                      id={inputId}
+                      checked={descriptor.control.value}
+                      disabled={propertiesReadOnly}
+                      aria-label={descriptor.fieldName}
+                      onCheckedChange={(checked) =>
+                        props.onFrontmatterFieldChange?.(
+                          descriptor.fieldName,
+                          checked,
+                        )
+                      }
+                    />
                   </div>
                 </div>
               );
-            })}
-          </div>
+            }
+
+            return (
+              <div
+                key={descriptor.fieldName}
+                data-mdcms-property-field={descriptor.fieldName}
+                data-mdcms-property-type={descriptor.typeLabel}
+                data-mdcms-property-editor={
+                  descriptor.status === "editable"
+                    ? descriptor.control.kind
+                    : "unsupported"
+                }
+                className={cn(
+                  "flex flex-col gap-1.5 border-b border-border py-2.5 last:border-b-0",
+                  descriptor.status !== "editable" && "opacity-50",
+                )}
+              >
+                <div className="flex items-baseline justify-between">
+                  <div className="flex items-baseline gap-1.5">
+                    <label
+                      htmlFor={inputId}
+                      className="text-xs font-medium text-foreground"
+                    >
+                      {descriptor.fieldName}
+                      {descriptor.field.required ? (
+                        <span className="text-destructive"> *</span>
+                      ) : null}
+                    </label>
+                    {envLabel ? (
+                      <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-500">
+                        {envLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="font-mono text-[10px] text-foreground-muted">
+                    {descriptor.typeLabel}
+                  </span>
+                </div>
+
+                {descriptor.status === "editable" ? (
+                  <>
+                    {descriptor.control.kind === "string" ? (
+                      <Input
+                        id={inputId}
+                        type="text"
+                        value={descriptor.control.value}
+                        disabled={propertiesReadOnly}
+                        onChange={(event) =>
+                          props.onFrontmatterFieldChange?.(
+                            descriptor.fieldName,
+                            event.currentTarget.value.length === 0 &&
+                              descriptor.control.canUnset
+                              ? unsetFieldValue(descriptor.field)
+                              : event.currentTarget.value,
+                          )
+                        }
+                      />
+                    ) : null}
+
+                    {descriptor.control.kind === "number" ? (
+                      <Input
+                        id={inputId}
+                        type="number"
+                        inputMode="decimal"
+                        value={descriptor.control.value ?? ""}
+                        disabled={propertiesReadOnly}
+                        onChange={(event) => {
+                          const rawValue = event.currentTarget.value.trim();
+
+                          if (rawValue.length === 0) {
+                            if (descriptor.control.canUnset) {
+                              props.onFrontmatterFieldChange?.(
+                                descriptor.fieldName,
+                                unsetFieldValue(descriptor.field),
+                              );
+                            }
+                            return;
+                          }
+
+                          const nextValue = Number(rawValue);
+
+                          if (Number.isFinite(nextValue)) {
+                            props.onFrontmatterFieldChange?.(
+                              descriptor.fieldName,
+                              nextValue,
+                            );
+                          }
+                        }}
+                      />
+                    ) : null}
+
+                    {descriptor.control.kind === "select" ? (
+                      <Select
+                        value={
+                          descriptor.control.value === undefined ||
+                          descriptor.control.value === null
+                            ? PROPERTY_SELECT_UNSET_VALUE
+                            : JSON.stringify(descriptor.control.value)
+                        }
+                        disabled={propertiesReadOnly}
+                        onValueChange={(value) =>
+                          props.onFrontmatterFieldChange?.(
+                            descriptor.fieldName,
+                            value === PROPERTY_SELECT_UNSET_VALUE
+                              ? unsetFieldValue(descriptor.field)
+                              : JSON.parse(value),
+                          )
+                        }
+                      >
+                        <SelectTrigger id={inputId} className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {descriptor.control.canUnset ? (
+                            <SelectItem value={PROPERTY_SELECT_UNSET_VALUE}>
+                              Unset
+                            </SelectItem>
+                          ) : null}
+                          {descriptor.control.options.map((option) => (
+                            <SelectItem
+                              key={JSON.stringify(option)}
+                              value={JSON.stringify(option)}
+                            >
+                              {formatPropertyOptionLabel(option)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : null}
+                  </>
+                ) : (
+                  <span className="text-[11px] italic text-foreground-muted">
+                    Not editable yet
+                  </span>
+                )}
+
+                {descriptor.error ? (
+                  <p
+                    data-mdcms-property-error={descriptor.fieldName}
+                    className="text-xs text-destructive"
+                  >
+                    {descriptor.error}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
       ) : null}
     </div>

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -261,6 +261,98 @@ test("loadStudioRuntime fetches bootstrap, verifies runtime, and mounts the remo
   });
 });
 
+test("loadStudioRuntime forwards document route environment metadata to the remote runtime", async () => {
+  await withTempDir("studio-loader-route-metadata-", async (directory) => {
+    const fixture = await createRuntimeFixture(directory);
+    const contexts: unknown[] = [];
+
+    await loadStudioRuntime({
+      config: {
+        project: "marketing-site",
+        environment: "staging",
+        serverUrl: "http://localhost:4000",
+        _schemaHash: "staging-schema-hash",
+        _documentRouteMetadata: {
+          schemaHashesByEnvironment: {
+            production: "production-schema-hash",
+            staging: "staging-schema-hash",
+          },
+          environmentFieldTargets: {
+            BlogPost: {
+              featured: ["staging"],
+            },
+          },
+        },
+      } as MdcmsConfig,
+      basePath: "/admin",
+      container: {},
+      hostBridge: validHostBridge,
+      fetcher: async (input) => {
+        const url = String(input);
+
+        if (url === "http://localhost:4000/api/v1/studio/bootstrap") {
+          return new Response(
+            JSON.stringify(
+              createReadyBootstrapPayload({
+                manifest: fixture.manifest,
+              }),
+            ),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          );
+        }
+
+        if (url === "http://localhost:4000" + fixture.manifest.entryUrl) {
+          return new Response(new Uint8Array(fixture.runtimeBytes), {
+            status: 200,
+            headers: {
+              "content-type": "text/javascript; charset=utf-8",
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      },
+      loadRemoteModule: async () => ({
+        mount: (_target: unknown, context: unknown) => {
+          contexts.push(context);
+          return () => {};
+        },
+      }),
+    });
+
+    const mountedContext = contexts[0] as {
+      documentRoute?: {
+        writeByEnvironment?: Record<
+          string,
+          { canWrite: boolean; schemaHash?: string; message?: string }
+        >;
+        environmentFieldTargets?: Record<string, Record<string, string[]>>;
+      };
+    };
+
+    assert.deepEqual(mountedContext.documentRoute?.writeByEnvironment, {
+      production: {
+        canWrite: true,
+        schemaHash: "production-schema-hash",
+      },
+      staging: {
+        canWrite: true,
+        schemaHash: "staging-schema-hash",
+      },
+    });
+    assert.deepEqual(mountedContext.documentRoute?.environmentFieldTargets, {
+      BlogPost: {
+        featured: ["staging"],
+      },
+    });
+  });
+});
+
 test("loadStudioRuntime preserves a path-prefixed studio serverUrl for bootstrap and runtime asset fetches", async () => {
   await withTempDir("studio-loader-prefixed-", async (directory) => {
     const fixture = await createRuntimeFixture(directory);

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -15,7 +15,11 @@ import {
 } from "@mdcms/shared";
 
 import { buildStudioRuntimeArtifacts } from "./build-runtime.js";
-import { loadStudioRuntime, type MdcmsConfig } from "./studio-loader.js";
+import {
+  isPreparedDocumentRouteMetadata,
+  loadStudioRuntime,
+  type MdcmsConfig,
+} from "./studio-loader.js";
 
 const validHostBridge: HostBridgeV1 = {
   version: "1",
@@ -351,6 +355,76 @@ test("loadStudioRuntime forwards document route environment metadata to the remo
       },
     });
   });
+});
+
+test("isPreparedDocumentRouteMetadata rejects malformed nested route metadata", () => {
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: "production-schema-hash",
+        staging: "staging-schema-hash",
+      },
+      environmentFieldTargets: {
+        BlogPost: {
+          featured: ["staging"],
+        },
+      },
+    }),
+    true,
+  );
+
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: " production-schema-hash ",
+      },
+      environmentFieldTargets: {
+        BlogPost: {
+          featured: ["production"],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: "production-schema-hash",
+      },
+      environmentFieldTargets: {
+        BlogPost: {
+          featured: [],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: "production-schema-hash",
+      },
+      environmentFieldTargets: {
+        BlogPost: {
+          featured: ["staging"],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: "production-schema-hash",
+      },
+      environmentFieldTargets: {
+        " BlogPost ": {
+          featured: ["production"],
+        },
+      },
+    }),
+    false,
+  );
 });
 
 test("loadStudioRuntime preserves a path-prefixed studio serverUrl for bootstrap and runtime asset fetches", async () => {

--- a/packages/studio/src/lib/studio-loader.test.ts
+++ b/packages/studio/src/lib/studio-loader.test.ts
@@ -401,6 +401,26 @@ test("isPreparedDocumentRouteMetadata rejects malformed nested route metadata", 
   );
   assert.equal(
     isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: ["production-schema-hash"],
+      environmentFieldTargets: {
+        BlogPost: {
+          featured: ["production"],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
+      schemaHashesByEnvironment: {
+        production: "production-schema-hash",
+      },
+      environmentFieldTargets: [],
+    }),
+    false,
+  );
+  assert.equal(
+    isPreparedDocumentRouteMetadata({
       schemaHashesByEnvironment: {
         production: "production-schema-hash",
       },

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -238,7 +238,7 @@ function isNonEmptyTrimmedString(value: unknown): value is string {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -18,7 +18,11 @@ import {
 } from "@mdcms/shared";
 
 import { assertStudioRuntimePublication } from "./bootstrap-verification.js";
-import { resolveStudioDocumentRouteSchemaCapability } from "./document-route-schema.js";
+import {
+  resolveStudioDocumentRouteSchemaCapability,
+  resolveStudioDocumentRoutePreparedMetadata,
+  type StudioDocumentRoutePreparedMetadata,
+} from "./document-route-schema.js";
 import type { MdcmsConfig } from "./studio.js";
 import {
   normalizeStudioBaseUrl,
@@ -227,6 +231,87 @@ function readTrimmedConfigString(value: unknown): string | undefined {
     : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
+
+function isPreparedDocumentRouteMetadata(
+  value: unknown,
+): value is StudioDocumentRoutePreparedMetadata {
+  if (!isRecord(value) || !isRecord(value.schemaHashesByEnvironment)) {
+    return false;
+  }
+
+  if (
+    !Object.values(value.schemaHashesByEnvironment).every(
+      (entry) => typeof entry === "string" && entry.trim().length > 0,
+    )
+  ) {
+    return false;
+  }
+
+  if (value.environmentFieldTargets === undefined) {
+    return false;
+  }
+
+  if (!isRecord(value.environmentFieldTargets)) {
+    return false;
+  }
+
+  return Object.values(value.environmentFieldTargets).every((typeFields) => {
+    if (!isRecord(typeFields)) {
+      return false;
+    }
+
+    return Object.values(typeFields).every(isStringArray);
+  });
+}
+
+function toWriteByEnvironment(
+  metadata: StudioDocumentRoutePreparedMetadata,
+): Record<
+  string,
+  {
+    canWrite: true;
+    schemaHash: string;
+  }
+> {
+  return Object.fromEntries(
+    Object.entries(metadata.schemaHashesByEnvironment)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([environment, schemaHash]) => [
+        environment,
+        {
+          canWrite: true as const,
+          schemaHash,
+        },
+      ]),
+  );
+}
+
+async function readPreparedDocumentRouteMetadata(
+  config: MdcmsConfig,
+): Promise<StudioDocumentRoutePreparedMetadata | undefined> {
+  const precomputed = (config as Record<string, unknown>)
+    ._documentRouteMetadata;
+
+  if (isPreparedDocumentRouteMetadata(precomputed)) {
+    return precomputed;
+  }
+
+  try {
+    return await resolveStudioDocumentRoutePreparedMetadata(config);
+  } catch {
+    return undefined;
+  }
+}
+
 async function createDocumentRouteMountContext(
   config: MdcmsConfig,
 ): Promise<StudioMountContext["documentRoute"] | undefined> {
@@ -244,10 +329,18 @@ async function createDocumentRouteMountContext(
     typeof (config as Record<string, unknown>)._schemaHash === "string"
       ? ((config as Record<string, unknown>)._schemaHash as string)
       : undefined;
+  const preparedDocumentRouteMetadata =
+    await readPreparedDocumentRouteMetadata(config);
+  const writeByEnvironment = preparedDocumentRouteMetadata
+    ? toWriteByEnvironment(preparedDocumentRouteMetadata)
+    : undefined;
+  const currentEnvironmentWrite = writeByEnvironment?.[environment];
 
-  const capability = precomputedSchemaHash
-    ? { canWrite: true as const, schemaHash: precomputedSchemaHash }
-    : await resolveStudioDocumentRouteSchemaCapability(config);
+  const capability = currentEnvironmentWrite
+    ? currentEnvironmentWrite
+    : precomputedSchemaHash
+      ? { canWrite: true as const, schemaHash: precomputedSchemaHash }
+      : await resolveStudioDocumentRouteSchemaCapability(config);
 
   let supportedLocales: string[] | undefined;
   let defaultLocale: string | undefined;
@@ -272,6 +365,15 @@ async function createDocumentRouteMountContext(
     initialEnvironment: environment,
     ...(supportedLocales && supportedLocales.length > 0
       ? { supportedLocales, defaultLocale }
+      : {}),
+    ...(writeByEnvironment ? { writeByEnvironment } : {}),
+    ...(preparedDocumentRouteMetadata &&
+    Object.keys(preparedDocumentRouteMetadata.environmentFieldTargets).length >
+      0
+      ? {
+          environmentFieldTargets:
+            preparedDocumentRouteMetadata.environmentFieldTargets,
+        }
       : {}),
     write: capability.canWrite
       ? {

--- a/packages/studio/src/lib/studio-loader.ts
+++ b/packages/studio/src/lib/studio-loader.ts
@@ -231,26 +231,35 @@ function readTrimmedConfigString(value: unknown): string | undefined {
     : undefined;
 }
 
+function isNonEmptyTrimmedString(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value.trim() === value
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
 function isStringArray(value: unknown): value is string[] {
-  return (
-    Array.isArray(value) && value.every((entry) => typeof entry === "string")
-  );
+  return Array.isArray(value) && value.every(isNonEmptyTrimmedString);
 }
 
-function isPreparedDocumentRouteMetadata(
+/** Validates precomputed route metadata before it reaches the mount contract. */
+export function isPreparedDocumentRouteMetadata(
   value: unknown,
 ): value is StudioDocumentRoutePreparedMetadata {
   if (!isRecord(value) || !isRecord(value.schemaHashesByEnvironment)) {
     return false;
   }
 
+  const schemaEntries = Object.entries(value.schemaHashesByEnvironment);
   if (
-    !Object.values(value.schemaHashesByEnvironment).every(
-      (entry) => typeof entry === "string" && entry.trim().length > 0,
+    schemaEntries.length === 0 ||
+    !schemaEntries.every(
+      ([environment, schemaHash]) =>
+        isNonEmptyTrimmedString(environment) &&
+        isNonEmptyTrimmedString(schemaHash),
     )
   ) {
     return false;
@@ -264,13 +273,34 @@ function isPreparedDocumentRouteMetadata(
     return false;
   }
 
-  return Object.values(value.environmentFieldTargets).every((typeFields) => {
-    if (!isRecord(typeFields)) {
-      return false;
-    }
+  const validEnvironments = new Set(
+    schemaEntries.map(([environment]) => environment),
+  );
 
-    return Object.values(typeFields).every(isStringArray);
-  });
+  return Object.entries(value.environmentFieldTargets).every(
+    ([typeName, typeFields]) => {
+      if (!isNonEmptyTrimmedString(typeName) || !isRecord(typeFields)) {
+        return false;
+      }
+
+      const fieldEntries = Object.entries(typeFields);
+      if (fieldEntries.length === 0) {
+        return false;
+      }
+
+      return fieldEntries.every(([fieldName, targets]) => {
+        if (!isNonEmptyTrimmedString(fieldName)) {
+          return false;
+        }
+
+        return (
+          isStringArray(targets) &&
+          targets.length > 0 &&
+          targets.every((target) => validEnvironments.has(target))
+        );
+      });
+    },
+  );
 }
 
 function toWriteByEnvironment(

--- a/packages/studio/src/lib/studio.ts
+++ b/packages/studio/src/lib/studio.ts
@@ -13,7 +13,11 @@ import {
   type RuntimeContext,
 } from "@mdcms/shared";
 import { extractMdxComponentProps } from "@mdcms/shared/mdx";
-import { resolveStudioDocumentRouteSchemaCapability } from "./document-route-schema.js";
+import {
+  resolveStudioDocumentRoutePreparedMetadata,
+  resolveStudioDocumentRouteSchemaCapability,
+  type StudioDocumentRoutePreparedMetadata,
+} from "./document-route-schema.js";
 
 /**
  * Studio runtime helpers align env resolution, logger setup, and error
@@ -45,6 +49,8 @@ type OptionalStudioClientConfig = Partial<
 export type MdcmsConfig = StudioEmbedConfig &
   OptionalStudioClientConfig & {
     components?: StudioComponentRegistration[];
+    _schemaHash?: string;
+    _documentRouteMetadata?: StudioDocumentRoutePreparedMetadata;
   };
 
 export { resolveStudioDocumentRouteSchemaCapability } from "./document-route-schema.js";
@@ -105,6 +111,14 @@ export async function prepareStudioConfig(
   // here ensures the Studio loader can enable writes without re-deriving.
   const schemaCapability =
     await resolveStudioDocumentRouteSchemaCapability(config);
+  let documentRouteMetadata: StudioDocumentRoutePreparedMetadata | undefined;
+
+  try {
+    documentRouteMetadata =
+      await resolveStudioDocumentRoutePreparedMetadata(config);
+  } catch {
+    documentRouteMetadata = undefined;
+  }
 
   return {
     ...config,
@@ -112,6 +126,9 @@ export async function prepareStudioConfig(
     ...(components !== undefined ? { components } : {}),
     ...(schemaCapability.canWrite
       ? { _schemaHash: schemaCapability.schemaHash }
+      : {}),
+    ...(documentRouteMetadata !== undefined
+      ? { _documentRouteMetadata: documentRouteMetadata }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary
- derive and forward environment-specific document-route metadata, including per-environment schema hashes and field target environments
- render environment-specific field badges in the Studio document sidebar and keep route write metadata aligned with the active environment switcher
- align the studio example/review apps and review fixtures with the new contract and badge behavior

## Test Plan
- bun test packages/studio/src/lib/document-route-schema.test.ts packages/shared/src/lib/contracts/extensibility.test.ts packages/studio/src/lib/studio-loader.test.ts packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx apps/studio-review/review/scenarios.test.ts
- bun run check

## Notes
- `bun run format:check` still fails because of a pre-existing unrelated formatting issue in `packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-aware document editor: per-environment schema hashes & write gating, environment-targeted fields, full frontmatter editing, new Info sidebar tab, and inline environment badges.
* **Bug Fixes**
  * Prevents stale UI updates and mismatched save/publish behavior when switching routes or environments.
* **Documentation**
  * Specs updated to detail editor behaviors, frontmatter persistence, and environment-field rules.
* **Tests**
  * Added tests covering metadata resolution, schema-hashes, environment badges, frontmatter flows, and post fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->