### PR TITLE
fix: preserve init translation groups

### DIFF
--- a/.changeset/quiet-kings-smell.md
+++ b/.changeset/quiet-kings-smell.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/cli": patch
+---
+
+Preserve translation groups when mdcms init imports localized files

--- a/apps/cli/src/lib/init.test.ts
+++ b/apps/cli/src/lib/init.test.ts
@@ -186,6 +186,115 @@ test("full init wizard creates config, schema state, and manifest", async () => 
   });
 });
 
+test("init imports localized suffix files into one translation group", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "campaigns"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "campaigns", "summer-sale.en.md"),
+      "---\ntitle: Summer sale\nslug: summer-sale\n---\nEnglish body\n",
+    );
+    await writeFile(
+      join(cwd, "content", "campaigns", "summer-sale.fr.md"),
+      "---\ntitle: Vente d'été\nslug: summer-sale\n---\nFrench body\n",
+    );
+
+    const createPayloads: Array<Record<string, unknown>> = [];
+    let contentCreateCount = 0;
+
+    const fetcher = createMockFetcher({
+      "/healthz": () =>
+        new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      "/api/v1/projects": (url: string, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          const body = JSON.parse(String(init.body)) as { name: string };
+          return new Response(
+            JSON.stringify({
+              data: {
+                id: "proj-001",
+                slug: body.name,
+                name: body.name,
+                environments: [{ id: "env-001", name: "production" }],
+              },
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/environments")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ id: "env-002", name: "staging" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+      "/api/v1/schema": () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              schemaHash:
+                "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+              syncedAt: "2026-03-31T12:00:00.000Z",
+              affectedTypes: ["campaign"],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      "/api/v1/content": (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        createPayloads.push(body);
+        contentCreateCount += 1;
+
+        return new Response(
+          JSON.stringify({
+            data: {
+              documentId: `doc-${contentCreateCount}`,
+              draftRevision: 1,
+              publishedVersion: null,
+            },
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const prompter = createMockPrompter({
+      text: ["http://localhost:4000", "marketing-demo", "staging"],
+      select: [],
+      multiSelect: [["content/campaigns"]],
+      confirm: [true, true, true],
+    });
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      skipAuth: true,
+    });
+
+    const exitCode = await runMdcmsCli(["init"], {
+      cwd,
+      commands: [command],
+      stdout: { write: () => undefined },
+      stderr: { write: () => undefined },
+      fetcher,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(createPayloads.length, 2);
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.path),
+      ["content/campaigns/summer-sale", "content/campaigns/summer-sale"],
+    );
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.locale),
+      ["en", "fr"],
+    );
+    assert.equal(createPayloads[0]!.sourceDocumentId, undefined);
+    assert.equal(createPayloads[1]!.sourceDocumentId, "doc-1");
+  });
+});
+
 test("init fails when server unreachable", async () => {
   await withTempDir(async (cwd) => {
     const fetcher = createMockFetcher({

--- a/apps/cli/src/lib/init.ts
+++ b/apps/cli/src/lib/init.ts
@@ -555,6 +555,7 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
           const manifest: ScopedManifest = {};
           let successCount = 0;
           let failCount = 0;
+          const localizedGroupSeeds = new Map<string, string>();
 
           for (const file of filesToImport) {
             const fullPath = join(cwd, file.relativePath);
@@ -607,6 +608,11 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
               locale = localeConfig?.defaultLocale ?? "en";
             }
             const hash = hashContent(rawContent);
+            const translationGroupKey =
+              type?.localized === true ? `${typeName}:${path}` : null;
+            const sourceDocumentId = translationGroupKey
+              ? localizedGroupSeeds.get(translationGroupKey)
+              : undefined;
 
             const contentHeaders: Record<string, string> = {
               "content-type": "application/json",
@@ -629,6 +635,7 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
                     format: file.format,
                     frontmatter,
                     body,
+                    ...(sourceDocumentId ? { sourceDocumentId } : {}),
                   }),
                 },
               );
@@ -707,6 +714,15 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
               };
 
               manifest[contentResult.data.documentId] = entry;
+              if (
+                translationGroupKey &&
+                !localizedGroupSeeds.has(translationGroupKey)
+              ) {
+                localizedGroupSeeds.set(
+                  translationGroupKey,
+                  contentResult.data.documentId,
+                );
+              }
               successCount++;
               stdout.write(
                 `Imported ${file.relativePath} -> ${contentResult.data.documentId}\n`,

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -113,7 +113,7 @@ The setup wizard uses `@inquirer/prompts` for the interactive TUI and walks thro
 9. **Schema + locale confirmation** — Present inferred schema and locale mapping plan, let developer adjust. Locale detection precedence is `frontmatter > filename suffix > folder segment`; frontmatter keys checked are `locale`, `lang`, and `language`.
 10. **Config generation** — Generate `mdcms.config.ts` with the confirmed schema, server URL, and settings. If localized types are present, generate `locales.default`, `locales.supported`, and persisted remaps in `locales.aliases`. The wizard recommends `locales.default` as the most frequently detected locale and prompts for confirmation/override.
 11. **Schema sync** — Sync schema to server via `PUT /api/v1/schema`. Persist the server-returned `schemaHash` to `.mdcms/schema/<project>.<environment>.json`. Skipped if no content types are defined.
-12. **Initial import** — Push all selected content to the CMS server with explicit `locale` and `content_format` per document. On `409` path conflict, the wizard falls back to `PUT` (update) using the `conflictDocumentId` from the error response. Manifest entries are written to `.mdcms/manifests/<project>.<environment>.json` on success.
+12. **Initial import** — Push all selected content to the CMS server with explicit `locale` and `content_format` per document. For localized types, the wizard creates one seed locale document per derived translation group, then creates remaining locale siblings as variants of that seed so they share a single `translation_group_id`. On `409` path conflict, the wizard falls back to `PUT` (update) using the `conflictDocumentId` from the error response. Manifest entries are written to `.mdcms/manifests/<project>.<environment>.json` on success.
 13. **Gitignore + untracking update** — Add managed content directories to `.gitignore` and explicitly remove already tracked managed content files from the Git index (`git rm -r --cached <dir>`), so they are no longer tracked.
 
 After the credential exchange, the wizard stores the API key in the credential store (keyed by `serverUrl`, `project`, `environment`) for use by subsequent commands.
@@ -140,6 +140,7 @@ For each candidate file discovered during `cms init`:
    - Two or more distinct locales => `localized: true`.
 8. For localized types, files with no locale marker are imported as default-locale variants and reported as warnings.
 9. Build translation groups from normalized base paths (locale markers stripped from suffix/folder forms) before initial import.
+10. During initial import, create one seed locale document per derived translation group and create remaining locale siblings as variants of that seed, so localized brownfield imports surface as one logical document with multiple translations in Studio.
 
 #### Brownfield Verification Scenarios
 


### PR DESCRIPTION
## Summary
- preserve translation groups during `mdcms init` by reusing the first localized document as `sourceDocumentId` for sibling locale imports
- add a CLI regression test covering localized suffix files imported from brownfield content
- include a changeset for `@mdcms/cli`

## Test Plan
- `bun test apps/cli/src/lib/init.test.ts`
- `bun nx run cli:build`
- `bun run check`
- `bun x prettier --check apps/cli/src/lib/init.ts apps/cli/src/lib/init.test.ts .changeset/quiet-kings-smell.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mdcms init` now preserves translation groups when importing multiple localized versions of the same content, creating a seed document and linking locale variants.

* **Tests**
  * Added a test ensuring multiple localized files with the same base path are imported into a single translation group.

* **Documentation**
  * Updated CLI spec to describe the seed+variant translation import flow.

* **Chores**
  * Added a changeset marking a patch release with the translation-group note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->