### PR TITLE
fix: use Node 24 in release workflow for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

- Upgrade Node from 22 to 24 in the release workflow
- Node 22 ships npm 10 which can sign provenance but cannot complete the OIDC token exchange for Trusted Publishers (causes 404 on publish)
- Node 24 ships npm 11 with full Trusted Publishers support — matches the working setup in next-cwv-monitor

## Test plan

- [ ] Re-run release workflow after merge — `@mdcms/cli@0.1.3` should publish via OIDC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to support the latest Node.js runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->