### PR TITLE
chore: bump published packages to 0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for MDCMS content workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Client SDK for MDCMS",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared contracts, types, and validators for MDCMS",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Embeddable Studio UI component for MDCMS",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump `@mdcms/shared`, `@mdcms/sdk`, `@mdcms/studio`, `@mdcms/cli` to 0.1.1
- These versions are already published to npm with fixed `^0.1.0` dependency ranges
- 0.1.0 has been deprecated (`broken: use >=0.1.1`)

## Test plan

- [x] All 4 packages published successfully to npm
- [x] `bunx @mdcms/cli@0.1.1` resolves deps correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch versions released for CLI, SDK, shared libraries, and Studio (0.1.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->