### PR TITLE
Group localized content list rows by translation group

### DIFF
--- a/.changeset/tough-geckos-clean.md
+++ b/.changeset/tough-geckos-clean.md
@@ -1,0 +1,6 @@
+---
+"@mdcms/shared": patch
+"@mdcms/studio": patch
+---
+
+Group localized Studio content lists by translation group.

--- a/apps/server/src/lib/content-api.integration.test.ts
+++ b/apps/server/src/lib/content-api.integration.test.ts
@@ -357,6 +357,249 @@ testWithDatabase(
 );
 
 testWithDatabase(
+  "content API DB list can group localized variants into logical translation rows",
+  async () => {
+    const { handler, dbConnection, cookie, csrfHeaders } =
+      await createDatabaseTestContext("test:content-api-db-grouped-list");
+    const testScopeHeaders = {
+      ...scopeHeaders,
+      "x-mdcms-project": stableFixtureName("content-db-grouped-list"),
+      "x-mdcms-environment": "production",
+    };
+    const scope = {
+      project: testScopeHeaders["x-mdcms-project"],
+      environment: testScopeHeaders["x-mdcms-environment"],
+    };
+
+    try {
+      await resetDatabaseTestScope(dbConnection.db, scope);
+      await seedSchemaRegistryScope(dbConnection.db, {
+        scope,
+        supportedLocales: ["fr", "en"],
+        entries: [
+          {
+            type: "Campaign",
+            directory: "content/campaigns",
+            localized: true,
+            fields: {
+              slug: {
+                kind: "string",
+                required: true,
+                nullable: false,
+              },
+              title: {
+                kind: "string",
+                required: false,
+                nullable: true,
+              },
+            },
+          },
+        ],
+      });
+
+      const launchPath = stableFixturePath("content/campaigns", "launch");
+      const summerPath = stableFixturePath("content/campaigns", "summer-sale");
+
+      const launchFr = (await createContentDocument(
+        handler,
+        csrfHeaders,
+        testScopeHeaders,
+        {
+          path: launchPath,
+          type: "Campaign",
+          locale: "fr",
+          format: "mdx",
+          frontmatter: {
+            slug: "launch",
+            title: "Lancement de printemps",
+          },
+          body: "Bonjour depuis le lancement.",
+        },
+      )) as { documentId: string };
+      await createContentDocument(handler, csrfHeaders, testScopeHeaders, {
+        path: launchPath,
+        type: "Campaign",
+        locale: "en",
+        format: "mdx",
+        sourceDocumentId: launchFr.documentId,
+        frontmatter: {
+          slug: "launch",
+          title: "Spring launch",
+        },
+        body: "Hello from launch.",
+      });
+
+      const publishLaunchFr = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${launchFr.documentId}/publish`,
+          {
+            method: "POST",
+            headers: csrfHeaders({
+              ...testScopeHeaders,
+              "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+              change_summary: "Publish French launch",
+            }),
+          },
+        ),
+      );
+      assert.equal(publishLaunchFr.status, 200);
+
+      const summerFr = (await createContentDocument(
+        handler,
+        csrfHeaders,
+        testScopeHeaders,
+        {
+          path: summerPath,
+          type: "Campaign",
+          locale: "fr",
+          format: "md",
+          frontmatter: {
+            slug: "summer-sale",
+            title: "Vente d'été",
+          },
+          body: "Bonjour depuis la vente d'été.",
+        },
+      )) as { documentId: string };
+      const summerEn = (await createContentDocument(
+        handler,
+        csrfHeaders,
+        testScopeHeaders,
+        {
+          path: summerPath,
+          type: "Campaign",
+          locale: "en",
+          format: "md",
+          sourceDocumentId: summerFr.documentId,
+          frontmatter: {
+            slug: "summer-sale",
+            title: "Summer sale",
+          },
+          body: "Hello from the summer sale.",
+        },
+      )) as { documentId: string };
+
+      const publishSummerFr = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${summerFr.documentId}/publish`,
+          {
+            method: "POST",
+            headers: csrfHeaders({
+              ...testScopeHeaders,
+              "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+              change_summary: "Publish French summer sale",
+            }),
+          },
+        ),
+      );
+      assert.equal(publishSummerFr.status, 200);
+
+      const publishSummerEn = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${summerEn.documentId}/publish`,
+          {
+            method: "POST",
+            headers: csrfHeaders({
+              ...testScopeHeaders,
+              "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+              change_summary: "Publish English summer sale",
+            }),
+          },
+        ),
+      );
+      assert.equal(publishSummerEn.status, 200);
+
+      const response = await handler(
+        new Request(
+          "http://localhost/api/v1/content?draft=true&type=Campaign&groupBy=translationGroup&sort=path&order=asc",
+          {
+            headers: {
+              ...testScopeHeaders,
+              cookie,
+            },
+          },
+        ),
+      );
+      const body = (await response.json()) as {
+        data: Array<{
+          documentId: string;
+          translationGroupId: string;
+          path: string;
+          locale: string;
+          frontmatter: { title?: string };
+          publishedVersion: number | null;
+          hasUnpublishedChanges: boolean;
+          localesPresent?: string[];
+          publishedLocales?: string[];
+        }>;
+        pagination: {
+          total: number;
+          limit: number;
+          offset: number;
+          hasMore: boolean;
+        };
+      };
+
+      assert.equal(response.status, 200);
+      assert.equal(body.pagination.total, 2);
+      assert.equal(body.data.length, 2);
+      assert.deepEqual(
+        body.data.map((row) => row.path),
+        [launchPath, summerPath],
+      );
+      assert.deepEqual(
+        body.data.map((row) => row.locale),
+        ["fr", "fr"],
+      );
+      assert.deepEqual(
+        body.data.map((row) => row.frontmatter.title),
+        ["Lancement de printemps", "Vente d'été"],
+      );
+      assert.deepEqual(
+        body.data.map((row) => [...(row.localesPresent ?? [])].sort()),
+        [
+          ["en", "fr"],
+          ["en", "fr"],
+        ],
+      );
+      assert.deepEqual(
+        body.data.map((row) => [...(row.publishedLocales ?? [])].sort()),
+        [["fr"], ["en", "fr"]],
+      );
+      assert.deepEqual(
+        body.data.map((row) => ({
+          translationGroupId: row.translationGroupId,
+          documentId: row.documentId,
+          publishedVersion: row.publishedVersion,
+          hasUnpublishedChanges: row.hasUnpublishedChanges,
+        })),
+        [
+          {
+            translationGroupId: body.data[0]!.translationGroupId,
+            documentId: launchFr.documentId,
+            publishedVersion: 1,
+            hasUnpublishedChanges: true,
+          },
+          {
+            translationGroupId: body.data[1]!.translationGroupId,
+            documentId: summerFr.documentId,
+            publishedVersion: 1,
+            hasUnpublishedChanges: false,
+          },
+        ],
+      );
+    } finally {
+      await dbConnection.close();
+    }
+  },
+);
+
+testWithDatabase(
   "content API overview returns metadata counts without exposing draft rows",
   async () => {
     const { handler, dbConnection, cookie, csrfHeaders } =

--- a/apps/server/src/lib/content-api.test.ts
+++ b/apps/server/src/lib/content-api.test.ts
@@ -251,6 +251,64 @@ test("content API supports create/list filters/sort/pagination", async () => {
   assert.equal(body.data[0]?.type, "BlogPost");
 });
 
+test("content API rejects translation group grouping for non-localized types", async () => {
+  const store = createInMemoryContentStore({
+    schemaScopes: [
+      {
+        project: scopeHeaders["x-mdcms-project"],
+        environment: scopeHeaders["x-mdcms-environment"],
+        schemas: {
+          SettingsPage: {
+            type: "SettingsPage",
+            directory: "content/settings",
+            localized: false,
+            fields: {},
+          },
+        },
+      },
+    ],
+  });
+  const rawHandler = createServerRequestHandler({
+    env: baseEnv,
+    configureApp: (app) => {
+      mountContentApiRoutes(app, {
+        store,
+        authorize: async () => undefined,
+        requireCsrf: async () => undefined,
+        getWriteSchemaSyncState: async () => ({
+          schemaHash: inMemorySchemaHash,
+        }),
+      });
+    },
+    now: () => new Date("2026-03-02T10:00:00.000Z"),
+  });
+  const handler = wrapHandlerWithAutoSchemaHash(
+    rawHandler,
+    () => inMemorySchemaHash,
+  );
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/content?draft=true&type=SettingsPage&groupBy=translationGroup",
+      {
+        headers: scopeHeaders,
+      },
+    ),
+  );
+  const body = (await response.json()) as {
+    code: string;
+    details?: {
+      field?: string;
+      value?: string;
+    };
+  };
+
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "INVALID_QUERY_PARAM");
+  assert.equal(body.details?.field, "groupBy");
+  assert.equal(body.details?.value, "translationGroup");
+});
+
 test("content API overview returns metadata-only counts per type using content:read scope", async () => {
   const authorizeCalls: Array<Record<string, unknown>> = [];
   const store = createInMemoryContentStore({

--- a/apps/server/src/lib/content-api.test.ts
+++ b/apps/server/src/lib/content-api.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { test } from "bun:test";
+import { RuntimeError } from "@mdcms/shared";
 
 import {
   createInMemoryContentStore,
@@ -307,6 +308,70 @@ test("content API rejects translation group grouping for non-localized types", a
   assert.equal(body.code, "INVALID_QUERY_PARAM");
   assert.equal(body.details?.field, "groupBy");
   assert.equal(body.details?.value, "translationGroup");
+});
+
+test("content API authorizes list reads before validating translation grouping", async () => {
+  let schemaReads = 0;
+  const store = createInMemoryContentStore({
+    schemaScopes: [
+      {
+        project: scopeHeaders["x-mdcms-project"],
+        environment: scopeHeaders["x-mdcms-environment"],
+        schemas: {
+          SettingsPage: {
+            type: "SettingsPage",
+            directory: "content/settings",
+            localized: false,
+            fields: {},
+          },
+        },
+      },
+    ],
+  });
+  const rawHandler = createServerRequestHandler({
+    env: baseEnv,
+    configureApp: (app) => {
+      mountContentApiRoutes(app, {
+        store: {
+          ...store,
+          async getSchema(scope, type) {
+            schemaReads += 1;
+            return store.getSchema(scope, type);
+          },
+        },
+        authorize: async () => {
+          throw new RuntimeError({
+            code: "FORBIDDEN",
+            message: "Forbidden",
+            statusCode: 403,
+          });
+        },
+        requireCsrf: async () => undefined,
+        getWriteSchemaSyncState: async () => ({
+          schemaHash: inMemorySchemaHash,
+        }),
+      });
+    },
+    now: () => new Date("2026-03-02T10:00:00.000Z"),
+  });
+  const handler = wrapHandlerWithAutoSchemaHash(
+    rawHandler,
+    () => inMemorySchemaHash,
+  );
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/content?draft=true&type=SettingsPage&groupBy=translationGroup",
+      {
+        headers: scopeHeaders,
+      },
+    ),
+  );
+  const body = (await response.json()) as { code: string };
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, "FORBIDDEN");
+  assert.equal(schemaReads, 0);
 });
 
 test("content API overview returns metadata-only counts per type using content:read scope", async () => {

--- a/apps/server/src/lib/content-api/database-store.ts
+++ b/apps/server/src/lib/content-api/database-store.ts
@@ -30,6 +30,7 @@ import {
   assertJsonObject,
   assertRequiredString,
   parseBoolean,
+  parseContentListGroupBy,
   parseContentFormat,
   parseOptionalString,
   parsePositiveInt,
@@ -41,11 +42,14 @@ import {
   buildContentPathConflict,
   getUniqueConstraintName,
   isUniqueViolation,
+  readDefaultLocale,
+  readOrderedSupportedLocales,
   readSupportedLocales,
   toContentDocument,
   toContentVersionDocument,
   toIsoString,
 } from "./responses.js";
+import { groupDocumentsByTranslationGroup } from "./grouped-list.js";
 import { validateReferenceFieldIdentities } from "./reference-validation.js";
 import { matchesDeletedListVisibility } from "./visibility.js";
 
@@ -194,6 +198,8 @@ export function createDatabaseContentStore(
   ): Promise<
     | {
         localized: boolean;
+        defaultLocale?: string;
+        orderedSupportedLocales?: string[];
         supportedLocales?: Set<string>;
       }
     | undefined
@@ -220,6 +226,10 @@ export function createDatabaseContentStore(
 
     return {
       localized: schemaEntry.localized,
+      defaultLocale: readDefaultLocale(schemaSync?.rawConfigSnapshot),
+      orderedSupportedLocales: readOrderedSupportedLocales(
+        schemaSync?.rawConfigSnapshot,
+      ),
       supportedLocales: readSupportedLocales(schemaSync?.rawConfigSnapshot),
     };
   }
@@ -782,6 +792,7 @@ export function createDatabaseContentStore(
       const normalizedLocale = query.locale?.trim();
       const normalizedSlug = query.slug?.trim();
       const normalizedQ = query.q?.trim().toLowerCase();
+      const groupBy = parseContentListGroupBy(query.groupBy);
       const scopeIds = await resolveScopeIds(scope, false);
 
       if (!scopeIds) {
@@ -836,7 +847,25 @@ export function createDatabaseContentStore(
         }),
       );
 
-      const sortedRows = sortDocuments(filteredRows, sort, order);
+      const localePolicy =
+        groupBy === "translationGroup" && normalizedType
+          ? await resolveVariantLocalePolicy(scopeIds, normalizedType)
+          : undefined;
+      const sortedRows =
+        groupBy === "translationGroup" && normalizedType
+          ? groupDocumentsByTranslationGroup({
+              matchedRows: filteredRows,
+              allRows: resolvedRows.filter(
+                (document) =>
+                  document.type === normalizedType &&
+                  document.isDeleted === false,
+              ),
+              sort,
+              order,
+              defaultLocale: localePolicy?.defaultLocale,
+              supportedLocales: localePolicy?.orderedSupportedLocales,
+            })
+          : sortDocuments(filteredRows, sort, order);
 
       return {
         rows: sortedRows.slice(offset, offset + limit),

--- a/apps/server/src/lib/content-api/grouped-list.test.ts
+++ b/apps/server/src/lib/content-api/grouped-list.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { groupDocumentsByTranslationGroup } from "./grouped-list.js";
+import type { ContentDocument } from "./types.js";
+
+function createDocument(
+  overrides: Partial<ContentDocument> & {
+    documentId: string;
+    locale: string;
+    path: string;
+  },
+): ContentDocument {
+  return {
+    documentId: overrides.documentId,
+    translationGroupId: overrides.translationGroupId ?? "tg-1",
+    project: overrides.project ?? "marketing-site",
+    environment: overrides.environment ?? "production",
+    path: overrides.path,
+    type: overrides.type ?? "Campaign",
+    locale: overrides.locale,
+    format: overrides.format ?? "mdx",
+    isDeleted: overrides.isDeleted ?? false,
+    hasUnpublishedChanges: overrides.hasUnpublishedChanges ?? false,
+    version: overrides.version ?? 1,
+    publishedVersion: overrides.publishedVersion ?? 1,
+    draftRevision: overrides.draftRevision ?? 1,
+    frontmatter: overrides.frontmatter ?? {},
+    body: overrides.body ?? "",
+    createdBy: overrides.createdBy ?? "user-1",
+    createdAt: overrides.createdAt ?? "2026-03-01T00:00:00.000Z",
+    updatedBy: overrides.updatedBy ?? "user-1",
+    updatedAt: overrides.updatedAt ?? "2026-03-20T00:00:00.000Z",
+    ...(overrides.localesPresent
+      ? { localesPresent: overrides.localesPresent }
+      : {}),
+    ...(overrides.publishedLocales
+      ? { publishedLocales: overrides.publishedLocales }
+      : {}),
+  };
+}
+
+test("groupDocumentsByTranslationGroup chooses the representative from matched rows only", () => {
+  const englishVariant = createDocument({
+    documentId: "doc-en",
+    locale: "en",
+    path: "content/campaigns/launch",
+    frontmatter: { title: "Spring launch" },
+  });
+  const frenchVariant = createDocument({
+    documentId: "doc-fr",
+    locale: "fr",
+    path: "content/campaigns/launch",
+    frontmatter: { title: "Lancement de printemps" },
+  });
+
+  const grouped = groupDocumentsByTranslationGroup({
+    matchedRows: [frenchVariant],
+    allRows: [englishVariant, frenchVariant],
+    sort: "path",
+    order: "asc",
+    defaultLocale: "en",
+    supportedLocales: ["en", "fr"],
+  });
+
+  assert.equal(grouped.length, 1);
+  assert.equal(grouped[0]?.documentId, "doc-fr");
+  assert.equal(grouped[0]?.locale, "fr");
+  assert.equal(grouped[0]?.frontmatter.title, "Lancement de printemps");
+  assert.deepEqual(grouped[0]?.localesPresent, ["en", "fr"]);
+});

--- a/apps/server/src/lib/content-api/grouped-list.ts
+++ b/apps/server/src/lib/content-api/grouped-list.ts
@@ -115,12 +115,12 @@ export function groupDocumentsByTranslationGroup(
   const rowsWithSortKeys = [
     ...new Set(input.matchedRows.map((row) => row.translationGroupId)),
   ].map((translationGroupId) => {
+    const matchedGroupRows = input.matchedRows.filter(
+      (row) => row.translationGroupId === translationGroupId,
+    );
     const groupRows =
-      availableGroupRows.get(translationGroupId) ??
-      input.matchedRows.filter(
-        (row) => row.translationGroupId === translationGroupId,
-      );
-    const representative = pickRepresentativeDocument(groupRows, {
+      availableGroupRows.get(translationGroupId) ?? matchedGroupRows;
+    const representative = pickRepresentativeDocument(matchedGroupRows, {
       defaultLocale: input.defaultLocale,
       supportedLocales: input.supportedLocales,
     });

--- a/apps/server/src/lib/content-api/grouped-list.ts
+++ b/apps/server/src/lib/content-api/grouped-list.ts
@@ -1,0 +1,177 @@
+import type { ContentDocument, SortField, SortOrder } from "./types.js";
+
+export type ContentGroupedListOptions = {
+  matchedRows: ContentDocument[];
+  allRows: ContentDocument[];
+  sort: SortField;
+  order: SortOrder;
+  defaultLocale?: string;
+  supportedLocales?: string[];
+};
+
+type GroupSortKeys = {
+  createdAt: string;
+  updatedAt: string;
+  path: string;
+};
+
+type LocalePreference = {
+  defaultLocale?: string;
+  supportedLocales?: string[];
+};
+
+function sortLocales(
+  locales: Iterable<string>,
+  preference: LocalePreference,
+): string[] {
+  const supportedRank = new Map(
+    (preference.supportedLocales ?? []).map((locale, index) => [locale, index]),
+  );
+
+  return [...new Set(locales)].sort((left, right) => {
+    const leftRank = supportedRank.get(left);
+    const rightRank = supportedRank.get(right);
+
+    if (leftRank !== undefined || rightRank !== undefined) {
+      if (leftRank === undefined) return 1;
+      if (rightRank === undefined) return -1;
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+    }
+
+    return left.localeCompare(right);
+  });
+}
+
+function pickRepresentativeDocument(
+  rows: ContentDocument[],
+  preference: LocalePreference,
+): ContentDocument {
+  const byLocale = new Map<string, ContentDocument>();
+
+  for (const row of rows) {
+    if (!byLocale.has(row.locale)) {
+      byLocale.set(row.locale, row);
+    }
+  }
+
+  const preferredLocales = [
+    ...(preference.defaultLocale ? [preference.defaultLocale] : []),
+    ...(preference.supportedLocales ?? []),
+  ];
+  const seen = new Set<string>();
+
+  for (const locale of preferredLocales) {
+    if (seen.has(locale)) {
+      continue;
+    }
+    seen.add(locale);
+    const preferred = byLocale.get(locale);
+    if (preferred) {
+      return preferred;
+    }
+  }
+
+  return [...rows].sort((left, right) => {
+    const localeCompared = left.locale.localeCompare(right.locale);
+    if (localeCompared !== 0) {
+      return localeCompared;
+    }
+    return left.documentId.localeCompare(right.documentId);
+  })[0]!;
+}
+
+function toGroupSortKeys(
+  rows: ContentDocument[],
+  representative: ContentDocument,
+): GroupSortKeys {
+  return {
+    createdAt: [...rows]
+      .map((row) => row.createdAt)
+      .sort((left, right) => left.localeCompare(right))[0]!,
+    updatedAt: [...rows]
+      .map((row) => row.updatedAt)
+      .sort((left, right) => right.localeCompare(left))[0]!,
+    path: representative.path,
+  };
+}
+
+export function groupDocumentsByTranslationGroup(
+  input: ContentGroupedListOptions,
+): ContentDocument[] {
+  const availableGroupRows = new Map<string, ContentDocument[]>();
+
+  for (const row of input.allRows) {
+    if (row.isDeleted) {
+      continue;
+    }
+
+    const existing = availableGroupRows.get(row.translationGroupId) ?? [];
+    existing.push(row);
+    availableGroupRows.set(row.translationGroupId, existing);
+  }
+
+  const rowsWithSortKeys = [
+    ...new Set(input.matchedRows.map((row) => row.translationGroupId)),
+  ].map((translationGroupId) => {
+    const groupRows =
+      availableGroupRows.get(translationGroupId) ??
+      input.matchedRows.filter(
+        (row) => row.translationGroupId === translationGroupId,
+      );
+    const representative = pickRepresentativeDocument(groupRows, {
+      defaultLocale: input.defaultLocale,
+      supportedLocales: input.supportedLocales,
+    });
+    const latestUpdated = [...groupRows].sort((left, right) =>
+      right.updatedAt.localeCompare(left.updatedAt),
+    )[0]!;
+    const publishedVersions = groupRows
+      .map((row) => row.publishedVersion)
+      .filter((version): version is number => version !== null);
+
+    return {
+      row: {
+        ...representative,
+        publishedVersion:
+          publishedVersions.length > 0 ? Math.max(...publishedVersions) : null,
+        hasUnpublishedChanges: groupRows.some(
+          (row) => row.publishedVersion === null || row.hasUnpublishedChanges,
+        ),
+        updatedAt: latestUpdated.updatedAt,
+        updatedBy: latestUpdated.updatedBy,
+        localesPresent: sortLocales(
+          groupRows.map((row) => row.locale),
+          {
+            defaultLocale: input.defaultLocale,
+            supportedLocales: input.supportedLocales,
+          },
+        ),
+        publishedLocales: sortLocales(
+          groupRows
+            .filter((row) => row.publishedVersion !== null)
+            .map((row) => row.locale),
+          {
+            defaultLocale: input.defaultLocale,
+            supportedLocales: input.supportedLocales,
+          },
+        ),
+      } satisfies ContentDocument,
+      sortKeys: toGroupSortKeys(groupRows, representative),
+    };
+  });
+
+  rowsWithSortKeys.sort((left, right) => {
+    const field =
+      input.sort === "createdAt"
+        ? "createdAt"
+        : input.sort === "path"
+          ? "path"
+          : "updatedAt";
+    const compared = left.sortKeys[field].localeCompare(right.sortKeys[field]);
+    return input.order === "asc" ? compared : compared * -1;
+  });
+
+  return rowsWithSortKeys.map((entry) => entry.row);
+}

--- a/apps/server/src/lib/content-api/in-memory-store.ts
+++ b/apps/server/src/lib/content-api/in-memory-store.ts
@@ -21,6 +21,7 @@ import {
   assertJsonObject,
   assertRequiredString,
   parseBoolean,
+  parseContentListGroupBy,
   parseContentFormat,
   parseOptionalString,
   parsePositiveInt,
@@ -28,6 +29,7 @@ import {
   validateContentPath,
   parseSortOrder,
 } from "./parsing.js";
+import { groupDocumentsByTranslationGroup } from "./grouped-list.js";
 import { validateReferenceFieldIdentities } from "./reference-validation.js";
 import { matchesDeletedListVisibility } from "./visibility.js";
 
@@ -47,8 +49,24 @@ export function createInMemoryContentStore(
     string,
     Map<string, SchemaRegistryTypeSnapshot>
   >();
+  const scopedLocales = new Map<
+    string,
+    {
+      defaultLocale?: string;
+      supportedLocales?: string[];
+    }
+  >();
 
   for (const scope of options.schemaScopes ?? []) {
+    if (scope.locales) {
+      scopedLocales.set(toScopeKey(scope.project, scope.environment), {
+        defaultLocale: scope.locales.default?.trim() || undefined,
+        supportedLocales:
+          scope.locales.supported
+            ?.map((locale) => locale.trim())
+            .filter((locale) => locale.length > 0) ?? undefined,
+      });
+    }
     scopedSchemas.set(
       toScopeKey(scope.project, scope.environment),
       new Map(Object.entries(scope.schemas)),
@@ -85,6 +103,15 @@ export function createInMemoryContentStore(
     scope: ContentScope,
   ): Map<string, SchemaRegistryTypeSnapshot> | undefined {
     return scopedSchemas.get(toScopeKey(scope.project, scope.environment));
+  }
+
+  function getScopeLocales(scope: ContentScope):
+    | {
+        defaultLocale?: string;
+        supportedLocales?: string[];
+      }
+    | undefined {
+    return scopedLocales.get(toScopeKey(scope.project, scope.environment));
   }
 
   function findPathConflict(
@@ -392,6 +419,7 @@ export function createInMemoryContentStore(
       const normalizedLocale = query.locale?.trim();
       const normalizedSlug = query.slug?.trim();
       const normalizedQ = query.q?.trim().toLowerCase();
+      const groupBy = parseContentListGroupBy(query.groupBy);
 
       const rows = [...store.values()]
         .map((document) =>
@@ -453,22 +481,45 @@ export function createInMemoryContentStore(
           return true;
         });
 
-      rows.sort((left, right) => {
-        let compared = 0;
+      const scopeLocales = getScopeLocales(scope);
+      const sortedRows =
+        groupBy === "translationGroup" && normalizedType
+          ? groupDocumentsByTranslationGroup({
+              matchedRows: rows,
+              allRows: [...store.values()]
+                .map((document) =>
+                  resolveReadDocument({
+                    document,
+                    draft,
+                    publishedSnapshots,
+                  }),
+                )
+                .filter((doc): doc is ContentDocument => Boolean(doc))
+                .filter(
+                  (doc) =>
+                    doc.type === normalizedType && doc.isDeleted === false,
+                ),
+              sort,
+              order,
+              defaultLocale: scopeLocales?.defaultLocale,
+              supportedLocales: scopeLocales?.supportedLocales,
+            })
+          : rows.sort((left, right) => {
+              let compared = 0;
 
-        if (sort === "path") {
-          compared = left.path.localeCompare(right.path);
-        } else if (sort === "createdAt") {
-          compared = left.createdAt.localeCompare(right.createdAt);
-        } else {
-          compared = left.updatedAt.localeCompare(right.updatedAt);
-        }
+              if (sort === "path") {
+                compared = left.path.localeCompare(right.path);
+              } else if (sort === "createdAt") {
+                compared = left.createdAt.localeCompare(right.createdAt);
+              } else {
+                compared = left.updatedAt.localeCompare(right.updatedAt);
+              }
 
-        return order === "asc" ? compared : compared * -1;
-      });
+              return order === "asc" ? compared : compared * -1;
+            });
 
-      const total = rows.length;
-      const pagedRows = rows.slice(offset, offset + limit);
+      const total = sortedRows.length;
+      const pagedRows = sortedRows.slice(offset, offset + limit);
 
       return {
         rows: pagedRows,

--- a/apps/server/src/lib/content-api/parsing.ts
+++ b/apps/server/src/lib/content-api/parsing.ts
@@ -2,11 +2,13 @@ import { RuntimeError, resolveRequestTargetRouting } from "@mdcms/shared";
 import { z } from "zod";
 
 import {
+  ContentListGroupBySchema,
   ContentFormatSchema,
   JsonObjectSchema,
   RestoreTargetStatusSchema,
   SortFieldSchema,
   SortOrderSchema,
+  type ContentListGroupBy,
   type ContentFormat,
   type ContentScope,
   type RestoreTargetStatus,
@@ -166,6 +168,20 @@ export function parseSortOrder(value: string | undefined): SortOrder {
     z.string().trim().toLowerCase().pipe(SortOrderSchema),
     value,
     "order",
+  );
+}
+
+export function parseContentListGroupBy(
+  value: string | undefined,
+): ContentListGroupBy | undefined {
+  if (value === undefined || value.trim().length === 0) {
+    return undefined;
+  }
+
+  return parseQueryParam(
+    z.string().trim().pipe(ContentListGroupBySchema),
+    value,
+    "groupBy",
   );
 }
 

--- a/apps/server/src/lib/content-api/responses.ts
+++ b/apps/server/src/lib/content-api/responses.ts
@@ -36,6 +36,12 @@ export function toDocumentResponse(
     draftRevision: document.draftRevision,
     frontmatter: document.frontmatter,
     body: document.body,
+    ...(document.localesPresent
+      ? { localesPresent: document.localesPresent }
+      : {}),
+    ...(document.publishedLocales
+      ? { publishedLocales: document.publishedLocales }
+      : {}),
     createdBy: document.createdBy,
     createdAt: document.createdAt,
     updatedBy: document.updatedBy,
@@ -138,6 +144,42 @@ export function readSupportedLocales(
   }
 
   return new Set(supportedLocales);
+}
+
+export function readOrderedSupportedLocales(
+  rawConfigSnapshot: unknown,
+): string[] | undefined {
+  if (!isRecord(rawConfigSnapshot)) {
+    return undefined;
+  }
+
+  const locales = rawConfigSnapshot.locales;
+  if (!isRecord(locales) || !Array.isArray(locales.supported)) {
+    return undefined;
+  }
+
+  const supportedLocales = locales.supported.filter(
+    (locale): locale is string =>
+      typeof locale === "string" && locale.trim().length > 0,
+  );
+
+  return supportedLocales.length > 0 ? supportedLocales : undefined;
+}
+
+export function readDefaultLocale(
+  rawConfigSnapshot: unknown,
+): string | undefined {
+  if (!isRecord(rawConfigSnapshot)) {
+    return undefined;
+  }
+
+  const locales = rawConfigSnapshot.locales;
+  if (!isRecord(locales) || typeof locales.default !== "string") {
+    return undefined;
+  }
+
+  const normalized = locales.default.trim();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 export function toContentDocument(

--- a/apps/server/src/lib/content-api/routes.ts
+++ b/apps/server/src/lib/content-api/routes.ts
@@ -143,6 +143,14 @@ export function mountContentApiRoutes(
       });
       const groupBy = parseContentListGroupBy(typedQuery.groupBy);
       const resolvedType = typedQuery.type?.trim();
+      await options.authorize(request, {
+        requiredScope,
+        project: scope.project,
+        environment: scope.environment,
+        documentPath:
+          requestedPath && requestedPath.length > 0 ? requestedPath : undefined,
+      });
+
       if (groupBy === "translationGroup") {
         if (!resolvedType) {
           throw new RuntimeError({
@@ -166,13 +174,6 @@ export function mountContentApiRoutes(
           });
         }
       }
-      await options.authorize(request, {
-        requiredScope,
-        project: scope.project,
-        environment: scope.environment,
-        documentPath:
-          requestedPath && requestedPath.length > 0 ? requestedPath : undefined,
-      });
 
       const result = await options.store.list(scope, typedQuery);
       const schemaCache = new Map<

--- a/apps/server/src/lib/content-api/routes.ts
+++ b/apps/server/src/lib/content-api/routes.ts
@@ -7,6 +7,7 @@ import { executeWithRuntimeErrorsHandled } from "../http-utils.js";
 import {
   assertRequiredString,
   parseBoolean,
+  parseContentListGroupBy,
   parseOptionalString,
   parsePathInt,
   parseRestoreTargetStatus,
@@ -140,7 +141,31 @@ export function mountContentApiRoutes(
         },
         requireType: true,
       });
+      const groupBy = parseContentListGroupBy(typedQuery.groupBy);
       const resolvedType = typedQuery.type?.trim();
+      if (groupBy === "translationGroup") {
+        if (!resolvedType) {
+          throw new RuntimeError({
+            code: "INVALID_QUERY_PARAM",
+            message:
+              'Query parameter "type" is required when "groupBy" is provided.',
+            statusCode: 400,
+            details: { field: "type" },
+          });
+        }
+
+        const schema = await options.store.getSchema(scope, resolvedType);
+
+        if (!schema?.localized) {
+          throw new RuntimeError({
+            code: "INVALID_QUERY_PARAM",
+            message:
+              'Query parameter "groupBy" is only valid for localized schema types.',
+            statusCode: 400,
+            details: { field: "groupBy", value: groupBy },
+          });
+        }
+      }
       await options.authorize(request, {
         requiredScope,
         project: scope.project,

--- a/apps/server/src/lib/content-api/types.ts
+++ b/apps/server/src/lib/content-api/types.ts
@@ -14,6 +14,7 @@ export const SortFieldSchema = z.enum(["createdAt", "updatedAt", "path"]);
 export const SortOrderSchema = z.enum(["asc", "desc"]);
 export const ContentFormatSchema = z.enum(["md", "mdx"]);
 export const RestoreTargetStatusSchema = z.enum(["draft", "published"]);
+export const ContentListGroupBySchema = z.enum(["translationGroup"]);
 
 export const JsonObjectSchema = z
   .record(z.string(), z.unknown())
@@ -27,6 +28,7 @@ export type SortField = z.infer<typeof SortFieldSchema>;
 export type SortOrder = z.infer<typeof SortOrderSchema>;
 export type ContentFormat = z.infer<typeof ContentFormatSchema>;
 export type RestoreTargetStatus = z.infer<typeof RestoreTargetStatusSchema>;
+export type ContentListGroupBy = z.infer<typeof ContentListGroupBySchema>;
 
 export type ContentScope = {
   project: string;
@@ -81,6 +83,7 @@ export type ContentListQuery = {
   sort?: string;
   order?: string;
   q?: string;
+  groupBy?: string;
 };
 
 export type ContentVariantSummary = TranslationVariantSummary;
@@ -229,6 +232,10 @@ export type InMemoryContentSchemaScope = {
   project: string;
   environment: string;
   schemas: Record<string, SchemaRegistryTypeSnapshot>;
+  locales?: {
+    default?: string;
+    supported?: string[];
+  };
 };
 
 export type CreateInMemoryContentStoreOptions = {

--- a/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
+++ b/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
@@ -262,24 +262,25 @@ Reference fields persist plain env-local `document_id` UUID strings in
 
 ## Query Parameters (Content Listing)
 
-| Parameter               | Type     | Description                                                                                                                                                                                                                                                      |
-| ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                  | string   | Filter by schema type (e.g., `BlogPost`)                                                                                                                                                                                                                         |
-| `path`                  | string   | Filter by path prefix (e.g., `blog/`)                                                                                                                                                                                                                            |
-| `locale`                | string   | Filter by locale (configured BCP 47 tag such as `en`/`fr`, or `__mdcms_default__` in implicit single-locale mode)                                                                                                                                                |
-| `slug`                  | string   | Filter by slug (when multiple documents share the same type)                                                                                                                                                                                                     |
-| `published`             | boolean  | Filter by whether `published_version` exists                                                                                                                                                                                                                     |
-| `isDeleted`             | boolean  | Filter by soft-deleted state (`is_deleted`)                                                                                                                                                                                                                      |
-| `hasUnpublishedChanges` | boolean  | Filter by unpublished divergence from latest publish                                                                                                                                                                                                             |
-| `draft`                 | boolean  | Return mutable head content (published API default is latest published only; requires draft permission)                                                                                                                                                          |
-| `resolve`               | string[] | Resolve listed references inline at read time (shallow only). See the Reference Resolution Contract above for `resolveErrors`, `null` fallback values, and `INVALID_QUERY_PARAM` treatment of invalid paths. When used on the list endpoint, `type` is required. |
-| `project`               | string   | Target project (required if header not set)                                                                                                                                                                                                                      |
-| `environment`           | string   | Target environment (required if header not set)                                                                                                                                                                                                                  |
-| `limit`                 | integer  | Page size (default: 20, max: 100)                                                                                                                                                                                                                                |
-| `offset`                | integer  | Pagination offset                                                                                                                                                                                                                                                |
-| `sort`                  | string   | Sort field (e.g., `createdAt`, `updatedAt`, `path`)                                                                                                                                                                                                              |
-| `order`                 | string   | Sort direction (`asc` or `desc`)                                                                                                                                                                                                                                 |
-| `q`                     | string   | Free-text search (server-side, matches against document path and frontmatter title)                                                                                                                                                                              |
+| Parameter               | Type     | Description                                                                                                                                                                                                                                                                     |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                  | string   | Filter by schema type (e.g., `BlogPost`)                                                                                                                                                                                                                                        |
+| `path`                  | string   | Filter by path prefix (e.g., `blog/`)                                                                                                                                                                                                                                           |
+| `locale`                | string   | Filter by locale (configured BCP 47 tag such as `en`/`fr`, or `__mdcms_default__` in implicit single-locale mode)                                                                                                                                                               |
+| `slug`                  | string   | Filter by slug (when multiple documents share the same type)                                                                                                                                                                                                                    |
+| `published`             | boolean  | Filter by whether `published_version` exists                                                                                                                                                                                                                                    |
+| `isDeleted`             | boolean  | Filter by soft-deleted state (`is_deleted`)                                                                                                                                                                                                                                     |
+| `hasUnpublishedChanges` | boolean  | Filter by unpublished divergence from latest publish                                                                                                                                                                                                                            |
+| `draft`                 | boolean  | Return mutable head content (published API default is latest published only; requires draft permission)                                                                                                                                                                         |
+| `resolve`               | string[] | Resolve listed references inline at read time (shallow only). See the Reference Resolution Contract above for `resolveErrors`, `null` fallback values, and `INVALID_QUERY_PARAM` treatment of invalid paths. When used on the list endpoint, `type` is required.                |
+| `project`               | string   | Target project (required if header not set)                                                                                                                                                                                                                                     |
+| `environment`           | string   | Target environment (required if header not set)                                                                                                                                                                                                                                 |
+| `limit`                 | integer  | Page size (default: 20, max: 100)                                                                                                                                                                                                                                               |
+| `offset`                | integer  | Pagination offset                                                                                                                                                                                                                                                               |
+| `sort`                  | string   | Sort field (e.g., `createdAt`, `updatedAt`, `path`)                                                                                                                                                                                                                             |
+| `order`                 | string   | Sort direction (`asc` or `desc`)                                                                                                                                                                                                                                                |
+| `q`                     | string   | Free-text search (server-side, matches against document path and frontmatter title)                                                                                                                                                                                             |
+| `groupBy`               | string   | Optional list shaping mode. `translationGroup` is valid only when `type` resolves to a localized schema type and returns one row per `translation_group_id`. Search/filter matching still considers locale variants, but sort, pagination, and `total` operate on grouped rows. |
 
 ### User Summary Sidecar
 
@@ -296,6 +297,46 @@ Reference fields persist plain env-local `document_id` UUID strings in
   separate per-user lookups.
 - The `users` map is informational only and does not affect authorization or
   document data integrity.
+
+### Grouped Translation List Mode
+
+`GET /api/v1/content` supports `groupBy=translationGroup` for Studio-style
+localized document lists.
+
+- `groupBy=translationGroup` requires `type`.
+- The resolved schema type for `type` must be localized; otherwise the request
+  fails with `INVALID_QUERY_PARAM` (`400`).
+- The server applies the normal list filters (`type`, `path`, `locale`, `slug`,
+  `published`, `isDeleted`, `hasUnpublishedChanges`, `draft`, `q`) to locale
+  variants first, then collapses the matching variants by
+  `translation_group_id`.
+- The grouped response returns one row per matching `translation_group_id`, not
+  one row per locale variant.
+- Search continues to match any locale variant in the group. A matching group is
+  returned once even when multiple locale variants match the same query.
+- Sort, pagination, and `pagination.total` are computed on grouped rows after
+  grouping, not on raw locale variants.
+- Each grouped row includes:
+  - representative variant metadata:
+    `documentId`, `project`, `environment`, `path`, `type`, `locale`,
+    `format`, `frontmatter`, `createdBy`, `createdAt`, `updatedBy`,
+    `updatedAt`
+  - group-level metadata:
+    `translationGroupId`, `publishedVersion`, `hasUnpublishedChanges`,
+    `localesPresent`, `publishedLocales`
+- The representative variant is chosen by locale preference in this order:
+  1. project default locale
+  2. first available supported locale in configured order
+  3. lexical locale order
+- `publishedVersion` and `hasUnpublishedChanges` on grouped rows are
+  group-level values:
+  - `publishedVersion` is `null` only when no locale variant in the group has a
+    published version
+  - `hasUnpublishedChanges` is `true` when at least one locale variant in the
+    group is unpublished or has unpublished changes
+- `localesPresent` and `publishedLocales` describe the full non-deleted
+  translation group in the active routed scope, not just the representative
+  variant.
 
 ## Document Duplication
 

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -259,8 +259,10 @@ Deterministic states:
 The `/admin/content/:type` route is a live document list for a specific schema
 type within the active `(project, environment)` target. It is backed by:
 
-- `GET /api/v1/content?type=<typeId>` for the paginated document list with
-  server-side search, status filtering, sort, and pagination
+- `GET /api/v1/content?type=<typeId>&groupBy=translationGroup` for localized
+  schema types so the route paginates logical documents instead of locale
+  variants
+- `GET /api/v1/content?type=<typeId>` for non-localized schema types
 - `GET /api/v1/schema` for type metadata (name, directory, localized flag)
 - `GET /api/v1/me/capabilities` for action gating (inherited from layout)
 
@@ -272,13 +274,40 @@ Normative behavior:
 
 - The document list is keyed by the `type` route parameter resolved against live
   schema entries. Studio must not use mock content-type fixtures.
+- For localized schema types, the list renders one row per
+  `translationGroupId`, not one row per locale variant.
+- For non-localized schema types, the list renders one row per document as it
+  does today.
+- For localized schema types, Studio must request grouped rows from the content
+  API instead of grouping client-side after pagination.
 - Server-side search uses the `q` query parameter. The Studio search input is
   debounced before issuing requests.
+- For localized schema types, search matches any locale variant in the
+  translation group, but the route renders a single grouped row for that
+  logical document.
 - Status filtering maps UI states (`published`, `draft`, `changed`) to the
   `published` and `hasUnpublishedChanges` query parameters.
 - Pagination is server-side with `limit` and `offset`. Page size is fixed at 20.
+- For localized schema types, pagination and total counts operate on grouped
+  rows returned by the backend, not raw locale variants.
 - Author initials are derived from the `users` sidecar email. When a user
   cannot be resolved, a placeholder is shown.
+- For localized schema types, grouped rows use these representative-field
+  rules:
+  - title and path come from the representative locale variant
+  - the representative locale prefers the project default locale, then the
+    first available supported locale in configured order, then lexical locale
+    order
+  - `Updated` and `Author` use the most recently updated locale variant in the
+    group
+  - `Translations` reflects group coverage, not the representative locale only
+- For localized schema types, grouped row status is derived from the full
+  translation group:
+  - `Draft` when no locale variant in the group has a published version
+  - `Changed` when at least one locale variant is published and at least one
+    locale variant is unpublished or has unpublished changes
+  - `Published` only when every existing locale variant in the group has a
+    published version and none have unpublished changes
 
 Deterministic states:
 
@@ -318,6 +347,10 @@ Row-level actions:
 | Delete    | `DELETE .../content/:id`, invalidate list      | `capabilities.content.delete`    | Always                  |
 
 - Row action failures are surfaced inline with a dismissible error banner.
+- For localized grouped rows, row click, `Edit`, `Publish`, `Unpublish`,
+  `Duplicate`, and `Delete` target the representative locale variant's
+  `documentId`. Grouped rows do not implicitly turn these actions into
+  group-wide mutations.
 - The `content.list.row.actions` extensibility slot applies to these actions.
 
 ### Document Editor (`/admin/content/:type/:documentId`)

--- a/packages/shared/src/lib/contracts/content-api.ts
+++ b/packages/shared/src/lib/contracts/content-api.ts
@@ -46,6 +46,8 @@ export type ContentDocumentResponse = {
   frontmatter: Record<string, unknown>;
   body: string;
   resolveErrors?: ResolveErrorsMap;
+  localesPresent?: string[];
+  publishedLocales?: string[];
   createdBy: string;
   createdAt: string;
   updatedBy: string;

--- a/packages/studio/src/lib/content-list-api.test.ts
+++ b/packages/studio/src/lib/content-list-api.test.ts
@@ -193,7 +193,7 @@ test("list passes translation-group grouping as a query param", async () => {
     type: "BlogPost",
     limit: 5,
     groupBy: "translationGroup",
-  } as never);
+  });
 
   const url = new URL(String(calls[0]?.input));
   assert.equal(url.searchParams.get("groupBy"), "translationGroup");

--- a/packages/studio/src/lib/content-list-api.test.ts
+++ b/packages/studio/src/lib/content-list-api.test.ts
@@ -178,6 +178,27 @@ test("list passes sort and order query params", async () => {
   assert.equal(url.searchParams.get("limit"), "5");
 });
 
+test("list passes translation-group grouping as a query param", async () => {
+  const calls: Array<{ input: string | URL | Request }> = [];
+  const api = createApi({
+    fetcher: async (input) => {
+      calls.push({ input });
+      return new Response(JSON.stringify(validPaginatedResponse), {
+        status: 200,
+      });
+    },
+  });
+
+  await api.list({
+    type: "BlogPost",
+    limit: 5,
+    groupBy: "translationGroup",
+  } as never);
+
+  const url = new URL(String(calls[0]?.input));
+  assert.equal(url.searchParams.get("groupBy"), "translationGroup");
+});
+
 test("list returns empty result for malformed response", async () => {
   const api = createApi({
     fetcher: async () =>

--- a/packages/studio/src/lib/content-list-api.ts
+++ b/packages/studio/src/lib/content-list-api.ts
@@ -24,6 +24,7 @@ export type StudioContentListApiOptions = {
 
 export type StudioContentListQuery = {
   type?: string;
+  groupBy?: "translationGroup";
   q?: string;
   draft?: boolean;
   published?: boolean;
@@ -75,6 +76,7 @@ export function createStudioContentListApi(
       const url = resolveStudioRelativeUrl("/api/v1/content", config.serverUrl);
 
       if (query.type) url.searchParams.set("type", query.type);
+      if (query.groupBy) url.searchParams.set("groupBy", query.groupBy);
       const trimmedQ = query.q?.trim();
       if (trimmedQ) url.searchParams.set("q", trimmedQ);
       if (query.draft !== undefined)

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -448,9 +448,7 @@ export default function ContentTypePage() {
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">{typeName}</h1>
           {capabilities.canCreateContent && schemaEntry && (
-            <Button
-              onClick={create.open}
-            >
+            <Button onClick={create.open}>
               <Plus className="mr-2 h-4 w-4" />
               New Document
             </Button>
@@ -580,9 +578,7 @@ export default function ContentTypePage() {
               Create your first {typeName} document to get started.
             </p>
             {capabilities.canCreateContent && schemaEntry && (
-              <Button
-                onClick={create.open}
-              >
+              <Button onClick={create.open}>
                 <Plus className="mr-2 h-4 w-4" />
                 New Document
               </Button>
@@ -654,7 +650,7 @@ export default function ContentTypePage() {
                             <Avatar className="h-6 w-6">
                               <AvatarFallback className="text-xs">
                                 {deriveAuthorInitials(
-                                  list.users[doc.createdBy]?.email,
+                                  list.users[doc.updatedBy]?.email,
                                 )}
                               </AvatarFallback>
                             </Avatar>

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
@@ -9,6 +9,7 @@ import {
   extractDocumentTitle,
   mapFiltersToQuery,
   getContentTypeListQueryKey,
+  getContentTypeListGroupingMode,
   getTranslationCoverageStatus,
   PAGE_SIZE,
   shouldEnableTranslationCoverage,
@@ -75,16 +76,18 @@ test("mapContentDocument transforms API response to view model", () => {
   assert.equal(mapped.status, "published");
   assert.equal(mapped.updatedAt, "2026-03-20T00:00:00.000Z");
   assert.equal(mapped.createdBy, "user-1");
+  assert.equal(mapped.updatedBy, "user-1");
 });
 
-test("mapContentDocument uses the latest updater as the row author", () => {
+test("mapContentDocument keeps creator and updater distinct", () => {
   const mapped = mapContentDocument({
     ...baseDoc,
     createdBy: "creator-1",
     updatedBy: "editor-2",
   });
 
-  assert.equal(mapped.createdBy, "editor-2");
+  assert.equal(mapped.createdBy, "creator-1");
+  assert.equal(mapped.updatedBy, "editor-2");
 });
 
 test("mapFiltersToQuery maps status filter to API params", () => {
@@ -131,6 +134,11 @@ test("getContentTypeListQueryKey returns the canonical type-scoped query prefix"
     getContentTypeListQueryKey("marketing-site", "production", "BlogPost"),
     ["content-list", "marketing-site", "production", "BlogPost"],
   );
+});
+
+test("getContentTypeListGroupingMode returns a stable grouping discriminator", () => {
+  assert.equal(getContentTypeListGroupingMode(true), "translationGroup");
+  assert.equal(getContentTypeListGroupingMode(false), "document");
 });
 
 test("shouldEnableTranslationCoverage requires both a localized type and supported locales", () => {

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts
@@ -77,6 +77,16 @@ test("mapContentDocument transforms API response to view model", () => {
   assert.equal(mapped.createdBy, "user-1");
 });
 
+test("mapContentDocument uses the latest updater as the row author", () => {
+  const mapped = mapContentDocument({
+    ...baseDoc,
+    createdBy: "creator-1",
+    updatedBy: "editor-2",
+  });
+
+  assert.equal(mapped.createdBy, "editor-2");
+});
+
 test("mapFiltersToQuery maps status filter to API params", () => {
   assert.deepEqual(mapFiltersToQuery({ status: "all" }), {});
   assert.deepEqual(mapFiltersToQuery({ status: "published" }), {

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -31,6 +31,7 @@ export type MappedContentDocument = {
   status: DocumentStatus;
   updatedAt: string;
   createdBy: string;
+  updatedBy: string;
 };
 
 export type ContentTypeTranslationCoverageStatus =
@@ -93,7 +94,8 @@ export function mapContentDocument(
       doc.hasUnpublishedChanges,
     ),
     updatedAt: doc.updatedAt,
-    createdBy: doc.updatedBy,
+    createdBy: doc.createdBy,
+    updatedBy: doc.updatedBy,
   };
 }
 
@@ -159,6 +161,12 @@ export function getContentTypeListQueryKey(
   return ["content-list", project, environment, typeId] as const;
 }
 
+export function getContentTypeListGroupingMode(
+  enableTranslationCoverage: boolean,
+): "document" | "translationGroup" {
+  return enableTranslationCoverage ? "translationGroup" : "document";
+}
+
 export function shouldEnableTranslationCoverage(input: {
   enableTranslationCoverage: boolean;
   supportedLocaleCount: number;
@@ -211,6 +219,9 @@ export function useContentTypeList(
   ]);
 
   const queryParams = useMemo(() => mapFiltersToQuery(filters), [filters]);
+  const groupingMode = getContentTypeListGroupingMode(
+    enableTranslationCoverage,
+  );
 
   const query = useQuery({
     queryKey: [
@@ -219,13 +230,14 @@ export function useContentTypeList(
         mountInfo.environment,
         typeId,
       ),
+      groupingMode,
       queryParams,
       offset,
     ],
     queryFn: async () => {
       const result = await api!.list({
         type: typeId,
-        ...(enableTranslationCoverage
+        ...(groupingMode === "translationGroup"
           ? { groupBy: "translationGroup" as const }
           : {}),
         ...queryParams,

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts
@@ -93,7 +93,7 @@ export function mapContentDocument(
       doc.hasUnpublishedChanges,
     ),
     updatedAt: doc.updatedAt,
-    createdBy: doc.createdBy,
+    createdBy: doc.updatedBy,
   };
 }
 
@@ -225,6 +225,9 @@ export function useContentTypeList(
     queryFn: async () => {
       const result = await api!.list({
         type: typeId,
+        ...(enableTranslationCoverage
+          ? { groupBy: "translationGroup" as const }
+          : {}),
         ...queryParams,
         draft: true,
         isDeleted: false,

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts
@@ -27,6 +27,29 @@ test("buildContentTranslationCoverageMap counts unique locales per translation g
   });
 });
 
+test("buildContentTranslationCoverageMap prefers grouped locale metadata when present", () => {
+  const coverage = buildContentTranslationCoverageMap(
+    [
+      {
+        translationGroupId: "tg-1",
+        locale: "fr",
+        localesPresent: ["en", "fr"],
+      },
+      {
+        translationGroupId: "tg-2",
+        locale: "en",
+        localesPresent: ["en"],
+      },
+    ],
+    2,
+  );
+
+  assert.deepEqual(coverage, {
+    "tg-1": { translatedLocales: 2, totalLocales: 2 },
+    "tg-2": { translatedLocales: 1, totalLocales: 2 },
+  });
+});
+
 test("formatContentTranslationCoverageLabel renders the translated locale count", () => {
   assert.equal(
     formatContentTranslationCoverageLabel({
@@ -53,7 +76,7 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
               environment: "production",
               path: "blog/hello-world",
               type: "BlogPost",
-              locale: "en",
+              locale: "fr",
               format: "md",
               isDeleted: false,
               hasUnpublishedChanges: false,
@@ -62,27 +85,8 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
               draftRevision: 0,
               frontmatter: { title: "Hello World" },
               body: "# Hello",
-              createdBy: "user-1",
-              createdAt: "2026-03-01T00:00:00.000Z",
-              updatedBy: "user-1",
-              updatedAt: "2026-03-20T00:00:00.000Z",
-            },
-            {
-              documentId: "doc-2",
-              translationGroupId: "tg-1",
-              project: "marketing-site",
-              environment: "production",
-              path: "blog/bonjour",
-              type: "BlogPost",
-              locale: "fr",
-              format: "md",
-              isDeleted: false,
-              hasUnpublishedChanges: false,
-              version: 1,
-              publishedVersion: 1,
-              draftRevision: 0,
-              frontmatter: { title: "Bonjour" },
-              body: "# Bonjour",
+              localesPresent: ["en", "fr"],
+              publishedLocales: ["en", "fr"],
               createdBy: "user-1",
               createdAt: "2026-03-01T00:00:00.000Z",
               updatedBy: "user-1",
@@ -90,8 +94,8 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
             },
           ],
           pagination: {
-            total: 3,
-            limit: 2,
+            total: 2,
+            limit: 100,
             offset: 0,
             hasMore: true,
           },
@@ -116,6 +120,8 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
             draftRevision: 0,
             frontmatter: { title: "Hallo" },
             body: "# Hallo",
+            localesPresent: ["de"],
+            publishedLocales: ["de"],
             createdBy: "user-1",
             createdAt: "2026-03-01T00:00:00.000Z",
             updatedBy: "user-1",
@@ -123,9 +129,9 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
           },
         ],
         pagination: {
-          total: 3,
-          limit: 2,
-          offset: 2,
+          total: 2,
+          limit: 100,
+          offset: 100,
           hasMore: false,
         },
       };
@@ -146,6 +152,7 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
       type: "BlogPost",
       draft: true,
       isDeleted: false,
+      groupBy: "translationGroup",
       limit: 100,
       offset: 0,
     },
@@ -153,8 +160,9 @@ test("loadContentTranslationCoverageMap paginates through the full type list", a
       type: "BlogPost",
       draft: true,
       isDeleted: false,
+      groupBy: "translationGroup",
       limit: 100,
-      offset: 2,
+      offset: 100,
     },
   ]);
 });

--- a/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts
@@ -19,7 +19,7 @@ export type ContentTranslationCoverageMap = Record<
 
 type TranslationCoverageDocument = Pick<
   ContentDocumentResponse,
-  "translationGroupId" | "locale"
+  "translationGroupId" | "locale" | "localesPresent"
 >;
 
 export function getContentTranslationCoverageQueryKey(
@@ -48,7 +48,16 @@ export function buildContentTranslationCoverageMap(
   for (const document of documents) {
     const locales =
       localesByGroup.get(document.translationGroupId) ?? new Set();
-    locales.add(document.locale);
+    if (
+      Array.isArray(document.localesPresent) &&
+      document.localesPresent.length > 0
+    ) {
+      for (const locale of document.localesPresent) {
+        locales.add(locale);
+      }
+    } else {
+      locales.add(document.locale);
+    }
     localesByGroup.set(document.translationGroupId, locales);
   }
 
@@ -92,6 +101,7 @@ export async function loadContentTranslationCoverageMap(
   while (pageCount < maxPages) {
     const response = await api.list({
       type: input.type,
+      groupBy: "translationGroup",
       draft: true,
       isDeleted: false,
       limit: CONTENT_TRANSLATION_COVERAGE_PAGE_SIZE,
@@ -103,6 +113,7 @@ export async function loadContentTranslationCoverageMap(
       ...response.data.map((document) => ({
         translationGroupId: document.translationGroupId,
         locale: document.locale,
+        localesPresent: document.localesPresent,
       })),
     );
 


### PR DESCRIPTION
## Summary
- add `groupBy=translationGroup` support to the content list API and shared response contract for localized types
- update Studio localized content lists to request grouped rows and derive translation coverage from grouped metadata
- document the grouped localized list behavior and cover it with server and Studio regression tests

## Test Plan
- `bun test --conditions @mdcms/source apps/server/src/lib/content-api.test.ts`
- `bun test --conditions @mdcms/source apps/server/src/lib/content-api.integration.test.ts`
- `bun test --conditions @mdcms/source packages/studio/src/lib/content-list-api.test.ts packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts 'packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx'`
- `bun x prettier --check apps/server/src/lib/content-api.integration.test.ts apps/server/src/lib/content-api.test.ts apps/server/src/lib/content-api/database-store.ts apps/server/src/lib/content-api/grouped-list.ts apps/server/src/lib/content-api/in-memory-store.ts apps/server/src/lib/content-api/parsing.ts apps/server/src/lib/content-api/responses.ts apps/server/src/lib/content-api/routes.ts apps/server/src/lib/content-api/types.ts docs/specs/SPEC-003-content-storage-versioning-and-migrations.md docs/specs/SPEC-006-studio-runtime-and-ui.md packages/shared/src/lib/contracts/content-api.ts packages/studio/src/lib/content-list-api.test.ts packages/studio/src/lib/content-list-api.ts packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.test.ts packages/studio/src/lib/runtime-ui/hooks/use-content-type-list.ts packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.test.ts packages/studio/src/lib/runtime-ui/lib/content-translation-coverage.ts .changeset/tough-geckos-clean.md`
- `bun nx run server:build`
- `bun nx run studio:build`
- `bun run check`

## Notes
- `bun run format:check` still fails on unrelated repo baseline files outside this PR, including local-only `AGENTS.md` and pre-existing formatting drift elsewhere in the workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio: grouped list for localized content showing one row per translation group with translation coverage, published/locales indicators, representative title/path, and Updated/Author from the most-recent variant; row actions target the representative variant.
  * Content API: supports grouping list results by translation group and returns locale presence/published-locale metadata.

* **Documentation**
  * API spec and Studio contract updated to describe grouped translation-list behavior and response semantics.

* **Tests**
  * Added integration and unit tests covering grouped-list behavior and API validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->