### PR TITLE
fix: remove bun export condition and bump to 0.1.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI for MDCMS content workflows",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,6 @@
     "./package.json": "./package.json",
     ".": {
       "@mdcms/source": "./src/index.ts",
-      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Client SDK for MDCMS",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,7 +18,6 @@
     "./package.json": "./package.json",
     ".": {
       "@mdcms/source": "./src/index.ts",
-      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/shared",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shared contracts, types, and validators for MDCMS",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,28 +18,24 @@
     "./package.json": "./package.json",
     "./mdx": {
       "@mdcms/source": "./src/lib/mdx/index.ts",
-      "bun": "./src/lib/mdx/index.ts",
       "types": "./dist/lib/mdx/index.d.ts",
       "import": "./dist/lib/mdx/index.js",
       "default": "./dist/lib/mdx/index.js"
     },
     "./action-catalog-contract": {
       "@mdcms/source": "./src/lib/contracts/action-catalog-contract.ts",
-      "bun": "./src/lib/contracts/action-catalog-contract.ts",
       "types": "./dist/lib/contracts/action-catalog-contract.d.ts",
       "import": "./dist/lib/contracts/action-catalog-contract.js",
       "default": "./dist/lib/contracts/action-catalog-contract.js"
     },
     "./server": {
       "@mdcms/source": "./src/lib/contracts/schema-hash.ts",
-      "bun": "./src/lib/contracts/schema-hash.ts",
       "types": "./dist/lib/contracts/schema-hash.d.ts",
       "import": "./dist/lib/contracts/schema-hash.js",
       "default": "./dist/lib/contracts/schema-hash.js"
     },
     ".": {
       "@mdcms/source": "./src/index.ts",
-      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdcms/studio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Embeddable Studio UI component for MDCMS",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,42 +18,36 @@
     "./package.json": "./package.json",
     "./action-catalog-adapter": {
       "@mdcms/source": "./src/lib/action-catalog-adapter.ts",
-      "bun": "./src/lib/action-catalog-adapter.ts",
       "types": "./dist/lib/action-catalog-adapter.d.ts",
       "import": "./dist/lib/action-catalog-adapter.js",
       "default": "./dist/lib/action-catalog-adapter.js"
     },
     "./build-runtime": {
       "@mdcms/source": "./src/lib/build-runtime.ts",
-      "bun": "./src/lib/build-runtime.ts",
       "types": "./dist/lib/build-runtime.d.ts",
       "import": "./dist/lib/build-runtime.js",
       "default": "./dist/lib/build-runtime.js"
     },
     "./document-shell": {
       "@mdcms/source": "./src/lib/document-shell.ts",
-      "bun": "./src/lib/document-shell.ts",
       "types": "./dist/lib/document-shell.d.ts",
       "import": "./dist/lib/document-shell.js",
       "default": "./dist/lib/document-shell.js"
     },
     "./markdown-pipeline": {
       "@mdcms/source": "./src/lib/markdown-pipeline.ts",
-      "bun": "./src/lib/markdown-pipeline.ts",
       "types": "./dist/lib/markdown-pipeline.d.ts",
       "import": "./dist/lib/markdown-pipeline.js",
       "default": "./dist/lib/markdown-pipeline.js"
     },
     "./runtime": {
       "@mdcms/source": "./src/lib/studio.ts",
-      "bun": "./src/lib/studio.ts",
       "types": "./dist/lib/studio.d.ts",
       "import": "./dist/lib/studio.js",
       "default": "./dist/lib/studio.js"
     },
     ".": {
       "@mdcms/source": "./src/index.ts",
-      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
## Summary

- Remove `"bun"` condition from exports in all publishable packages — it pointed to `src/` files not included in the npm tarball, breaking bun users
- Bump versions to 0.1.2 (already published to npm)
- 0.1.0 and 0.1.1 have been unpublished

## Test plan

- [x] `npm view @mdcms/cli@0.1.2 exports` has no `bun` condition
- [x] Monorepo build passes (uses `@mdcms/source` condition, not `bun`)
- [ ] `bunx --package @mdcms/cli@0.1.2 mdcms` resolves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 0.1.2 for CLI, SDK, shared, and studio packages
  * Removed Bun runtime support from package export configurations across all packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->