### PR TITLE
fix(studio): preserve missing token auth state

### DIFF
--- a/.changeset/purple-beers-peel.md
+++ b/.changeset/purple-beers-peel.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/studio": patch
+---
+
+Preserve the missing-token Studio error state and add follow-up token auth coverage.

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import type { StudioMountContext } from "@mdcms/shared";
 
 import {
+  AdminTokenErrorStateView,
   createAdminLayoutCapabilitiesLoadInput,
   createAdminLayoutSessionLoadInput,
+  createAdminLayoutTokenErrorState,
   createAdminLayoutTokenSessionState,
 } from "./layout.js";
 
@@ -44,6 +48,13 @@ test("createAdminLayoutCapabilitiesLoadInput maps the mounted project and enviro
 test("createAdminLayoutCapabilitiesLoadInput returns null without an active document route", () => {
   const context = createContext();
   delete context.documentRoute;
+
+  assert.equal(createAdminLayoutCapabilitiesLoadInput(context), null);
+});
+
+test("createAdminLayoutCapabilitiesLoadInput returns null for token auth without a token", () => {
+  const context = createContext();
+  context.auth = { mode: "token" };
 
   assert.equal(createAdminLayoutCapabilitiesLoadInput(context), null);
 });
@@ -97,4 +108,52 @@ test("createAdminLayoutTokenSessionState returns token-error when token is undef
     result && "reason" in result ? result.reason : undefined,
     "missing",
   );
+});
+
+test("createAdminLayoutTokenErrorState maps 401 to an invalid-token error", () => {
+  assert.deepEqual(createAdminLayoutTokenErrorState(401), {
+    status: "token-error",
+    reason: "invalid",
+    message: "The bearer token is invalid, expired, or has been revoked.",
+  });
+});
+
+test("createAdminLayoutTokenErrorState maps 403 to a forbidden-token error", () => {
+  assert.deepEqual(createAdminLayoutTokenErrorState(403), {
+    status: "token-error",
+    reason: "forbidden",
+    message:
+      "The bearer token is not allowed for the requested project or environment.",
+  });
+});
+
+test("createAdminLayoutTokenErrorState ignores non-auth status codes", () => {
+  assert.equal(createAdminLayoutTokenErrorState(500), null);
+  assert.equal(createAdminLayoutTokenErrorState(null), null);
+});
+
+test("AdminTokenErrorStateView renders retry action and technical details", () => {
+  const markup = renderToStaticMarkup(
+    createElement(AdminTokenErrorStateView, {
+      state: {
+        status: "token-error",
+        reason: "missing",
+        message:
+          'No bearer token was provided. The host application must supply a token when using auth.mode = "token".',
+      },
+      context: createContext(),
+      activeEnvironment: "staging",
+    }),
+  );
+
+  assert.match(markup, /Token authentication failed/);
+  assert.match(markup, /Retry/);
+  assert.match(markup, /Reason:/);
+  assert.match(markup, /missing/);
+  assert.match(markup, /Auth mode:/);
+  assert.match(markup, /Project:/);
+  assert.match(markup, /marketing-site/);
+  assert.match(markup, /Environment:/);
+  assert.match(markup, /staging/);
+  assert.match(markup, /auth.mode = &quot;token&quot;/);
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -34,12 +34,17 @@ type AdminLayoutSessionLoadInput = {
   auth: StudioMountContext["auth"];
 };
 
+type AdminLayoutTokenErrorState = Extract<
+  StudioSessionState,
+  { status: "token-error" }
+>;
+
 export function createAdminLayoutCapabilitiesLoadInput(
   context: StudioMountContext,
 ): AdminLayoutCapabilitiesLoadInput | null {
   const route = context.documentRoute;
 
-  if (!route) {
+  if (!route || (context.auth.mode === "token" && !context.auth.token)) {
     return null;
   }
 
@@ -74,7 +79,7 @@ export function createAdminLayoutTokenSessionState(
       status: "token-error",
       reason: "missing",
       message:
-        "No bearer token was provided. The host application must supply a token when using auth.mode = \"token\".",
+        'No bearer token was provided. The host application must supply a token when using auth.mode = "token".',
     };
   }
 
@@ -89,6 +94,91 @@ export function createAdminLayoutTokenSessionState(
     },
     csrfToken: "",
   };
+}
+
+export function createAdminLayoutTokenErrorState(
+  statusCode: number | null,
+): AdminLayoutTokenErrorState | null {
+  if (statusCode === 401) {
+    return {
+      status: "token-error",
+      reason: "invalid",
+      message: "The bearer token is invalid, expired, or has been revoked.",
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      status: "token-error",
+      reason: "forbidden",
+      message:
+        "The bearer token is not allowed for the requested project or environment.",
+    };
+  }
+
+  return null;
+}
+
+export function AdminTokenErrorStateView({
+  state,
+  context,
+  activeEnvironment,
+}: {
+  state: AdminLayoutTokenErrorState;
+  context: StudioMountContext;
+  activeEnvironment: string | null;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="max-w-md w-full rounded-xl border border-border bg-card p-8 shadow-sm space-y-4">
+        <div className="space-y-1 text-center">
+          <p className="text-sm font-medium text-foreground">
+            Token authentication failed
+          </p>
+          <p className="text-sm text-foreground-muted">
+            Studio is configured for token-based authentication (
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">
+              auth.mode = &quot;token&quot;
+            </code>
+            ) but the supplied token could not be used.
+          </p>
+        </div>
+
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {state.message}
+        </div>
+
+        <div className="rounded-md bg-muted px-3 py-2 text-xs text-foreground-muted space-y-1">
+          <p>
+            <span className="font-medium">Reason:</span> {state.reason}
+          </p>
+          <p>
+            <span className="font-medium">Auth mode:</span> token
+          </p>
+          {context.documentRoute?.project && (
+            <p>
+              <span className="font-medium">Project:</span>{" "}
+              {context.documentRoute.project}
+            </p>
+          )}
+          {activeEnvironment && (
+            <p>
+              <span className="font-medium">Environment:</span>{" "}
+              {activeEnvironment}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default function AdminLayout({
@@ -142,16 +232,15 @@ export default function AdminLayout({
 
   // Fetch capabilities
   useEffect(() => {
-    const project = context.documentRoute?.project;
+    const baseLoadInput = createAdminLayoutCapabilitiesLoadInput(context);
     const loadInput =
-      project && activeEnvironment
+      baseLoadInput && activeEnvironment
         ? {
+            ...baseLoadInput,
             config: {
-              project,
+              ...baseLoadInput.config,
               environment: activeEnvironment,
-              serverUrl: context.apiBaseUrl,
             },
-            auth: context.auth,
           }
         : null;
 
@@ -208,20 +297,11 @@ export default function AdminLayout({
                 ? error.statusCode
                 : null;
 
-            if (statusCode === 401) {
-              setSessionState({
-                status: "token-error",
-                reason: "invalid",
-                message:
-                  "The bearer token is invalid, expired, or has been revoked.",
-              });
-            } else if (statusCode === 403) {
-              setSessionState({
-                status: "token-error",
-                reason: "forbidden",
-                message:
-                  "The bearer token is not allowed for the requested project or environment.",
-              });
+            const nextTokenErrorState =
+              createAdminLayoutTokenErrorState(statusCode);
+
+            if (nextTokenErrorState) {
+              setSessionState(nextTokenErrorState);
             }
           }
         }
@@ -365,56 +445,11 @@ export default function AdminLayout({
 
   if (sessionState.status === "token-error") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background p-4">
-        <div className="max-w-md w-full rounded-xl border border-border bg-card p-8 shadow-sm space-y-4">
-          <div className="space-y-1 text-center">
-            <p className="text-sm font-medium text-foreground">
-              Token authentication failed
-            </p>
-            <p className="text-sm text-foreground-muted">
-              Studio is configured for token-based authentication (
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">
-                auth.mode = &quot;token&quot;
-              </code>
-              ) but the supplied token could not be used.
-            </p>
-          </div>
-
-          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {sessionState.message}
-          </div>
-
-          <div className="rounded-md bg-muted px-3 py-2 text-xs text-foreground-muted space-y-1">
-            <p>
-              <span className="font-medium">Reason:</span>{" "}
-              {sessionState.reason}
-            </p>
-            <p>
-              <span className="font-medium">Auth mode:</span> token
-            </p>
-            {context.documentRoute?.project && (
-              <p>
-                <span className="font-medium">Project:</span>{" "}
-                {context.documentRoute.project}
-              </p>
-            )}
-            {activeEnvironment && (
-              <p>
-                <span className="font-medium">Environment:</span>{" "}
-                {activeEnvironment}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-          >
-            Retry
-          </button>
-        </div>
-      </div>
+      <AdminTokenErrorStateView
+        state={sessionState}
+        context={context}
+        activeEnvironment={activeEnvironment}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- stop the token-mode capabilities path when no token is present so the deterministic missing-token state is not overwritten
- factor the token auth error mapping and token error view into testable helpers and add follow-up coverage for missing, invalid, and forbidden token states
- add a patch changeset for `@mdcms/studio`

## Testing
- `bun test --conditions @mdcms/source packages/studio/src/lib/runtime-ui/app/admin`

## Notes
- `bun x tsc --noEmit -p packages/studio/tsconfig.lib.json` still fails on existing package-wide issues unrelated to this diff, including missing built `packages/shared/dist` artifacts and pre-existing strict-type errors