### PR TITLE
docs: rewrite install docs for end users (CMS-194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,13 @@ Developers define schemas in code and sync via CLI. Editors get a visual Studio 
 
 ## Quick Start
 
-### 1. Install the CLI
+### 1. Install packages
 
 ```bash
-npm install -g @mdcms/cli
+npm install @mdcms/cli @mdcms/sdk
 ```
 
-### 2. Add the SDK to your app
-
-```bash
-npm install @mdcms/sdk
-```
-
-### 3. Define your content schema
+### 2. Define your content schema
 
 Create a `mdcms.config.ts` in your project root:
 
@@ -68,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-### 4. Pull and push content
+### 3. Pull and push content
 
 ```bash
 # Authenticate with your MDCMS server
@@ -81,7 +75,7 @@ npx mdcms pull
 npx mdcms push
 ```
 
-### 5. Fetch content in your app
+### 4. Fetch content in your app
 
 ```ts
 import { createClient } from "@mdcms/sdk";

--- a/README.md
+++ b/README.md
@@ -31,69 +31,106 @@ Developers define schemas in code and sync via CLI. Editors get a visual Studio 
 
 ## Quick Start
 
-### 1. Start the infrastructure
+### 1. Install the CLI
 
 ```bash
-git clone https://github.com/Blazity/mdcms.git
-cd mdcms
-bun install
-docker compose up -d --build
+npm install -g @mdcms/cli
 ```
 
-### 2. Start the dev server
+### 2. Add the SDK to your app
 
 ```bash
-bun run dev
+npm install @mdcms/sdk
 ```
 
-This starts the backend API server, Studio UI build watcher, and the example Next.js host app.
+### 3. Define your content schema
 
-### 3. Open Studio
+Create a `mdcms.config.ts` in your project root:
 
-Visit [http://127.0.0.1:4173/admin](http://127.0.0.1:4173/admin) to open the Studio UI.
+```ts
+import { defineConfig, defineType } from "@mdcms/cli";
+import { z } from "zod";
 
-Default demo credentials:
-- Email: `demo@mdcms.local`
-- Password: `Demo12345!`
+export default defineConfig({
+  project: "my-site",
+  environment: "production",
+  serverUrl: "https://your-mdcms-server.example.com",
+  contentDirectories: ["content"],
+  types: [
+    defineType("BlogPost", {
+      directory: "content/blog",
+      fields: {
+        title: z.string().min(1),
+        summary: z.string().optional(),
+      },
+    }),
+  ],
+});
+```
 
-### 4. Pull and push content with the CLI
+### 4. Pull and push content
 
 ```bash
-# Authenticate
-bun --conditions @mdcms/source apps/cli/src/bin/mdcms.ts login --config apps/studio-example/mdcms.config.ts
+# Authenticate with your MDCMS server
+npx mdcms login
 
-# Pull content to local files
-bun --conditions @mdcms/source apps/cli/src/bin/mdcms.ts pull --force
+# Pull content to local Markdown files
+npx mdcms pull
 
-# Edit a .md or .mdx file, then push changes back
-bun --conditions @mdcms/source apps/cli/src/bin/mdcms.ts push --force
+# Edit your .md or .mdx files, then push changes back
+npx mdcms push
 ```
+
+### 5. Fetch content in your app
+
+```ts
+import { createClient } from "@mdcms/sdk";
+
+const cms = createClient({
+  serverUrl: "https://your-mdcms-server.example.com",
+  apiKey: process.env.MDCMS_API_KEY!,
+  project: "my-site",
+  environment: "production",
+});
+
+const posts = await cms.list("BlogPost", { locale: "en", published: true });
+```
+
+### Embed the Studio UI (optional)
+
+Add a visual editing interface to your app:
+
+```bash
+npm install @mdcms/studio
+```
+
+See the [`@mdcms/studio` README](packages/studio) for embedding instructions.
 
 ## Features
 
-| Feature | Description |
-| --- | --- |
-| **Markdown/MDX content** | Author content in Markdown or MDX with custom component support |
-| **Code-first schema** | Define content types, fields, and references in TypeScript with Zod validation |
-| **Studio UI** | Embeddable React admin interface with a rich document editor, schema browser, and environment management |
-| **CLI workflows** | Pull content to local files, edit with any tool, push changes back |
-| **Client SDK** | Type-safe read API for fetching content in your app |
-| **Versioning and publishing** | Full draft/publish lifecycle with immutable version history |
-| **Auth and RBAC** | Session auth, OIDC/SAML SSO, API keys, and role-based access control |
-| **Environments** | Manage multiple environments (production, staging, preview) with schema overlays |
-| **i18n** | Locale-aware content with translation groups |
-| **Extensible modules** | First-party module system for extending server and CLI behavior |
+| Feature                       | Description                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Markdown/MDX content**      | Author content in Markdown or MDX with custom component support                                          |
+| **Code-first schema**         | Define content types, fields, and references in TypeScript with Zod validation                           |
+| **Studio UI**                 | Embeddable React admin interface with a rich document editor, schema browser, and environment management |
+| **CLI workflows**             | Pull content to local files, edit with any tool, push changes back                                       |
+| **Client SDK**                | Type-safe read API for fetching content in your app                                                      |
+| **Versioning and publishing** | Full draft/publish lifecycle with immutable version history                                              |
+| **Auth and RBAC**             | Session auth, OIDC/SAML SSO, API keys, and role-based access control                                     |
+| **Environments**              | Manage multiple environments (production, staging, preview) with schema overlays                         |
+| **i18n**                      | Locale-aware content with translation groups                                                             |
+| **Extensible modules**        | First-party module system for extending server and CLI behavior                                          |
 
 ## Packages
 
-| Package | npm | Description |
-| --- | --- | --- |
-| [`@mdcms/cli`](apps/cli) | `npm install @mdcms/cli` | CLI for content workflows (pull, push, login, schema sync) |
-| [`@mdcms/studio`](packages/studio) | `npm install @mdcms/studio` | Embeddable Studio UI component for host apps |
-| [`@mdcms/sdk`](packages/sdk) | `npm install @mdcms/sdk` | Read-focused client SDK for content APIs |
-| [`@mdcms/shared`](packages/shared) | `npm install @mdcms/shared` | Shared contracts, types, and validators |
-| [`@mdcms/server`](apps/server) | Private | Backend API server (Elysia + PostgreSQL) |
-| [`@mdcms/modules`](packages/modules) | Private | First-party module registry |
+| Package                              | npm                         | Description                                                |
+| ------------------------------------ | --------------------------- | ---------------------------------------------------------- |
+| [`@mdcms/cli`](apps/cli)             | `npm install @mdcms/cli`    | CLI for content workflows (pull, push, login, schema sync) |
+| [`@mdcms/studio`](packages/studio)   | `npm install @mdcms/studio` | Embeddable Studio UI component for host apps               |
+| [`@mdcms/sdk`](packages/sdk)         | `npm install @mdcms/sdk`    | Read-focused client SDK for content APIs                   |
+| [`@mdcms/shared`](packages/shared)   | `npm install @mdcms/shared` | Shared contracts, types, and validators                    |
+| [`@mdcms/server`](apps/server)       | Private                     | Backend API server (Elysia + PostgreSQL)                   |
+| [`@mdcms/modules`](packages/modules) | Private                     | First-party module registry                                |
 
 ## Coming Soon
 
@@ -113,6 +150,27 @@ bun --conditions @mdcms/source apps/cli/src/bin/mdcms.ts push --force
 Full documentation is available at [docs.mdcms.ai](https://docs.mdcms.ai/).
 
 For architecture decisions and specs, see the [`docs/`](docs) directory.
+
+## Development
+
+To work on MDCMS itself, clone the repo and use [Bun](https://bun.sh/) as the runtime:
+
+```bash
+git clone https://github.com/Blazity/mdcms.git
+cd mdcms
+bun install
+docker compose up -d --build   # Start Postgres, Redis, MinIO, Mailhog
+bun run dev                     # Start backend, Studio watcher, and example app
+```
+
+Visit [http://127.0.0.1:4173/admin](http://127.0.0.1:4173/admin) to open the Studio UI in the example host app.
+
+Default demo credentials:
+
+- Email: `demo@mdcms.local`
+- Password: `Demo12345!`
+
+See the [contributing guide](https://docs.mdcms.ai/development/contributing) for conventions, branch workflow, and how to run the test suite.
 
 ## Contributing
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -4,8 +4,17 @@ CLI for MDCMS content workflows — pull content to local Markdown files, edit w
 
 ## Install
 
+Install globally to use the `mdcms` command anywhere:
+
+```bash
+npm install -g @mdcms/cli
+```
+
+Or add it as a project dependency and run via `npx`:
+
 ```bash
 npm install @mdcms/cli
+npx mdcms pull
 ```
 
 ## Configuration
@@ -46,12 +55,12 @@ export default defineConfig({
 
 ## Commands
 
-| Command | Description |
-| --- | --- |
-| `mdcms login` | Authenticate via browser-based OAuth flow |
-| `mdcms logout` | Revoke credentials and clear local profile |
-| `mdcms pull` | Pull content from the server to local Markdown files |
-| `mdcms push` | Push local content changes back to the server |
+| Command             | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `mdcms login`       | Authenticate via browser-based OAuth flow                |
+| `mdcms logout`      | Revoke credentials and clear local profile               |
+| `mdcms pull`        | Pull content from the server to local Markdown files     |
+| `mdcms push`        | Push local content changes back to the server            |
 | `mdcms schema sync` | Sync your local schema definition to the server registry |
 
 ### Pull
@@ -73,13 +82,13 @@ mdcms push --dry-run    # Preview changes without uploading
 
 ### Global Flags
 
-| Flag | Env Variable | Description |
-| --- | --- | --- |
-| `--project` | `MDCMS_PROJECT` | Target project name |
-| `--environment` | `MDCMS_ENVIRONMENT` | Target environment name |
-| `--server-url` | `MDCMS_SERVER_URL` | Server URL |
-| `--api-key` | `MDCMS_API_KEY` | API key (for headless/CI use) |
-| `--config` | | Path to config file (default: `mdcms.config.ts`) |
+| Flag            | Env Variable        | Description                                      |
+| --------------- | ------------------- | ------------------------------------------------ |
+| `--project`     | `MDCMS_PROJECT`     | Target project name                              |
+| `--environment` | `MDCMS_ENVIRONMENT` | Target environment name                          |
+| `--server-url`  | `MDCMS_SERVER_URL`  | Server URL                                       |
+| `--api-key`     | `MDCMS_API_KEY`     | API key (for headless/CI use)                    |
+| `--config`      |                     | Path to config file (default: `mdcms.config.ts`) |
 
 ## Documentation
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -2,7 +2,11 @@
 
 Backend API server for MDCMS, built with [Elysia](https://elysiajs.com/) and PostgreSQL via [Drizzle ORM](https://orm.drizzle.team/).
 
-## Getting Started
+## Getting Started (Development)
+
+> **End users / self-hosted operators:** See the [deployment guide](https://docs.mdcms.ai/deployment) for production setup instructions.
+
+The steps below are for contributors working inside the monorepo.
 
 ### With Docker Compose (recommended)
 
@@ -22,29 +26,29 @@ The server starts on `http://localhost:4000`. Verify with `GET /healthz`.
 
 ## API Endpoints
 
-| Group | Path | Description |
-| --- | --- | --- |
-| Health | `GET /healthz` | Process health check |
-| Content | `/api/v1/content` | CRUD, publish/unpublish, version history, restore |
-| Schema | `/api/v1/schema` | Schema registry sync and read |
-| Environments | `/api/v1/environments` | List, create, delete environments |
-| Auth | `/api/v1/auth` | Session login/logout, OIDC, SAML, API key management |
-| Studio | `/api/v1/studio/bootstrap` | Studio runtime publication and asset delivery |
-| Actions | `/api/v1/actions` | Action catalog (typed endpoint metadata) |
-| Collaboration | `/api/v1/collaboration` | Collaboration handshake authorization |
+| Group         | Path                       | Description                                          |
+| ------------- | -------------------------- | ---------------------------------------------------- |
+| Health        | `GET /healthz`             | Process health check                                 |
+| Content       | `/api/v1/content`          | CRUD, publish/unpublish, version history, restore    |
+| Schema        | `/api/v1/schema`           | Schema registry sync and read                        |
+| Environments  | `/api/v1/environments`     | List, create, delete environments                    |
+| Auth          | `/api/v1/auth`             | Session login/logout, OIDC, SAML, API key management |
+| Studio        | `/api/v1/studio/bootstrap` | Studio runtime publication and asset delivery        |
+| Actions       | `/api/v1/actions`          | Action catalog (typed endpoint metadata)             |
+| Collaboration | `/api/v1/collaboration`    | Collaboration handshake authorization                |
 
 ## Environment Variables
 
-| Variable | Required | Default | Description |
-| --- | --- | --- | --- |
-| `DATABASE_URL` | Yes | | PostgreSQL connection string |
-| `PORT` | No | `4000` | Server listen port |
-| `MDCMS_STUDIO_ALLOWED_ORIGINS` | No | | Comma-separated origins for cross-origin Studio embedding |
-| `MDCMS_AUTH_OIDC_PROVIDERS` | No | | JSON array of OIDC provider configurations |
-| `MDCMS_AUTH_SAML_PROVIDERS` | No | | JSON array of SAML provider configurations |
-| `MDCMS_AUTH_ADMIN_USER_IDS` | No | | Comma-separated admin user IDs |
-| `MDCMS_AUTH_ADMIN_EMAILS` | No | | Comma-separated admin emails |
-| `MDCMS_AUTH_INSECURE_COOKIES` | No | `false` | Set `true` for local dev without HTTPS |
+| Variable                       | Required | Default | Description                                               |
+| ------------------------------ | -------- | ------- | --------------------------------------------------------- |
+| `DATABASE_URL`                 | Yes      |         | PostgreSQL connection string                              |
+| `PORT`                         | No       | `4000`  | Server listen port                                        |
+| `MDCMS_STUDIO_ALLOWED_ORIGINS` | No       |         | Comma-separated origins for cross-origin Studio embedding |
+| `MDCMS_AUTH_OIDC_PROVIDERS`    | No       |         | JSON array of OIDC provider configurations                |
+| `MDCMS_AUTH_SAML_PROVIDERS`    | No       |         | JSON array of SAML provider configurations                |
+| `MDCMS_AUTH_ADMIN_USER_IDS`    | No       |         | Comma-separated admin user IDs                            |
+| `MDCMS_AUTH_ADMIN_EMAILS`      | No       |         | Comma-separated admin emails                              |
+| `MDCMS_AUTH_INSECURE_COOKIES`  | No       | `false` | Set `true` for local dev without HTTPS                    |
 
 ## Database Migrations
 

--- a/docs/specs/SPEC-011-local-development-and-operations.md
+++ b/docs/specs/SPEC-011-local-development-and-operations.md
@@ -105,27 +105,34 @@ volumes:
   miniodata:
 ```
 
-### Getting Started (Developer Experience)
+### Getting Started (End-User Project)
+
+Set up MDCMS in your own application. This assumes an MDCMS server is already running (self-hosted or managed).
 
 ```bash
-# 1. Clone the repo and start the backend
+# 1. Install the packages
+npm install @mdcms/cli @mdcms/studio @mdcms/sdk
+
+# 2. Initialize MDCMS in the project
+npx mdcms init
+
+# 3. Embed the Studio in the app (e.g., Next.js)
+# Create app/admin/[[...path]]/page.tsx with <Studio />
+
+# 4. Start developing
+npm run dev
+# Visit /admin to access the CMS
+```
+
+### Getting Started (Contributor / Monorepo Development)
+
+To work on MDCMS itself, clone the repository and use Bun as the runtime:
+
+```bash
 git clone <repo>
 cd mdcms
 bun install
 docker compose up -d
-
-# 2. In the user's project, install the packages
-npm install @mdcms/cli @mdcms/studio @mdcms/sdk
-
-# 3. Initialize MDCMS in the project
-npx cms init
-
-# 4. Embed the Studio in the app (e.g., Next.js)
-# Create app/admin/[[...path]]/page.tsx with <Studio />
-
-# 5. Start developing
-npm run dev
-# Visit /admin to access the CMS
 ```
 
 Repository-local Git hooks are installed during `bun install` when the repo is

--- a/docs/specs/SPEC-011-local-development-and-operations.md
+++ b/docs/specs/SPEC-011-local-development-and-operations.md
@@ -105,34 +105,27 @@ volumes:
   miniodata:
 ```
 
-### Getting Started (End-User Project)
-
-Set up MDCMS in your own application. This assumes an MDCMS server is already running (self-hosted or managed).
+### Getting Started (Developer Experience)
 
 ```bash
-# 1. Install the packages
-npm install @mdcms/cli @mdcms/studio @mdcms/sdk
-
-# 2. Initialize MDCMS in the project
-npx mdcms init
-
-# 3. Embed the Studio in the app (e.g., Next.js)
-# Create app/admin/[[...path]]/page.tsx with <Studio />
-
-# 4. Start developing
-npm run dev
-# Visit /admin to access the CMS
-```
-
-### Getting Started (Contributor / Monorepo Development)
-
-To work on MDCMS itself, clone the repository and use Bun as the runtime:
-
-```bash
+# 1. Clone the repo and start the backend
 git clone <repo>
 cd mdcms
 bun install
 docker compose up -d
+
+# 2. In the user's project, install the packages
+npm install @mdcms/cli @mdcms/studio @mdcms/sdk
+
+# 3. Initialize MDCMS in the project
+npx cms init
+
+# 4. Embed the Studio in the app (e.g., Next.js)
+# Create app/admin/[[...path]]/page.tsx with <Studio />
+
+# 5. Start developing
+npm run dev
+# Visit /admin to access the CMS
 ```
 
 Repository-local Git hooks are installed during `bun install` when the repo is


### PR DESCRIPTION
## Summary

- Rewrites the root README Quick Start from a contributor-oriented flow (git clone, bun install, docker compose) to an end-user flow: install CLI globally via npm, add SDK to your app, define schema, pull/push content, fetch in code
- Moves contributor/dev setup (Bun, Docker Compose, demo credentials) into a dedicated **Development** section at the bottom of the root README
- Clarifies global vs project-local install in the CLI README
- Marks the server README Getting Started as development-only with a pointer to the deployment guide for self-hosted operators

Closes CMS-194.

## Test plan

- [ ] Verify root README Quick Start reads as an end-user-first flow (no Bun, no monorepo source paths)
- [ ] Verify CLI README distinguishes global install (`npm install -g`) from project dependency install (`npm install` + `npx`)
- [ ] Verify server README clearly labels its Getting Started as contributor/development context
- [ ] Verify Development section in root README still contains all previous contributor setup info
- [ ] Verify no formatting regressions (`bun run format:check` passes on changed files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Restructured Quick Start guide with updated npm-based installation workflow and new CLI commands
- Added TypeScript configuration example with Zod schema definitions
- Provided content retrieval examples using API key authentication
- Documented local development setup with Bun and Docker Compose
- Clarified documentation for development vs. production deployments
- Improved table formatting and readability across all README files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->