### PR TITLE
fix: normalize localized init paths when locale comes from frontmatter

### DIFF
--- a/.changeset/pretty-boxes-mix.md
+++ b/.changeset/pretty-boxes-mix.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/cli": patch
+---
+
+Fix localized init imports when locale is declared in frontmatter.

--- a/apps/cli/src/lib/init.test.ts
+++ b/apps/cli/src/lib/init.test.ts
@@ -295,6 +295,133 @@ test("init imports localized suffix files into one translation group", async () 
   });
 });
 
+test("init strips locale suffixes from import paths even when locale comes from frontmatter", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "campaigns"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "campaigns", "launch.en.mdx"),
+      [
+        "---",
+        "title: Spring launch",
+        "slug: launch",
+        "locale: en",
+        "---",
+        "",
+        "English body",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(cwd, "content", "campaigns", "launch.fr.mdx"),
+      [
+        "---",
+        "title: Lancement de printemps",
+        "slug: launch",
+        "locale: fr",
+        "---",
+        "",
+        "French body",
+        "",
+      ].join("\n"),
+    );
+
+    const createPayloads: Array<Record<string, unknown>> = [];
+    let contentCreateCount = 0;
+
+    const fetcher = createMockFetcher({
+      "/healthz": () =>
+        new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      "/api/v1/projects": (url: string, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          const body = JSON.parse(String(init.body)) as { name: string };
+          return new Response(
+            JSON.stringify({
+              data: {
+                id: "proj-001",
+                slug: body.name,
+                name: body.name,
+                environments: [{ id: "env-001", name: "production" }],
+              },
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/environments")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ id: "env-002", name: "staging" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+      "/api/v1/schema": () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              schemaHash:
+                "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+              syncedAt: "2026-03-31T12:00:00.000Z",
+              affectedTypes: ["campaign"],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      "/api/v1/content": (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        createPayloads.push(body);
+        contentCreateCount += 1;
+
+        return new Response(
+          JSON.stringify({
+            data: {
+              documentId: `doc-${contentCreateCount}`,
+              draftRevision: 1,
+              publishedVersion: null,
+            },
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const prompter = createMockPrompter({
+      text: ["http://localhost:4000", "marketing-demo", "staging"],
+      select: [],
+      multiSelect: [["content/campaigns"]],
+      confirm: [true, true, true],
+    });
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      skipAuth: true,
+    });
+
+    const exitCode = await runMdcmsCli(["init"], {
+      cwd,
+      commands: [command],
+      stdout: { write: () => undefined },
+      stderr: { write: () => undefined },
+      fetcher,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(createPayloads.length, 2);
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.path),
+      ["content/campaigns/launch", "content/campaigns/launch"],
+    );
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.locale),
+      ["en", "fr"],
+    );
+    assert.equal(createPayloads[0]!.sourceDocumentId, undefined);
+    assert.equal(createPayloads[1]!.sourceDocumentId, "doc-1");
+  });
+});
+
 test("init fails when server unreachable", async () => {
   await withTempDir(async (cwd) => {
     const fetcher = createMockFetcher({

--- a/apps/cli/src/lib/init.test.ts
+++ b/apps/cli/src/lib/init.test.ts
@@ -422,6 +422,135 @@ test("init strips locale suffixes from import paths even when locale comes from 
   });
 });
 
+test("init preserves non-locale directory segments that resemble locale tags", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "campaigns", "us"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(cwd, "content", "campaigns", "us", "launch.en.mdx"),
+      [
+        "---",
+        "title: Spring launch",
+        "slug: launch",
+        "locale: en",
+        "---",
+        "",
+        "English body",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(cwd, "content", "campaigns", "us", "launch.fr.mdx"),
+      [
+        "---",
+        "title: Lancement de printemps",
+        "slug: launch",
+        "locale: fr",
+        "---",
+        "",
+        "French body",
+        "",
+      ].join("\n"),
+    );
+
+    const createPayloads: Array<Record<string, unknown>> = [];
+    let contentCreateCount = 0;
+
+    const fetcher = createMockFetcher({
+      "/healthz": () =>
+        new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      "/api/v1/projects": (url: string, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          const body = JSON.parse(String(init.body)) as { name: string };
+          return new Response(
+            JSON.stringify({
+              data: {
+                id: "proj-001",
+                slug: body.name,
+                name: body.name,
+                environments: [{ id: "env-001", name: "production" }],
+              },
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/environments")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ id: "env-002", name: "staging" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+      "/api/v1/schema": () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              schemaHash:
+                "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+              syncedAt: "2026-03-31T12:00:00.000Z",
+              affectedTypes: ["campaign"],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      "/api/v1/content": (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        createPayloads.push(body);
+        contentCreateCount += 1;
+
+        return new Response(
+          JSON.stringify({
+            data: {
+              documentId: `doc-${contentCreateCount}`,
+              draftRevision: 1,
+              publishedVersion: null,
+            },
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const prompter = createMockPrompter({
+      text: ["http://localhost:4000", "marketing-demo", "staging"],
+      select: [],
+      multiSelect: [["content/campaigns"]],
+      confirm: [true, true, true],
+    });
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      skipAuth: true,
+    });
+
+    const exitCode = await runMdcmsCli(["init"], {
+      cwd,
+      commands: [command],
+      stdout: { write: () => undefined },
+      stderr: { write: () => undefined },
+      fetcher,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(createPayloads.length, 2);
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.path),
+      ["content/campaigns/us/launch", "content/campaigns/us/launch"],
+    );
+    assert.deepEqual(
+      createPayloads.map((payload) => payload.locale),
+      ["en", "fr"],
+    );
+    assert.equal(createPayloads[0]!.sourceDocumentId, undefined);
+    assert.equal(createPayloads[1]!.sourceDocumentId, "doc-1");
+  });
+});
+
 test("init fails when server unreachable", async () => {
   await withTempDir(async (cwd) => {
     const fetcher = createMockFetcher({

--- a/apps/cli/src/lib/init.ts
+++ b/apps/cli/src/lib/init.ts
@@ -79,9 +79,64 @@ function stripExtension(relativePath: string): string {
   return relativePath;
 }
 
+function createLocaleMarkerAllowlist(
+  file: DiscoveredFile,
+  localeConfig: LocaleConfig | null,
+): Set<string> {
+  const markers = new Set<string>();
+
+  if (localeConfig) {
+    for (const locale of localeConfig.supported) {
+      markers.add(locale);
+      const normalized = normalizeLocale(locale);
+      if (normalized) {
+        markers.add(normalized);
+      }
+    }
+
+    for (const [alias, target] of Object.entries(localeConfig.aliases)) {
+      markers.add(alias);
+      markers.add(target);
+
+      const normalizedAlias = normalizeLocale(alias);
+      if (normalizedAlias) {
+        markers.add(normalizedAlias);
+      }
+
+      const normalizedTarget = normalizeLocale(target);
+      if (normalizedTarget) {
+        markers.add(normalizedTarget);
+      }
+    }
+  }
+
+  if (file.localeHint) {
+    markers.add(file.localeHint.rawValue);
+    const normalizedHint = normalizeLocale(file.localeHint.rawValue);
+    if (normalizedHint) {
+      markers.add(normalizedHint);
+    }
+  }
+
+  return markers;
+}
+
+function isKnownLocaleMarker(
+  candidate: string,
+  localeMarkerAllowlist: ReadonlySet<string>,
+): boolean {
+  if (localeMarkerAllowlist.has(candidate)) {
+    return true;
+  }
+
+  const normalized = normalizeLocale(candidate);
+  return normalized !== null && localeMarkerAllowlist.has(normalized);
+}
+
 function normalizeLocalizedImportPath(
   relativePath: string,
   directory?: string,
+  localeMarkerAllowlist: ReadonlySet<string> = new Set(),
 ): string {
   const strippedPath = stripExtension(relativePath);
   const pathSegments = strippedPath.split("/");
@@ -109,16 +164,16 @@ function normalizeLocalizedImportPath(
     basenameSegments.length >= 2
       ? basenameSegments[basenameSegments.length - 1]!
       : null;
-  const normalizedSuffix =
-    suffixCandidate !== null ? normalizeLocale(suffixCandidate) : null;
-  const normalizedBasename =
-    normalizedSuffix !== null
-      ? basenameSegments.slice(0, -1).join(".")
-      : basename;
+  const hasLocaleSuffix =
+    suffixCandidate !== null &&
+    isKnownLocaleMarker(suffixCandidate, localeMarkerAllowlist);
+  const normalizedBasename = hasLocaleSuffix
+    ? basenameSegments.slice(0, -1).join(".")
+    : basename;
 
   const normalizedDirectorySegments = contentSegments
     .slice(0, -1)
-    .filter((segment) => normalizeLocale(segment) === null);
+    .filter((segment) => !isKnownLocaleMarker(segment, localeMarkerAllowlist));
 
   return [
     ...prefixSegments,
@@ -619,11 +674,16 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
             const { frontmatter, body } = parseMarkdownDocument(rawContent);
             const type = findTypeForFile(file, inferredTypes);
             const typeName = type?.name ?? "unknown";
+            const localeMarkerAllowlist = createLocaleMarkerAllowlist(
+              file,
+              localeConfig,
+            );
             const path =
               type?.localized === true
                 ? normalizeLocalizedImportPath(
                     file.relativePath,
                     type.directory,
+                    localeMarkerAllowlist,
                   )
                 : stripExtension(file.relativePath);
 

--- a/apps/cli/src/lib/init.ts
+++ b/apps/cli/src/lib/init.ts
@@ -79,6 +79,54 @@ function stripExtension(relativePath: string): string {
   return relativePath;
 }
 
+function normalizeLocalizedImportPath(
+  relativePath: string,
+  directory?: string,
+): string {
+  const strippedPath = stripExtension(relativePath);
+  const pathSegments = strippedPath.split("/");
+  const directorySegments = directory?.split("/") ?? [];
+  const hasDirectoryPrefix =
+    directorySegments.length > 0 &&
+    directorySegments.every(
+      (segment, index) => pathSegments[index] === segment,
+    );
+
+  const prefixSegments = hasDirectoryPrefix
+    ? pathSegments.slice(0, directorySegments.length)
+    : [];
+  const contentSegments = hasDirectoryPrefix
+    ? pathSegments.slice(directorySegments.length)
+    : [...pathSegments];
+
+  if (contentSegments.length === 0) {
+    return strippedPath;
+  }
+
+  const basename = contentSegments[contentSegments.length - 1]!;
+  const basenameSegments = basename.split(".");
+  const suffixCandidate =
+    basenameSegments.length >= 2
+      ? basenameSegments[basenameSegments.length - 1]!
+      : null;
+  const normalizedSuffix =
+    suffixCandidate !== null ? normalizeLocale(suffixCandidate) : null;
+  const normalizedBasename =
+    normalizedSuffix !== null
+      ? basenameSegments.slice(0, -1).join(".")
+      : basename;
+
+  const normalizedDirectorySegments = contentSegments
+    .slice(0, -1)
+    .filter((segment) => normalizeLocale(segment) === null);
+
+  return [
+    ...prefixSegments,
+    ...normalizedDirectorySegments,
+    normalizedBasename,
+  ].join("/");
+}
+
 function findTypeForFile(
   file: DiscoveredFile,
   inferredTypes: InferredType[],
@@ -571,26 +619,13 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
             const { frontmatter, body } = parseMarkdownDocument(rawContent);
             const type = findTypeForFile(file, inferredTypes);
             const typeName = type?.name ?? "unknown";
-            let path = stripExtension(file.relativePath);
-
-            // For localized types with suffix locale, strip the locale from the path
-            if (type?.localized && file.localeHint?.source === "suffix") {
-              const lastDot = path.lastIndexOf(".");
-              if (lastDot > 0) {
-                path = path.slice(0, lastDot);
-              }
-            }
-
-            // For localized types with folder locale, strip the locale folder segment
-            if (type?.localized && file.localeHint?.source === "folder") {
-              const rawLocale = file.localeHint.rawValue;
-              const normalized = normalizeLocale(rawLocale);
-              const segments = path.split("/");
-              const filtered = segments.filter(
-                (s) => s !== rawLocale && s !== normalized,
-              );
-              path = filtered.join("/");
-            }
+            const path =
+              type?.localized === true
+                ? normalizeLocalizedImportPath(
+                    file.relativePath,
+                    type.directory,
+                  )
+                : stripExtension(file.relativePath);
 
             // Determine locale: normalize raw hint, or use default for localized types
             let locale: string;

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -139,7 +139,7 @@ For each candidate file discovered during `cms init`:
    - No multi-locale evidence => `localized: false`.
    - Two or more distinct locales => `localized: true`.
 8. For localized types, files with no locale marker are imported as default-locale variants and reported as warnings.
-9. Build translation groups from normalized base paths (locale markers stripped from suffix/folder forms) before initial import.
+9. Build translation groups from normalized base paths before initial import. Base-path normalization is derived from the filesystem path and strips locale markers from suffix/folder forms even when frontmatter provides the canonical locale value for the document.
 10. During initial import, create one seed locale document per derived translation group and create remaining locale siblings as variants of that seed, so localized brownfield imports surface as one logical document with multiple translations in Studio.
 
 #### Brownfield Verification Scenarios


### PR DESCRIPTION
## Summary
- normalize localized init import paths from the filesystem path instead of tying path stripping to the winning locale hint source
- add a regression test for files that declare locale in frontmatter and still use `.en`/`.fr` filename suffixes
- clarify the brownfield import spec and include a generated changeset for `@mdcms/cli`

## Verification
- `bun test --conditions @mdcms/source apps/cli/src/lib/init.test.ts`
- `bun nx run cli:build`
- `bun x prettier --check apps/cli/src/lib/init.ts apps/cli/src/lib/init.test.ts docs/specs/SPEC-008-cli-and-sdk.md .changeset/pretty-boxes-mix.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI init handling of localized content so import paths are normalized to strip locale markers while preserving locale metadata across variants.

* **Tests**
  * Added CLI init tests covering locale-specified frontmatter and path normalization across nested directories.

* **Documentation**
  * Clarified init/translation-group behavior: base paths are normalized to remove locale markers before import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->