### PR TITLE
docs: add self-hosting section to README (CMS-195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> &middot;
+  <a href="#self-hosting">Self-Hosting</a> &middot;
   <a href="https://docs.mdcms.ai">Docs</a> &middot;
   <a href="#coming-soon">Roadmap</a> &middot;
   <a href="#contributing">Contributing</a>
@@ -99,6 +100,33 @@ npm install @mdcms/studio
 ```
 
 See the [`@mdcms/studio` README](packages/studio) for embedding instructions.
+
+## Self-Hosting
+
+Run your own MDCMS server with Docker Compose. The only prerequisites are Docker and Docker Compose.
+
+```bash
+git clone https://github.com/Blazity/mdcms.git
+cd mdcms
+cp .env.example .env
+docker compose up -d --build
+```
+
+This starts the MDCMS server along with PostgreSQL, Redis, MinIO, and Mailhog. Migrations run automatically on first boot.
+
+Verify the server is running:
+
+```bash
+curl http://localhost:4000/healthz
+```
+
+Then point your CLI at the server:
+
+```bash
+npx mdcms init --server-url http://localhost:4000
+```
+
+See the [self-hosting guide](https://docs.mdcms.ai/guide/self-hosting) for environment variable configuration, auth provider setup, and production deployment recommendations.
 
 ## Features
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -4,7 +4,7 @@ Backend API server for MDCMS, built with [Elysia](https://elysiajs.com/) and Pos
 
 ## Getting Started (Development)
 
-> **End users / self-hosted operators:** See the [deployment guide](https://docs.mdcms.ai/deployment) for production setup instructions.
+> **End users / self-hosted operators:** See the [self-hosting guide](https://docs.mdcms.ai/guide/self-hosting) for production setup instructions.
 
 The steps below are for contributors working inside the monorepo.
 


### PR DESCRIPTION
## Summary
- Add a **Self-Hosting** section to the root README with Docker Compose quick-start instructions and a link to the full self-hosting guide on docs.mdcms.ai
- Fix the broken `/deployment` link in `apps/server/README.md` to point to `/guide/self-hosting`
- Add Self-Hosting to the README nav links

## Context
Part of CMS-195 (rewrite getting started docs for self-hosted operators). The companion PR with the full self-hosting guide on the docs site targets the `docs` branch.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `apps/server/README.md` link points to correct URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive self-hosting setup guide with Docker Compose instructions for PostgreSQL, Redis, MinIO, and Mailhog configuration.
  * Updated documentation links to reference the self-hosting guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->