### PR TITLE
fix: style CLI auth pages and studio shell to match CMS design

### DIFF
--- a/apps/cli/src/lib/login.ts
+++ b/apps/cli/src/lib/login.ts
@@ -126,7 +126,34 @@ export function createLoopbackCallbackListener(): Promise<LoopbackCallbackListen
           response.statusCode = 200;
           response.setHeader("content-type", "text/html; charset=utf-8");
           response.end(
-            "<html><body><h1>MDCMS CLI</h1><p>Login complete. You can close this tab.</p></body></html>",
+            [
+              "<!doctype html>",
+              '<html lang="en">',
+              "<head>",
+              '<meta charset="utf-8" />',
+              '<meta name="viewport" content="width=device-width,initial-scale=1" />',
+              "<title>MDCMS CLI</title>",
+              "<style>",
+              "*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}",
+              "body{font-family:Inter,-apple-system,system-ui,sans-serif;background:#FCF9F8;color:#1C1B1B;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:16px;}",
+              ".card{width:100%;max-width:384px;background:#FFFFFF;border:1px solid rgba(197,197,216,0.2);border-radius:12px;padding:32px;box-shadow:0 1px 3px rgba(0,0,0,0.04);}",
+              ".logo{font-weight:700;font-size:20px;letter-spacing:-0.02em;text-align:center;margin-bottom:16px;}",
+              ".icon{width:48px;height:48px;margin:0 auto 16px;border-radius:50%;background:#f0fdf4;display:flex;align-items:center;justify-content:center;}",
+              ".icon svg{width:24px;height:24px;}",
+              ".title{text-align:center;font-size:16px;font-weight:600;margin-bottom:4px;}",
+              ".hint{text-align:center;font-size:14px;color:#444655;}",
+              "</style>",
+              "</head>",
+              "<body>",
+              '<div class="card">',
+              '<div class="logo">MDCMS</div>',
+              '<div class="icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="#22c55e"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg></div>',
+              '<p class="title">Login complete</p>',
+              '<p class="hint">You can close this tab and return to the terminal.</p>',
+              "</div>",
+              "</body>",
+              "</html>",
+            ].join(""),
           );
 
           finalize(() => {

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -913,30 +913,56 @@ function appendQueryParams(
   return parsed.toString();
 }
 
+function renderCliPageShell(title: string, body: string): string {
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width,initial-scale=1" />',
+    `<title>${title}</title>`,
+    "<style>",
+    "*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}",
+    "body{font-family:Inter,-apple-system,system-ui,sans-serif;background:#FCF9F8;color:#1C1B1B;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:16px;}",
+    ".card{width:100%;max-width:384px;background:#FFFFFF;border:1px solid rgba(197,197,216,0.2);border-radius:12px;padding:32px;box-shadow:0 1px 3px rgba(0,0,0,0.04);}",
+    ".logo{font-family:system-ui,sans-serif;font-weight:700;font-size:20px;letter-spacing:-0.02em;text-align:center;margin-bottom:4px;}",
+    ".subtitle{text-align:center;font-size:14px;color:#444655;margin-bottom:24px;}",
+    ".field{margin-bottom:16px;}",
+    ".field label{display:block;font-size:14px;font-weight:500;margin-bottom:6px;}",
+    ".field input{width:100%;height:40px;padding:0 12px;font-size:14px;border:1px solid #C5C5D8;border-radius:6px;outline:none;transition:border-color 0.15s;}",
+    ".field input:focus{border-color:#2F49E5;box-shadow:0 0 0 2px rgba(47,73,229,0.15);}",
+    "button[type=submit]{display:block;width:100%;height:40px;margin-top:8px;font-size:14px;font-weight:500;color:#FFFFFF;background:#2F49E5;border:none;border-radius:6px;cursor:pointer;transition:background 0.15s;}",
+    "button[type=submit]:hover{background:#2338b8;}",
+    ".success-icon{width:48px;height:48px;margin:0 auto 16px;border-radius:50%;background:#f0fdf4;display:flex;align-items:center;justify-content:center;}",
+    ".success-icon svg{width:24px;height:24px;color:#22c55e;}",
+    ".hint{text-align:center;font-size:13px;color:#444655;margin-top:8px;}",
+    "</style>",
+    "</head>",
+    "<body>",
+    '<div class="card">',
+    body,
+    "</div>",
+    "</body>",
+    "</html>",
+  ].join("");
+}
+
 function renderCliAuthorizeLoginForm(input: {
   challengeId: string;
   state: string;
 }): string {
-  return [
-    "<!doctype html>",
-    "<html>",
-    "<head>",
-    '<meta charset="utf-8" />',
-    '<meta name="viewport" content="width=device-width,initial-scale=1" />',
-    "<title>MDCMS CLI Login</title>",
-    "<style>body{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;max-width:420px;margin:48px auto;padding:0 16px;}label{display:block;font-size:14px;margin-top:12px;}input{width:100%;padding:8px;margin-top:4px;box-sizing:border-box;}button{margin-top:16px;padding:10px 14px;cursor:pointer;}</style>",
-    "</head>",
-    "<body>",
-    "<h1>MDCMS CLI Login</h1>",
-    "<p>Zaloguj się, aby autoryzować CLI.</p>",
-    `<form method="post" action="/api/v1/auth/cli/login/authorize?challenge=${encodeURIComponent(input.challengeId)}&state=${encodeURIComponent(input.state)}">`,
-    '<label>Email<input name="email" type="email" autocomplete="email" required /></label>',
-    '<label>Password<input name="password" type="password" autocomplete="current-password" required /></label>',
-    '<button type="submit">Authorize CLI</button>',
-    "</form>",
-    "</body>",
-    "</html>",
-  ].join("");
+  return renderCliPageShell(
+    "MDCMS CLI Login",
+    [
+      '<div class="logo">MDCMS</div>',
+      '<p class="subtitle">Sign in to authorize the CLI</p>',
+      `<form method="post" action="/api/v1/auth/cli/login/authorize?challenge=${encodeURIComponent(input.challengeId)}&state=${encodeURIComponent(input.state)}">`,
+      '<div class="field"><label for="cli-email">Email</label><input id="cli-email" name="email" type="email" placeholder="you@company.com" autocomplete="email" required autofocus /></div>',
+      '<div class="field"><label for="cli-password">Password</label><input id="cli-password" name="password" type="password" placeholder="\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022" autocomplete="current-password" required /></div>',
+      '<button type="submit">Authorize CLI</button>',
+      "</form>",
+    ].join(""),
+  );
 }
 
 function ensureValidApiKeyToken(token: string): void {

--- a/packages/studio/src/lib/studio-component.tsx
+++ b/packages/studio/src/lib/studio-component.tsx
@@ -69,17 +69,17 @@ const STUDIO_SHELL_STYLES = `
   isolation: isolate;
   overflow-x: hidden;
   overflow-y: auto;
-  background: linear-gradient(180deg, #0d1320 0%, #090d16 48%, #06070b 100%);
-  color: #f8fafc;
-  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  background: #FCF9F8;
+  color: #1C1B1B;
+  font-family: Inter, -apple-system, system-ui, sans-serif;
 }
 
 .mdcms-studio-shell__backdrop {
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(180deg, rgba(148, 163, 184, 0.06), transparent 10rem),
-    radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 24%);
+    radial-gradient(circle at top left, rgba(47, 73, 229, 0.08), transparent 24rem),
+    linear-gradient(180deg, #FCF9F8 0%, #F6F3F2 100%);
 }
 
 .mdcms-studio-shell__frame {
@@ -97,11 +97,11 @@ const STUDIO_SHELL_STYLES = `
   width: 100%;
   display: flex;
   flex-direction: column;
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(197, 197, 216, 0.2);
   border-radius: 1.125rem;
-  background: rgba(8, 12, 20, 0.86);
+  background: #FFFFFF;
   padding: 1.25rem;
-  box-shadow: 0 20px 60px rgba(2, 6, 23, 0.32);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
 .mdcms-studio-shell__header {
@@ -109,7 +109,7 @@ const STUDIO_SHELL_STYLES = `
   flex-direction: column;
   gap: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  border-bottom: 1px solid rgba(197, 197, 216, 0.3);
 }
 
 .mdcms-studio-shell__brand-group {
@@ -133,16 +133,16 @@ const STUDIO_SHELL_STYLES = `
 }
 
 .mdcms-studio-shell__brand-badge {
-  border: 1px solid rgba(148, 163, 184, 0.14);
-  background: rgba(148, 163, 184, 0.08);
-  color: #cbd5e1;
+  border: 1px solid rgba(197, 197, 216, 0.3);
+  background: rgba(47, 73, 229, 0.08);
+  color: #2F49E5;
 }
 
 .mdcms-studio-shell__path-chip {
-  border: 1px solid rgba(148, 163, 184, 0.14);
-  background: rgba(15, 23, 42, 0.55);
-  color: #cbd5e1;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  border: 1px solid rgba(197, 197, 216, 0.3);
+  background: #F6F3F2;
+  color: #444655;
+  font-family: "Geist Mono", ui-monospace, monospace;
   letter-spacing: 0.04em;
   text-transform: none;
 }
@@ -150,10 +150,10 @@ const STUDIO_SHELL_STYLES = `
 .mdcms-studio-shell__display,
 .mdcms-studio-shell__title {
   margin: 0;
-  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
-  font-weight: 600;
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  font-weight: 700;
   letter-spacing: -0.03em;
-  color: #fff;
+  color: #1C1B1B;
 }
 
 .mdcms-studio-shell__display {
@@ -175,8 +175,10 @@ const STUDIO_SHELL_STYLES = `
 .mdcms-studio-shell__meta-label,
 .mdcms-studio-shell__details-hint {
   margin: 0;
-  color: #94a3b8;
+  color: #444655;
+  font-family: "Geist Mono", ui-monospace, monospace;
   font-size: 0.72rem;
+  font-weight: 500;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -195,29 +197,29 @@ const STUDIO_SHELL_STYLES = `
 .mdcms-studio-shell__copy,
 .mdcms-studio-shell__summary {
   max-width: 42rem;
-  color: #cbd5e1;
+  color: #444655;
 }
 
 .mdcms-studio-shell__note {
   max-width: 42rem;
-  color: rgba(254, 243, 199, 0.92);
+  color: #92400e;
 }
 
 .mdcms-studio-shell__surface,
 .mdcms-studio-shell__aside,
 .mdcms-studio-shell__details {
   border-radius: 0.95rem;
-  border: 1px solid rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(197, 197, 216, 0.3);
 }
 
 .mdcms-studio-shell__surface,
 .mdcms-studio-shell__details {
-  background: rgba(2, 6, 23, 0.46);
+  background: #F6F3F2;
   padding: 1rem;
 }
 
 .mdcms-studio-shell__aside {
-  background: rgba(15, 23, 42, 0.42);
+  background: #F6F3F2;
   padding: 1rem;
 }
 
@@ -237,14 +239,14 @@ const STUDIO_SHELL_STYLES = `
   height: 0.75rem;
   width: 7rem;
   border-radius: 999px;
-  background: rgba(71, 85, 105, 0.82);
+  background: rgba(197, 197, 216, 0.5);
 }
 
 .mdcms-studio-shell__skeleton-bar {
   height: 2.25rem;
   width: 100%;
-  border-radius: 1rem;
-  background: rgba(30, 41, 59, 0.75);
+  border-radius: 0.5rem;
+  background: rgba(197, 197, 216, 0.25);
 }
 
 .mdcms-studio-shell__skeleton-grid {
@@ -254,16 +256,16 @@ const STUDIO_SHELL_STYLES = `
 
 .mdcms-studio-shell__skeleton-card {
   height: 6rem;
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.72);
+  border-radius: 0.5rem;
+  background: rgba(197, 197, 216, 0.2);
 }
 
 .mdcms-studio-shell__skeleton-card:nth-child(2) {
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(197, 197, 216, 0.15);
 }
 
 .mdcms-studio-shell__skeleton-card:nth-child(3) {
-  background: rgba(15, 23, 42, 0.48);
+  background: rgba(197, 197, 216, 0.1);
 }
 
 .mdcms-studio-shell__check-list {
@@ -277,23 +279,23 @@ const STUDIO_SHELL_STYLES = `
   align-items: center;
   gap: 0.75rem;
   padding: 0.8rem 0.9rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.1);
-  background: rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(197, 197, 216, 0.2);
+  background: #FFFFFF;
 }
 
 .mdcms-studio-shell__check-dot {
   width: 0.55rem;
   height: 0.55rem;
   border-radius: 50%;
-  background: #cbd5e1;
+  background: #2F49E5;
 }
 
 .mdcms-studio-shell__category-badge {
   margin-bottom: 0.75rem;
-  border: 1px solid rgba(248, 113, 113, 0.18);
-  background: rgba(127, 29, 29, 0.22);
-  color: #fecaca;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: rgba(239, 68, 68, 0.06);
+  color: #ef4444;
 }
 
 .mdcms-studio-shell__details {
@@ -303,7 +305,7 @@ const STUDIO_SHELL_STYLES = `
 .mdcms-studio-shell__details-summary {
   cursor: pointer;
   list-style: none;
-  color: #f8fafc;
+  color: #1C1B1B;
   font-weight: 500;
 }
 
@@ -318,17 +320,17 @@ const STUDIO_SHELL_STYLES = `
 }
 
 .mdcms-studio-shell__details[open] .mdcms-studio-shell__details-hint {
-  color: #cbd5e1;
+  color: #444655;
 }
 
 .mdcms-studio-shell__details-pre {
   margin: 1rem 0 0;
   padding: 1rem;
-  border-radius: 0.8rem;
-  border: 1px solid rgba(148, 163, 184, 0.1);
-  background: #02040a;
-  color: #cbd5e1;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(197, 197, 216, 0.3);
+  background: #F0EDEC;
+  color: #1C1B1B;
+  font-family: "Geist Mono", ui-monospace, monospace;
   font-size: 0.78rem;
   line-height: 1.7;
   white-space: pre-wrap;
@@ -349,7 +351,7 @@ const STUDIO_SHELL_STYLES = `
   display: grid;
   gap: 0.3rem;
   padding: 0.75rem 0;
-  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  border-top: 1px solid rgba(197, 197, 216, 0.3);
 }
 
 .mdcms-studio-shell__meta-row:first-child {
@@ -358,14 +360,14 @@ const STUDIO_SHELL_STYLES = `
 }
 
 .mdcms-studio-shell__meta-value {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  color: #f8fafc;
+  font-family: "Geist Mono", ui-monospace, monospace;
+  color: #1C1B1B;
   word-break: break-word;
 }
 
 @keyframes mdcms-studio-shell-pulse {
   0%, 100% {
-    opacity: 0.55;
+    opacity: 0.4;
   }
 
   50% {


### PR DESCRIPTION
## Summary
- Restyle the CLI login form and callback success page with a centered card layout, studio colors, and Inter font — replacing the unstyled HTML and Polish copy
- Restyle the studio shell loading/error frame from dark cyberpunk to the studio's light theme (warm whites, Space Grotesk headings, Geist Mono labels, blue primary accent)

## Test plan
- [ ] Trigger `mdcms login` and verify the browser auth page renders a styled card with email/password fields
- [ ] Complete the login flow and verify the callback tab shows a styled success card with green checkmark
- [ ] Embed the studio and verify the loading shell renders with the light theme before the runtime mounts
- [ ] Force a startup error and verify the error panel uses studio colors and typography

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Studio interface from dark to light theme with refined typography, colors, and visual styling across all UI elements.

* **Improvements**
  * Enhanced login callback page with complete HTML structure, improved visual styling, and clearer completion messaging.
  * Improved CLI authorization form with better-structured form layout, including properly-paired labels and input placeholders for enhanced user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->