### PR TITLE
feat(cms-199): make CLI logs user-friendly, add --verbose

### DIFF
--- a/.changeset/quiet-lions-glow.md
+++ b/.changeset/quiet-lions-glow.md
@@ -1,0 +1,6 @@
+---
+"@mdcms/shared": patch
+"@mdcms/cli": patch
+---
+
+Make default CLI logs user-friendly and move internal runtime diagnostics behind --verbose mode.

--- a/apps/cli/src/bin/mdcms.ts
+++ b/apps/cli/src/bin/mdcms.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env bun
 
 import { runMdcmsCli } from "../lib/framework.js";
-import { createCliRuntimeContextWithModules } from "../lib/runtime-with-modules.js";
 
-const runtimeWithModules = createCliRuntimeContextWithModules(process.env);
 const exitCode = await runMdcmsCli(process.argv.slice(2), {
   env: process.env,
-  runtimeWithModules,
 });
 process.exit(exitCode);

--- a/apps/cli/src/lib/cli.test.ts
+++ b/apps/cli/src/lib/cli.test.ts
@@ -35,6 +35,43 @@ test("createCliRuntimeContext wires env and logger", () => {
   assert.ok(context.logger);
 });
 
+test("createCliRuntimeContext sets LOG_LEVEL to debug when verbose is true", () => {
+  const context = createCliRuntimeContext(
+    {
+      NODE_ENV: "test",
+      APP_VERSION: "1.0.0",
+    } as NodeJS.ProcessEnv,
+    { verbose: true },
+  );
+
+  assert.equal(context.env.LOG_LEVEL, "debug");
+});
+
+test("createCliRuntimeContext respects explicit LOG_LEVEL over verbose", () => {
+  const context = createCliRuntimeContext(
+    {
+      NODE_ENV: "test",
+      LOG_LEVEL: "warn",
+      APP_VERSION: "1.0.0",
+    } as NodeJS.ProcessEnv,
+    { verbose: true },
+  );
+
+  assert.equal(context.env.LOG_LEVEL, "warn");
+});
+
+test("createCliRuntimeContext defaults to info when verbose is false", () => {
+  const context = createCliRuntimeContext(
+    {
+      NODE_ENV: "test",
+      APP_VERSION: "1.0.0",
+    } as NodeJS.ProcessEnv,
+    { verbose: false },
+  );
+
+  assert.equal(context.env.LOG_LEVEL, "info");
+});
+
 test("formatCliErrorEnvelope keeps RuntimeError code", () => {
   const envelope = formatCliErrorEnvelope(
     new RuntimeError({

--- a/apps/cli/src/lib/cli.ts
+++ b/apps/cli/src/lib/cli.ts
@@ -1,4 +1,6 @@
 import {
+  createCliConsoleSink,
+  createConsoleLogger,
   createNamedRuntimeContext,
   formatRuntimeErrorEnvelope,
   resolveNamedRuntimeEnv,
@@ -23,16 +25,34 @@ export function resolveCliEnv(rawEnv: NodeJS.ProcessEnv): CliEnv {
   }));
 }
 
+export type CreateCliRuntimeContextOptions = {
+  verbose?: boolean;
+};
+
 export function createCliRuntimeContext(
   rawEnv: NodeJS.ProcessEnv = process.env,
+  options?: CreateCliRuntimeContextOptions,
 ): CliRuntimeContext {
+  const verbose = options?.verbose ?? false;
+  const hasExplicitLogLevel =
+    rawEnv.LOG_LEVEL !== undefined && rawEnv.LOG_LEVEL.trim().length > 0;
+  const effectiveEnv =
+    verbose && !hasExplicitLogLevel
+      ? { ...rawEnv, LOG_LEVEL: "debug" }
+      : rawEnv;
+
   return createNamedRuntimeContext({
-    rawEnv,
+    rawEnv: effectiveEnv,
     resolveEnv: resolveCliEnv,
     loggerContext: (env) => ({
       runtime: "cli",
       cliName: env.CLI_NAME,
     }),
+    createLogger: (opts) =>
+      createConsoleLogger({
+        ...opts,
+        sink: createCliConsoleSink(),
+      }),
   });
 }
 

--- a/apps/cli/src/lib/framework.test.ts
+++ b/apps/cli/src/lib/framework.test.ts
@@ -74,6 +74,7 @@ test("resolveExecutionContext applies target precedence flag > env > config", as
   const resolved = await resolveExecutionContext({
     global: {
       help: false,
+      verbose: false,
       project: "flag-project",
       environment: "flag-env",
     },
@@ -99,6 +100,7 @@ test("resolveExecutionContext applies auth precedence --api-key > env > stored",
   const fromFlag = await resolveExecutionContext({
     global: {
       help: false,
+      verbose: false,
       project: "project",
       environment: "env",
       apiKey: "flag-key",
@@ -119,6 +121,7 @@ test("resolveExecutionContext applies auth precedence --api-key > env > stored",
   const fromEnv = await resolveExecutionContext({
     global: {
       help: false,
+      verbose: false,
       project: "project",
       environment: "env",
     },
@@ -473,6 +476,26 @@ test("runMdcmsCli passes remaining tokens as args for multi-word command", async
 
   assert.equal(exitCode, 0);
   assert.deepEqual(capturedArgs, ["--dry-run"]);
+});
+
+test("parseCliInvocation parses --verbose flag", () => {
+  const parsed = parseCliInvocation(["cms", "pull", "--verbose"]);
+
+  assert.equal(parsed.global.verbose, true);
+  assert.equal(parsed.commandName, "pull");
+});
+
+test("parseCliInvocation parses -v shorthand", () => {
+  const parsed = parseCliInvocation(["cms", "push", "-v"]);
+
+  assert.equal(parsed.global.verbose, true);
+  assert.equal(parsed.commandName, "push");
+});
+
+test("parseCliInvocation defaults verbose to false", () => {
+  const parsed = parseCliInvocation(["cms", "pull"]);
+
+  assert.equal(parsed.global.verbose, false);
 });
 
 test("runMdcmsCli still resolves single-word commands when multi-word commands exist", async () => {

--- a/apps/cli/src/lib/framework.ts
+++ b/apps/cli/src/lib/framework.ts
@@ -32,6 +32,7 @@ export type MultiSelectPrompt = <T extends string>(
 
 export type CliGlobalOptions = {
   help: boolean;
+  verbose: boolean;
   project?: string;
   environment?: string;
   apiKey?: string;
@@ -147,6 +148,7 @@ function readFlagValue(argv: string[], index: number, flag: string): string {
 export function parseCliInvocation(argv: string[]): ParsedCliInvocation {
   const global: CliGlobalOptions = {
     help: false,
+    verbose: false,
   };
   const commandTokens: string[] = [];
 
@@ -155,6 +157,11 @@ export function parseCliInvocation(argv: string[]): ParsedCliInvocation {
 
     if (token === "-h" || token === "--help") {
       global.help = true;
+      continue;
+    }
+
+    if (token === "-v" || token === "--verbose") {
+      global.verbose = true;
       continue;
     }
 
@@ -358,6 +365,7 @@ function renderHelp(commands: readonly CliCommand[]): string {
     "  --api-key <token>      API key for headless/CI auth",
     "  --config <path>        Config file path (default: mdcms.config.ts)",
     "  --server-url <url>     Override server URL",
+    "  -v, --verbose          Show internal runtime diagnostics",
     "  -h, --help             Show help",
     "",
     "Commands:",

--- a/apps/cli/src/lib/framework.ts
+++ b/apps/cli/src/lib/framework.ts
@@ -449,8 +449,13 @@ export async function runMdcmsCli(
   const fetcher = options.fetcher ?? fetch;
   const confirm = options.confirm ?? defaultConfirmPrompt;
   const multiSelect = options.multiSelect ?? defaultMultiSelectPrompt;
+  const registry = createCommandRegistry(commands);
+  const invocation = parseCliInvocation(argv);
   const runtimeWithModules =
-    options.runtimeWithModules ?? createCliRuntimeContextWithModules(env);
+    options.runtimeWithModules ??
+    createCliRuntimeContextWithModules(env, {
+      verbose: invocation.global.verbose,
+    });
   const credentialStore =
     options.credentialStore ??
     createCredentialStore({
@@ -462,8 +467,6 @@ export async function runMdcmsCli(
       const profile = await credentialStore.getProfile(input);
       return profile?.apiKey;
     });
-  const registry = createCommandRegistry(commands);
-  const invocation = parseCliInvocation(argv);
 
   if (invocation.global.help) {
     stdout.write(renderHelp(commands));

--- a/apps/cli/src/lib/runtime-with-modules.ts
+++ b/apps/cli/src/lib/runtime-with-modules.ts
@@ -1,4 +1,8 @@
-import { createCliRuntimeContext, type CliRuntimeContext } from "./cli.js";
+import {
+  createCliRuntimeContext,
+  type CreateCliRuntimeContextOptions,
+  type CliRuntimeContext,
+} from "./cli.js";
 import type {
   CliActionAlias,
   CliOutputFormatter,
@@ -26,8 +30,9 @@ export type CliRuntimeContextWithModules = CliRuntimeContext & {
  */
 export function createCliRuntimeContextWithModules(
   rawEnv: NodeJS.ProcessEnv = process.env,
+  options?: CreateCliRuntimeContextOptions,
 ): CliRuntimeContextWithModules {
-  const runtimeContext = createCliRuntimeContext(rawEnv);
+  const runtimeContext = createCliRuntimeContext(rawEnv, options);
   const moduleLoadReport = loadCliModules({
     coreVersion: runtimeContext.env.APP_VERSION,
     logger: runtimeContext.logger,

--- a/packages/shared/src/lib/runtime/logger.test.ts
+++ b/packages/shared/src/lib/runtime/logger.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import { createCliConsoleSink } from "./logger.js";
+import type { LogEntry } from "./logger.js";
+
+function makeEntry(
+  level: LogEntry["level"],
+  message: string,
+  meta?: LogEntry["meta"],
+): LogEntry {
+  return {
+    level,
+    message,
+    timestamp: "2026-04-15T00:00:00.000Z",
+    meta,
+  };
+}
+
+test("debug entries get [debug] prefix with meta as key=value pairs", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("debug", "loading module", { moduleId: "core.system" }));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "[debug] loading module moduleId=core.system");
+});
+
+test("info entries are just the message, no prefix", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("info", "server started"));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "server started");
+});
+
+test("warn entries get Warning: prefix", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("warn", "deprecated config option"));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "Warning: deprecated config option");
+});
+
+test("error entries get Error: prefix with meta", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("error", "connection failed", { host: "localhost", port: 5432 }));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "Error: connection failed host=localhost port=5432");
+});
+
+test("fatal entries get Error: prefix", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("fatal", "out of memory"));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "Error: out of memory");
+});
+
+test("debug with no meta omits trailing space", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("debug", "checkpoint reached"));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "[debug] checkpoint reached");
+});
+
+test("multiple meta keys are space-separated", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("debug", "action dispatched", { action: "publish", status: "ok", retries: 3 }));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "[debug] action dispatched action=publish status=ok retries=3");
+});
+
+test("trace entries get [trace] prefix", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("trace", "entering function", { fn: "loadModule" }));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "[trace] entering function fn=loadModule");
+});
+
+test("array values in meta are joined with commas", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("info", "modules loaded", { moduleIds: ["core.system", "domain.content"] }));
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0], "modules loaded moduleIds=core.system,domain.content");
+});

--- a/packages/shared/src/lib/runtime/logger.test.ts
+++ b/packages/shared/src/lib/runtime/logger.test.ts
@@ -151,3 +151,28 @@ test("array values in meta are joined with commas", () => {
   assert.equal(lines.length, 1);
   assert.equal(lines[0], "modules loaded moduleIds=core.system,domain.content");
 });
+
+test("object values in meta are JSON-serialized", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(
+    makeEntry("error", "plan failed", {
+      violations: [{ code: "DUPLICATE_MODULE_ID", moduleId: "dup" }],
+    }),
+  );
+
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /^Error: plan failed violations=\[/);
+  assert.match(lines[0], /"code":"DUPLICATE_MODULE_ID"/);
+  assert.match(lines[0], /"moduleId":"dup"/);
+});
+
+test("single object value in meta is JSON-serialized", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink(makeEntry("warn", "drift detected", { details: { hash: "abc123" } }));
+
+  assert.equal(lines[0], 'Warning: drift detected details={"hash":"abc123"}');
+});

--- a/packages/shared/src/lib/runtime/logger.test.ts
+++ b/packages/shared/src/lib/runtime/logger.test.ts
@@ -51,7 +51,9 @@ test("error entries get Error: prefix with meta", () => {
   const lines: string[] = [];
   const sink = createCliConsoleSink((line) => lines.push(line));
 
-  sink(makeEntry("error", "connection failed", { host: "localhost", port: 5432 }));
+  sink(
+    makeEntry("error", "connection failed", { host: "localhost", port: 5432 }),
+  );
 
   assert.equal(lines.length, 1);
   assert.equal(lines[0], "Error: connection failed host=localhost port=5432");
@@ -81,10 +83,19 @@ test("multiple meta keys are space-separated", () => {
   const lines: string[] = [];
   const sink = createCliConsoleSink((line) => lines.push(line));
 
-  sink(makeEntry("debug", "action dispatched", { action: "publish", status: "ok", retries: 3 }));
+  sink(
+    makeEntry("debug", "action dispatched", {
+      action: "publish",
+      status: "ok",
+      retries: 3,
+    }),
+  );
 
   assert.equal(lines.length, 1);
-  assert.equal(lines[0], "[debug] action dispatched action=publish status=ok retries=3");
+  assert.equal(
+    lines[0],
+    "[debug] action dispatched action=publish status=ok retries=3",
+  );
 });
 
 test("trace entries get [trace] prefix", () => {
@@ -131,7 +142,11 @@ test("array values in meta are joined with commas", () => {
   const lines: string[] = [];
   const sink = createCliConsoleSink((line) => lines.push(line));
 
-  sink(makeEntry("info", "modules loaded", { moduleIds: ["core.system", "domain.content"] }));
+  sink(
+    makeEntry("info", "modules loaded", {
+      moduleIds: ["core.system", "domain.content"],
+    }),
+  );
 
   assert.equal(lines.length, 1);
   assert.equal(lines[0], "modules loaded moduleIds=core.system,domain.content");

--- a/packages/shared/src/lib/runtime/logger.test.ts
+++ b/packages/shared/src/lib/runtime/logger.test.ts
@@ -97,6 +97,36 @@ test("trace entries get [trace] prefix", () => {
   assert.equal(lines[0], "[trace] entering function fn=loadModule");
 });
 
+test("context fields are included in formatted output", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink({
+    level: "debug",
+    message: "loading",
+    timestamp: "2026-04-15T00:00:00.000Z",
+    context: { runtime: "cli" },
+    meta: { moduleId: "core.system" },
+  });
+
+  assert.equal(lines[0], "[debug] loading runtime=cli moduleId=core.system");
+});
+
+test("meta overrides context when keys overlap", () => {
+  const lines: string[] = [];
+  const sink = createCliConsoleSink((line) => lines.push(line));
+
+  sink({
+    level: "debug",
+    message: "event",
+    timestamp: "2026-04-15T00:00:00.000Z",
+    context: { source: "base" },
+    meta: { source: "override" },
+  });
+
+  assert.equal(lines[0], "[debug] event source=override");
+});
+
 test("array values in meta are joined with commas", () => {
   const lines: string[] = [];
   const sink = createCliConsoleSink((line) => lines.push(line));

--- a/packages/shared/src/lib/runtime/logger.ts
+++ b/packages/shared/src/lib/runtime/logger.ts
@@ -71,6 +71,68 @@ function defaultConsoleSink(entry: LogEntry): void {
   console.error(payload);
 }
 
+function formatMeta(meta?: LogContext): string {
+  if (!meta || Object.keys(meta).length === 0) {
+    return "";
+  }
+
+  const pairs = Object.entries(meta)
+    .map(([key, value]) => {
+      const formatted = Array.isArray(value) ? value.join(",") : String(value);
+      return `${key}=${formatted}`;
+    })
+    .join(" ");
+
+  return ` ${pairs}`;
+}
+
+/**
+ * createCliConsoleSink formats log entries as human-friendly text for CLI use.
+ * When write is provided, it is called with each formatted line.
+ * When omitted, routes through console methods matching defaultConsoleSink routing.
+ */
+export function createCliConsoleSink(
+  write?: (line: string) => void,
+): (entry: LogEntry) => void {
+  return (entry: LogEntry): void => {
+    const meta = formatMeta(entry.meta);
+    let line: string;
+
+    if (entry.level === "trace" || entry.level === "debug") {
+      line = `[${entry.level}] ${entry.message}${meta}`;
+    } else if (entry.level === "info") {
+      line = `${entry.message}${meta}`;
+    } else if (entry.level === "warn") {
+      line = `Warning: ${entry.message}${meta}`;
+    } else {
+      // error | fatal
+      line = `Error: ${entry.message}${meta}`;
+    }
+
+    if (write !== undefined) {
+      write(line);
+      return;
+    }
+
+    if (entry.level === "trace" || entry.level === "debug") {
+      console.debug(line);
+      return;
+    }
+
+    if (entry.level === "info") {
+      console.info(line);
+      return;
+    }
+
+    if (entry.level === "warn") {
+      console.warn(line);
+      return;
+    }
+
+    console.error(line);
+  };
+}
+
 /**
  * createConsoleLogger provides a lightweight structured logger implementation
  * for all runtime adapters without introducing a third-party logger yet.

--- a/packages/shared/src/lib/runtime/logger.ts
+++ b/packages/shared/src/lib/runtime/logger.ts
@@ -78,8 +78,18 @@ function formatMeta(meta?: LogContext): string {
 
   const pairs = Object.entries(meta)
     .map(([key, value]) => {
-      const formatted = Array.isArray(value) ? value.join(",") : String(value);
-      return `${key}=${formatted}`;
+      if (Array.isArray(value)) {
+        const hasObjects = value.some(
+          (item) => typeof item === "object" && item !== null,
+        );
+        return `${key}=${hasObjects ? JSON.stringify(value) : value.join(",")}`;
+      }
+
+      if (typeof value === "object" && value !== null) {
+        return `${key}=${JSON.stringify(value)}`;
+      }
+
+      return `${key}=${String(value)}`;
     })
     .join(" ");
 

--- a/packages/shared/src/lib/runtime/logger.ts
+++ b/packages/shared/src/lib/runtime/logger.ts
@@ -95,7 +95,10 @@ export function createCliConsoleSink(
   write?: (line: string) => void,
 ): (entry: LogEntry) => void {
   return (entry: LogEntry): void => {
-    const meta = formatMeta(entry.meta);
+    const merged = { ...entry.context, ...entry.meta };
+    const meta = formatMeta(
+      Object.keys(merged).length > 0 ? merged : undefined,
+    );
     let line: string;
 
     if (entry.level === "trace" || entry.level === "debug") {

--- a/packages/shared/src/lib/runtime/module-loader-core.test.ts
+++ b/packages/shared/src/lib/runtime/module-loader-core.test.ts
@@ -348,3 +348,73 @@ test("buildModuleLoadReport remains skip-based compatibility wrapper", () => {
     ],
   );
 });
+
+test("buildRuntimeModulePlan logs plan_ready at debug level", () => {
+  const entries: Array<{ level: string; message: string }> = [];
+  const capturingLogger = createConsoleLogger({
+    level: "debug",
+    sink: (entry) => {
+      entries.push({ level: entry.level, message: entry.message });
+    },
+  });
+
+  const plan = buildRuntimeModulePlan(
+    [createModule("alpha", { cli: true })],
+    {
+      coreVersion: "1.0.0",
+      surface: "cli",
+      runtime: "cli",
+      logger: capturingLogger,
+    },
+  );
+
+  assert.equal(plan.ok, true);
+
+  const planReadyEntry = entries.find(
+    (entry) => entry.message === "cli_module_plan_ready",
+  );
+  assert.ok(planReadyEntry, "cli_module_plan_ready entry should be logged");
+  assert.equal(planReadyEntry.level, "debug");
+});
+
+test("buildModuleLoadReport logs loaded and summary at debug level and skipped at debug level", () => {
+  const entries: Array<{ level: string; message: string }> = [];
+  const capturingLogger = createConsoleLogger({
+    level: "debug",
+    sink: (entry) => {
+      entries.push({ level: entry.level, message: entry.message });
+    },
+  });
+
+  buildModuleLoadReport(
+    [
+      createModule("a.with-cli", { cli: true }),
+      createModule("b.no-cli", { server: true }),
+    ],
+    {
+      coreVersion: "1.0.0",
+      surface: "cli",
+      runtime: "cli",
+      logger: capturingLogger,
+    },
+  );
+
+  const loadedEntry = entries.find(
+    (entry) => entry.message === "cli_module_loaded",
+  );
+  const skippedEntry = entries.find(
+    (entry) => entry.message === "cli_module_skipped",
+  );
+  const summaryEntry = entries.find(
+    (entry) => entry.message === "cli_module_load_summary",
+  );
+
+  assert.ok(loadedEntry, "cli_module_loaded entry should be logged");
+  assert.equal(loadedEntry.level, "debug");
+
+  assert.ok(skippedEntry, "cli_module_skipped entry should be logged");
+  assert.equal(skippedEntry.level, "debug");
+
+  assert.ok(summaryEntry, "cli_module_load_summary entry should be logged");
+  assert.equal(summaryEntry.level, "debug");
+});

--- a/packages/shared/src/lib/runtime/module-loader-core.test.ts
+++ b/packages/shared/src/lib/runtime/module-loader-core.test.ts
@@ -358,15 +358,12 @@ test("buildRuntimeModulePlan logs plan_ready at debug level", () => {
     },
   });
 
-  const plan = buildRuntimeModulePlan(
-    [createModule("alpha", { cli: true })],
-    {
-      coreVersion: "1.0.0",
-      surface: "cli",
-      runtime: "cli",
-      logger: capturingLogger,
-    },
-  );
+  const plan = buildRuntimeModulePlan([createModule("alpha", { cli: true })], {
+    coreVersion: "1.0.0",
+    surface: "cli",
+    runtime: "cli",
+    logger: capturingLogger,
+  });
 
   assert.equal(plan.ok, true);
 

--- a/packages/shared/src/lib/runtime/module-loader-core.ts
+++ b/packages/shared/src/lib/runtime/module-loader-core.ts
@@ -520,7 +520,7 @@ export function buildRuntimeModulePlan<
 
   const moduleIds = loaded.map((moduleResult) => moduleResult.id);
 
-  logger.info(`${options.runtime}_module_plan_ready`, {
+  logger.debug(`${options.runtime}_module_plan_ready`, {
     moduleIds,
   });
 
@@ -616,13 +616,13 @@ export function buildModuleLoadReport<
     options.summaryEvent ?? defaultSummaryEvent(options.runtime);
 
   for (const moduleResult of loaded) {
-    logger.info(loadedEvent, {
+    logger.debug(loadedEvent, {
       moduleId: moduleResult.id,
     });
   }
 
   for (const skippedModule of skipped) {
-    logger.warn(skippedEvent, {
+    logger.debug(skippedEvent, {
       moduleId: skippedModule.id,
       reason: skippedModule.reason,
       details: skippedModule.details,
@@ -637,7 +637,7 @@ export function buildModuleLoadReport<
     skipped,
   };
 
-  logger.info(summaryEvent, {
+  logger.debug(summaryEvent, {
     evaluatedModuleIds: report.evaluatedModuleIds,
     loadedModuleIds: report.loadedModuleIds,
     skippedModuleIds: report.skippedModuleIds,


### PR DESCRIPTION
## Summary

- Default CLI output no longer emits raw JSON structured events like `cli_module_plan_ready` — module loader diagnostics are demoted to `debug` level and hidden by default
- Adds `--verbose` / `-v` global CLI flag that sets log level to `debug`, making internal runtime diagnostics visible for troubleshooting
- Replaces the CLI's JSON logger sink with a human-friendly text formatter (`[debug] msg key=value` / `Warning: msg` / `Error: msg`)
- `LOG_LEVEL` env var still takes precedence over `--verbose`; error-level events (`*_module_plan_failed`) remain visible in all modes

## Test plan

- [ ] Run `bun test --cwd packages/shared ./src` — 141 tests pass (logger + module-loader-core)
- [ ] Run `bun test --cwd apps/cli ./src` — 183 tests pass (framework, cli, module-loader)
- [ ] Run `bun run typecheck` — all packages pass
- [ ] Verify `cms pull` without `--verbose` shows no internal structured events
- [ ] Verify `cms pull --verbose` shows `[debug] cli_module_plan_ready ...` style output