### PR TITLE
CMS-141: align the schema browser with the admin shell

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -219,6 +219,8 @@ environments[]` so the document sidebar can label environment-specific
 - Remote runtime route: `/admin/schema`
 - The schema page is a live read-only browser over `GET /api/v1/schema` for the
   active `(project, environment)` route context.
+- It keeps the page explicitly code-first: schema definitions stay in the host
+  app repo and operators publish updates with `cms schema sync`.
 - It renders loading, empty, forbidden, error, and ready states from shared
   schema registry data.
 - The browser is intentionally descriptive only:
@@ -226,7 +228,8 @@ environments[]` so the document sidebar can label environment-specific
   - directory
   - localization mode
   - field kind / required / nullable metadata
-  - simple constraint summaries derived from the synced schema snapshot
+  - readable validation and schema-detail summaries derived from the synced
+    schema snapshot
 - `/admin/settings` now links users to `/admin/schema` instead of maintaining a
   second mock schema viewer.
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.test.tsx
@@ -8,6 +8,10 @@ import {
   createEmptyCurrentPrincipalCapabilities,
   type StudioMountContext,
 } from "@mdcms/shared";
+import { ThemeProvider } from "../../adapters/next-themes.js";
+import { StudioNavigationProvider } from "../../navigation.js";
+import { StudioMountInfoProvider } from "./mount-info-context.js";
+import { StudioSessionProvider } from "./session-context.js";
 import {
   createStudioSchemaLoadingState,
   type StudioSchemaReadyState,
@@ -37,9 +41,46 @@ function createReadyState(
 
 function renderMarkup(state: StudioSchemaState): string {
   return renderToStaticMarkup(
-    createElement(SchemaPageView, {
-      state,
-    }),
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(
+        StudioSessionProvider,
+        {
+          value: { status: "unauthenticated" },
+        },
+        createElement(
+          StudioMountInfoProvider,
+          {
+            value: {
+              project: "marketing-site",
+              environment: "staging",
+              setEnvironment: () => {},
+              apiBaseUrl: "http://localhost:4000",
+              auth: { mode: "cookie" },
+              environments: [],
+              hostBridge: null,
+            },
+          },
+          createElement(
+            StudioNavigationProvider,
+            {
+              value: {
+                pathname: "/schema",
+                params: {},
+                basePath: "/admin",
+                push: () => {},
+                replace: () => {},
+                back: () => {},
+              },
+            },
+            createElement(SchemaPageView, {
+              state,
+            }),
+          ),
+        ),
+      ),
+    ),
   );
 }
 
@@ -76,6 +117,9 @@ test("createSchemaPageLoadInput maps the mounted project and environment", () =>
 test("SchemaPageView renders the loading state deterministically", () => {
   const markup = renderMarkup(createStudioSchemaLoadingState());
 
+  assert.match(markup, /class="min-h-screen"/);
+  assert.match(markup, /sticky top-0/);
+  assert.match(markup, /p-6 space-y-6|space-y-6 p-6/);
   assert.match(markup, /data-mdcms-schema-page-state="loading"/);
   assert.match(markup, /Loading schema state/i);
   assert.match(markup, /Schema/i);
@@ -85,7 +129,9 @@ test("SchemaPageView renders an empty read-only browser state", () => {
   const markup = renderMarkup(createReadyState());
 
   assert.match(markup, /data-mdcms-schema-page-state="empty"/);
-  assert.match(markup, /No schema entries/i);
+  assert.match(markup, /Schema definitions are managed in code/i);
+  assert.match(markup, /No synced schema is available/i);
+  assert.match(markup, /cms schema sync/i);
   assert.match(markup, /marketing-site/);
   assert.match(markup, /staging/);
 });
@@ -112,6 +158,17 @@ test("SchemaPageView renders live schema entries with simple constraint metadata
                 reference: {
                   targetType: "Author",
                 },
+              },
+              title: {
+                kind: "string",
+                required: true,
+                nullable: false,
+                checks: [
+                  {
+                    kind: "min_length",
+                    minimum: 1,
+                  },
+                ],
               },
               status: {
                 kind: "enum",
@@ -144,15 +201,19 @@ test("SchemaPageView renders live schema entries with simple constraint metadata
   );
 
   assert.match(markup, /data-mdcms-schema-page-state="ready"/);
+  assert.match(markup, /Schema definitions are managed in code/i);
+  assert.match(markup, /validation rules/i);
   assert.match(markup, /data-mdcms-schema-entry-type="BlogPost"/);
   assert.match(markup, /content\/blog/);
   assert.match(markup, /Localized/);
   assert.match(markup, /data-mdcms-schema-field-name="author"/);
   assert.match(markup, /data-mdcms-schema-field-kind="string"/);
   assert.match(markup, /reference: Author/);
+  assert.match(markup, /data-mdcms-schema-field-name="title"/);
+  assert.match(markup, /min_length: 1/);
   assert.match(markup, /data-mdcms-schema-field-name="status"/);
   assert.match(markup, /options: draft, published/);
-  assert.match(markup, /checks: 1/);
+  assert.doesNotMatch(markup, /checks: 1/);
   assert.match(markup, /data-mdcms-schema-field-name="tags"/);
   assert.match(markup, /default: \[\]/);
   assert.match(markup, /item: string/);
@@ -178,4 +239,80 @@ test("SchemaPageView renders forbidden and error states", () => {
   assert.match(forbiddenMarkup, /Forbidden\./);
   assert.match(errorMarkup, /data-mdcms-schema-page-state="error"/);
   assert.match(errorMarkup, /Failed to load schema state\./);
+});
+
+test("SchemaPageView remains descriptive-only even when schema sync capability exists", () => {
+  const markup = renderMarkup(
+    createReadyState({
+      canSync: true,
+      hasLocalSyncPayload: true,
+      capabilities: {
+        ...createEmptyCurrentPrincipalCapabilities(),
+        schema: {
+          read: true,
+          write: true,
+        },
+      },
+      entries: [
+        {
+          type: "BlogPost",
+          directory: "content/blog",
+          localized: false,
+          schemaHash: "server-hash",
+          syncedAt: "2026-03-31T12:00:00.000Z",
+          resolvedSchema: {
+            type: "BlogPost",
+            directory: "content/blog",
+            localized: false,
+            fields: {},
+          },
+        },
+      ],
+    }),
+  );
+
+  assert.match(markup, /Read-only/i);
+  assert.doesNotMatch(markup, /Sync Schema/);
+  assert.doesNotMatch(markup, /Edit schema/i);
+  assert.doesNotMatch(markup, /Schema Builder/i);
+});
+
+test("SchemaPageView renders shared sync metadata once for the whole page", () => {
+  const markup = renderMarkup(
+    createReadyState({
+      entries: [
+        {
+          type: "Author",
+          directory: "content/authors",
+          localized: false,
+          schemaHash: "server-hash",
+          syncedAt: "2026-03-31T12:00:00.000Z",
+          resolvedSchema: {
+            type: "Author",
+            directory: "content/authors",
+            localized: false,
+            fields: {},
+          },
+        },
+        {
+          type: "BlogPost",
+          directory: "content/blog",
+          localized: true,
+          schemaHash: "server-hash",
+          syncedAt: "2026-03-31T12:00:00.000Z",
+          resolvedSchema: {
+            type: "BlogPost",
+            directory: "content/blog",
+            localized: true,
+            fields: {},
+          },
+        },
+      ],
+    }),
+  );
+
+  assert.equal(markup.match(/Schema hash/g)?.length ?? 0, 1);
+  assert.equal(markup.match(/Synced at/g)?.length ?? 0, 1);
+  assert.match(markup, /data-mdcms-schema-entry-type="Author"/);
+  assert.match(markup, /data-mdcms-schema-entry-type="BlogPost"/);
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
@@ -15,6 +15,12 @@ import {
   PageHeaderDescription,
   PageHeaderHeading,
 } from "../../components/layout/page-header.js";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../../components/ui/card.js";
 import { Badge } from "../../components/ui/badge.js";
 import {
   Table,
@@ -37,6 +43,9 @@ type SchemaPageLoadInput = {
 type SchemaFieldSnapshot =
   SchemaRegistryEntry["resolvedSchema"]["fields"][string];
 
+const SCHEMA_READ_ONLY_COPY =
+  "Schema definitions are managed in code and synced with cms schema sync. Studio shows the active types, fields, and validation rules for this target.";
+
 function formatConstraintValue(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -51,6 +60,35 @@ function formatConstraintValue(value: unknown): string {
   }
 
   return JSON.stringify(value);
+}
+
+function formatCheckValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((entry) => formatConstraintValue(entry)).join(", ");
+  }
+
+  return formatConstraintValue(value);
+}
+
+function describeCheckDefinition(
+  check: Record<string, unknown>,
+): string | null {
+  const kind = typeof check.kind === "string" ? check.kind : "rule";
+  const details = Object.entries(check).filter(
+    ([key, value]) => key !== "kind" && value !== undefined,
+  );
+
+  if (details.length === 0) {
+    return kind;
+  }
+
+  if (details.length === 1) {
+    return `${kind}: ${formatCheckValue(details[0][1])}`;
+  }
+
+  return `${kind}: ${details
+    .map(([key, value]) => `${key} ${formatCheckValue(value)}`)
+    .join(", ")}`;
 }
 
 function describeSchemaFieldConstraints(field: SchemaFieldSnapshot): string[] {
@@ -79,7 +117,11 @@ function describeSchemaFieldConstraints(field: SchemaFieldSnapshot): string[] {
   }
 
   if (field.checks?.length) {
-    constraints.push(`checks: ${field.checks.length}`);
+    constraints.push(
+      ...field.checks
+        .map((check) => describeCheckDefinition(check))
+        .filter((summary): summary is string => summary !== null),
+    );
   }
 
   return constraints;
@@ -146,143 +188,204 @@ function sortFields(fields: SchemaRegistryEntry["resolvedSchema"]["fields"]) {
   );
 }
 
+function getSharedSchemaSyncSummary(entries: SchemaRegistryEntry[]): {
+  schemaHash?: string;
+  syncedAt?: string;
+} | null {
+  const firstEntry = entries[0];
+
+  if (!firstEntry) {
+    return null;
+  }
+
+  const schemaHash = firstEntry.schemaHash.trim();
+  const syncedAt = firstEntry.syncedAt.trim();
+
+  return {
+    ...(schemaHash.length > 0 &&
+    entries.every((entry) => entry.schemaHash === schemaHash)
+      ? { schemaHash }
+      : {}),
+    ...(syncedAt.length > 0 &&
+    entries.every((entry) => entry.syncedAt === syncedAt)
+      ? { syncedAt }
+      : {}),
+  };
+}
+
 export function SchemaPageView({ state }: { state: StudioSchemaState }) {
   const pageDescription =
     state.status === "loading"
       ? state.message
       : `Read-only schema browser for ${state.project} / ${state.environment}.`;
+  const sharedSyncSummary =
+    state.status === "ready" ? getSharedSchemaSyncSummary(state.entries) : null;
 
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader>
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Schema" }]} />
+
+      <div className="space-y-6 p-6">
         <div className="space-y-1">
           <PageHeaderHeading>Schema</PageHeaderHeading>
           <PageHeaderDescription>{pageDescription}</PageHeaderDescription>
         </div>
-      </PageHeader>
 
-      {state.status === "loading" ? (
-        <div
-          data-mdcms-schema-page-state="loading"
-          className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
-        >
-          {state.message}
-        </div>
-      ) : state.status === "forbidden" ? (
-        <section
-          data-mdcms-schema-page-state="forbidden"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="secondary">Forbidden</Badge>
-          <p className="text-sm text-muted-foreground">{state.message}</p>
-          <p className="text-xs text-muted-foreground">
-            {state.project} / {state.environment}
-          </p>
-        </section>
-      ) : state.status === "error" ? (
-        <section
-          data-mdcms-schema-page-state="error"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="destructive">Error</Badge>
-          <p className="text-sm text-muted-foreground">{state.message}</p>
-          <p className="text-xs text-muted-foreground">
-            {state.project} / {state.environment}
-          </p>
-        </section>
-      ) : state.entries.length === 0 ? (
-        <section
-          data-mdcms-schema-page-state="empty"
-          className="space-y-3 rounded-lg border border-dashed p-6"
-        >
-          <Badge variant="outline">Empty</Badge>
-          <p className="text-sm text-muted-foreground">
-            No schema entries were returned for this project and environment.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {state.project} / {state.environment}
-          </p>
-        </section>
-      ) : (
-        <div data-mdcms-schema-page-state="ready" className="space-y-4">
-          {sortEntries(state.entries).map((entry) => (
-            <article
-              key={entry.type}
-              data-mdcms-schema-entry-type={entry.type}
-              className="space-y-4 rounded-lg border p-4"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="text-lg font-semibold tracking-tight">
-                      {entry.type}
-                    </h2>
-                    <Badge variant={entry.localized ? "secondary" : "outline"}>
-                      {entry.localized ? "Localized" : "Single locale"}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {entry.directory}
-                  </p>
-                </div>
-                <div className="space-y-1 text-right text-xs text-muted-foreground">
-                  <p>
+        <Card>
+          <CardContent className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-start">
+            <div className="flex flex-wrap items-start gap-3">
+              <Badge variant="secondary">Read-only</Badge>
+              <p className="max-w-3xl text-sm text-muted-foreground">
+                {SCHEMA_READ_ONLY_COPY}
+              </p>
+            </div>
+
+            {sharedSyncSummary &&
+            (sharedSyncSummary.schemaHash || sharedSyncSummary.syncedAt) ? (
+              <div
+                data-mdcms-schema-sync-summary="page"
+                className="grid gap-2 text-xs text-muted-foreground xl:justify-items-end"
+              >
+                {sharedSyncSummary.syncedAt ? (
+                  <p className="flex flex-wrap items-baseline gap-1 xl:justify-end">
                     <span className="font-medium text-foreground">
                       Synced at
-                    </span>{" "}
-                    {entry.syncedAt}
+                    </span>
+                    <span>{sharedSyncSummary.syncedAt}</span>
                   </p>
-                  <p>
+                ) : null}
+                {sharedSyncSummary.schemaHash ? (
+                  <p className="flex flex-wrap items-start gap-1 xl:justify-end">
                     <span className="font-medium text-foreground">
                       Schema hash
-                    </span>{" "}
-                    <code>{entry.schemaHash}</code>
+                    </span>
+                    <code className="break-all font-mono text-[11px] leading-relaxed">
+                      {sharedSyncSummary.schemaHash}
+                    </code>
                   </p>
-                </div>
+                ) : null}
               </div>
+            ) : null}
+          </CardContent>
+        </Card>
 
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Field</TableHead>
-                    <TableHead>Kind</TableHead>
-                    <TableHead>Required</TableHead>
-                    <TableHead>Nullable</TableHead>
-                    <TableHead>Constraints</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sortFields(entry.resolvedSchema.fields).map(
-                    ([fieldName, field]) => (
-                      <TableRow
-                        key={fieldName}
-                        data-mdcms-schema-field-name={fieldName}
-                        data-mdcms-schema-field-kind={field.kind}
+        {state.status === "loading" ? (
+          <div
+            data-mdcms-schema-page-state="loading"
+            className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+          >
+            {state.message}
+          </div>
+        ) : state.status === "forbidden" ? (
+          <section
+            data-mdcms-schema-page-state="forbidden"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="secondary">Forbidden</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : state.status === "error" ? (
+          <section
+            data-mdcms-schema-page-state="error"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="destructive">Error</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : state.entries.length === 0 ? (
+          <section
+            data-mdcms-schema-page-state="empty"
+            className="space-y-3 rounded-lg border border-dashed p-6"
+          >
+            <Badge variant="outline">Empty</Badge>
+            <p className="text-sm text-muted-foreground">
+              No synced schema is available for this project and environment.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Ask an admin or developer to run <code>cms schema sync</code> from
+              the host app repo to publish the latest schema.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {state.project} / {state.environment}
+            </p>
+          </section>
+        ) : (
+          <div data-mdcms-schema-page-state="ready" className="space-y-4">
+            {sortEntries(state.entries).map((entry) => (
+              <Card key={entry.type} data-mdcms-schema-entry-type={entry.type}>
+                <CardHeader className="gap-2">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <CardTitle className="text-2xl tracking-tight">
+                        {entry.type}
+                      </CardTitle>
+                      <Badge
+                        variant={entry.localized ? "secondary" : "outline"}
                       >
-                        <TableCell className="font-medium">
-                          {fieldName}
-                        </TableCell>
-                        <TableCell>{field.kind}</TableCell>
-                        <TableCell>{field.required ? "Yes" : "No"}</TableCell>
-                        <TableCell>{field.nullable ? "Yes" : "No"}</TableCell>
-                        <TableCell>
-                          <div
-                            data-mdcms-schema-field-constraints={describeSchemaFieldConstraints(
-                              field,
-                            ).join(" | ")}
-                          >
-                            {renderConstraintSummary(field)}
-                          </div>
-                        </TableCell>
+                        {entry.localized ? "Localized" : "Single locale"}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {entry.directory}
+                    </p>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="pt-0">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Field</TableHead>
+                        <TableHead>Kind</TableHead>
+                        <TableHead>Required</TableHead>
+                        <TableHead>Nullable</TableHead>
+                        <TableHead>Constraints</TableHead>
                       </TableRow>
-                    ),
-                  )}
-                </TableBody>
-              </Table>
-            </article>
-          ))}
-        </div>
-      )}
+                    </TableHeader>
+                    <TableBody>
+                      {sortFields(entry.resolvedSchema.fields).map(
+                        ([fieldName, field]) => (
+                          <TableRow
+                            key={fieldName}
+                            data-mdcms-schema-field-name={fieldName}
+                            data-mdcms-schema-field-kind={field.kind}
+                          >
+                            <TableCell className="font-medium">
+                              {fieldName}
+                            </TableCell>
+                            <TableCell>{field.kind}</TableCell>
+                            <TableCell>
+                              {field.required ? "Yes" : "No"}
+                            </TableCell>
+                            <TableCell>
+                              {field.nullable ? "Yes" : "No"}
+                            </TableCell>
+                            <TableCell>
+                              <div
+                                data-mdcms-schema-field-constraints={describeSchemaFieldConstraints(
+                                  field,
+                                ).join(" | ")}
+                              >
+                                {renderConstraintSummary(field)}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ),
+                      )}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move the schema page onto the standard admin shell layout used by other Studio pages
- make the schema browser explicitly read-only and code-first, with better empty-state guidance
- render readable validation summaries and move shared sync metadata to a single page-level summary

## Verification
- bun test packages/studio/src/lib/runtime-ui/app/admin/schema-page.test.tsx packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.test.tsx packages/studio/src/lib/remote-studio-app.test.ts
- bun run check

## Notes
- `bun run format:check` still reports unrelated pre-existing formatting drift outside this change set (`apps/server/src/lib/auth.ts`, `packages/studio/src/lib/remote-studio-app.test.ts`, `docs/plans/2026-04-12-conversation-export.md`, and local-only files under `.superpowers/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that schema definitions are maintained in the host app repository and updated through schema sync operations.

* **New Features**
  * Added read-only information block at the top of Schema Browser with guidance text.
  * Display shared schema sync metadata including hash and synchronization timestamp.
  * Enhanced validation rule descriptions with detailed per-constraint information instead of summary counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->