### PR TITLE
docs: add end-user quickstart and fix install guidance (CMS-194)

### DIFF
--- a/apps/docs/api-reference/sdk.mdx
+++ b/apps/docs/api-reference/sdk.mdx
@@ -9,10 +9,6 @@ The `@mdcms/sdk` package provides a type-safe TypeScript client for querying con
 
 <CodeGroup>
 
-```bash bun
-bun add @mdcms/sdk
-```
-
 ```bash npm
 npm install @mdcms/sdk
 ```
@@ -23,6 +19,10 @@ pnpm add @mdcms/sdk
 
 ```bash yarn
 yarn add @mdcms/sdk
+```
+
+```bash bun
+bun add @mdcms/sdk
 ```
 
 </CodeGroup>

--- a/apps/docs/development/setup.mdx
+++ b/apps/docs/development/setup.mdx
@@ -3,7 +3,11 @@ title: "Local Development Setup"
 description: "Prerequisites, installation, environment variables, and running MDCMS locally"
 ---
 
-This guide walks you through setting up a local MDCMS development environment from scratch. By the end, you will have all services running and be ready to develop.
+This guide walks you through setting up a local MDCMS development environment from scratch for **contributing to MDCMS itself**. By the end, you will have all services running and be ready to develop.
+
+<Note>
+  If you want to use MDCMS in your own project (not contribute to the MDCMS codebase), see the [Quick Start](/guide/quickstart) instead.
+</Note>
 
 ## Prerequisites
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -46,7 +46,7 @@
     "primary": {
       "type": "button",
       "label": "Get Started",
-      "href": "/development/setup"
+      "href": "/guide/quickstart"
     }
   },
   "footer": {
@@ -61,7 +61,7 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["index", "guide/concepts", "agent-instructions"]
+            "pages": ["index", "guide/quickstart", "guide/concepts", "agent-instructions"]
           },
           {
             "group": "Studio",

--- a/apps/docs/guide/cli/installation.mdx
+++ b/apps/docs/guide/cli/installation.mdx
@@ -8,7 +8,7 @@ description: "Installing and setting up the MDCMS CLI"
   icon="terminal"
   actions={["copy", "cursor"]}
 >
-Install and configure the MDCMS CLI in this project. Run `bun add -D @mdcms/cli` (or npm equivalent). Then run `bunx mdcms init` to interactively set up the project — it will prompt for server URL (default http://localhost:4000), project name, and environment. After init completes, run `bunx mdcms schema sync` to push the generated schema to the server. Verify with `bunx mdcms status` (exit code 0 means success). If the MDCMS server isn't running, start it with Docker: clone the mdcms repo and run `docker compose -f docker-compose.dev.yml up -d`.
+Install and configure the MDCMS CLI in this project. Run `npm install --save-dev @mdcms/cli`. Then run `npx mdcms init` to interactively set up the project — it will prompt for server URL (default http://localhost:4000), project name, and environment. After init completes, run `npx mdcms schema sync` to push the generated schema to the server. Verify with `npx mdcms status` (exit code 0 means success).
 </Prompt>
 
 The MDCMS CLI lets you sync content and schema between your local filesystem and the MDCMS server. It handles authentication, push/pull workflows, and CI/CD integration.
@@ -16,26 +16,32 @@ The MDCMS CLI lets you sync content and schema between your local filesystem and
 ## Install
 
 <CodeGroup>
-```bash bun
-bun add -D @mdcms/cli
-```
-
 ```bash npm
 npm install --save-dev @mdcms/cli
 ```
+
+```bash bun
+bun add -D @mdcms/cli
+```
 </CodeGroup>
 
-The binary name is `mdcms`. You can run it directly if installed globally, or use your package manager's runner:
+Or install globally to use the `mdcms` command directly:
 
 ```bash
-bunx mdcms --help
-# or
+npm install -g @mdcms/cli
+```
+
+The binary name is `mdcms`. If installed as a project dependency, use your package manager's runner:
+
+```bash
 npx mdcms --help
+# or
+bunx mdcms --help
 ```
 
 ### Prerequisites
 
-- **Bun** 1.3.11+ or **Node.js** 20+
+- **Node.js** 20+ or **Bun** 1.3.11+
 - A running MDCMS server instance
 
 ## First-time setup

--- a/apps/docs/guide/quickstart.mdx
+++ b/apps/docs/guide/quickstart.mdx
@@ -1,0 +1,179 @@
+---
+title: "Quick Start"
+description: "Install MDCMS packages and start managing content in your project"
+---
+
+Get MDCMS running in your own application. This guide assumes you have an MDCMS server available (self-hosted or managed).
+
+<Note>
+  Looking to contribute to MDCMS itself? See [Development Setup](/development/setup).
+</Note>
+
+## 1. Install the CLI
+
+<CodeGroup>
+```bash npm
+npm install --save-dev @mdcms/cli
+```
+
+```bash bun
+bun add -D @mdcms/cli
+```
+</CodeGroup>
+
+## 2. Initialize your project
+
+The `mdcms init` wizard configures everything — server connection, project/environment selection, content type detection, and initial sync:
+
+```bash
+npx mdcms init
+```
+
+It will:
+- Ask for your MDCMS server URL
+- Open a browser for authentication
+- Scan your repo for existing Markdown/MDX files
+- Generate a `mdcms.config.ts` with inferred content types
+- Push the initial schema and content to the server
+
+See [CLI Installation](/guide/cli/installation) for details on the init wizard.
+
+## 3. Define your content schema
+
+The generated `mdcms.config.ts` is your starting point. Customize it to match your content model:
+
+```typescript mdcms.config.ts
+import { defineConfig, defineType, reference } from "@mdcms/cli";
+import { z } from "zod";
+
+const Author = defineType("Author", {
+  directory: "content/authors",
+  fields: {
+    name: z.string().min(1),
+    bio: z.string().optional(),
+  },
+});
+
+const BlogPost = defineType("BlogPost", {
+  directory: "content/blog",
+  localized: true,
+  fields: {
+    title: z.string().min(1),
+    author: reference("Author"),
+    tags: z.array(z.string()),
+  },
+});
+
+export default defineConfig({
+  project: "my-site",
+  environment: "production",
+  serverUrl: "https://your-mdcms-server.example.com",
+  contentDirectories: ["content"],
+  locales: {
+    default: "en",
+    supported: ["en", "fr"],
+  },
+  types: [Author, BlogPost],
+});
+```
+
+See the [Schema Guide](/guide/schema/defining-types) for field types, references, and environment overlays.
+
+## 4. Sync schema and content
+
+```bash
+# Push your schema to the server
+npx mdcms push
+
+# Pull content from the server to local Markdown files
+npx mdcms pull
+
+# Edit .md or .mdx files with any tool, then push changes back
+npx mdcms push
+```
+
+See the [CLI Commands](/guide/cli/commands) reference for all available flags.
+
+## 5. Fetch content in your app
+
+Install the SDK:
+
+<CodeGroup>
+```bash npm
+npm install @mdcms/sdk
+```
+
+```bash bun
+bun add @mdcms/sdk
+```
+</CodeGroup>
+
+Query content in your application:
+
+```typescript
+import { createClient } from "@mdcms/sdk";
+
+const cms = createClient({
+  serverUrl: "https://your-mdcms-server.example.com",
+  apiKey: process.env.MDCMS_API_KEY!,
+  project: "my-site",
+  environment: "production",
+});
+
+// List published blog posts
+const { data: posts } = await cms.list("BlogPost", {
+  locale: "en",
+  published: true,
+  limit: 10,
+});
+
+// Fetch a single post with resolved references
+const post = await cms.get("BlogPost", {
+  slug: "hello-world",
+  resolve: ["author"],
+});
+```
+
+See the [SDK reference](/api-reference/sdk) for the full API.
+
+## 6. Embed the Studio UI (optional)
+
+Add a visual editing interface to your app:
+
+<CodeGroup>
+```bash npm
+npm install @mdcms/studio
+```
+
+```bash bun
+bun add @mdcms/studio
+```
+</CodeGroup>
+
+```tsx app/admin/[[...path]]/page.tsx
+// Next.js example — catch-all route for Studio
+import { Studio } from "@mdcms/studio";
+
+export default function AdminPage() {
+  return <Studio config={config} basePath="/admin" />;
+}
+```
+
+See the [Studio Guide](/guide/studio/dashboard) for full embedding and usage instructions.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
+    Push, pull, login, schema sync, and all CLI flags
+  </Card>
+  <Card title="Schema Guide" icon="file-code" href="/guide/schema/defining-types">
+    Field types, references, environment overlays, MDX components
+  </Card>
+  <Card title="Studio Guide" icon="layout-dashboard" href="/guide/studio/dashboard">
+    Visual content editing, publishing, and version history
+  </Card>
+  <Card title="SDK Reference" icon="plug" href="/api-reference/sdk">
+    Full typed client API for content reads
+  </Card>
+</CardGroup>

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -31,8 +31,8 @@ MDCMS is an open-source, headless CMS for teams managing structured Markdown and
 ## Get Started
 
 <CardGroup cols={3}>
-  <Card title="I want to use MDCMS" icon="rocket" href="/guide/concepts">
-    Learn the core concepts, set up the server, define your schema, and start managing content.
+  <Card title="I want to use MDCMS" icon="rocket" href="/guide/quickstart">
+    Install the packages, define your schema, and start managing content in your project.
   </Card>
   <Card title="I want to integrate the API" icon="plug" href="/api-reference/overview">
     Explore the REST API, authentication, and the TypeScript SDK for querying content.
@@ -43,6 +43,12 @@ MDCMS is an open-source, headless CMS for teams managing structured Markdown and
 </CardGroup>
 
 ## Quick Start
+
+Install the CLI and SDK in your project:
+
+```bash
+npm install @mdcms/cli @mdcms/sdk
+```
 
 Define your content types in `mdcms.config.ts` at the root of your project:
 


### PR DESCRIPTION
## Summary

The docs site (docs.mdcms.ai) install guidance defaults to Bun-first and contributor-oriented workflows. End users arriving via the "Get Started" button land on the development setup page (clone repo, bun install, docker compose) instead of learning how to install MDCMS packages in their own project.

**Changes:**

- **New `guide/quickstart.mdx`** — end-user-focused page: install CLI/SDK via npm, run `mdcms init`, define schema, push/pull content, fetch via SDK, embed Studio
- **`guide/cli/installation.mdx`** — npm first in install tabs, global install option added, AI agent prompt updated to use npm/npx instead of bun, prerequisites reordered (Node.js first)
- **`api-reference/sdk.mdx`** — npm first in install CodeGroup
- **`docs.json`** — navbar "Get Started" button retargeted from `/development/setup` to `/guide/quickstart`, quickstart added to Guide Introduction nav
- **`index.mdx`** — "I want to use MDCMS" card points to quickstart, install step added before Quick Start code
- **`development/setup.mdx`** — note added at top redirecting end users to quickstart

Companion PR for READMEs: #72

## Test plan

- [ ] Verify "Get Started" navbar button links to `/guide/quickstart`
- [ ] Verify quickstart page walks through npm install, init, schema, push/pull, SDK, Studio
- [ ] Verify CLI installation page shows npm first, includes global install option
- [ ] Verify SDK page shows npm first in CodeGroup
- [ ] Verify development/setup page has note pointing end users to quickstart
- [ ] Verify index "I want to use MDCMS" card links to quickstart