### PR TITLE
CMS-140 fix environment delete 404 reload

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -101,10 +101,13 @@ Backend API/runtime package boundary for MDCMS.
   - `DELETE /api/v1/environments/:id`
 - Environment management rules:
   - explicit `project` routing is required
-  - authenticated Studio session required
-  - global `owner` or `admin` only
-  - valid environment names and `extends` chains are derived from
-    `mdcms.config.ts`
+  - global `owner` or `admin` only, including list reads
+  - `GET /api/v1/environments` returns live rows plus definitions readiness
+    metadata
+  - valid environment names and `extends` chains are derived from the latest
+    synced project config snapshot, not request-time filesystem reads
+  - `POST /api/v1/environments` returns `CONFIG_SNAPSHOT_REQUIRED` (`409`)
+    until schema sync has published environment definitions for the project
   - project provisioning guarantees a default `production` environment
   - deleting `production` or any environment with content/schema state returns
     deterministic `CONFLICT` (`409`)

--- a/apps/server/drizzle/0011_optimal_valeria_richards.sql
+++ b/apps/server/drizzle/0011_optimal_valeria_richards.sql
@@ -6,5 +6,3 @@ CREATE TABLE "project_environment_topology_snapshots" (
 	"synced_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "unique_project_environment_topology_snapshot" UNIQUE("project")
 );
---> statement-breakpoint
-CREATE INDEX "idx_project_environment_topology_snapshots_project" ON "project_environment_topology_snapshots" USING btree ("project");

--- a/apps/server/drizzle/0011_optimal_valeria_richards.sql
+++ b/apps/server/drizzle/0011_optimal_valeria_richards.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "project_environment_topology_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project" text NOT NULL,
+	"config_snapshot_hash" text NOT NULL,
+	"definitions" jsonb NOT NULL,
+	"synced_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_project_environment_topology_snapshot" UNIQUE("project")
+);
+--> statement-breakpoint
+CREATE INDEX "idx_project_environment_topology_snapshots_project" ON "project_environment_topology_snapshots" USING btree ("project");

--- a/apps/server/drizzle/meta/0011_snapshot.json
+++ b/apps/server/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2229 @@
+{
+  "id": "83209ec8-345d-4f8e-9427-c04fbc0f4685",
+  "prevId": "c768c933-2372-406b-87f2-b52c97f7cb8c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_allowlist": {
+          "name": "context_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_keys_active": {
+          "name": "idx_api_keys_active",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_created_by": {
+          "name": "idx_api_keys_created_by",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_created_by_user_id_users_id_fk": {
+          "name": "api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_api_keys_key_hash": {
+          "name": "uniq_api_keys_key_hash",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_accounts_user_id": {
+          "name": "idx_auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_login_backoffs": {
+      "name": "auth_login_backoffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "login_key": {
+          "name": "login_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_failed_at": {
+          "name": "first_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_allowed_at": {
+          "name": "next_allowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_login_backoffs_next_allowed": {
+          "name": "idx_auth_login_backoffs_next_allowed",
+          "columns": [
+            {
+              "expression": "next_allowed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_auth_login_backoffs_login_key": {
+          "name": "uniq_auth_login_backoffs_login_key",
+          "nullsNotDistinct": false,
+          "columns": ["login_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_auth_sessions_user_id": {
+          "name": "idx_auth_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_auth_sessions_token": {
+          "name": "uniq_auth_sessions_token",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_auth_users_email": {
+          "name": "uniq_auth_users_email",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_verifications_identifier": {
+          "name": "idx_auth_verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_login_challenges": {
+      "name": "cli_login_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_scopes": {
+          "name": "requested_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code_hash": {
+          "name": "authorization_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_at": {
+          "name": "authorized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cli_login_challenges_status_expires": {
+          "name": "idx_cli_login_challenges_status_expires",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cli_login_challenges_user": {
+          "name": "idx_cli_login_challenges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_login_challenges_user_id_users_id_fk": {
+          "name": "cli_login_challenges_user_id_users_id_fk",
+          "tableFrom": "cli_login_challenges",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cli_login_challenges_status_check": {
+          "name": "cli_login_challenges_status_check",
+          "value": "\"cli_login_challenges\".\"status\" in ('pending', 'authorized', 'exchanged')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_versions": {
+      "name": "document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_group_id": {
+          "name": "translation_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_type": {
+          "name": "schema_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_versions_document": {
+          "name": "idx_versions_document",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_scope": {
+          "name": "idx_versions_scope",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_document_id_documents_document_id_fk": {
+          "name": "document_versions_document_id_documents_document_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["document_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_versions_project_id_projects_id_fk": {
+          "name": "document_versions_project_id_projects_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_versions_environment_id_environments_id_fk": {
+          "name": "document_versions_environment_id_environments_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_document_versions_env_project": {
+          "name": "fk_document_versions_env_project",
+          "tableFrom": "document_versions",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id", "project_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_version": {
+          "name": "unique_document_version",
+          "nullsNotDistinct": false,
+          "columns": ["document_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "document_versions_content_format_check": {
+          "name": "document_versions_content_format_check",
+          "value": "\"document_versions\".\"content_format\" in ('md', 'mdx')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "translation_group_id": {
+          "name": "translation_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_type": {
+          "name": "schema_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_unpublished_changes": {
+          "name": "has_unpublished_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_documents_active_scope_type_locale_path": {
+          "name": "idx_documents_active_scope_type_locale_path",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_active_scope_updated_at": {
+          "name": "idx_documents_active_scope_updated_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_active_scope_unpublished_updated_at": {
+          "name": "idx_documents_active_scope_unpublished_updated_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"is_deleted\" = false and \"documents\".\"has_unpublished_changes\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_scope_translation_group": {
+          "name": "idx_documents_scope_translation_group",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "translation_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_documents_active_path": {
+          "name": "uniq_documents_active_path",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"documents\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_documents_active_translation_locale": {
+          "name": "uniq_documents_active_translation_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "translation_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"documents\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_project_id_projects_id_fk": {
+          "name": "documents_project_id_projects_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_environment_id_environments_id_fk": {
+          "name": "documents_environment_id_environments_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_documents_env_project": {
+          "name": "fk_documents_env_project",
+          "tableFrom": "documents",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id", "project_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_documents_published_version": {
+          "name": "fk_documents_published_version",
+          "tableFrom": "documents",
+          "tableTo": "document_versions",
+          "columnsFrom": ["document_id", "published_version"],
+          "columnsTo": ["document_id", "version"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "documents_content_format_check": {
+          "name": "documents_content_format_check",
+          "value": "\"documents\".\"content_format\" in ('md', 'mdx')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_environment_id_project": {
+          "name": "unique_environment_id_project",
+          "nullsNotDistinct": false,
+          "columns": ["id", "project_id"]
+        },
+        "unique_environment_per_project": {
+          "name": "unique_environment_per_project",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grants": {
+          "name": "grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invites_email": {
+          "name": "idx_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invites_status": {
+          "name": "idx_invites_status",
+          "columns": [
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_users_id_fk": {
+          "name": "invites_created_by_user_id_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invites_token_hash": {
+          "name": "uniq_invites_token_hash",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_project_id_projects_id_fk": {
+          "name": "media_project_id_projects_id_fk",
+          "tableFrom": "media",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_type": {
+          "name": "schema_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by": {
+          "name": "applied_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documents_affected": {
+          "name": "documents_affected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_migrations_scope": {
+          "name": "idx_migrations_scope",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_project_id_projects_id_fk": {
+          "name": "migrations_project_id_projects_id_fk",
+          "tableFrom": "migrations",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_migrations_env_project": {
+          "name": "fk_migrations_env_project",
+          "tableFrom": "migrations",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id", "project_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_environment_topology_snapshots": {
+      "name": "project_environment_topology_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_snapshot_hash": {
+          "name": "config_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definitions": {
+          "name": "definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_environment_topology_snapshots_project": {
+          "name": "idx_project_environment_topology_snapshots_project",
+          "columns": [
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_environment_topology_snapshot": {
+          "name": "unique_project_environment_topology_snapshot",
+          "nullsNotDistinct": false,
+          "columns": ["project"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rbac_grants": {
+      "name": "rbac_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_prefix": {
+          "name": "path_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rbac_grants_user_active": {
+          "name": "idx_rbac_grants_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rbac_grants_scope_active": {
+          "name": "idx_rbac_grants_scope_active",
+          "columns": [
+            {
+              "expression": "scope_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rbac_grants_user_id_users_id_fk": {
+          "name": "rbac_grants_user_id_users_id_fk",
+          "tableFrom": "rbac_grants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rbac_grants_created_by_user_id_users_id_fk": {
+          "name": "rbac_grants_created_by_user_id_users_id_fk",
+          "tableFrom": "rbac_grants",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rbac_grants_role_check": {
+          "name": "rbac_grants_role_check",
+          "value": "\"rbac_grants\".\"role\" in ('owner', 'admin', 'editor', 'viewer')"
+        },
+        "rbac_grants_scope_kind_check": {
+          "name": "rbac_grants_scope_kind_check",
+          "value": "\"rbac_grants\".\"scope_kind\" in ('global', 'project', 'folder_prefix')"
+        },
+        "rbac_grants_scope_fields_check": {
+          "name": "rbac_grants_scope_fields_check",
+          "value": "(\n        (\"rbac_grants\".\"scope_kind\" = 'global' and \"rbac_grants\".\"project\" is null and \"rbac_grants\".\"environment\" is null and \"rbac_grants\".\"path_prefix\" is null)\n        or\n        (\"rbac_grants\".\"scope_kind\" = 'project' and \"rbac_grants\".\"project\" is not null and \"rbac_grants\".\"environment\" is null and \"rbac_grants\".\"path_prefix\" is null)\n        or\n        (\"rbac_grants\".\"scope_kind\" = 'folder_prefix' and \"rbac_grants\".\"project\" is not null and \"rbac_grants\".\"environment\" is not null and \"rbac_grants\".\"path_prefix\" is not null)\n      )"
+        },
+        "rbac_grants_admin_owner_global_check": {
+          "name": "rbac_grants_admin_owner_global_check",
+          "value": "(\n        \"rbac_grants\".\"role\" not in ('owner', 'admin')\n        or \"rbac_grants\".\"scope_kind\" = 'global'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.schema_registry_entries": {
+      "name": "schema_registry_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_type": {
+          "name": "schema_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "localized": {
+          "name": "localized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_schema": {
+          "name": "resolved_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schema_registry_entries_scope": {
+          "name": "idx_schema_registry_entries_scope",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schema_registry_entries_project_id_projects_id_fk": {
+          "name": "schema_registry_entries_project_id_projects_id_fk",
+          "tableFrom": "schema_registry_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schema_registry_entries_environment_id_environments_id_fk": {
+          "name": "schema_registry_entries_environment_id_environments_id_fk",
+          "tableFrom": "schema_registry_entries",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_schema_registry_entries_env_project": {
+          "name": "fk_schema_registry_entries_env_project",
+          "tableFrom": "schema_registry_entries",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id", "project_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_schema_registry_entry_per_type": {
+          "name": "unique_schema_registry_entry_per_type",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "environment_id", "schema_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schema_syncs": {
+      "name": "schema_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_config_snapshot": {
+          "name": "raw_config_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schema_syncs_scope": {
+          "name": "idx_schema_syncs_scope",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schema_syncs_project_id_projects_id_fk": {
+          "name": "schema_syncs_project_id_projects_id_fk",
+          "tableFrom": "schema_syncs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schema_syncs_environment_id_environments_id_fk": {
+          "name": "schema_syncs_environment_id_environments_id_fk",
+          "tableFrom": "schema_syncs",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_schema_syncs_env_project": {
+          "name": "fk_schema_syncs_env_project",
+          "tableFrom": "schema_syncs",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id", "project_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_schema_sync_per_environment": {
+          "name": "unique_schema_sync_per_environment",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "environment_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/0011_snapshot.json
+++ b/apps/server/drizzle/meta/0011_snapshot.json
@@ -1711,23 +1711,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "idx_project_environment_topology_snapshots_project": {
-          "name": "idx_project_environment_topology_snapshots_project",
-          "columns": [
-            {
-              "expression": "project",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1775730517964,
       "tag": "0010_big_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776124217943,
+      "tag": "0011_optimal_valeria_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -1817,6 +1817,9 @@ function createSchemaSyncPayload(
   return {
     rawConfigSnapshot: {
       project,
+      environments: {
+        production: {},
+      },
     },
     resolvedSchema: {
       Post: {

--- a/apps/server/src/lib/db/schema.contract.test.ts
+++ b/apps/server/src/lib/db/schema.contract.test.ts
@@ -315,6 +315,10 @@ test("snapshot includes required named constraints and indexes", () => {
   assert.ok(authVerificationsTable, "expected verifications table in snapshot");
   assert.ok(schemaSyncsTable, "expected schema_syncs table in snapshot");
   assert.ok(
+    projectEnvironmentTopologySnapshotsTable,
+    "expected project_environment_topology_snapshots table in snapshot",
+  );
+  assert.ok(
     schemaRegistryEntriesTable,
     "expected schema_registry_entries table in snapshot",
   );
@@ -448,11 +452,6 @@ test("snapshot includes required named constraints and indexes", () => {
     projectEnvironmentTopologySnapshotsTable.uniqueConstraints
       .unique_project_environment_topology_snapshot,
     "expected unique constraint unique_project_environment_topology_snapshot on project_environment_topology_snapshots",
-  );
-  assert.ok(
-    projectEnvironmentTopologySnapshotsTable.indexes
-      .idx_project_environment_topology_snapshots_project,
-    "expected index idx_project_environment_topology_snapshots_project on project_environment_topology_snapshots",
   );
   assert.ok(
     schemaRegistryEntriesTable.uniqueConstraints

--- a/apps/server/src/lib/db/schema.contract.test.ts
+++ b/apps/server/src/lib/db/schema.contract.test.ts
@@ -238,6 +238,13 @@ test("schema snapshot includes CMS-11/CMS-12 core tables and columns", () => {
       "raw_config_snapshot",
       "synced_at",
     ],
+    "public.project_environment_topology_snapshots": [
+      "id",
+      "project",
+      "config_snapshot_hash",
+      "definitions",
+      "synced_at",
+    ],
     "public.schema_registry_entries": [
       "id",
       "project_id",
@@ -281,6 +288,8 @@ test("snapshot includes required named constraints and indexes", () => {
   const authAccountsTable = snapshot.tables["public.accounts"];
   const authVerificationsTable = snapshot.tables["public.verifications"];
   const schemaSyncsTable = snapshot.tables["public.schema_syncs"];
+  const projectEnvironmentTopologySnapshotsTable =
+    snapshot.tables["public.project_environment_topology_snapshots"];
   const schemaRegistryEntriesTable =
     snapshot.tables["public.schema_registry_entries"];
 
@@ -434,6 +443,16 @@ test("snapshot includes required named constraints and indexes", () => {
   assert.ok(
     schemaSyncsTable.foreignKeys.fk_schema_syncs_env_project,
     "expected foreign key fk_schema_syncs_env_project on schema_syncs",
+  );
+  assert.ok(
+    projectEnvironmentTopologySnapshotsTable.uniqueConstraints
+      .unique_project_environment_topology_snapshot,
+    "expected unique constraint unique_project_environment_topology_snapshot on project_environment_topology_snapshots",
+  );
+  assert.ok(
+    projectEnvironmentTopologySnapshotsTable.indexes
+      .idx_project_environment_topology_snapshots_project,
+    "expected index idx_project_environment_topology_snapshots_project on project_environment_topology_snapshots",
   );
   assert.ok(
     schemaRegistryEntriesTable.uniqueConstraints

--- a/apps/server/src/lib/db/schema.ts
+++ b/apps/server/src/lib/db/schema.ts
@@ -324,9 +324,6 @@ export const projectEnvironmentTopologySnapshots = pgTable(
   },
   (table) => [
     unique("unique_project_environment_topology_snapshot").on(table.project),
-    index("idx_project_environment_topology_snapshots_project").on(
-      table.project,
-    ),
   ],
 );
 

--- a/apps/server/src/lib/db/schema.ts
+++ b/apps/server/src/lib/db/schema.ts
@@ -313,6 +313,23 @@ export const schemaSyncs = pgTable(
   ],
 );
 
+export const projectEnvironmentTopologySnapshots = pgTable(
+  "project_environment_topology_snapshots",
+  {
+    id: uuid().defaultRandom().primaryKey(),
+    project: text().notNull(),
+    configSnapshotHash: text().notNull(),
+    definitions: jsonb().notNull(),
+    syncedAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique("unique_project_environment_topology_snapshot").on(table.project),
+    index("idx_project_environment_topology_snapshots_project").on(
+      table.project,
+    ),
+  ],
+);
+
 export const schemaRegistryEntries = pgTable(
   "schema_registry_entries",
   {

--- a/apps/server/src/lib/demo-seed.ts
+++ b/apps/server/src/lib/demo-seed.ts
@@ -4,6 +4,7 @@ import { buildSchemaSyncPayload } from "@mdcms/shared/server";
 import { createDatabaseEnvironmentStore } from "./environments-api.js";
 import { loadServerConfig } from "./config.js";
 import type { DrizzleDatabase } from "./db.js";
+import { upsertProjectEnvironmentTopologySnapshot } from "./environment-topology.js";
 import {
   DEFAULT_ENVIRONMENT_NAME,
   ensureProjectProvisioned,
@@ -86,9 +87,17 @@ export async function ensureDemoScopeProvisioned(
     );
   }
 
+  await upsertProjectEnvironmentTopologySnapshot(options.db, {
+    project: options.project,
+    rawConfigSnapshot: buildSchemaSyncPayload(
+      loaded.config,
+      DEFAULT_ENVIRONMENT_NAME,
+    ).rawConfigSnapshot,
+    syncedAt: new Date(),
+  });
+
   const environmentStore = createDatabaseEnvironmentStore({
     db: options.db,
-    getConfig: async () => loaded.config,
   });
 
   await environmentStore.create(options.project, {

--- a/apps/server/src/lib/environment-topology.test.ts
+++ b/apps/server/src/lib/environment-topology.test.ts
@@ -5,6 +5,7 @@ import { test } from "bun:test";
 import {
   createConfigSnapshotHash,
   toProjectTopologySnapshot,
+  upsertProjectEnvironmentTopologySnapshot,
 } from "./environment-topology.js";
 
 test("toProjectTopologySnapshot strips environment-scoped fields", () => {
@@ -63,4 +64,39 @@ test("createConfigSnapshotHash is stable across object key order changes", () =>
   });
 
   assert.equal(left, right);
+});
+
+test("upsertProjectEnvironmentTopologySnapshot rejects project mismatches", async () => {
+  await assert.rejects(
+    () =>
+      upsertProjectEnvironmentTopologySnapshot(
+        {
+          insert: () => {
+            throw new Error("should not reach database insert");
+          },
+        } as never,
+        {
+          project: "docs-site",
+          rawConfigSnapshot: {
+            project: "marketing-site",
+            environments: {
+              production: {},
+            },
+          },
+          syncedAt: new Date("2026-04-14T10:00:00.000Z"),
+        },
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal("code" in error ? error.code : undefined, "INVALID_INPUT");
+      assert.equal("statusCode" in error ? error.statusCode : undefined, 400);
+      const details =
+        "details" in error && error.details && typeof error.details === "object"
+          ? (error.details as Record<string, unknown>)
+          : undefined;
+      assert.equal(details?.expected, "docs-site");
+      assert.equal(details?.actual, "marketing-site");
+      return true;
+    },
+  );
 });

--- a/apps/server/src/lib/environment-topology.test.ts
+++ b/apps/server/src/lib/environment-topology.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import {
+  createConfigSnapshotHash,
+  toProjectTopologySnapshot,
+} from "./environment-topology.js";
+
+test("toProjectTopologySnapshot strips environment-scoped fields", () => {
+  const snapshot = toProjectTopologySnapshot({
+    project: "marketing-site",
+    serverUrl: "http://localhost:4000",
+    environment: "staging",
+    contentDirectories: ["content"],
+    locales: {
+      default: "en",
+      supported: ["en", "fr"],
+    },
+    environments: {
+      preview: {
+        extends: "staging",
+      },
+      production: {},
+      staging: {
+        extends: "production",
+      },
+    },
+  });
+
+  assert.deepEqual(snapshot, {
+    project: "marketing-site",
+    environments: {
+      preview: {
+        extends: "staging",
+      },
+      production: {},
+      staging: {
+        extends: "production",
+      },
+    },
+  });
+});
+
+test("createConfigSnapshotHash is stable across object key order changes", () => {
+  const left = createConfigSnapshotHash({
+    project: "marketing-site",
+    environments: {
+      production: {},
+      staging: {
+        extends: "production",
+      },
+    },
+  });
+  const right = createConfigSnapshotHash({
+    environments: {
+      staging: {
+        extends: "production",
+      },
+      production: {},
+    },
+    project: "marketing-site",
+  });
+
+  assert.equal(left, right);
+});

--- a/apps/server/src/lib/environment-topology.ts
+++ b/apps/server/src/lib/environment-topology.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 
-import { RuntimeError, type JsonObject } from "@mdcms/shared";
+import {
+  RuntimeError,
+  stableStringifyJson,
+  type JsonObject,
+} from "@mdcms/shared";
 import { eq } from "drizzle-orm";
 
 import type { DrizzleDatabase } from "./db.js";
@@ -132,11 +136,32 @@ export function readEnvironmentDefinitionsFromRawConfigSnapshot(
     });
 }
 
+export function toProjectTopologySnapshot(
+  rawConfigSnapshot: JsonObject,
+): JsonObject {
+  const project = parseRequiredString(
+    rawConfigSnapshot.project,
+    "payload.rawConfigSnapshot.project",
+  );
+  const definitions =
+    readEnvironmentDefinitionsFromRawConfigSnapshot(rawConfigSnapshot);
+
+  return {
+    project,
+    environments: Object.fromEntries(
+      definitions.map((definition) => [
+        definition.name,
+        definition.extends ? { extends: definition.extends } : {},
+      ]),
+    ) as JsonObject,
+  };
+}
+
 export function createConfigSnapshotHash(
   rawConfigSnapshot: JsonObject,
 ): string {
   return `sha256:${createHash("sha256")
-    .update(JSON.stringify(rawConfigSnapshot))
+    .update(stableStringifyJson(rawConfigSnapshot))
     .digest("hex")}`;
 }
 
@@ -187,10 +212,10 @@ export async function upsertProjectEnvironmentTopologySnapshot(
     syncedAt: Date;
   },
 ): Promise<void> {
-  const definitions = readEnvironmentDefinitionsFromRawConfigSnapshot(
-    input.rawConfigSnapshot,
-  );
-  const configSnapshotHash = createConfigSnapshotHash(input.rawConfigSnapshot);
+  const topologySnapshot = toProjectTopologySnapshot(input.rawConfigSnapshot);
+  const definitions =
+    readEnvironmentDefinitionsFromRawConfigSnapshot(topologySnapshot);
+  const configSnapshotHash = createConfigSnapshotHash(topologySnapshot);
 
   await db
     .insert(projectEnvironmentTopologySnapshots)

--- a/apps/server/src/lib/environment-topology.ts
+++ b/apps/server/src/lib/environment-topology.ts
@@ -1,0 +1,231 @@
+import { createHash } from "node:crypto";
+
+import { RuntimeError, type JsonObject } from "@mdcms/shared";
+import { eq } from "drizzle-orm";
+
+import type { DrizzleDatabase } from "./db.js";
+import { projectEnvironmentTopologySnapshots } from "./db/schema.js";
+import { DEFAULT_ENVIRONMENT_NAME } from "./project-provisioning.js";
+
+export type PersistedEnvironmentDefinition = {
+  name: string;
+  extends: string | null;
+  isDefault: boolean;
+};
+
+export type ProjectEnvironmentTopologySnapshot = {
+  project: string;
+  configSnapshotHash: string;
+  syncedAt: string;
+  definitions: PersistedEnvironmentDefinition[];
+};
+
+function createInvalidInputError(
+  field: string,
+  message: string,
+  details: Record<string, unknown> = {},
+): RuntimeError {
+  return new RuntimeError({
+    code: "INVALID_INPUT",
+    message,
+    statusCode: 400,
+    details: {
+      field,
+      ...details,
+    },
+  });
+}
+
+function createInternalError(message: string): RuntimeError {
+  return new RuntimeError({
+    code: "INTERNAL_ERROR",
+    message,
+    statusCode: 500,
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRequiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw createInvalidInputError(
+      field,
+      `Field "${field}" must be a non-empty string.`,
+    );
+  }
+
+  return value.trim();
+}
+
+function parseOptionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  return parseRequiredString(value, field);
+}
+
+function parseStoredRequiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw createInternalError(
+      `Persisted environment topology field "${field}" is invalid.`,
+    );
+  }
+
+  return value.trim();
+}
+
+function parseStoredOptionalString(
+  value: unknown,
+  field: string,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  return parseStoredRequiredString(value, field);
+}
+
+export function readEnvironmentDefinitionsFromRawConfigSnapshot(
+  rawConfigSnapshot: JsonObject,
+): PersistedEnvironmentDefinition[] {
+  const environmentsCandidate = rawConfigSnapshot.environments;
+
+  if (!isRecord(environmentsCandidate)) {
+    throw createInvalidInputError(
+      "payload.rawConfigSnapshot.environments",
+      'Field "payload.rawConfigSnapshot.environments" must be an object.',
+      {
+        path: "payload.rawConfigSnapshot.environments",
+      },
+    );
+  }
+
+  return Object.entries(environmentsCandidate)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([environmentName, definition]) => {
+      const name = parseRequiredString(
+        environmentName,
+        `payload.rawConfigSnapshot.environments.${environmentName}`,
+      );
+
+      if (!isRecord(definition)) {
+        throw createInvalidInputError(
+          `payload.rawConfigSnapshot.environments.${name}`,
+          `Field "payload.rawConfigSnapshot.environments.${name}" must be an object.`,
+          {
+            path: `payload.rawConfigSnapshot.environments.${name}`,
+          },
+        );
+      }
+
+      return {
+        name,
+        extends: parseOptionalString(
+          definition.extends,
+          `payload.rawConfigSnapshot.environments.${name}.extends`,
+        ),
+        isDefault: name === DEFAULT_ENVIRONMENT_NAME,
+      };
+    });
+}
+
+export function createConfigSnapshotHash(
+  rawConfigSnapshot: JsonObject,
+): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(rawConfigSnapshot))
+    .digest("hex")}`;
+}
+
+function parseStoredDefinitions(
+  value: unknown,
+): PersistedEnvironmentDefinition[] {
+  if (!Array.isArray(value)) {
+    throw createInternalError(
+      "Persisted environment topology snapshot is invalid.",
+    );
+  }
+
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw createInternalError(
+        `Persisted environment topology entry ${index} is invalid.`,
+      );
+    }
+
+    const name = parseStoredRequiredString(
+      entry.name,
+      `definitions[${index}].name`,
+    );
+    const extendsName = parseStoredOptionalString(
+      entry.extends,
+      `definitions[${index}].extends`,
+    );
+
+    if (typeof entry.isDefault !== "boolean") {
+      throw createInternalError(
+        `Persisted environment topology entry ${index} is invalid.`,
+      );
+    }
+
+    return {
+      name,
+      extends: extendsName,
+      isDefault: entry.isDefault,
+    };
+  });
+}
+
+export async function upsertProjectEnvironmentTopologySnapshot(
+  db: DrizzleDatabase,
+  input: {
+    project: string;
+    rawConfigSnapshot: JsonObject;
+    syncedAt: Date;
+  },
+): Promise<void> {
+  const definitions = readEnvironmentDefinitionsFromRawConfigSnapshot(
+    input.rawConfigSnapshot,
+  );
+  const configSnapshotHash = createConfigSnapshotHash(input.rawConfigSnapshot);
+
+  await db
+    .insert(projectEnvironmentTopologySnapshots)
+    .values({
+      project: input.project,
+      configSnapshotHash,
+      definitions,
+      syncedAt: input.syncedAt,
+    })
+    .onConflictDoUpdate({
+      target: [projectEnvironmentTopologySnapshots.project],
+      set: {
+        configSnapshotHash,
+        definitions,
+        syncedAt: input.syncedAt,
+      },
+    });
+}
+
+export async function loadProjectEnvironmentTopologySnapshot(
+  db: DrizzleDatabase,
+  project: string,
+): Promise<ProjectEnvironmentTopologySnapshot | undefined> {
+  const row = await db.query.projectEnvironmentTopologySnapshots.findFirst({
+    where: eq(projectEnvironmentTopologySnapshots.project, project),
+  });
+
+  if (!row) {
+    return undefined;
+  }
+
+  return {
+    project: row.project,
+    configSnapshotHash: row.configSnapshotHash,
+    syncedAt: row.syncedAt.toISOString(),
+    definitions: parseStoredDefinitions(row.definitions),
+  };
+}

--- a/apps/server/src/lib/environment-topology.ts
+++ b/apps/server/src/lib/environment-topology.ts
@@ -213,6 +213,20 @@ export async function upsertProjectEnvironmentTopologySnapshot(
   },
 ): Promise<void> {
   const topologySnapshot = toProjectTopologySnapshot(input.rawConfigSnapshot);
+  const snapshotProject = topologySnapshot.project;
+
+  if (snapshotProject !== input.project) {
+    throw createInvalidInputError(
+      "payload.rawConfigSnapshot.project",
+      `Field "payload.rawConfigSnapshot.project" must match project "${input.project}".`,
+      {
+        path: "payload.rawConfigSnapshot.project",
+        expected: input.project,
+        actual: snapshotProject,
+      },
+    );
+  }
+
   const definitions =
     readEnvironmentDefinitionsFromRawConfigSnapshot(topologySnapshot);
   const configSnapshotHash = createConfigSnapshotHash(topologySnapshot);

--- a/apps/server/src/lib/environments-api.config.test.ts
+++ b/apps/server/src/lib/environments-api.config.test.ts
@@ -4,10 +4,15 @@ import { test } from "bun:test";
 
 import { createDatabaseEnvironmentStore } from "./environments-api.js";
 
-test("createDatabaseEnvironmentStore explains when backend config is unavailable", async () => {
+test("createDatabaseEnvironmentStore explains when synced definitions are unavailable", async () => {
   const store = createDatabaseEnvironmentStore({
-    db: {} as never,
-    getConfig: async () => undefined,
+    db: {
+      query: {
+        projectEnvironmentTopologySnapshots: {
+          findFirst: async () => undefined,
+        },
+      },
+    } as never,
   });
 
   await assert.rejects(
@@ -15,8 +20,10 @@ test("createDatabaseEnvironmentStore explains when backend config is unavailable
     (error: unknown) =>
       !!error &&
       typeof error === "object" &&
+      "code" in error &&
+      error.code === "CONFIG_SNAPSHOT_REQUIRED" &&
       "message" in error &&
       error.message ===
-        "Environment management is unavailable because the connected backend could not load mdcms.config.ts.",
+        "Environment management is unavailable until this project's config has been synced to the backend. Run cms schema sync from the host app repo.",
   );
 });

--- a/apps/server/src/lib/environments-api.config.test.ts
+++ b/apps/server/src/lib/environments-api.config.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { createDatabaseEnvironmentStore } from "./environments-api.js";
+
+test("createDatabaseEnvironmentStore explains when backend config is unavailable", async () => {
+  const store = createDatabaseEnvironmentStore({
+    db: {} as never,
+    getConfig: async () => undefined,
+  });
+
+  await assert.rejects(
+    () => store.create("marketing-site", { name: "staging" }),
+    (error: unknown) =>
+      !!error &&
+      typeof error === "object" &&
+      "message" in error &&
+      error.message ===
+        "Environment management is unavailable because the connected backend could not load mdcms.config.ts.",
+  );
+});

--- a/apps/server/src/lib/environments-api.route.test.ts
+++ b/apps/server/src/lib/environments-api.route.test.ts
@@ -20,16 +20,23 @@ test("environment routes list project-scoped environments for admin sessions", a
         store: {
           async list(project) {
             assert.equal(project, "marketing-site");
-            return [
-              {
-                id: "env-production",
-                project: "marketing-site",
-                name: "production",
-                extends: null,
-                isDefault: true,
-                createdAt: "2026-03-11T12:00:00.000Z",
+            return {
+              data: [
+                {
+                  id: "env-production",
+                  project: "marketing-site",
+                  name: "production",
+                  extends: null,
+                  isDefault: true,
+                  createdAt: "2026-03-11T12:00:00.000Z",
+                },
+              ],
+              meta: {
+                definitionsStatus: "ready",
+                configSnapshotHash: "sha256:abc123",
+                syncedAt: "2026-03-11T12:00:00.000Z",
               },
-            ];
+            };
           },
           async create() {
             throw new Error("not used");
@@ -50,6 +57,7 @@ test("environment routes list project-scoped environments for admin sessions", a
   );
   const body = (await response.json()) as {
     data: Array<{ name: string }>;
+    meta: { definitionsStatus: string };
   };
 
   assert.equal(response.status, 200);
@@ -57,6 +65,7 @@ test("environment routes list project-scoped environments for admin sessions", a
     body.data.map((entry) => entry.name),
     ["production"],
   );
+  assert.equal(body.meta.definitionsStatus, "ready");
 });
 
 test("environment routes reject create requests without admin privileges", async () => {
@@ -66,7 +75,12 @@ test("environment routes reject create requests without admin privileges", async
       mountEnvironmentApiRoutes(app, {
         store: {
           async list() {
-            return [];
+            return {
+              data: [],
+              meta: {
+                definitionsStatus: "missing",
+              },
+            };
           },
           async create() {
             throw new Error("not used");

--- a/apps/server/src/lib/environments-api.test.ts
+++ b/apps/server/src/lib/environments-api.test.ts
@@ -9,6 +9,7 @@ import postgres from "postgres";
 import {
   documents,
   environments,
+  projectEnvironmentTopologySnapshots,
   rbacGrants,
   schemaSyncs,
 } from "./db/schema.js";
@@ -199,6 +200,62 @@ async function grantGlobalOwner(
     .onConflictDoNothing();
 }
 
+async function insertTopologySnapshot(
+  db: ReturnType<
+    typeof createServerRequestHandlerWithModules
+  >["dbConnection"]["db"],
+  project: string,
+) {
+  await db
+    .insert(projectEnvironmentTopologySnapshots)
+    .values({
+      project,
+      configSnapshotHash: "sha256:test-topology",
+      definitions: [
+        {
+          name: "preview",
+          extends: "staging",
+          isDefault: false,
+        },
+        {
+          name: "production",
+          extends: null,
+          isDefault: true,
+        },
+        {
+          name: "staging",
+          extends: "production",
+          isDefault: false,
+        },
+      ],
+      syncedAt: new Date("2026-03-19T10:00:00.000Z"),
+    })
+    .onConflictDoUpdate({
+      target: [projectEnvironmentTopologySnapshots.project],
+      set: {
+        configSnapshotHash: "sha256:test-topology",
+        definitions: [
+          {
+            name: "preview",
+            extends: "staging",
+            isDefault: false,
+          },
+          {
+            name: "production",
+            extends: null,
+            isDefault: true,
+          },
+          {
+            name: "staging",
+            extends: "production",
+            isDefault: false,
+          },
+        ],
+        syncedAt: new Date("2026-03-19T10:00:00.000Z"),
+      },
+    });
+}
+
 type EnvironmentSummary = {
   id: string;
   project: string;
@@ -228,6 +285,7 @@ testWithDatabase(
         loginResult.session.userId,
         "test:environments-success-owner",
       );
+      await insertTopologySnapshot(dbConnection.db, project);
 
       const createResponse = await handler(
         new Request(`http://localhost/api/v1/environments?project=${project}`, {
@@ -260,9 +318,15 @@ testWithDatabase(
       );
       const listBody = (await listResponse.json()) as {
         data: EnvironmentSummary[];
+        meta: {
+          definitionsStatus: string;
+          configSnapshotHash: string;
+        };
       };
 
       assert.equal(listResponse.status, 200);
+      assert.equal(listBody.meta.definitionsStatus, "ready");
+      assert.equal(listBody.meta.configSnapshotHash, "sha256:test-topology");
       assert.deepEqual(
         listBody.data.map((entry) => ({
           project: entry.project,
@@ -307,6 +371,53 @@ testWithDatabase(
 );
 
 testWithDatabase(
+  "environments API requires a synced topology snapshot before create",
+  async () => {
+    const { handler, dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: testConfig,
+    });
+    const email = uniqueEmail();
+    const password = "Admin12345!";
+    const project = uniqueProject("env-missing-topology");
+
+    try {
+      await signUp(handler, { email, password });
+      const loginResult = await login(handler, { email, password });
+      await grantGlobalOwner(
+        dbConnection.db,
+        loginResult.session.userId,
+        "test:environments-missing-topology-owner",
+      );
+
+      const createResponse = await handler(
+        new Request(`http://localhost/api/v1/environments?project=${project}`, {
+          method: "POST",
+          headers: createCsrfHeaders(loginResult, {
+            "content-type": "application/json",
+          }),
+          body: JSON.stringify({
+            name: "staging",
+            extends: "production",
+          }),
+        }),
+      );
+      const createBody = (await createResponse.json()) as {
+        code: string;
+        message: string;
+      };
+
+      assert.equal(createResponse.status, 409);
+      assert.equal(createBody.code, "CONFIG_SNAPSHOT_REQUIRED");
+      assert.match(createBody.message, /cms schema sync/i);
+    } finally {
+      await dbConnection.close();
+    }
+  },
+);
+
+testWithDatabase(
   "environments API rejects session mutations without CSRF and accepts matching tokens",
   async () => {
     const { handler, dbConnection } = createServerRequestHandlerWithModules({
@@ -326,6 +437,7 @@ testWithDatabase(
         loginResult.session.userId,
         "test:environments-csrf-owner",
       );
+      await insertTopologySnapshot(dbConnection.db, project);
 
       const missingHeaderResponse = await handler(
         new Request(`http://localhost/api/v1/environments?project=${project}`, {
@@ -387,6 +499,7 @@ testWithDatabase(
         loginResult.session.userId,
         "test:environments-invalid-owner",
       );
+      await insertTopologySnapshot(dbConnection.db, project);
 
       const firstCreateResponse = await handler(
         new Request(`http://localhost/api/v1/environments?project=${project}`, {
@@ -482,6 +595,7 @@ testWithDatabase(
         loginResult.session.userId,
         "test:environments-delete-owner",
       );
+      await insertTopologySnapshot(dbConnection.db, project);
 
       const createStagingResponse = await handler(
         new Request(`http://localhost/api/v1/environments?project=${project}`, {
@@ -697,6 +811,8 @@ testWithDatabase(
         loginResult.session.userId,
         "test:environments-project-owner",
       );
+      await insertTopologySnapshot(dbConnection.db, primaryProject);
+      await insertTopologySnapshot(dbConnection.db, foreignProject);
 
       const primaryCreateResponse = await handler(
         new Request(

--- a/apps/server/src/lib/environments-api.ts
+++ b/apps/server/src/lib/environments-api.ts
@@ -153,7 +153,8 @@ async function requireConfig(
   if (!config) {
     throw new RuntimeError({
       code: "INTERNAL_ERROR",
-      message: "Server config is required to manage environments.",
+      message:
+        "Environment management is unavailable because the connected backend could not load mdcms.config.ts.",
       statusCode: 500,
     });
   }

--- a/apps/server/src/lib/environments-api.ts
+++ b/apps/server/src/lib/environments-api.ts
@@ -2,8 +2,9 @@ import {
   RuntimeError,
   assertEnvironmentCreateInput,
   type EnvironmentCreateInput,
+  type EnvironmentDefinitionsMeta,
+  type EnvironmentListResponse,
   type EnvironmentSummary,
-  type ParsedMdcmsConfig,
   resolveRequestTargetRouting,
 } from "@mdcms/shared";
 import { and, eq, sql } from "drizzle-orm";
@@ -17,6 +18,10 @@ import {
   schemaRegistryEntries,
   schemaSyncs,
 } from "./db/schema.js";
+import {
+  loadProjectEnvironmentTopologySnapshot,
+  type PersistedEnvironmentDefinition,
+} from "./environment-topology.js";
 import { executeWithRuntimeErrorsHandled } from "./http-utils.js";
 import {
   DEFAULT_ENVIRONMENT_NAME,
@@ -36,7 +41,7 @@ type EnvironmentRouteApp = {
 };
 
 export type EnvironmentStore = {
-  list: (project: string) => Promise<EnvironmentSummary[]>;
+  list: (project: string) => Promise<EnvironmentListResponse>;
   create: (
     project: string,
     input: EnvironmentCreateInput,
@@ -68,7 +73,6 @@ export type MountEnvironmentApiRoutesOptions = {
 
 export type CreateDatabaseEnvironmentStoreOptions = {
   db: DrizzleDatabase;
-  getConfig: () => Promise<ParsedMdcmsConfig | undefined>;
 };
 
 function createInvalidInputError(
@@ -96,6 +100,18 @@ function createConflictError(
     message,
     statusCode: 409,
     details,
+  });
+}
+
+function createConfigSnapshotRequiredError(project: string): RuntimeError {
+  return new RuntimeError({
+    code: "CONFIG_SNAPSHOT_REQUIRED",
+    message:
+      "Environment management is unavailable until this project's config has been synced to the backend. Run cms schema sync from the host app repo.",
+    statusCode: 409,
+    details: {
+      project,
+    },
   });
 }
 
@@ -133,45 +149,54 @@ function toIsoString(value: unknown): string {
 function toEnvironmentSummary(input: {
   project: string;
   row: typeof environments.$inferSelect;
-  config?: ParsedMdcmsConfig;
+  definition?: PersistedEnvironmentDefinition;
 }): EnvironmentSummary {
   return {
     id: input.row.id,
     project: input.project,
     name: input.row.name,
-    extends: input.config?.environments[input.row.name]?.extends ?? null,
-    isDefault: input.row.name === DEFAULT_ENVIRONMENT_NAME,
+    extends: input.definition?.extends ?? null,
+    isDefault:
+      input.definition?.isDefault ??
+      input.row.name === DEFAULT_ENVIRONMENT_NAME,
     createdAt: toIsoString(input.row.createdAt),
   };
 }
 
-async function requireConfig(
-  getConfig: () => Promise<ParsedMdcmsConfig | undefined>,
-): Promise<ParsedMdcmsConfig> {
-  const config = await getConfig();
-
-  if (!config) {
-    throw new RuntimeError({
-      code: "INTERNAL_ERROR",
-      message:
-        "Environment management is unavailable because the connected backend could not load mdcms.config.ts.",
-      statusCode: 500,
-    });
+function toDefinitionsMeta(
+  snapshot: Awaited<ReturnType<typeof loadProjectEnvironmentTopologySnapshot>>,
+): EnvironmentDefinitionsMeta {
+  if (!snapshot) {
+    return {
+      definitionsStatus: "missing",
+    };
   }
 
-  return config;
+  return {
+    definitionsStatus: "ready",
+    configSnapshotHash: snapshot.configSnapshotHash,
+    syncedAt: snapshot.syncedAt,
+  };
 }
 
-function assertEnvironmentAllowedByConfig(
-  config: ParsedMdcmsConfig,
+function toDefinitionMap(
+  definitions: readonly PersistedEnvironmentDefinition[],
+): Map<string, PersistedEnvironmentDefinition> {
+  return new Map(
+    definitions.map((definition) => [definition.name, definition]),
+  );
+}
+
+function assertEnvironmentAllowedByDefinitions(
+  definitions: Map<string, PersistedEnvironmentDefinition>,
   input: EnvironmentCreateInput,
 ): void {
-  const definition = config.environments[input.name];
+  const definition = definitions.get(input.name);
 
   if (!definition) {
     throw createInvalidInputError(
       "name",
-      `Environment "${input.name}" is not defined in mdcms.config.ts.`,
+      `Environment "${input.name}" is not defined in the latest synced project config snapshot.`,
       {
         environment: input.name,
       },
@@ -184,7 +209,7 @@ function assertEnvironmentAllowedByConfig(
   if (providedExtends !== null && providedExtends !== expectedExtends) {
     throw createInvalidInputError(
       "extends",
-      `Environment "${input.name}" must extend "${expectedExtends ?? "null"}" according to mdcms.config.ts.`,
+      `Environment "${input.name}" must extend "${expectedExtends ?? "null"}" according to the latest synced project config snapshot.`,
       {
         environment: input.name,
         expectedExtends,
@@ -197,34 +222,41 @@ function assertEnvironmentAllowedByConfig(
 export function createDatabaseEnvironmentStore(
   options: CreateDatabaseEnvironmentStoreOptions,
 ): EnvironmentStore {
-  const { db, getConfig } = options;
+  const { db } = options;
 
   return {
     async list(project) {
       const normalizedProject = assertRequiredString(project, "project");
-      const [projectRow, config] = await Promise.all([
+      const [projectRow, snapshot] = await Promise.all([
         findProjectBySlug(db, normalizedProject),
-        getConfig(),
+        loadProjectEnvironmentTopologySnapshot(db, normalizedProject),
       ]);
 
       if (!projectRow) {
-        return [];
+        return {
+          data: [],
+          meta: toDefinitionsMeta(snapshot),
+        };
       }
 
       const rows = await db
         .select()
         .from(environments)
         .where(eq(environments.projectId, projectRow.id));
+      const definitions = toDefinitionMap(snapshot?.definitions ?? []);
 
-      return rows
-        .map((row) =>
-          toEnvironmentSummary({
-            project: normalizedProject,
-            row,
-            config: config ?? undefined,
-          }),
-        )
-        .sort((left, right) => left.name.localeCompare(right.name));
+      return {
+        data: rows
+          .map((row) =>
+            toEnvironmentSummary({
+              project: normalizedProject,
+              row,
+              definition: definitions.get(row.name),
+            }),
+          )
+          .sort((left, right) => left.name.localeCompare(right.name)),
+        meta: toDefinitionsMeta(snapshot),
+      };
     },
 
     async create(project, input) {
@@ -237,9 +269,18 @@ export function createDatabaseEnvironmentStore(
             }
           : {}),
       } satisfies EnvironmentCreateInput;
-      const config = await requireConfig(getConfig);
+      const snapshot = await loadProjectEnvironmentTopologySnapshot(
+        db,
+        normalizedProject,
+      );
 
-      assertEnvironmentAllowedByConfig(config, payload);
+      if (!snapshot) {
+        throw createConfigSnapshotRequiredError(normalizedProject);
+      }
+
+      const definitions = toDefinitionMap(snapshot.definitions);
+
+      assertEnvironmentAllowedByDefinitions(definitions, payload);
 
       return db.transaction(async (tx) => {
         const existingProject = await findProjectBySlug(
@@ -295,7 +336,7 @@ export function createDatabaseEnvironmentStore(
           return toEnvironmentSummary({
             project: normalizedProject,
             row: productionRow,
-            config,
+            definition: definitions.get(productionRow.name),
           });
         }
 
@@ -330,7 +371,7 @@ export function createDatabaseEnvironmentStore(
         return toEnvironmentSummary({
           project: normalizedProject,
           row: created,
-          config,
+          definition: definitions.get(created.name),
         });
       });
     },
@@ -474,11 +515,9 @@ export function mountEnvironmentApiRoutes(
   environmentApp.get?.("/api/v1/environments", ({ request }: any) => {
     return executeWithRuntimeErrorsHandled(request, async () => {
       const project = pickProject(request);
-      await options.authorizeSession(request);
+      await options.authorizeAdmin(request);
 
-      return {
-        data: await options.store.list(project),
-      };
+      return options.store.list(project);
     });
   });
 

--- a/apps/server/src/lib/runtime-with-modules.ts
+++ b/apps/server/src/lib/runtime-with-modules.ts
@@ -37,7 +37,6 @@ import {
   createDatabaseProjectStore,
   mountProjectApiRoutes,
 } from "./projects-api.js";
-import { loadServerConfig } from "./config.js";
 import type { ParsedMdcmsConfig } from "@mdcms/shared";
 import {
   createRefreshingStudioRuntimePublicationSelection,
@@ -116,22 +115,8 @@ export function createServerRequestHandlerWithModules(
   });
   const contentStore = createDatabaseContentStore({ db: dbConnection.db });
   const schemaStore = createDatabaseSchemaStore({ db: dbConnection.db });
-  let configPromise: Promise<ParsedMdcmsConfig | undefined> | undefined;
-  const getConfig = () => {
-    if (options.config) {
-      return Promise.resolve(options.config);
-    }
-
-    configPromise ??= loadServerConfig({
-      cwd: options.cwd,
-      configPath: options.configPath,
-    }).then((loaded) => loaded?.config);
-
-    return configPromise;
-  };
   const environmentStore = createDatabaseEnvironmentStore({
     db: dbConnection.db,
-    getConfig,
   });
   const projectStore = createDatabaseProjectStore({ db: dbConnection.db });
   const actions = collectServerModuleActions(moduleLoadReport);

--- a/apps/server/src/lib/schema-api.test.ts
+++ b/apps/server/src/lib/schema-api.test.ts
@@ -10,6 +10,7 @@ import { createDatabaseConnection } from "./db.js";
 import {
   documents,
   environments,
+  projectEnvironmentTopologySnapshots,
   projects,
   rbacGrants,
   schemaRegistryEntries,
@@ -271,6 +272,9 @@ function createSyncPayload(input: {
   return {
     rawConfigSnapshot: {
       project: "marketing-site",
+      environments: {
+        production: {},
+      },
       ...(input.supportedLocales
         ? {
             locales: {
@@ -605,6 +609,24 @@ testWithDatabase(
         Reflect.has(syncRows[0] ?? {}, "extractedComponents"),
         false,
       );
+
+      const topologyRows = await dbConnection.db
+        .select()
+        .from(projectEnvironmentTopologySnapshots)
+        .where(eq(projectEnvironmentTopologySnapshots.project, scope.project));
+
+      assert.equal(topologyRows.length, 1);
+      assert.equal(
+        topologyRows[0]?.configSnapshotHash.startsWith("sha256:"),
+        true,
+      );
+      assert.deepEqual(topologyRows[0]?.definitions, [
+        {
+          name: "production",
+          extends: null,
+          isDefault: true,
+        },
+      ]);
 
       const entryRows = await dbConnection.db
         .select()

--- a/apps/server/src/lib/schema-api.test.ts
+++ b/apps/server/src/lib/schema-api.test.ts
@@ -718,6 +718,77 @@ testWithDatabase(
 );
 
 testWithDatabase(
+  "schema API keeps the project topology hash stable across environment-specific sync payloads",
+  async () => {
+    const dbConnection = createDatabaseConnection({ env: dbEnv });
+    const store = createDatabaseSchemaStore({
+      db: dbConnection.db,
+      now: () => fixedNow,
+    });
+    const project = `schema-topology-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    const productionScope = { project, environment: "production" };
+    const stagingScope = { project, environment: "staging" };
+    const baseRawConfigSnapshot = {
+      project,
+      serverUrl: "http://localhost:4000",
+      environments: {
+        production: {},
+        staging: {
+          extends: "production",
+        },
+      },
+    };
+
+    try {
+      await seedScope(dbConnection, productionScope);
+      await seedScope(dbConnection, stagingScope);
+
+      await store.sync(productionScope, {
+        rawConfigSnapshot: {
+          ...baseRawConfigSnapshot,
+          environment: "production",
+        },
+        resolvedSchema: {},
+        schemaHash: "hash-production",
+      });
+
+      const firstTopologyRow =
+        await dbConnection.db.query.projectEnvironmentTopologySnapshots.findFirst(
+          {
+            where: eq(projectEnvironmentTopologySnapshots.project, project),
+          },
+        );
+      assert.ok(firstTopologyRow);
+
+      await store.sync(stagingScope, {
+        rawConfigSnapshot: {
+          ...baseRawConfigSnapshot,
+          environment: "staging",
+        },
+        resolvedSchema: {},
+        schemaHash: "hash-staging",
+      });
+
+      const secondTopologyRow =
+        await dbConnection.db.query.projectEnvironmentTopologySnapshots.findFirst(
+          {
+            where: eq(projectEnvironmentTopologySnapshots.project, project),
+          },
+        );
+      assert.ok(secondTopologyRow);
+      assert.equal(
+        firstTopologyRow.configSnapshotHash,
+        secondTopologyRow.configSnapshotHash,
+      );
+    } finally {
+      await dbConnection.close();
+    }
+  },
+);
+
+testWithDatabase(
   "schema API rejects removing a type that still has active documents",
   async () => {
     const { handler, dbConnection } = createHandler();

--- a/apps/server/src/lib/schema-api.test.ts
+++ b/apps/server/src/lib/schema-api.test.ts
@@ -265,13 +265,14 @@ async function insertDocument(
 }
 
 function createSyncPayload(input: {
+  project?: string;
   schemaHash: string;
   supportedLocales?: string[];
   resolvedSchema: Record<string, unknown>;
 }) {
   return {
     rawConfigSnapshot: {
-      project: "marketing-site",
+      project: input.project ?? "marketing-site",
       environments: {
         production: {},
       },
@@ -459,6 +460,7 @@ testWithDatabase(
     const scope = createScope();
     const scopeHeaders = toScopeHeaders(scope);
     const payload = createSyncPayload({
+      project: scope.project,
       schemaHash: "csrf-hash-1",
       resolvedSchema: {
         Post: createRegistryType({
@@ -539,6 +541,7 @@ testWithDatabase(
       const scopeIds = await seedScope(dbConnection, scope);
       const scopeHeaders = toScopeHeaders(scope);
       const payload = createSyncPayload({
+        project: scope.project,
         schemaHash: "hash-1",
         supportedLocales: ["en", "fr"],
         resolvedSchema: {
@@ -798,6 +801,7 @@ testWithDatabase(
       const scopeIds = await seedScope(dbConnection, scope);
       const scopeHeaders = toScopeHeaders(scope);
       const initialPayload = createSyncPayload({
+        project: scope.project,
         schemaHash: "hash-1",
         resolvedSchema: {
           Post: createRegistryType({
@@ -837,6 +841,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-2",
               resolvedSchema: {},
             }),
@@ -876,6 +881,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-1",
               resolvedSchema: {
                 Post: createRegistryType({
@@ -911,6 +917,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-2",
               resolvedSchema: {
                 Post: createRegistryType({
@@ -959,6 +966,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-1",
               supportedLocales: ["en", "fr"],
               resolvedSchema: {
@@ -992,6 +1000,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-2",
               supportedLocales: ["en"],
               resolvedSchema: {
@@ -1041,6 +1050,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-1",
               supportedLocales: ["en", "fr"],
               resolvedSchema: {
@@ -1081,6 +1091,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-2",
               supportedLocales: ["en", "fr"],
               resolvedSchema: {
@@ -1131,6 +1142,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-1",
               resolvedSchema: {
                 Post: createRegistryType({
@@ -1163,6 +1175,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: scope.project,
               schemaHash: "hash-2",
               resolvedSchema: {},
             }),
@@ -1204,6 +1217,7 @@ testWithDatabase(
           },
           body: JSON.stringify(
             createSyncPayload({
+              project: marketingScope.project,
               schemaHash: "hash-marketing",
               resolvedSchema: {
                 Post: createRegistryType({

--- a/apps/server/src/lib/schema-api.ts
+++ b/apps/server/src/lib/schema-api.ts
@@ -14,7 +14,10 @@ import { and, eq, sql } from "drizzle-orm";
 import type { ApiKeyOperationScope, AuthorizationRequirement } from "./auth.js";
 import type { DrizzleDatabase } from "./db.js";
 import { documents, schemaRegistryEntries, schemaSyncs } from "./db/schema.js";
-import { upsertProjectEnvironmentTopologySnapshot } from "./environment-topology.js";
+import {
+  toProjectTopologySnapshot,
+  upsertProjectEnvironmentTopologySnapshot,
+} from "./environment-topology.js";
 import { executeWithRuntimeErrorsHandled } from "./http-utils.js";
 import { resolveProjectEnvironmentScope } from "./project-provisioning.js";
 
@@ -703,6 +706,9 @@ export function createDatabaseSchemaStore(
         const affectedTypes = Object.keys(payload.resolvedSchema).sort(
           (left, right) => left.localeCompare(right),
         );
+        const topologySnapshot = toProjectTopologySnapshot(
+          payload.rawConfigSnapshot,
+        );
 
         await tx
           .insert(schemaSyncs)
@@ -726,7 +732,7 @@ export function createDatabaseSchemaStore(
           tx as unknown as DrizzleDatabase,
           {
             project: scope.project,
-            rawConfigSnapshot: payload.rawConfigSnapshot,
+            rawConfigSnapshot: topologySnapshot,
             syncedAt,
           },
         );

--- a/apps/server/src/lib/schema-api.ts
+++ b/apps/server/src/lib/schema-api.ts
@@ -14,6 +14,7 @@ import { and, eq, sql } from "drizzle-orm";
 import type { ApiKeyOperationScope, AuthorizationRequirement } from "./auth.js";
 import type { DrizzleDatabase } from "./db.js";
 import { documents, schemaRegistryEntries, schemaSyncs } from "./db/schema.js";
+import { upsertProjectEnvironmentTopologySnapshot } from "./environment-topology.js";
 import { executeWithRuntimeErrorsHandled } from "./http-utils.js";
 import { resolveProjectEnvironmentScope } from "./project-provisioning.js";
 
@@ -720,6 +721,15 @@ export function createDatabaseSchemaStore(
               syncedAt,
             },
           });
+
+        await upsertProjectEnvironmentTopologySnapshot(
+          tx as unknown as DrizzleDatabase,
+          {
+            project: scope.project,
+            rawConfigSnapshot: payload.rawConfigSnapshot,
+            syncedAt,
+          },
+        );
 
         await tx
           .delete(schemaRegistryEntries)

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.test.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.test.ts
@@ -2,7 +2,30 @@ import assert from "node:assert/strict";
 
 import { test } from "bun:test";
 
-import { POST } from "./route";
+import { GET, POST } from "./route";
+
+test("environment review GET returns environments with readiness metadata", async () => {
+  const response = await GET(
+    new Request("http://localhost/review-api/owner/api/v1/environments"),
+    {
+      params: Promise.resolve({
+        scenario: "owner",
+      }),
+    },
+  );
+
+  const payload = (await response.json()) as {
+    data: Array<{ name: string }>;
+    meta: { definitionsStatus: string };
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.meta.definitionsStatus, "ready");
+  assert.deepEqual(
+    payload.data.map((environment) => environment.name),
+    ["production", "staging"],
+  );
+});
 
 test("environment review POST returns 400 for malformed json bodies", async () => {
   const response = await POST(

--- a/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
+++ b/apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.ts
@@ -63,9 +63,7 @@ export async function GET(
   try {
     const { scenario } = await context.params;
 
-    return Response.json({
-      data: listReviewEnvironments(scenario),
-    });
+    return Response.json(listReviewEnvironments(scenario));
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/studio-review/review/environments.test.ts
+++ b/apps/studio-review/review/environments.test.ts
@@ -16,9 +16,10 @@ beforeEach(() => {
 test("listReviewEnvironments allows owner scenarios and returns seeded rows", () => {
   const environments = listReviewEnvironments("owner");
 
-  assert.equal(environments.length, 2);
-  assert.equal(environments[0]?.name, "production");
-  assert.equal(environments[1]?.name, "staging");
+  assert.equal(environments.meta.definitionsStatus, "ready");
+  assert.equal(environments.data.length, 2);
+  assert.equal(environments.data[0]?.name, "production");
+  assert.equal(environments.data[1]?.name, "staging");
 });
 
 test("listReviewEnvironments forbids non-admin scenarios", () => {
@@ -37,8 +38,8 @@ test("createReviewEnvironment persists newly created review rows", () => {
   const environments = listReviewEnvironments("owner");
 
   assert.equal(created.name, "preview");
-  assert.equal(environments.length, 3);
-  assert.equal(environments[2]?.name, "preview");
+  assert.equal(environments.data.length, 3);
+  assert.equal(environments.data[2]?.name, "preview");
 });
 
 test("createReviewEnvironment forbids non-admin scenarios", () => {
@@ -59,7 +60,7 @@ test("deleteReviewEnvironment removes non-default rows and rejects deleting prod
     deleted: true,
     id: "env-staging",
   });
-  assert.equal(listReviewEnvironments("owner").length, 1);
+  assert.equal(listReviewEnvironments("owner").data.length, 1);
 
   assert.throws(
     () => deleteReviewEnvironment("owner", "env-production"),

--- a/apps/studio-review/review/environments.test.ts
+++ b/apps/studio-review/review/environments.test.ts
@@ -34,12 +34,18 @@ test("listReviewEnvironments forbids non-admin scenarios", () => {
 });
 
 test("createReviewEnvironment persists newly created review rows", () => {
+  const before = listReviewEnvironments("owner");
   const created = createReviewEnvironment("owner", { name: "preview" });
   const environments = listReviewEnvironments("owner");
 
   assert.equal(created.name, "preview");
   assert.equal(environments.data.length, 3);
   assert.equal(environments.data[2]?.name, "preview");
+  assert.notEqual(
+    before.meta.configSnapshotHash,
+    environments.meta.configSnapshotHash,
+  );
+  assert.notEqual(before.meta.syncedAt, environments.meta.syncedAt);
 });
 
 test("createReviewEnvironment forbids non-admin scenarios", () => {
@@ -54,13 +60,20 @@ test("createReviewEnvironment forbids non-admin scenarios", () => {
 });
 
 test("deleteReviewEnvironment removes non-default rows and rejects deleting production", () => {
+  const before = listReviewEnvironments("owner");
   const deleted = deleteReviewEnvironment("owner", "env-staging");
+  const after = listReviewEnvironments("owner");
 
   assert.deepEqual(deleted, {
     deleted: true,
     id: "env-staging",
   });
-  assert.equal(listReviewEnvironments("owner").data.length, 1);
+  assert.equal(after.data.length, 1);
+  assert.notEqual(
+    before.meta.configSnapshotHash,
+    after.meta.configSnapshotHash,
+  );
+  assert.notEqual(before.meta.syncedAt, after.meta.syncedAt);
 
   assert.throws(
     () => deleteReviewEnvironment("owner", "env-production"),

--- a/apps/studio-review/review/environments.ts
+++ b/apps/studio-review/review/environments.ts
@@ -1,12 +1,21 @@
+import { createHash } from "node:crypto";
+
 import {
   RuntimeError,
   type EnvironmentListResponse,
   type EnvironmentSummary,
+  stableStringifyJson,
+  type JsonValue,
 } from "@mdcms/shared";
 
 import { getReviewScenario } from "./scenarios";
 
-type ReviewEnvironmentStore = Map<string, EnvironmentSummary[]>;
+type ReviewEnvironmentStoreEntry = {
+  environments: EnvironmentSummary[];
+  syncedAt: string;
+};
+
+type ReviewEnvironmentStore = Map<string, ReviewEnvironmentStoreEntry>;
 
 const reviewEnvironmentSeeds: readonly EnvironmentSummary[] = [
   {
@@ -27,20 +36,42 @@ const reviewEnvironmentSeeds: readonly EnvironmentSummary[] = [
   },
 ] as const;
 
+const REVIEW_ENVIRONMENT_SEED_SYNCED_AT = "2026-03-20T10:00:00.000Z";
+
 const store: ReviewEnvironmentStore = new Map();
 
 function cloneSeedData(): EnvironmentSummary[] {
   return reviewEnvironmentSeeds.map((environment) => ({ ...environment }));
 }
 
-function readScenarioStore(scenarioId: string): EnvironmentSummary[] {
+function createReviewConfigSnapshotHash(
+  environments: EnvironmentSummary[],
+): string {
+  return `sha256:${createHash("sha256")
+    .update(stableStringifyJson(environments as unknown as JsonValue))
+    .digest("hex")}`;
+}
+
+function bumpSyncedAt(currentSyncedAt: string): string {
+  const currentTimestamp = Date.parse(currentSyncedAt);
+  const minimumNextTimestamp = Number.isNaN(currentTimestamp)
+    ? 0
+    : currentTimestamp + 1;
+
+  return new Date(Math.max(Date.now(), minimumNextTimestamp)).toISOString();
+}
+
+function readScenarioStore(scenarioId: string): ReviewEnvironmentStoreEntry {
   const existing = store.get(scenarioId);
 
   if (existing) {
     return existing;
   }
 
-  const seeded = cloneSeedData();
+  const seeded: ReviewEnvironmentStoreEntry = {
+    environments: cloneSeedData(),
+    syncedAt: REVIEW_ENVIRONMENT_SEED_SYNCED_AT,
+  };
   store.set(scenarioId, seeded);
   return seeded;
 }
@@ -96,14 +127,16 @@ export function listReviewEnvironments(
     throw createForbiddenError();
   }
 
+  const entry = readScenarioStore(scenarioId);
+
   return {
-    data: readScenarioStore(scenarioId).map((environment) => ({
+    data: entry.environments.map((environment) => ({
       ...environment,
     })),
     meta: {
       definitionsStatus: "ready",
-      configSnapshotHash: "sha256:review-scenario",
-      syncedAt: "2026-03-19T10:00:00.000Z",
+      configSnapshotHash: createReviewConfigSnapshotHash(entry.environments),
+      syncedAt: entry.syncedAt,
     },
   };
 }
@@ -122,7 +155,8 @@ export function createReviewEnvironment(
     throw createInvalidInputError();
   }
 
-  const environments = readScenarioStore(scenarioId);
+  const entry = readScenarioStore(scenarioId);
+  const environments = entry.environments;
 
   if (environments.some((environment) => environment.name === name)) {
     throw createConflictError(`Environment "${name}" already exists.`);
@@ -138,6 +172,7 @@ export function createReviewEnvironment(
   };
 
   environments.push(created);
+  entry.syncedAt = bumpSyncedAt(entry.syncedAt);
 
   return { ...created };
 }
@@ -150,7 +185,8 @@ export function deleteReviewEnvironment(
     throw createForbiddenError();
   }
 
-  const environments = readScenarioStore(scenarioId);
+  const entry = readScenarioStore(scenarioId);
+  const environments = entry.environments;
   const index = environments.findIndex(
     (environment) => environment.id === environmentId,
   );
@@ -172,6 +208,7 @@ export function deleteReviewEnvironment(
   }
 
   environments.splice(index, 1);
+  entry.syncedAt = bumpSyncedAt(entry.syncedAt);
 
   return {
     deleted: true,

--- a/apps/studio-review/review/environments.ts
+++ b/apps/studio-review/review/environments.ts
@@ -1,4 +1,8 @@
-import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
+import {
+  RuntimeError,
+  type EnvironmentListResponse,
+  type EnvironmentSummary,
+} from "@mdcms/shared";
 
 import { getReviewScenario } from "./scenarios";
 
@@ -87,14 +91,21 @@ export function resetReviewEnvironmentStore(): void {
 
 export function listReviewEnvironments(
   scenarioId: string,
-): EnvironmentSummary[] {
+): EnvironmentListResponse {
   if (!canManageReviewEnvironments(scenarioId)) {
     throw createForbiddenError();
   }
 
-  return readScenarioStore(scenarioId).map((environment) => ({
-    ...environment,
-  }));
+  return {
+    data: readScenarioStore(scenarioId).map((environment) => ({
+      ...environment,
+    })),
+    meta: {
+      definitionsStatus: "ready",
+      configSnapshotHash: "sha256:review-scenario",
+      syncedAt: "2026-03-19T10:00:00.000Z",
+    },
+  };
 }
 
 export function createReviewEnvironment(

--- a/docs/specs/SPEC-004-schema-system-and-sync.md
+++ b/docs/specs/SPEC-004-schema-system-and-sync.md
@@ -120,6 +120,7 @@ Schema updates are persisted to the backend schema registry only through explici
 - Studio may trigger the same sync operation as a developer convenience action (for example, a "Sync Schema" button in Settings) for privileged users (Owner/Admin). It only forwards the local `mdcms.config.ts` snapshot; it does not create or edit schema definitions in the UI.
 - `cms migrate` is used only when existing content must be transformed/backfilled to satisfy schema changes.
 - CI/CD pipelines should run `cms schema sync` before deploy-time writes.
+- The backend does not read `mdcms.config.ts` from the host app repo at request time. Sync publishes the config-derived backend state needed for schema and environment operations.
 
 **Registry model:**
 
@@ -127,6 +128,7 @@ Schema updates are persisted to the backend schema registry only through explici
 - The read surface is type-centric: `GET /schema` returns one entry per content type for the target environment.
 - The server persists:
   - one environment-level sync record containing `schemaHash`, `rawConfigSnapshot`, and `syncedAt`
+  - one project-level environment topology snapshot derived from `rawConfigSnapshot`, containing the latest synced environment names and `extends` graph for the project
   - derived per-type registry entries for the target environment
 
 **Snapshot fidelity limitation:**
@@ -216,7 +218,7 @@ export default defineConfig({
 
 **Environment inheritance:** Environments can extend other environments via `extends`, creating a chain (e.g., `production → staging → preview`). Each level only specifies its incremental changes.
 
-**Runtime environment provisioning:** The environments API provisions and removes project-local database rows for environments, but it does not author schema topology. Runtime environment records must correspond to names defined in `mdcms.config.ts`, and any reported `extends` value is derived from the config-defined environment graph rather than persisted separately in the database.
+**Runtime environment provisioning:** The environments API provisions and removes project-local database rows for environments, but it does not author schema topology. Runtime environment records must correspond to names defined in the latest synced project environment topology snapshot derived from `mdcms.config.ts`. The backend does not require direct filesystem access to the host app repo at request time; request-time validation uses the most recent successful sync state.
 
 **Validation per environment:** When content is read or written, the server validates against the **target environment's resolved schema**. Fields that exist in one environment but not another are silently stripped from API responses (Zod's default `strip` behavior). Data is preserved in the database — it's just invisible at the API layer for environments whose schema doesn't include that field.
 
@@ -323,6 +325,7 @@ Notes:
 
 - `schemaHash` and `syncedAt` are repeated on each entry for the target environment.
 - `rawConfigSnapshot` is stored with the environment-level sync record and is not returned by `GET` endpoints.
+- The latest successful `PUT /api/v1/schema` also refreshes the project-level environment topology snapshot derived from `rawConfigSnapshot`.
 - `resolvedSchema` is a descriptive JSON snapshot for the type, not an executable validator.
 
 | Method | Path                   | Auth Mode          | Required Scope | Target Routing                  | Request                                                   | Success                                                   | Deterministic Errors                                                                                                                                                     |

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -457,12 +457,19 @@ Normative behavior:
 - The route manages only list/create/delete behavior in MVP. Clone, promote,
   rename, description editing, and other environment workflows are out of scope
   for this route until their owning work is specified.
-- Environment rows are rendered from the live `EnvironmentSummary[]` contract.
-  Studio must not render mock environment metadata, synthetic document counts,
-  or fake promotion history on this route.
+- Environment rows are rendered from the live `EnvironmentSummary[]` contract,
+  and the route also consumes the `GET /api/v1/environments` metadata that
+  reports whether synced environment definitions are available. Studio must not
+  render mock environment metadata, synthetic document counts, or fake
+  promotion history on this route.
 - The create flow submits `{ name }` to `POST /api/v1/environments`. Studio may
-  omit `extends` and rely on the server-side config validation rules defined by
-  the environment-management contract.
+  omit `extends` and rely on the server-side synced environment-definition
+  validation rules defined by the environment-management contract.
+- If `GET /api/v1/environments` reports `meta.definitionsStatus = "missing"`,
+  the route remains readable but the create affordance must stay disabled or
+  immediately explain that environment management requires a successful
+  `cms schema sync` from the host app repo before new environments can be
+  created.
 - On successful create, the creation dialog closes and the environment list
   reloads from the live API before the new row is presented as ready.
 - The default `production` environment is rendered as the non-deletable default
@@ -472,8 +479,13 @@ Normative behavior:
   UI.
 - The route must surface deterministic server failures truthfully:
   - `INVALID_INPUT` (`400`) on create is shown inline on the creation form.
+  - `CONFIG_SNAPSHOT_REQUIRED` (`409`) on create is shown inline on the
+    creation form with actionable guidance to run `cms schema sync` from the
+    host app repo.
   - `CONFLICT` (`409`) on create or delete is shown inline without replacing the
-    current ready view.
+    current ready view. When the delete confirmation dialog is still open, the
+    delete conflict is shown inside that dialog instead of as a detached page
+    error.
   - `NOT_FOUND` (`404`) on delete is surfaced as a non-destructive row/action
     failure and followed by a live list reload.
 - The shell navigation entry for `/admin/environments` follows the same
@@ -497,7 +509,8 @@ Deterministic states:
   route renders an error state with a retry action.
 - If `GET /api/v1/environments` succeeds with zero rows, the route renders an
   empty state for the active project. When the current caller is allowed to use
-  the route, the empty state may include the create affordance.
+  the route and synced environment definitions are available, the empty state
+  may include the create affordance.
 - When the list request succeeds with one or more rows, the route renders a
   ready state with per-row metadata limited to the live environment summary
   contract (`name`, `extends`, default status, `createdAt`).

--- a/docs/specs/SPEC-009-i18n-and-environments.md
+++ b/docs/specs/SPEC-009-i18n-and-environments.md
@@ -271,25 +271,46 @@ All `/api/v1/environments*` endpoints require explicit project routing. Clone/pr
 }
 ```
 
+`EnvironmentDefinitionsMeta`:
+
+```json
+{
+  "definitionsStatus": "ready",
+  "configSnapshotHash": "sha256:abc123",
+  "syncedAt": "2026-03-11T12:00:00.000Z"
+}
+```
+
+Notes:
+
+- `definitionsStatus` is `ready` or `missing`.
+- `configSnapshotHash` and `syncedAt` are returned only when
+  `definitionsStatus` is `ready`.
+
 Rules:
 
 - Environment management requires an authenticated Studio session with global `owner` or `admin` privileges.
-- `mdcms.config.ts` is authoritative for valid environment names and `extends` chains.
+- The latest synced project config snapshot derived from `mdcms.config.ts` is authoritative for valid environment names and `extends` chains.
+- `GET /api/v1/environments` may return existing environment rows even when no synced project config snapshot is available yet. In that case:
+  - `meta.definitionsStatus` is `missing`
+  - `extends` may be `null` for rows whose parent chain cannot be derived from synced config
 - `POST /api/v1/environments` may create the project row implicitly if it does not yet exist; any such provisioning must also ensure a default `production` environment row exists transactionally.
 - `POST /api/v1/environments` accepts `{ name, extends? }`.
+  - a synced project config snapshot must exist; otherwise the request fails with `CONFIG_SNAPSHOT_REQUIRED` (`409`)
   - `name` must be non-empty and unique within the routed project.
-  - `name` must exist in config-defined environments.
-  - if `extends` is provided, it must exactly match the config-defined parent for that environment.
+  - `name` must exist in the synced environment definitions for the routed project.
+  - if `extends` is provided, it must exactly match the synced parent for that environment.
   - creating `production` succeeds only when that row is missing; otherwise it returns `CONFLICT`.
 - `DELETE /api/v1/environments/:id`:
   - must reject deleting `production`
   - must reject deleting environments that still have content rows or schema sync state
   - returns `NOT_FOUND` when the environment id does not belong to the routed project
+  - must not fail solely because the latest synced project config snapshot is missing
 
-| Method | Path                                     | Auth Mode          | Required Scope         | Target Routing      | Request                                                                                                  | Success                                                    | Deterministic Errors                                                                                                                                          |
-| ------ | ---------------------------------------- | ------------------ | ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GET    | `/api/v1/environments`                   | session            | none                   | required: `project` | explicit project routing only                                                                            | `200` `{ data: EnvironmentSummary[] }`                     | `MISSING_TARGET_ROUTING` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`)                                                                                 |
-| POST   | `/api/v1/environments`                   | session            | none                   | required: `project` | JSON: `{ name, extends? }`                                                                               | `200` `{ data: EnvironmentSummary }`                       | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `CONFLICT` (`409`)                                    |
-| DELETE | `/api/v1/environments/:id`               | session            | none                   | required: `project` | path `id`                                                                                                | `200` `{ data: { deleted: true, id } }`                    | `MISSING_TARGET_ROUTING` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `CONFLICT` (`409`)                                        |
-| POST   | `/api/v1/environments/:id/clone`         | session_or_api_key | `environments:clone`   | required: `project` | path `id`; JSON: `{ sourceEnvironmentId, include: { content, settings }, includeDrafts, preservePaths }` | `200` `{ data: { targetEnvironmentId, documentsCloned } }` | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `REFERENCE_REMAP_FAILED` (`409`) |
-| POST   | `/api/v1/environments/:targetId/promote` | session_or_api_key | `environments:promote` | required: `project` | path `targetId`; JSON: `{ sourceEnvironmentId, documentIds, includeUnpublished, dryRun }`                | `200` `{ data: { promoted: DocumentPromotionResult[] } }`  | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `REFERENCE_REMAP_FAILED` (`409`) |
+| Method | Path                                     | Auth Mode          | Required Scope         | Target Routing      | Request                                                                                                  | Success                                                                  | Deterministic Errors                                                                                                                                           |
+| ------ | ---------------------------------------- | ------------------ | ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/v1/environments`                   | session            | none                   | required: `project` | explicit project routing only                                                                            | `200` `{ data: EnvironmentSummary[], meta: EnvironmentDefinitionsMeta }` | `MISSING_TARGET_ROUTING` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`)                                                                                  |
+| POST   | `/api/v1/environments`                   | session            | none                   | required: `project` | JSON: `{ name, extends? }`                                                                               | `200` `{ data: EnvironmentSummary }`                                     | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `CONFIG_SNAPSHOT_REQUIRED` (`409`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `CONFLICT` (`409`) |
+| DELETE | `/api/v1/environments/:id`               | session            | none                   | required: `project` | path `id`                                                                                                | `200` `{ data: { deleted: true, id } }`                                  | `MISSING_TARGET_ROUTING` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `CONFLICT` (`409`)                                         |
+| POST   | `/api/v1/environments/:id/clone`         | session_or_api_key | `environments:clone`   | required: `project` | path `id`; JSON: `{ sourceEnvironmentId, include: { content, settings }, includeDrafts, preservePaths }` | `200` `{ data: { targetEnvironmentId, documentsCloned } }`               | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `REFERENCE_REMAP_FAILED` (`409`)  |
+| POST   | `/api/v1/environments/:targetId/promote` | session_or_api_key | `environments:promote` | required: `project` | path `targetId`; JSON: `{ sourceEnvironmentId, documentIds, includeUnpublished, dryRun }`                | `200` `{ data: { promoted: DocumentPromotionResult[] } }`                | `MISSING_TARGET_ROUTING` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `REFERENCE_REMAP_FAILED` (`409`)  |

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -85,8 +85,12 @@ This package is intentionally scaffolded in CMS-1 to provide a stable import bou
 
 - Shared environment management surface:
   - `EnvironmentSummary`
+  - `EnvironmentDefinitionsMeta`
+  - `EnvironmentListResponse`
   - `EnvironmentCreateInput`
   - `assertEnvironmentSummary(...)`
+  - `assertEnvironmentDefinitionsMeta(...)`
+  - `assertEnvironmentListResponse(...)`
   - `assertEnvironmentCreateInput(...)`
 - `EnvironmentSummary` is the canonical admin-facing environment payload:
   - `id`
@@ -96,8 +100,12 @@ This package is intentionally scaffolded in CMS-1 to provide a stable import bou
   - `isDefault`
   - `createdAt`
 - Environment management remains config-authoritative:
-  - valid environment names come from `mdcms.config.ts`
-  - `extends` metadata is derived from config, not authored in the database
+  - valid environment names come from the latest synced config snapshot derived
+    from `mdcms.config.ts`
+  - `GET /api/v1/environments` returns `EnvironmentListResponse` with
+    definitions readiness metadata
+  - `extends` metadata is derived from the synced topology snapshot, not
+    authored in the database
 
 ## Schema Registry Contracts (CMS-17)
 

--- a/packages/shared/src/lib/contracts/environments.test.ts
+++ b/packages/shared/src/lib/contracts/environments.test.ts
@@ -4,6 +4,8 @@ import { test } from "bun:test";
 import { RuntimeError } from "../runtime/error.js";
 import {
   assertEnvironmentCreateInput,
+  assertEnvironmentDefinitionsMeta,
+  assertEnvironmentListResponse,
   assertEnvironmentSummary,
 } from "./environments.js";
 
@@ -91,5 +93,57 @@ test("assertEnvironmentSummary uses the provided path in error messages", () => 
       error instanceof RuntimeError &&
       error.code === "INVALID_INPUT" &&
       error.message.includes("response.data"),
+  );
+});
+
+test("assertEnvironmentDefinitionsMeta accepts ready and missing metadata", () => {
+  assert.doesNotThrow(() =>
+    assertEnvironmentDefinitionsMeta({
+      definitionsStatus: "ready",
+      configSnapshotHash: "sha256:abc123",
+      syncedAt: "2026-03-19T10:00:00.000Z",
+    }),
+  );
+
+  assert.doesNotThrow(() =>
+    assertEnvironmentDefinitionsMeta({
+      definitionsStatus: "missing",
+    }),
+  );
+});
+
+test("assertEnvironmentDefinitionsMeta rejects incomplete ready metadata", () => {
+  assert.throws(
+    () =>
+      assertEnvironmentDefinitionsMeta({
+        definitionsStatus: "ready",
+        syncedAt: "2026-03-19T10:00:00.000Z",
+      }),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.code === "INVALID_INPUT" &&
+      error.message.includes("value.configSnapshotHash"),
+  );
+});
+
+test("assertEnvironmentListResponse validates environment rows with readiness metadata", () => {
+  assert.doesNotThrow(() =>
+    assertEnvironmentListResponse({
+      data: [
+        {
+          id: "env-production",
+          project: "marketing-site",
+          name: "production",
+          extends: null,
+          isDefault: true,
+          createdAt: "2026-03-19T10:00:00.000Z",
+        },
+      ],
+      meta: {
+        definitionsStatus: "ready",
+        configSnapshotHash: "sha256:abc123",
+        syncedAt: "2026-03-19T10:00:00.000Z",
+      },
+    }),
   );
 });

--- a/packages/shared/src/lib/contracts/environments.ts
+++ b/packages/shared/src/lib/contracts/environments.ts
@@ -10,12 +10,40 @@ export type EnvironmentSummary = {
   createdAt: string;
 };
 
+export type EnvironmentDefinitionsMeta =
+  | {
+      definitionsStatus: "missing";
+    }
+  | {
+      definitionsStatus: "ready";
+      configSnapshotHash: string;
+      syncedAt: string;
+    };
+
+export type EnvironmentListResponse = {
+  data: EnvironmentSummary[];
+  meta: EnvironmentDefinitionsMeta;
+};
+
 export type EnvironmentCreateInput = {
   name: string;
   extends?: string;
 };
 
 const NonEmptyStringSchema = z.string().trim().min(1);
+const EnvironmentDefinitionsMetaSchema = z.discriminatedUnion(
+  "definitionsStatus",
+  [
+    z.object({
+      definitionsStatus: z.literal("missing"),
+    }),
+    z.object({
+      definitionsStatus: z.literal("ready"),
+      configSnapshotHash: NonEmptyStringSchema,
+      syncedAt: NonEmptyStringSchema,
+    }),
+  ],
+);
 const EnvironmentCreateInputSchema = z.object({
   name: NonEmptyStringSchema,
   extends: NonEmptyStringSchema.nullable().optional(),
@@ -27,6 +55,10 @@ const EnvironmentSummarySchema = z.object({
   extends: NonEmptyStringSchema.nullable().optional(),
   isDefault: z.boolean(),
   createdAt: NonEmptyStringSchema,
+});
+const EnvironmentListResponseSchema = z.object({
+  data: z.array(EnvironmentSummarySchema),
+  meta: EnvironmentDefinitionsMetaSchema,
 });
 
 function invalidInput(
@@ -85,4 +117,18 @@ export function assertEnvironmentSummary(
   path = "value",
 ): asserts value is EnvironmentSummary {
   assertWithSchema(EnvironmentSummarySchema, value, path);
+}
+
+export function assertEnvironmentDefinitionsMeta(
+  value: unknown,
+  path = "value",
+): asserts value is EnvironmentDefinitionsMeta {
+  assertWithSchema(EnvironmentDefinitionsMetaSchema, value, path);
+}
+
+export function assertEnvironmentListResponse(
+  value: unknown,
+  path = "value",
+): asserts value is EnvironmentListResponse {
+  assertWithSchema(EnvironmentListResponseSchema, value, path);
 }

--- a/packages/shared/src/lib/contracts/schema-hash.ts
+++ b/packages/shared/src/lib/contracts/schema-hash.ts
@@ -2,22 +2,27 @@ import { createHash } from "node:crypto";
 
 import type { ParsedMdcmsConfig } from "./config.js";
 import {
+  buildSchemaRegistrySyncPayloadBase,
+  serializeSchemaRegistrySyncHashInput,
   type SchemaRegistrySyncPayload,
-  serializeResolvedEnvironmentSchema,
-  toRawConfigSnapshot,
 } from "./schema.js";
 
 export function buildSchemaSyncPayload(
   config: ParsedMdcmsConfig,
   environment: string,
 ): SchemaRegistrySyncPayload {
-  const rawConfigSnapshot = toRawConfigSnapshot(config);
-  const resolvedSchema = serializeResolvedEnvironmentSchema(
-    config,
-    environment,
-  );
+  const payloadBase = buildSchemaRegistrySyncPayloadBase(config, environment);
   const schemaHash = createHash("sha256")
-    .update(JSON.stringify({ environment, rawConfigSnapshot, resolvedSchema }))
+    .update(
+      serializeSchemaRegistrySyncHashInput({
+        environment,
+        ...payloadBase,
+      }),
+    )
     .digest("hex");
-  return { rawConfigSnapshot, resolvedSchema, schemaHash };
+
+  return {
+    ...payloadBase,
+    schemaHash,
+  };
 }

--- a/packages/shared/src/lib/contracts/schema.test.ts
+++ b/packages/shared/src/lib/contracts/schema.test.ts
@@ -14,6 +14,7 @@ import {
   assertSchemaRegistryEntry,
   assertSchemaRegistrySyncPayload,
   serializeResolvedEnvironmentSchema,
+  stableStringifyJson,
   toRawConfigSnapshot,
   type SchemaRegistryEntry,
 } from "./schema.js";
@@ -437,6 +438,41 @@ test("toRawConfigSnapshot omits contentDirectories when empty", () => {
   const snapshot = toRawConfigSnapshot(parsed);
 
   assert.equal(snapshot.contentDirectories, undefined);
+});
+
+test("stableStringifyJson sorts object keys recursively and preserves array order", () => {
+  const left = stableStringifyJson({
+    z: [
+      {
+        beta: 2,
+        alpha: 1,
+      },
+      "tail",
+    ],
+    a: {
+      delta: 4,
+      gamma: 3,
+    },
+  });
+  const right = stableStringifyJson({
+    a: {
+      gamma: 3,
+      delta: 4,
+    },
+    z: [
+      {
+        alpha: 1,
+        beta: 2,
+      },
+      "tail",
+    ],
+  });
+
+  assert.equal(
+    left,
+    '{"a":{"delta":4,"gamma":3},"z":[{"alpha":1,"beta":2},"tail"]}',
+  );
+  assert.equal(left, right);
 });
 
 test("buildSchemaSyncPayload returns rawConfigSnapshot, resolvedSchema and a deterministic hash", () => {

--- a/packages/shared/src/lib/contracts/schema.test.ts
+++ b/packages/shared/src/lib/contracts/schema.test.ts
@@ -328,7 +328,37 @@ test("toRawConfigSnapshot includes project, serverUrl and omits implicit locales
   assert.equal(snapshot.project, "my-site");
   assert.equal(snapshot.serverUrl, "http://localhost:4000");
   assert.deepEqual(snapshot.contentDirectories, ["content"]);
+  assert.deepEqual(snapshot.environments, {
+    production: {},
+  });
   assert.equal(snapshot.locales, undefined);
+});
+
+test("toRawConfigSnapshot includes environment topology definitions", () => {
+  const parsed = parseMdcmsConfig(
+    defineConfig({
+      project: "marketing-site",
+      serverUrl: "http://localhost:4000",
+      types: [
+        defineType("Post", {
+          fields: { title: z.string() },
+        }),
+      ],
+      environments: {
+        production: {},
+        staging: { extends: "production" },
+        preview: { extends: "staging" },
+      },
+    }),
+  );
+
+  const snapshot = toRawConfigSnapshot(parsed);
+
+  assert.deepEqual(snapshot.environments, {
+    preview: { extends: "staging" },
+    production: {},
+    staging: { extends: "production" },
+  });
 });
 
 test("toRawConfigSnapshot includes explicit locales with aliases when configured", () => {

--- a/packages/shared/src/lib/contracts/schema.ts
+++ b/packages/shared/src/lib/contracts/schema.ts
@@ -140,6 +140,31 @@ export function assertJsonObject(
   assertJsonValue(value, path);
 }
 
+export function stableStringifyJson(value: JsonValue): string {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringifyJson(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+
+  return `{${entries
+    .map(
+      ([key, entry]) => `${JSON.stringify(key)}:${stableStringifyJson(entry)}`,
+    )
+    .join(",")}}`;
+}
+
 function readSchemaMetadata(value: object): unknown {
   const candidate = value as { meta?: () => unknown };
   return typeof candidate.meta === "function" ? candidate.meta() : undefined;

--- a/packages/shared/src/lib/contracts/schema.ts
+++ b/packages/shared/src/lib/contracts/schema.ts
@@ -49,6 +49,15 @@ export type SchemaRegistrySyncPayload = {
   schemaHash: string;
 };
 
+export type SchemaRegistrySyncPayloadBase = Omit<
+  SchemaRegistrySyncPayload,
+  "schemaHash"
+>;
+
+export type SchemaRegistrySyncHashInput = SchemaRegistrySyncPayloadBase & {
+  environment: string;
+};
+
 type SerializerContext = {
   required: boolean;
   nullable: boolean;
@@ -791,6 +800,22 @@ export type SchemaStateFile = {
   syncedAt: string;
   serverUrl: string;
 };
+
+export function buildSchemaRegistrySyncPayloadBase(
+  config: ParsedMdcmsConfig,
+  environmentName: string,
+): SchemaRegistrySyncPayloadBase {
+  return {
+    rawConfigSnapshot: toRawConfigSnapshot(config),
+    resolvedSchema: serializeResolvedEnvironmentSchema(config, environmentName),
+  };
+}
+
+export function serializeSchemaRegistrySyncHashInput(
+  input: SchemaRegistrySyncHashInput,
+): string {
+  return stableStringifyJson(input as JsonValue);
+}
 
 export function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
   const environments = Object.fromEntries(

--- a/packages/shared/src/lib/contracts/schema.ts
+++ b/packages/shared/src/lib/contracts/schema.ts
@@ -768,10 +768,22 @@ export type SchemaStateFile = {
 };
 
 export function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
+  const environments = Object.fromEntries(
+    Object.entries(config.environments)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, definition]) => [
+        name,
+        (definition.extends
+          ? { extends: definition.extends }
+          : {}) as JsonObject,
+      ]),
+  ) as JsonObject;
+
   return {
     project: config.project,
     serverUrl: config.serverUrl,
     ...(config.environment ? { environment: config.environment } : {}),
+    environments,
     ...(config.contentDirectories.length > 0
       ? { contentDirectories: config.contentDirectories }
       : {}),

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -201,13 +201,17 @@ environments[]` so the document sidebar can label environment-specific
   - `DELETE /api/v1/environments/:id`
 - The page is intentionally scoped to list/create/delete only.
 - It renders deterministic loading, empty, forbidden, error, and ready states.
+- `GET /api/v1/environments` metadata gates create when synced environment
+  definitions are missing.
 - Environment rows render only contract-backed metadata:
   - `name`
   - `extends`
   - default status
   - `createdAt`
 - The create dialog submits `{ name }`; the server remains authoritative for
-  config-defined environment validation.
+  validation against the latest synced project config snapshot.
+- When definitions are missing, Studio keeps the page readable but disables
+  create with guidance to run `cms schema sync` from the host app repo.
 - The default `production` environment is rendered as non-deletable.
 
 ## Schema Browser

--- a/packages/studio/src/lib/document-route-schema.test.ts
+++ b/packages/studio/src/lib/document-route-schema.test.ts
@@ -9,7 +9,13 @@ import {
   resolveStudioDocumentRoutePreparedMetadata,
   type StudioDocumentRouteSchemaCapability,
 } from "./document-route-schema.js";
-import { defineConfig, defineType, reference } from "@mdcms/shared";
+import {
+  defineConfig,
+  defineType,
+  parseMdcmsConfig,
+  reference,
+} from "@mdcms/shared";
+import { buildSchemaSyncPayload } from "@mdcms/shared/server";
 
 const unsupportedExecutableFieldSchema = {
   "~standard": {
@@ -133,6 +139,31 @@ test("derived schema details expose the local sync payload pieces", async () => 
     "Author",
   ]);
   assert.match(details.syncPayload.schemaHash, /^[a-f0-9]{64}$/);
+});
+
+test("derived schema details use the shared schema-hash construction", async () => {
+  const config = createAuthoredConfig();
+  const details = await resolveStudioDocumentRouteSchemaDetails(config);
+
+  assert.equal(details.canWrite, true);
+  if (!details.canWrite) {
+    throw new Error("Expected a write-capable schema result.");
+  }
+
+  const sharedPayload = buildSchemaSyncPayload(
+    parseMdcmsConfig(config),
+    "staging",
+  );
+
+  assert.equal(details.syncPayload.schemaHash, sharedPayload.schemaHash);
+  assert.deepEqual(
+    details.syncPayload.rawConfigSnapshot,
+    sharedPayload.rawConfigSnapshot,
+  );
+  assert.deepEqual(
+    details.syncPayload.resolvedSchema,
+    sharedPayload.resolvedSchema,
+  );
 });
 
 test("prepared document route metadata includes per-environment hashes and field targets", async () => {

--- a/packages/studio/src/lib/document-route-schema.test.ts
+++ b/packages/studio/src/lib/document-route-schema.test.ts
@@ -112,6 +112,12 @@ test("derived schema details expose the local sync payload pieces", async () => 
     project: "marketing-site",
     serverUrl: "http://localhost:4000",
     environment: "staging",
+    environments: {
+      production: {},
+      staging: {
+        extends: "production",
+      },
+    },
     contentDirectories: ["content"],
     locales: {
       default: "en",
@@ -180,6 +186,7 @@ test("equivalent authored config data yields the same schema hash", async () => 
       ],
       environments: {
         staging: {
+          extends: "production",
           types: {
             Author: {
               modify: {

--- a/packages/studio/src/lib/document-route-schema.ts
+++ b/packages/studio/src/lib/document-route-schema.ts
@@ -1,10 +1,10 @@
 import {
   parseMdcmsConfig,
   serializeResolvedEnvironmentSchema,
-  type JsonObject,
   type MdcmsConfig as SharedMdcmsConfig,
   type ParsedMdcmsConfig,
   type SchemaRegistrySyncPayload,
+  toRawConfigSnapshot,
 } from "@mdcms/shared";
 
 export type StudioDocumentRouteSchemaCapability =
@@ -39,40 +39,6 @@ export type StudioDocumentRoutePreparedMetadata = {
   schemaHashesByEnvironment: Record<string, string>;
   environmentFieldTargets: Record<string, Record<string, string[]>>;
 };
-
-function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
-  const environments = Object.fromEntries(
-    Object.entries(config.environments)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([name, definition]) => [
-        name,
-        (definition.extends
-          ? { extends: definition.extends }
-          : {}) as JsonObject,
-      ]),
-  ) as JsonObject;
-
-  return {
-    project: config.project,
-    serverUrl: config.serverUrl,
-    ...(config.environment ? { environment: config.environment } : {}),
-    environments,
-    ...(config.contentDirectories.length > 0
-      ? { contentDirectories: config.contentDirectories }
-      : {}),
-    ...(config.locales.implicit
-      ? {}
-      : {
-          locales: {
-            default: config.locales.default,
-            supported: config.locales.supported,
-            ...(Object.keys(config.locales.aliases).length > 0
-              ? { aliases: config.locales.aliases }
-              : {}),
-          },
-        }),
-  };
-}
 
 function encodeUtf8(value: string): Uint8Array {
   return new TextEncoder().encode(value);

--- a/packages/studio/src/lib/document-route-schema.ts
+++ b/packages/studio/src/lib/document-route-schema.ts
@@ -1,10 +1,10 @@
 import {
+  buildSchemaRegistrySyncPayloadBase,
   parseMdcmsConfig,
-  serializeResolvedEnvironmentSchema,
+  serializeSchemaRegistrySyncHashInput,
   type MdcmsConfig as SharedMdcmsConfig,
   type ParsedMdcmsConfig,
   type SchemaRegistrySyncPayload,
-  toRawConfigSnapshot,
 } from "@mdcms/shared";
 
 export type StudioDocumentRouteSchemaCapability =
@@ -156,25 +156,32 @@ function resolveEnvironmentFieldTargets(
   return result;
 }
 
+async function buildStudioSchemaSyncPayload(
+  config: ParsedMdcmsConfig,
+  environment: string,
+): Promise<SchemaRegistrySyncPayload> {
+  const payloadBase = buildSchemaRegistrySyncPayloadBase(config, environment);
+  const schemaHash = await sha256Hex(
+    serializeSchemaRegistrySyncHashInput({
+      environment,
+      ...payloadBase,
+    }),
+  );
+
+  return {
+    ...payloadBase,
+    schemaHash,
+  };
+}
+
 async function resolveSchemaHashesByEnvironment(
   config: ParsedMdcmsConfig,
 ): Promise<Record<string, string>> {
-  const rawConfigSnapshot = toRawConfigSnapshot(config);
   const entries = await Promise.all(
     listResolvedEnvironments(config).map(async (environment) => {
-      const resolvedSchema = serializeResolvedEnvironmentSchema(
-        config,
-        environment,
-      );
-      const schemaHash = await sha256Hex(
-        JSON.stringify({
-          environment,
-          rawConfigSnapshot,
-          resolvedSchema,
-        }),
-      );
+      const payload = await buildStudioSchemaSyncPayload(config, environment);
 
-      return [environment, schemaHash] as const;
+      return [environment, payload.schemaHash] as const;
     }),
   );
 
@@ -255,29 +262,15 @@ export async function resolveStudioDocumentRouteSchemaDetails(
   }
 
   try {
-    const rawConfigSnapshot = toRawConfigSnapshot(parsedConfig);
-    const resolvedSchema = serializeResolvedEnvironmentSchema(
+    const syncPayload = await buildStudioSchemaSyncPayload(
       parsedConfig,
       environment,
     );
-    const schemaHash = (await resolveSchemaHashesByEnvironment(parsedConfig))[
-      environment
-    ];
-
-    if (!schemaHash) {
-      throw new Error(
-        `Studio writes require a resolved schema for environment "${environment}".`,
-      );
-    }
 
     return {
       canWrite: true,
       environment,
-      syncPayload: {
-        rawConfigSnapshot,
-        resolvedSchema,
-        schemaHash,
-      },
+      syncPayload,
     };
   } catch (error) {
     return createReadOnlyCapability(

--- a/packages/studio/src/lib/document-route-schema.ts
+++ b/packages/studio/src/lib/document-route-schema.ts
@@ -41,10 +41,22 @@ export type StudioDocumentRoutePreparedMetadata = {
 };
 
 function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
+  const environments = Object.fromEntries(
+    Object.entries(config.environments)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, definition]) => [
+        name,
+        (definition.extends
+          ? { extends: definition.extends }
+          : {}) as JsonObject,
+      ]),
+  ) as JsonObject;
+
   return {
     project: config.project,
     serverUrl: config.serverUrl,
     ...(config.environment ? { environment: config.environment } : {}),
+    environments,
     ...(config.contentDirectories.length > 0
       ? { contentDirectories: config.contentDirectories }
       : {}),

--- a/packages/studio/src/lib/environment-api.test.ts
+++ b/packages/studio/src/lib/environment-api.test.ts
@@ -62,10 +62,20 @@ test("list fetches environments with project header", async () => {
     auth: { mode: "cookie" },
     fetcher: async (input, init) => {
       calls.push({ input, init });
-      return new Response(JSON.stringify({ data: [validEnvSummary] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({
+          data: [validEnvSummary],
+          meta: {
+            definitionsStatus: "ready",
+            configSnapshotHash: "sha256:abc123",
+            syncedAt: "2026-03-19T10:00:00.000Z",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     },
   });
 
@@ -78,22 +88,34 @@ test("list fetches environments with project header", async () => {
   );
   assert.equal(readHeader(calls[0]?.init, "x-mdcms-project"), "marketing-site");
   assert.equal(readHeader(calls[0]?.init, "x-mdcms-environment"), "production");
-  assert.equal(result.length, 1);
-  assert.equal(result[0]?.name, "production");
+  assert.equal(result.data.length, 1);
+  assert.equal(result.data[0]?.name, "production");
+  assert.equal(result.meta.definitionsStatus, "ready");
 });
 
 test("list returns empty array for empty response", async () => {
   const api = createApi({
     fetcher: async () =>
-      new Response(JSON.stringify({ data: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+      new Response(
+        JSON.stringify({
+          data: [],
+          meta: {
+            definitionsStatus: "missing",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
   });
 
   const result = await api.list();
 
-  assert.deepEqual(result, []);
+  assert.deepEqual(result.data, []);
+  assert.deepEqual(result.meta, {
+    definitionsStatus: "missing",
+  });
 });
 
 test("list resolves scenario-relative environment routes", async () => {
@@ -103,10 +125,20 @@ test("list resolves scenario-relative environment routes", async () => {
     {
       fetcher: async (input, init) => {
         calls.push({ input, init });
-        return new Response(JSON.stringify({ data: [validEnvSummary] }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
+        return new Response(
+          JSON.stringify({
+            data: [validEnvSummary],
+            meta: {
+              definitionsStatus: "ready",
+              configSnapshotHash: "sha256:abc123",
+              syncedAt: "2026-03-19T10:00:00.000Z",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
       },
     },
     {

--- a/packages/studio/src/lib/environment-api.ts
+++ b/packages/studio/src/lib/environment-api.ts
@@ -1,8 +1,10 @@
 import {
   RuntimeError,
   assertEnvironmentCreateInput,
+  assertEnvironmentListResponse,
   assertEnvironmentSummary,
   type EnvironmentCreateInput,
+  type EnvironmentListResponse,
   type EnvironmentSummary,
 } from "@mdcms/shared";
 
@@ -25,7 +27,7 @@ export type StudioEnvironmentApiOptions = {
 };
 
 export type StudioEnvironmentApi = {
-  list: () => Promise<EnvironmentSummary[]>;
+  list: () => Promise<EnvironmentListResponse>;
   create: (input: EnvironmentCreateInput) => Promise<EnvironmentSummary>;
   delete: (environmentId: string) => Promise<void>;
 };
@@ -110,6 +112,14 @@ function parseEnvironmentSummaryFromPayload(
   return data;
 }
 
+function parseEnvironmentListResponseFromPayload(
+  payload: unknown,
+  path: string,
+): EnvironmentListResponse {
+  assertEnvironmentListResponse(payload, path);
+  return payload;
+}
+
 export function createStudioEnvironmentApi(
   config: StudioEnvironmentApiConfig,
   options: StudioEnvironmentApiOptions = {},
@@ -141,15 +151,7 @@ export function createStudioEnvironmentApi(
         );
       }
 
-      if (!isRecord(payload) || !Array.isArray(payload.data)) {
-        return [];
-      }
-
-      payload.data.forEach((item, index) => {
-        assertEnvironmentSummary(item, `response.data[${index}]`);
-      });
-
-      return payload.data;
+      return parseEnvironmentListResponseFromPayload(payload, "response");
     },
 
     async create(input) {

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -29,7 +29,10 @@ function createEnvironmentSummary(
   };
 }
 
-function renderMarkup(state: EnvironmentManagementState): string {
+function renderMarkup(
+  state: EnvironmentManagementState,
+  props: Partial<Parameters<typeof EnvironmentManagementPageView>[0]> = {},
+): string {
   return renderToStaticMarkup(
     createElement(
       ThemeProvider,
@@ -54,6 +57,7 @@ function renderMarkup(state: EnvironmentManagementState): string {
           },
           createElement(EnvironmentManagementPageView, {
             state,
+            ...props,
           }),
         ),
       ),
@@ -133,6 +137,42 @@ test("EnvironmentManagementPageView renders forbidden and error states", () => {
   assert.match(errorMarkup, /data-mdcms-environments-page-state="error"/);
 });
 
+test("EnvironmentManagementPageView keeps delete conflicts inside the modal", () => {
+  const markup = renderMarkup(
+    {
+      status: "ready",
+      project: "marketing-site",
+      environments: [
+        createEnvironmentSummary(),
+        createEnvironmentSummary({
+          id: "env-staging",
+          name: "staging",
+          extends: "production",
+          isDefault: false,
+        }),
+      ],
+    },
+    {
+      deleteTarget: createEnvironmentSummary({
+        id: "env-staging",
+        name: "staging",
+        extends: "production",
+        isDefault: false,
+      }),
+      deleteError:
+        'Environment "staging" cannot be deleted while content or schema state still exists.',
+    },
+  );
+
+  assert.match(markup, /data-mdcms-delete-error/);
+  assert.match(markup, /Delete Environment/);
+  assert.match(
+    markup,
+    /Environment &quot;staging&quot; cannot be deleted while content or schema state still exists\./,
+  );
+  assert.doesNotMatch(markup, /data-mdcms-page-action-error/);
+});
+
 test("resolveDeleteFailureState reloads after not-found delete failures", () => {
   const notFound = resolveDeleteFailureState(
     new RuntimeError({
@@ -153,10 +193,12 @@ test("resolveDeleteFailureState reloads after not-found delete failures", () => 
     message: "Environment not found.",
     shouldCloseDialog: true,
     shouldReload: true,
+    renderInDialog: false,
   });
   assert.deepEqual(conflict, {
     message: "Environment is not empty.",
     shouldCloseDialog: false,
     shouldReload: false,
+    renderInDialog: true,
   });
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -4,7 +4,7 @@ import { test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import type { EnvironmentSummary } from "@mdcms/shared";
+import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
 
 import { ThemeProvider } from "../../adapters/next-themes.js";
 import { StudioMountInfoProvider } from "./mount-info-context.js";
@@ -12,6 +12,7 @@ import { StudioSessionProvider } from "./session-context.js";
 import {
   EnvironmentManagementPageView,
   type EnvironmentManagementState,
+  resolveDeleteFailureState,
 } from "./environments-page.js";
 
 function createEnvironmentSummary(
@@ -130,4 +131,32 @@ test("EnvironmentManagementPageView renders forbidden and error states", () => {
     /data-mdcms-environments-page-state="forbidden"/,
   );
   assert.match(errorMarkup, /data-mdcms-environments-page-state="error"/);
+});
+
+test("resolveDeleteFailureState reloads after not-found delete failures", () => {
+  const notFound = resolveDeleteFailureState(
+    new RuntimeError({
+      code: "NOT_FOUND",
+      message: "Environment not found.",
+      statusCode: 404,
+    }),
+  );
+  const conflict = resolveDeleteFailureState(
+    new RuntimeError({
+      code: "CONFLICT",
+      message: "Environment is not empty.",
+      statusCode: 409,
+    }),
+  );
+
+  assert.deepEqual(notFound, {
+    message: "Environment not found.",
+    shouldCloseDialog: true,
+    shouldReload: true,
+  });
+  assert.deepEqual(conflict, {
+    message: "Environment is not empty.",
+    shouldCloseDialog: false,
+    shouldReload: false,
+  });
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -4,7 +4,11 @@ import { test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { RuntimeError, type EnvironmentSummary } from "@mdcms/shared";
+import {
+  RuntimeError,
+  type EnvironmentDefinitionsMeta,
+  type EnvironmentSummary,
+} from "@mdcms/shared";
 
 import { ThemeProvider } from "../../adapters/next-themes.js";
 import { StudioMountInfoProvider } from "./mount-info-context.js";
@@ -65,6 +69,17 @@ function renderMarkup(
   );
 }
 
+function createDefinitionsMeta(
+  overrides: Partial<EnvironmentDefinitionsMeta> = {},
+): EnvironmentDefinitionsMeta {
+  return {
+    definitionsStatus: "ready",
+    configSnapshotHash: "sha256:abc123",
+    syncedAt: "2026-03-19T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
 test("EnvironmentManagementPageView renders loading and empty states deterministically", () => {
   const loadingMarkup = renderMarkup({
     status: "loading",
@@ -75,6 +90,7 @@ test("EnvironmentManagementPageView renders loading and empty states determinist
     status: "ready",
     project: "marketing-site",
     environments: [],
+    definitionsMeta: createDefinitionsMeta(),
   });
 
   assert.match(loadingMarkup, /class="min-h-screen"/);
@@ -103,6 +119,7 @@ test("EnvironmentManagementPageView renders live environment summaries and only 
         createdAt: "2026-03-20T11:30:45.000Z",
       }),
     ],
+    definitionsMeta: createDefinitionsMeta(),
   });
 
   assert.match(markup, /data-mdcms-environments-page-state="ready"/);
@@ -151,6 +168,7 @@ test("EnvironmentManagementPageView keeps delete conflicts inside the modal", ()
           isDefault: false,
         }),
       ],
+      definitionsMeta: createDefinitionsMeta(),
     },
     {
       deleteTarget: createEnvironmentSummary({
@@ -171,6 +189,24 @@ test("EnvironmentManagementPageView keeps delete conflicts inside the modal", ()
     /Environment &quot;staging&quot; cannot be deleted while content or schema state still exists\./,
   );
   assert.doesNotMatch(markup, /data-mdcms-page-action-error/);
+});
+
+test("EnvironmentManagementPageView disables creation when synced definitions are missing", () => {
+  const markup = renderMarkup({
+    status: "ready",
+    project: "marketing-site",
+    environments: [createEnvironmentSummary()],
+    definitionsMeta: {
+      definitionsStatus: "missing",
+    },
+  });
+
+  assert.match(
+    markup,
+    /Environment management requires a successful cms schema sync/i,
+  );
+  assert.match(markup, /New Environment/);
+  assert.match(markup, /disabled=""/);
 });
 
 test("resolveDeleteFailureState reloads after not-found delete failures", () => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState } from "react";
 
-import type { EnvironmentSummary } from "@mdcms/shared";
+import type {
+  EnvironmentDefinitionsMeta,
+  EnvironmentSummary,
+} from "@mdcms/shared";
 import {
   ArrowRightLeft,
   Clock,
@@ -69,6 +72,7 @@ export type EnvironmentManagementState =
       status: "ready";
       project: string;
       environments: EnvironmentSummary[];
+      definitionsMeta: EnvironmentDefinitionsMeta;
     };
 
 type EnvironmentManagementPageViewProps = {
@@ -91,6 +95,9 @@ type EnvironmentManagementPageViewProps = {
   onSwitchEnvironment?: (environment: string) => void;
   onRetry?: () => void;
 };
+
+const CREATE_SYNC_REQUIRED_MESSAGE =
+  "Environment management requires a successful cms schema sync from the host app repo before new environments can be created.";
 
 function createLoadingState(project: string): EnvironmentManagementState {
   return {
@@ -252,6 +259,9 @@ export function EnvironmentManagementPageView({
   onRetry,
 }: EnvironmentManagementPageViewProps) {
   const canManage = state.status === "ready";
+  const canCreate =
+    state.status === "ready" &&
+    state.definitionsMeta.definitionsStatus === "ready";
 
   return (
     <div className="min-h-screen">
@@ -273,7 +283,11 @@ export function EnvironmentManagementPageView({
                 onOpenChange={onCreateDialogChange}
               >
                 <DialogTrigger asChild>
-                  <Button className="w-full sm:w-auto" type="button">
+                  <Button
+                    className="w-full sm:w-auto"
+                    type="button"
+                    disabled={!canCreate}
+                  >
                     <Plus className="mr-2 h-4 w-4" />
                     New Environment
                   </Button>
@@ -327,6 +341,16 @@ export function EnvironmentManagementPageView({
             className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive"
           >
             {actionError}
+          </section>
+        ) : null}
+
+        {state.status === "ready" &&
+        state.definitionsMeta.definitionsStatus === "missing" ? (
+          <section
+            data-mdcms-environments-create-gated
+            className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground"
+          >
+            {CREATE_SYNC_REQUIRED_MESSAGE}
           </section>
         ) : null}
 
@@ -553,7 +577,7 @@ export default function EnvironmentsPage() {
 
     void environmentApi
       .list()
-      .then((environments) => {
+      .then((result) => {
         if (cancelled) {
           return;
         }
@@ -561,7 +585,8 @@ export default function EnvironmentsPage() {
         setState({
           status: "ready",
           project,
-          environments: sortEnvironments(environments),
+          environments: sortEnvironments(result.data),
+          definitionsMeta: result.meta,
         });
       })
       .catch((error) => {
@@ -598,6 +623,14 @@ export default function EnvironmentsPage() {
   async function handleCreateSubmit() {
     if (!project || !environment) {
       setCreateError("Environment management requires an active project.");
+      return;
+    }
+
+    if (
+      state.status !== "ready" ||
+      state.definitionsMeta.definitionsStatus !== "ready"
+    ) {
+      setCreateError(CREATE_SYNC_REQUIRED_MESSAGE);
       return;
     }
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -146,6 +146,24 @@ function readRuntimeErrorStatus(error: unknown): number | null {
   return null;
 }
 
+export function resolveDeleteFailureState(error: unknown): {
+  message: string;
+  shouldCloseDialog: boolean;
+  shouldReload: boolean;
+} {
+  const message = readRuntimeErrorMessage(
+    error,
+    "Environment deletion failed.",
+  );
+  const statusCode = readRuntimeErrorStatus(error);
+
+  return {
+    message,
+    shouldCloseDialog: statusCode === 404,
+    shouldReload: statusCode === 404,
+  };
+}
+
 function formatCreatedAt(value: string): string {
   const date = new Date(value);
 
@@ -428,9 +446,7 @@ export function EnvironmentManagementPageView({
                       variant="outline"
                       size="sm"
                       className="w-full"
-                      onClick={() =>
-                        onSwitchEnvironment?.(environment.name)
-                      }
+                      onClick={() => onSwitchEnvironment?.(environment.name)}
                     >
                       <ArrowRightLeft className="mr-2 h-4 w-4" />
                       Switch to {environment.name}
@@ -633,9 +649,17 @@ export default function EnvironmentsPage() {
       setDeleteTarget(null);
       setReloadVersion((current) => current + 1);
     } catch (error) {
-      setActionError(
-        readRuntimeErrorMessage(error, "Environment deletion failed."),
-      );
+      const failure = resolveDeleteFailureState(error);
+
+      setActionError(failure.message);
+
+      if (failure.shouldCloseDialog) {
+        setDeleteTarget(null);
+      }
+
+      if (failure.shouldReload) {
+        setReloadVersion((current) => current + 1);
+      }
     } finally {
       setPendingDeleteId(null);
     }

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -77,6 +77,7 @@ type EnvironmentManagementPageViewProps = {
   createName?: string;
   createError?: string | null;
   actionError?: string | null;
+  deleteError?: string | null;
   pendingCreate?: boolean;
   pendingDeleteId?: string | null;
   deleteTarget?: EnvironmentSummary | null;
@@ -120,6 +121,11 @@ function isEnvironmentSummary(value: unknown): value is EnvironmentSummary {
 }
 
 function readRuntimeErrorMessage(error: unknown, fallback: string): string {
+  const normalizeMessage = (message: string): string =>
+    message === "Server config is required to manage environments."
+      ? "Environment management is unavailable because the connected backend could not load mdcms.config.ts."
+      : message;
+
   if (
     error &&
     typeof error === "object" &&
@@ -127,10 +133,10 @@ function readRuntimeErrorMessage(error: unknown, fallback: string): string {
     typeof error.message === "string" &&
     error.message.trim().length > 0
   ) {
-    return error.message;
+    return normalizeMessage(error.message);
   }
 
-  return fallback;
+  return normalizeMessage(fallback);
 }
 
 function readRuntimeErrorStatus(error: unknown): number | null {
@@ -150,6 +156,7 @@ export function resolveDeleteFailureState(error: unknown): {
   message: string;
   shouldCloseDialog: boolean;
   shouldReload: boolean;
+  renderInDialog: boolean;
 } {
   const message = readRuntimeErrorMessage(
     error,
@@ -161,6 +168,7 @@ export function resolveDeleteFailureState(error: unknown): {
     message,
     shouldCloseDialog: statusCode === 404,
     shouldReload: statusCode === 404,
+    renderInDialog: statusCode !== 404,
   };
 }
 
@@ -229,6 +237,7 @@ export function EnvironmentManagementPageView({
   createName = "",
   createError = null,
   actionError = null,
+  deleteError = null,
   pendingCreate = false,
   pendingDeleteId = null,
   deleteTarget = null,
@@ -313,7 +322,10 @@ export function EnvironmentManagementPageView({
         </div>
 
         {actionError ? (
-          <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          <section
+            data-mdcms-page-action-error
+            className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive"
+          >
             {actionError}
           </section>
         ) : null}
@@ -471,6 +483,11 @@ export function EnvironmentManagementPageView({
                   : "Delete this environment?"}
               </DialogDescription>
             </DialogHeader>
+            {deleteError ? (
+              <p data-mdcms-delete-error className="text-sm text-destructive">
+                {deleteError}
+              </p>
+            ) : null}
             <DialogFooter>
               <Button
                 variant="outline"
@@ -509,6 +526,7 @@ export default function EnvironmentsPage() {
   const [createName, setCreateName] = useState("");
   const [createError, setCreateError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [pendingCreate, setPendingCreate] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<EnvironmentSummary | null>(
@@ -631,6 +649,7 @@ export default function EnvironmentsPage() {
 
     setPendingDeleteId(deleteTarget.id);
     setActionError(null);
+    setDeleteError(null);
 
     try {
       const environmentApi = createStudioEnvironmentApi(
@@ -646,12 +665,14 @@ export default function EnvironmentsPage() {
       );
 
       await environmentApi.delete(deleteTarget.id);
+      setDeleteError(null);
       setDeleteTarget(null);
       setReloadVersion((current) => current + 1);
     } catch (error) {
       const failure = resolveDeleteFailureState(error);
 
-      setActionError(failure.message);
+      setActionError(failure.renderInDialog ? null : failure.message);
+      setDeleteError(failure.renderInDialog ? failure.message : null);
 
       if (failure.shouldCloseDialog) {
         setDeleteTarget(null);
@@ -687,14 +708,17 @@ export default function EnvironmentsPage() {
       onCreateSubmit={handleCreateSubmit}
       onDeleteDialogChange={(open) => {
         if (!open) {
+          setDeleteError(null);
           setDeleteTarget(null);
         }
       }}
       onRequestDelete={(environment) => {
         setActionError(null);
+        setDeleteError(null);
         setDeleteTarget(environment);
       }}
       onDeleteConfirm={handleDeleteConfirm}
+      deleteError={deleteError}
       onSwitchEnvironment={setEnvironment}
       onRetry={() => {
         setActionError(null);

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -245,9 +245,9 @@ export default function AdminLayout({
 
     void envApi
       .list()
-      .then((list) => {
+      .then((result) => {
         if (!cancelled) {
-          setEnvironments(list);
+          setEnvironments(result.data);
         }
       })
       .catch(() => {

--- a/packages/studio/src/lib/schema-route-api.test.ts
+++ b/packages/studio/src/lib/schema-route-api.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { RuntimeError } from "@mdcms/shared";
+import { RuntimeError, type JsonObject } from "@mdcms/shared";
 import { test } from "bun:test";
 
 import {
@@ -45,6 +45,22 @@ function createSchemaRouteApi(options: StudioSchemaRouteApiOptions = {}) {
     },
     options,
   );
+}
+
+function createRawConfigSnapshot(
+  overrides: Record<string, unknown> = {},
+): JsonObject {
+  return {
+    project: "marketing-site",
+    environment: "staging",
+    environments: {
+      production: {},
+      staging: {
+        extends: "production",
+      },
+    },
+    ...(overrides as JsonObject),
+  } satisfies JsonObject;
 }
 
 test("list fetches schema entries with scoped headers", async () => {
@@ -128,11 +144,9 @@ test("cookie-authenticated sync bootstraps csrf from auth/session", async () => 
       assert.equal(readHeader(init, "authorization"), null);
       assert.equal(init?.credentials, "include");
       assert.deepEqual(readJsonBody(init), {
-        rawConfigSnapshot: {
-          project: "marketing-site",
-          environment: "staging",
+        rawConfigSnapshot: createRawConfigSnapshot({
           contentDirectories: ["content/blog"],
-        },
+        }),
         resolvedSchema: {
           BlogPost: {
             type: "BlogPost",
@@ -163,11 +177,9 @@ test("cookie-authenticated sync bootstraps csrf from auth/session", async () => 
   });
 
   const result = await api.sync({
-    rawConfigSnapshot: {
-      project: "marketing-site",
-      environment: "staging",
+    rawConfigSnapshot: createRawConfigSnapshot({
       contentDirectories: ["content/blog"],
-    },
+    }),
     resolvedSchema: {
       BlogPost: {
         type: "BlogPost",
@@ -215,10 +227,7 @@ test("token-authenticated sync does not bootstrap csrf", async () => {
   });
 
   const result = await api.sync({
-    rawConfigSnapshot: {
-      project: "marketing-site",
-      environment: "staging",
-    },
+    rawConfigSnapshot: createRawConfigSnapshot(),
     resolvedSchema: {},
     schemaHash: "schema-hash-123",
   });
@@ -289,11 +298,9 @@ test("cookie-authenticated sync preserves a path-prefixed studio serverUrl", asy
   );
 
   await api.sync({
-    rawConfigSnapshot: {
-      project: "marketing-site",
-      environment: "staging",
+    rawConfigSnapshot: createRawConfigSnapshot({
       contentDirectories: ["content/blog"],
-    },
+    }),
     resolvedSchema: {
       BlogPost: {
         type: "BlogPost",
@@ -334,10 +341,7 @@ test("sync surfaces forbidden responses as runtime errors", async () => {
   await assert.rejects(
     () =>
       api.sync({
-        rawConfigSnapshot: {
-          project: "marketing-site",
-          environment: "staging",
-        },
+        rawConfigSnapshot: createRawConfigSnapshot(),
         resolvedSchema: {},
         schemaHash: "schema-hash-123",
       }),
@@ -368,10 +372,7 @@ test("sync surfaces incompatible responses as runtime errors", async () => {
   await assert.rejects(
     () =>
       api.sync({
-        rawConfigSnapshot: {
-          project: "marketing-site",
-          environment: "staging",
-        },
+        rawConfigSnapshot: createRawConfigSnapshot(),
         resolvedSchema: {},
         schemaHash: "schema-hash-123",
       }),


### PR DESCRIPTION
## Summary
- handle `DELETE /api/v1/environments/:id` `404 NOT_FOUND` as a non-destructive row/action failure on the environments page
- close the delete dialog and trigger a live environment list reload after a not-found delete response
- add a regression test for the not-found delete handling while leaving the existing create/list/delete flows intact

## Test Plan
- `bun test packages/shared/src/lib/contracts/environments.test.ts packages/studio/src/lib/environment-api.test.ts packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx apps/server/src/lib/environments-api.route.test.ts apps/studio-review/review/environments.test.ts 'apps/studio-review/app/review-api/[scenario]/api/v1/environments/route.test.ts'`

## Notes
- `bun run check` is currently blocked by an existing server build issue: `apps/server/src/lib/email.ts` cannot resolve `nodemailer`
- `bun run format:check` is currently blocked by pre-existing formatting issues in unrelated files outside this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environments list now returns readiness metadata (data + meta). Creation is disabled with guidance until definitions are synced; syncs persist a project-level environment snapshot and use deterministic hashing.

* **Bug Fixes**
  * Creation now surfaces a clear CONFIG_SNAPSHOT_REQUIRED (409) error when snapshots are missing. Delete conflicts show inside the confirmation dialog; not-found deletes auto-close and trigger reloads.

* **Documentation**
  * Specs and READMEs updated to describe metadata, create-gating, and snapshot-driven validation.

* **Tests**
  * Added tests for list metadata, create-gating, delete-failure UI, snapshot persistence, and deterministic hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->