### PR TITLE
fix: remove npm self-upgrade step that crashes release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
-      - name: Update npm for Trusted Publishers
-        run: npm install -g npm@latest
-
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Remove `npm install -g npm@latest` step from the release workflow — it crashes with `MODULE_NOT_FOUND (promise-retry)` when npm tries to upgrade itself mid-run on GitHub Actions
- Node 22 already ships npm with Trusted Publishers support

## Context

The release workflow failed on the first run after #55 was merged: https://github.com/Blazity/mdcms/actions/runs/24414031360

## Test plan

- [ ] Release workflow passes on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow by removing a redundant npm upgrade step during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->