### PR TITLE
chore: add changeset for CMS-188 visual refresh

### DIFF
--- a/.changeset/itchy-ants-film.md
+++ b/.changeset/itchy-ants-film.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/studio": patch
+---
+
+Visual refresh for Studio runtime bundle loading screen


### PR DESCRIPTION
## Summary
- Adds a patch changeset for `@mdcms/studio` covering the visual refresh of the Studio runtime bundle loading screen from PR #74

## Test plan
- [ ] Verify `bunx changeset status` shows `@mdcms/studio` as a patch bump