### PR TITLE
CMS-192 Fix MDX props editor and slash command UX

### DIFF
--- a/.changeset/neat-pets-joke.md
+++ b/.changeset/neat-pets-joke.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/studio": patch
+---
+
+Clarify wrapper MDX component editing in Studio and align bundled examples with the current Callout prop contract.

--- a/apps/studio-review/review/scenarios.test.ts
+++ b/apps/studio-review/review/scenarios.test.ts
@@ -25,3 +25,12 @@ test("review owner scenario exposes staging-only editor fields in the schema fix
     "title",
   ]);
 });
+
+test("review scenarios keep Callout markdown aligned with the prepared MDX prop contract", () => {
+  const owner = getReviewScenario("owner");
+
+  assert.match(owner.document.body, /<Callout tone="info">/);
+  assert.doesNotMatch(owner.document.body, /<Callout type="info">/);
+  assert.match(owner.versions[1]!.body, /<Callout tone="info">/);
+  assert.doesNotMatch(owner.versions[1]!.body, /<Callout type="info">/);
+});

--- a/apps/studio-review/review/scenarios.ts
+++ b/apps/studio-review/review/scenarios.ts
@@ -158,7 +158,7 @@ function createDraftDocument(overrides?: Partial<ReviewScenario["document"]>) {
     body: [
       "# Hello World",
       "",
-      '<Callout type="info">Preview scenario</Callout>',
+      '<Callout tone="info">Preview scenario</Callout>',
       "",
       '<Chart type="bar" color="#0f766e" data={[12, 18, 9]} />',
     ].join("\n"),
@@ -209,7 +209,7 @@ function createVersions(): ReviewScenario["versions"] {
       body: [
         "# Hello World",
         "",
-        '<Callout type="info">Preview scenario</Callout>',
+        '<Callout tone="info">Preview scenario</Callout>',
       ].join("\n"),
     },
   ];

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -382,18 +382,23 @@ Normative behavior:
   to that mutable head snapshot.
 - The primary canvas edits the document `body` through the editor engine owned
   by SPEC-007.
-- The right sidebar exposes three tabs in this order:
+- The right sidebar exposes these tabs in order:
   - `Info` for document system metadata
   - `Properties` for schema-driven frontmatter editing
+  - `Component` for the currently selected MDX component props
   - `History` for publish history and version comparison
+- `Component` appears only while an MDX component node is selected in the
+  editor canvas. Selecting a component switches the sidebar to that tab.
 - `Properties` is dedicated to schema-derived frontmatter fields for the
   current type in the active environment.
 - `Properties` does not render document system metadata such as `status`,
   `publishedVersion`, `locale`, `updatedAt`, or `path`.
+- `Properties` does not render MDX component prop editors.
 - `Info` shows the existing read-only document metadata (`status`,
   `publishedVersion`, `locale`, `updatedAt`, `path`).
 - The default selected sidebar tab is `Properties` even though `Info` appears
-  first in the tab strip.
+  first in the tab strip unless an MDX component is actively selected, in which
+  case `Component` becomes the selected tab.
 - Frontmatter controls are derived from the live resolved schema. Studio must
   not ship hard-coded per-type property forms for routed document editing.
 - Every property row shows an always-visible compact type label derived from

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -447,9 +447,13 @@ The custom props editor host supports these states:
   shows a non-interactive loading state.
 - `ready`: resolution succeeds with an executable editor component; the runtime
   mounts it and passes `value`, `onChange`, and `readOnly`.
+- `content-only`: no top-level prop controls are available, but the component
+  exposes nested rich-text `children`; the props panel points the author to the
+  wrapper block's inline content area instead of implying the component is not
+  editable.
 - `empty`: resolution returns `null` and no fallback auto-generated controls
-  are available; the props panel shows that the component has no editable
-  props.
+  are available, and the component has no nested rich-text editing surface; the
+  props panel shows that the component has no editable props.
 - `error`: resolution rejects, or the resolved editor fails during initial
   render; the props panel shows an error state and does not silently switch to
   a different editor mode.
@@ -462,12 +466,16 @@ The custom props editor host supports these states:
 Components that accept `children` (content between opening and closing tags) are treated specially:
 
 ```mdx
-<Callout type="warning">
+<Callout tone="warning">
   This is **important** markdown content inside the component.
 </Callout>
 ```
 
 In the editor, the children area is a **nested TipTap rich text editor** within the component's node view. This means content editors can use full markdown formatting (bold, links, lists, etc.) inside component blocks, and it participates in the Yjs collaboration session.
+
+Wrapper component chrome and the props panel must make this distinction clear:
+top-level props remain in the side panel, while nested markdown content is
+edited directly inside the component block in the canvas.
 
 ### Editor Integration (Node Views)
 
@@ -495,7 +503,7 @@ All registered MDX components share this single node type, differentiated by the
 **Insertion:**
 
 1. User opens the component insertion panel (toolbar button or `/` slash command).
-2. Panel lists all registered components from the local catalog with names and descriptions.
+2. Panel lists all registered components from the local catalog with names and descriptions. When opened from `/`, the picker is positioned inline near the active cursor location instead of docking at the top of the editor.
 3. User selects a component.
 4. The component is inserted into the document as a node view block.
 5. Props form appears (auto-generated or custom editor) for initial configuration.

--- a/packages/studio/src/lib/mdx-props-editor-host.test.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.test.tsx
@@ -9,6 +9,7 @@ import {
   createInitialMdxPropsEditorHostState,
   createMdxPropsEditorBindings,
   MdxPropsEditorHost,
+  renderReadyMdxPropsEditor,
   resolveMdxPropsEditorHostState,
   type PropsEditorComponentProps,
 } from "./mdx-props-editor-host.js";
@@ -268,4 +269,32 @@ test("MdxPropsEditorHost renders interactive auto-form controls for fallback pro
   assert.match(markup, /type="checkbox"/);
   assert.match(markup, /data-mdcms-mdx-auto-control="Chart:variant:select"/);
   assert.match(markup, /<select/);
+});
+
+test("renderReadyMdxPropsEditor keeps diagnostics out of the visible custom editor surface", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      "section",
+      null,
+      renderReadyMdxPropsEditor({
+        componentName: "PricingTable",
+        editor: (_props: PropsEditorComponentProps) =>
+          createElement(
+            "div",
+            { "data-test-editor": "PricingTable" },
+            "Editor",
+          ),
+        bindings: {
+          value: {},
+          readOnly: false,
+          onChange: () => {},
+        },
+      }),
+    ),
+  );
+
+  assert.match(markup, /data-mdcms-mdx-props-editor-surface="PricingTable"/);
+  assert.match(markup, /data-test-editor="PricingTable"/);
+  assert.doesNotMatch(markup, /Custom editor ready/);
+  assert.doesNotMatch(markup, />Custom editor</);
 });

--- a/packages/studio/src/lib/mdx-props-editor-host.test.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.test.tsx
@@ -154,6 +154,23 @@ test("resolveMdxPropsEditorHostState returns empty when no editor or auto-form c
   });
 });
 
+test("resolveMdxPropsEditorHostState returns content-only for wrapper components whose editable surface is nested children", async () => {
+  const state = await resolveMdxPropsEditorHostState({
+    component: createComponent({
+      name: "Callout",
+      extractedProps: {
+        children: { type: "rich-text", required: false },
+      },
+    }),
+    context: createContext(async () => null),
+    readOnly: false,
+  });
+
+  assert.deepEqual(state, {
+    status: "content-only",
+  });
+});
+
 test("resolveMdxPropsEditorHostState returns error when the custom editor resolver rejects", async () => {
   const state = await resolveMdxPropsEditorHostState({
     component: createComponent({

--- a/packages/studio/src/lib/mdx-props-editor-host.test.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.test.tsx
@@ -271,6 +271,40 @@ test("MdxPropsEditorHost renders interactive auto-form controls for fallback pro
   assert.match(markup, /<select/);
 });
 
+test("MdxPropsEditorHost renders compact type hints for generated auto-form fields", () => {
+  const markup = renderToStaticMarkup(
+    createElement(MdxPropsEditorHost, {
+      component: createComponent({
+        propHints: {
+          color: { widget: "color-picker" },
+        },
+        extractedProps: {
+          data: { type: "array", required: true, items: "number" },
+          type: {
+            type: "enum",
+            required: true,
+            values: ["bar", "line", "pie"],
+          },
+          title: { type: "string", required: false },
+          color: { type: "string", required: false },
+        },
+      }),
+      context: createContext(async () => null),
+      value: {},
+      onChange: () => {},
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-mdx-auto-field-hint="Chart:data"/);
+  assert.match(markup, />number\[\]</);
+  assert.match(markup, /data-mdcms-mdx-auto-field-hint="Chart:type"/);
+  assert.match(markup, />bar \| line \| pie</);
+  assert.match(markup, /data-mdcms-mdx-auto-field-hint="Chart:title"/);
+  assert.match(markup, />string</);
+  assert.match(markup, /data-mdcms-mdx-auto-field-hint="Chart:color"/);
+  assert.match(markup, />color</);
+});
+
 test("renderReadyMdxPropsEditor keeps diagnostics out of the visible custom editor surface", () => {
   const markup = renderToStaticMarkup(
     createElement(

--- a/packages/studio/src/lib/mdx-props-editor-host.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.tsx
@@ -36,6 +36,7 @@ export type MdxPropsEditorHostState =
   | { status: "loading" }
   | { status: "ready"; editor: PropsEditorComponent }
   | { status: "auto-form"; fields: MdxAutoFormField[] }
+  | { status: "content-only" }
   | { status: "empty" }
   | { status: "error"; message: string }
   | { status: "forbidden" };
@@ -278,6 +279,15 @@ export function MdxPropsEditorHost({
           No editable props.
         </span>
       );
+    case "content-only":
+      return (
+        <span
+          data-mdcms-mdx-props-editor-state={`${component.name}:content-only`}
+        >
+          This wrapper component is edited through its nested content block in
+          the editor canvas.
+        </span>
+      );
     case "error":
       return (
         <span data-mdcms-mdx-props-editor-state={`${component.name}:error`}>
@@ -307,7 +317,15 @@ function createFallbackState(
 
   return fields.length > 0
     ? { status: "auto-form", fields }
-    : { status: "empty" };
+    : hasNestedRichTextChildren(component)
+      ? { status: "content-only" }
+      : { status: "empty" };
+}
+
+function hasNestedRichTextChildren(component: MdxCatalogComponent): boolean {
+  return (
+    component.extractedProps?.[MDX_CHILDREN_PROP_NAME]?.type === "rich-text"
+  );
 }
 
 function renderAutoFormFields(

--- a/packages/studio/src/lib/mdx-props-editor-host.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.tsx
@@ -354,12 +354,20 @@ function renderAutoFormFields(
         >
           <label
             htmlFor={getAutoFormFieldId(componentName, field.name)}
-            className="block text-xs font-medium text-foreground"
+            className="flex items-baseline gap-1.5 text-xs font-medium text-foreground"
           >
-            {field.name}
-            {field.required ? (
-              <span className="ml-1 text-destructive">*</span>
-            ) : null}
+            <span>
+              {field.name}
+              {field.required ? (
+                <span className="ml-1 text-destructive">*</span>
+              ) : null}
+            </span>
+            <span
+              data-mdcms-mdx-auto-field-hint={`${componentName}:${field.name}`}
+              className="font-mono text-[10px] text-foreground-muted"
+            >
+              {formatAutoFormFieldTypeHint(field)}
+            </span>
           </label>
           {renderAutoFormFieldControl({
             componentName,
@@ -629,6 +637,48 @@ function renderAutoFormFieldControl(input: {
 
 function getAutoFormFieldId(componentName: string, fieldName: string): string {
   return `${componentName}-${fieldName}`.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+function formatAutoFormFieldTypeHint(field: MdxAutoFormField): string {
+  switch (field.control) {
+    case "text":
+    case "textarea":
+      return "string";
+    case "url":
+      return "url";
+    case "color-picker":
+      return "color";
+    case "number":
+    case "slider":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "image":
+      return "image";
+    case "string-list":
+      return "string[]";
+    case "number-list":
+      return "number[]";
+    case "date":
+      return "date";
+    case "json":
+      return "JSON";
+    case "rich-text":
+      return "rich text";
+    case "select":
+      return formatAutoFormSelectTypeHint(field.options);
+  }
+}
+
+function formatAutoFormSelectTypeHint(
+  options: Extract<MdxAutoFormField, { control: "select" }>["options"],
+): string {
+  const labels = options.map((option) => getAutoFormSelectOptionLabel(option));
+  const compactLabel = labels.join(" | ");
+
+  return labels.length > 0 && labels.length <= 4 && compactLabel.length <= 32
+    ? compactLabel
+    : "enum";
 }
 
 function getAutoFormInputType(

--- a/packages/studio/src/lib/mdx-props-editor-host.tsx
+++ b/packages/studio/src/lib/mdx-props-editor-host.tsx
@@ -248,20 +248,11 @@ export function MdxPropsEditorHost({
 
       return (
         <PropsEditorRenderBoundary componentName={component.name}>
-          <>
-            <span data-mdcms-mdx-props-editor-state={`${component.name}:ready`}>
-              Custom editor ready.
-            </span>
-            <span data-mdcms-mdx-props-editor={component.name}>
-              Custom editor
-            </span>
-            <div data-mdcms-mdx-props-editor-surface={component.name}>
-              {createElement(
-                state.editor as PropsEditorComponent<PropsEditorValue>,
-                bindings,
-              )}
-            </div>
-          </>
+          {renderReadyMdxPropsEditor({
+            componentName: component.name,
+            editor: state.editor as PropsEditorComponent<PropsEditorValue>,
+            bindings,
+          })}
         </PropsEditorRenderBoundary>
       );
     }
@@ -320,6 +311,25 @@ function createFallbackState(
     : hasNestedRichTextChildren(component)
       ? { status: "content-only" }
       : { status: "empty" };
+}
+
+export function renderReadyMdxPropsEditor(input: {
+  componentName: string;
+  editor: PropsEditorComponent<PropsEditorValue>;
+  bindings: PropsEditorComponentProps<PropsEditorValue>;
+}): ReactNode {
+  return (
+    <>
+      <span
+        hidden
+        data-mdcms-mdx-props-editor-state={`${input.componentName}:ready`}
+      />
+      <span hidden data-mdcms-mdx-props-editor={input.componentName} />
+      <div data-mdcms-mdx-props-editor-surface={input.componentName}>
+        {createElement(input.editor, input.bindings)}
+      </div>
+    </>
+  );
 }
 
 function hasNestedRichTextChildren(component: MdxCatalogComponent): boolean {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
@@ -31,6 +31,7 @@ test("MdxComponentNodeFrame renders wrapper component chrome with nested slot", 
   assert.match(markup, />Callout</);
   assert.match(markup, /type=&quot;warning&quot;/);
   assert.match(markup, /data-test-slot="children"/);
+  assert.doesNotMatch(markup, />Wrapper</);
 });
 
 test("MdxComponentNodeFrame renders void component chrome without child slot", () => {
@@ -49,6 +50,7 @@ test("MdxComponentNodeFrame renders void component chrome without child slot", (
   assert.match(markup, /Local preview unavailable/);
   assert.match(markup, /Self-closing component/);
   assert.doesNotMatch(markup, /data-test-slot="children"/);
+  assert.doesNotMatch(markup, />Void</);
 });
 
 test("formatMdxComponentPropsSummary distinguishes empty props from non-editable components", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
@@ -67,7 +67,7 @@ test("createMdxComponentPreviewProps injects wrapper children into preview props
   assert.match(markup, /<strong>Body<\/strong>/);
 });
 
-test("MdxComponentNodeFrame renders 'Content' label for wrapper components", () => {
+test("MdxComponentNodeFrame renders 'Inner content' guidance for wrapper components", () => {
   const markup = renderToStaticMarkup(
     createElement(
       MdxComponentNodeFrame,
@@ -82,7 +82,8 @@ test("MdxComponentNodeFrame renders 'Content' label for wrapper components", () 
   );
 
   assert.match(markup, /data-mdcms-mdx-content-label="Callout"/);
-  assert.match(markup, />Content</);
+  assert.match(markup, />Inner content</);
+  assert.match(markup, /Edit nested markdown directly in this block/);
 });
 
 test("MdxComponentNodeFrame does not render content label for void components", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   createMdxComponentPreviewProps,
+  formatMdxComponentPropsSummary,
   MdxComponentNodeFrame,
 } from "./mdx-component-node-view.js";
 
@@ -48,6 +49,11 @@ test("MdxComponentNodeFrame renders void component chrome without child slot", (
   assert.match(markup, /Local preview unavailable/);
   assert.match(markup, /Self-closing component/);
   assert.doesNotMatch(markup, /data-test-slot="children"/);
+});
+
+test("formatMdxComponentPropsSummary distinguishes empty props from non-editable components", () => {
+  assert.equal(formatMdxComponentPropsSummary({}), "No props set yet");
+  assert.equal(formatMdxComponentPropsSummary(undefined), "No props set yet");
 });
 
 test("createMdxComponentPreviewProps injects wrapper children into preview props", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
@@ -15,7 +15,7 @@ import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { isMdxExpressionValue } from "../../../mdx-component-extension.js";
 import { Badge } from "../ui/badge.js";
 
-function formatPropsSummary(
+export function formatMdxComponentPropsSummary(
   props: Record<string, unknown> | undefined,
 ): string {
   const entries = Object.entries(props ?? {}).filter(
@@ -23,7 +23,7 @@ function formatPropsSummary(
   );
 
   if (entries.length === 0) {
-    return "No props";
+    return "No props set yet";
   }
 
   return entries
@@ -180,7 +180,7 @@ export function MdxComponentNodeView(
     (props.node.attrs.props as Record<string, unknown> | undefined) ?? {};
   const serializedPreviewProps = JSON.stringify(mdxProps);
   const serializedChildren = JSON.stringify(props.node.content.toJSON());
-  const propsSummary = formatPropsSummary(mdxProps);
+  const propsSummary = formatMdxComponentPropsSummary(mdxProps);
 
   useEffect(() => {
     const container = previewContainerRef.current;

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
@@ -13,7 +13,6 @@ import type { ReactNodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 
 import { isMdxExpressionValue } from "../../../mdx-component-extension.js";
-import { Badge } from "../ui/badge.js";
 
 export function formatMdxComponentPropsSummary(
   props: Record<string, unknown> | undefined,
@@ -57,7 +56,7 @@ export function MdxComponentNodeFrame(props: {
       data-mdcms-mdx-component-kind={props.isVoid ? "void" : "wrapper"}
       className="my-4 rounded-lg border border-dashed border-border bg-background-subtle"
     >
-      <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+      <div className="border-b border-border px-3 py-2">
         <div className="space-y-1">
           <div className="text-sm font-medium text-foreground">
             {props.componentName}
@@ -66,9 +65,6 @@ export function MdxComponentNodeFrame(props: {
             {props.propsSummary}
           </div>
         </div>
-        <Badge variant="outline" className="text-[10px]">
-          {props.isVoid ? "Void" : "Wrapper"}
-        </Badge>
       </div>
 
       <div className="space-y-3 px-3 py-3">

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
@@ -99,7 +99,10 @@ export function MdxComponentNodeFrame(props: {
               data-mdcms-mdx-content-label={props.componentName}
               className="text-xs font-medium text-foreground-muted"
             >
-              Content
+              Inner content
+            </p>
+            <p className="text-xs text-foreground-muted">
+              Edit nested markdown directly in this block.
             </p>
             {props.children}
           </div>

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
@@ -94,3 +94,31 @@ test("MdxPropsPanel renders an unresolved state when the selected component is m
   assert.match(markup, /data-mdcms-mdx-props-panel="unregistered"/);
   assert.match(markup, /UnknownWidget/);
 });
+
+test("MdxPropsPanel explains that wrapper component children are edited inside the canvas", () => {
+  const wrapperComponent = {
+    name: "Callout",
+    importPath: "@/components/mdx/Callout",
+    description: "Wrapper callout",
+    extractedProps: {
+      tone: { type: "enum", required: true, values: ["info", "warning"] },
+      children: { type: "rich-text", required: false },
+    },
+  } satisfies NonNullable<
+    StudioMountContext["mdx"]
+  >["catalog"]["components"][number];
+  const markup = renderToStaticMarkup(
+    createElement(MdxPropsPanel, {
+      context: createContext(),
+      selection: createSelection({
+        component: wrapperComponent,
+        componentName: wrapperComponent.name,
+        isVoid: false,
+        props: { tone: "warning" },
+      }),
+    }),
+  );
+
+  assert.match(markup, /Wrapper content lives in the editor canvas/);
+  assert.match(markup, /data-mdcms-mdx-auto-form="Callout"/);
+});

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
@@ -78,6 +78,10 @@ test("MdxPropsPanel renders the selected component instead of an arbitrary catal
   assert.match(markup, /data-mdcms-mdx-props-panel="HeroBanner"/);
   assert.match(markup, /Selected component/);
   assert.match(markup, /data-mdcms-mdx-auto-form="HeroBanner"/);
+  assert.doesNotMatch(markup, />Void</);
+  assert.doesNotMatch(markup, />Auto</);
+  assert.doesNotMatch(markup, />Custom</);
+  assert.doesNotMatch(markup, />Wrapper</);
 });
 
 test("MdxPropsPanel renders an unresolved state when the selected component is missing from the local catalog", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
@@ -7,7 +7,6 @@ import {
   type PropsEditorChangeHandler,
   type PropsEditorValue,
 } from "../../../mdx-props-editor-host.js";
-import { Badge } from "../ui/badge.js";
 import { getMdxComponentKind } from "./mdx-component-catalog.js";
 
 type MdxCatalogComponent = NonNullable<
@@ -67,21 +66,11 @@ export function MdxPropsPanel({
 
   return (
     <section data-mdcms-mdx-props-panel={component.name} className="space-y-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <p className="text-sm font-medium text-foreground">
-            MDX component props
-          </p>
-          <p className="text-xs text-foreground-muted">Selected component</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant="outline" className="text-[10px]">
-            {kind === "wrapper" ? "Wrapper" : "Void"}
-          </Badge>
-          <Badge variant="outline" className="text-[10px]">
-            {component.propsEditor ? "Custom" : "Auto"}
-          </Badge>
-        </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">
+          MDX component props
+        </p>
+        <p className="text-xs text-foreground-muted">Selected component</p>
       </div>
 
       <div className="space-y-1">

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
@@ -91,6 +91,16 @@ export function MdxPropsPanel({
             {component.description}
           </p>
         ) : null}
+        {kind === "wrapper" ? (
+          <p
+            data-mdcms-mdx-wrapper-guidance={component.name}
+            className="text-xs text-foreground-muted"
+          >
+            Wrapper content lives in the editor canvas. Use the inner content
+            area in the component block to edit nested markdown; this panel only
+            covers top-level props.
+          </p>
+        ) : null}
       </div>
 
       <div className="rounded-md border border-border bg-background-subtle p-3">

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
 
-import { createTipTapEditorDependencies } from "./tiptap-editor.js";
+import {
+  createTipTapEditorDependencies,
+  resolveSlashPickerCoordsForEditor,
+} from "./tiptap-editor.js";
 
 test("createTipTapEditorDependencies keeps editor lifetime independent of onChange identity", () => {
   const hostBridge = {
@@ -18,5 +21,34 @@ test("createTipTapEditorDependencies keeps editor lifetime independent of onChan
       forbidden: false,
     }),
     ["Start writing, or press / for commands...", hostBridge, false, false],
+  );
+});
+
+test("resolveSlashPickerCoordsForEditor returns null while the editor view is remounting", () => {
+  const trigger = {
+    query: "PricingTable",
+    from: 12,
+    to: 25,
+  };
+  const container = {
+    getBoundingClientRect: () => ({
+      top: 32,
+      left: 24,
+    }),
+  };
+
+  assert.equal(
+    resolveSlashPickerCoordsForEditor({
+      editor: {
+        get view() {
+          throw new Error(
+            "[tiptap error]: The editor view is not available. Cannot access view['coordsAtPos']. The editor may not be mounted yet.",
+          );
+        },
+      } as never,
+      trigger,
+      container,
+    }),
+    null,
   );
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -88,7 +88,7 @@ const defaultContent = `
 
 This is a sample markdown document created in MDCMS Studio.
 
-<Callout type="warning">
+<Callout tone="warning">
 This is **important** nested markdown content inside an MDX wrapper component.
 
 - First point
@@ -309,10 +309,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             "data-placeholder": placeholder,
           },
           handleKeyDown: (_view, event) => {
-            if (
-              event.key === "Escape" &&
-              pickerSourceRef.current === "slash"
-            ) {
+            if (event.key === "Escape" && pickerSourceRef.current === "slash") {
               setPickerSource(null);
               setSlashTrigger(null);
               setSlashPickerCoords(null);
@@ -652,9 +649,14 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
                     type="button"
                     variant="ghost"
                     size="sm"
-                    disabled={item.availability !== "enabled" || isEditorReadOnly}
+                    disabled={
+                      item.availability !== "enabled" || isEditorReadOnly
+                    }
                     onClick={() => {
-                      if (item.availability === "enabled" && !isEditorReadOnly) {
+                      if (
+                        item.availability === "enabled" &&
+                        !isEditorReadOnly
+                      ) {
                         triggerToolbarItem(item.id);
                       }
                     }}

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -149,6 +149,24 @@ export function createTipTapEditorDependencies(input: {
   return [input.placeholder, input.hostBridge, input.readOnly, input.forbidden];
 }
 
+export function resolveSlashPickerCoordsForEditor(input: {
+  editor: {
+    view: Parameters<typeof getSlashTriggerCoords>[0];
+  };
+  trigger: MdxComponentSlashTrigger;
+  container: Parameters<typeof getSlashTriggerCoords>[2];
+}): SlashTriggerCoords | null {
+  try {
+    return getSlashTriggerCoords(
+      input.editor.view,
+      input.trigger,
+      input.container,
+    );
+  } catch {
+    return null;
+  }
+}
+
 export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
   function TipTapEditor(
     {
@@ -209,11 +227,11 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
 
         if (nextTrigger && editorWrapperRef.current) {
           setSlashPickerCoords(
-            getSlashTriggerCoords(
-              nextEditor.view,
-              nextTrigger,
-              editorWrapperRef.current,
-            ),
+            resolveSlashPickerCoordsForEditor({
+              editor: nextEditor,
+              trigger: nextTrigger,
+              container: editorWrapperRef.current,
+            }),
           );
         } else {
           setSlashPickerCoords(null);

--- a/packages/studio/src/lib/runtime-ui/lib/mock-data.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/mock-data.ts
@@ -115,7 +115,7 @@ function createMockDocumentBody(title: string): string {
     "",
     '<HeroBanner title="Launch" />',
     "",
-    '<Callout type="warning">',
+    '<Callout tone="warning">',
     "Review this section before publishing.",
     "</Callout>",
   ].join("\n");

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -467,8 +467,56 @@ test("ContentDocumentPageView renders guarded schema mismatch recovery controls"
   assert.match(markup, /Sync Schema/);
 });
 
-test("ContentDocumentPageView renders the active MDX component props panel in the sidebar properties tab", () => {
-  const markup = renderPageMarkup(createReadyState(), {
+test("ContentDocumentPageView keeps the dedicated Component tab hidden until an MDX component is selected", () => {
+  const state = createReadyState();
+  state.schemaState = createReadySchemaState({
+    entries: [
+      createSchemaEntry({
+        title: {
+          kind: "string",
+          required: true,
+          nullable: false,
+        },
+      }),
+    ],
+  });
+  state.document.frontmatter = {
+    title: "Launch Notes",
+  };
+  state.draftFrontmatter = {
+    ...state.document.frontmatter,
+  };
+
+  const markup = renderPageMarkup(state, {
+    context: createMdxMountContext(),
+  });
+
+  assert.doesNotMatch(markup, />Component</);
+  assert.match(markup, /data-mdcms-property-field="title"/);
+  assert.doesNotMatch(markup, /data-mdcms-mdx-props-panel="PricingTable"/);
+});
+
+test("ContentDocumentPageView renders the active MDX component props panel in a dedicated Component tab", () => {
+  const state = createReadyState();
+  state.schemaState = createReadySchemaState({
+    entries: [
+      createSchemaEntry({
+        title: {
+          kind: "string",
+          required: true,
+          nullable: false,
+        },
+      }),
+    ],
+  });
+  state.document.frontmatter = {
+    title: "Launch Notes",
+  };
+  state.draftFrontmatter = {
+    ...state.document.frontmatter,
+  };
+
+  const markup = renderPageMarkup(state, {
     context: createMdxMountContext(),
     activeMdxComponent: {
       component: createMdxMountContext().mdx!.catalog.components[0]!,
@@ -481,8 +529,10 @@ test("ContentDocumentPageView renders the active MDX component props panel in th
     },
   });
 
+  assert.match(markup, />Component</);
   assert.match(markup, /data-mdcms-mdx-props-panel="PricingTable"/);
   assert.match(markup, /MDX component props/);
+  assert.doesNotMatch(markup, /data-mdcms-property-field="title"/);
 });
 
 test("loadContentDocumentPageState applies the schema mismatch guard before returning the ready document state", async () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -4,6 +4,7 @@ import { test } from "bun:test";
 import {
   RuntimeError,
   type SchemaRegistryEntry,
+  type StudioMountContext,
   createEmptyCurrentPrincipalCapabilities,
 } from "@mdcms/shared";
 import { createElement } from "react";
@@ -75,6 +76,9 @@ function createErrorShell(
 
 function renderPageMarkup(
   state: Parameters<typeof ContentDocumentPageView>[0]["state"],
+  props: Partial<
+    Omit<Parameters<typeof ContentDocumentPageView>[0], "state">
+  > = {},
 ): string {
   return renderToStaticMarkup(
     createElement(
@@ -94,6 +98,7 @@ function renderPageMarkup(
       },
       createElement(ContentDocumentPageView, {
         state,
+        ...props,
       }),
     ),
   );
@@ -217,6 +222,24 @@ function createMountContext(canWrite = true) {
       renderMdxPreview: () => () => {},
     },
     documentRoute: createRouteContext(canWrite),
+  };
+}
+
+function createMdxMountContext(): StudioMountContext {
+  return {
+    ...createMountContext(),
+    mdx: {
+      catalog: {
+        components: [
+          {
+            name: "PricingTable",
+            importPath: "@/components/mdx/PricingTable",
+            propsEditor: "@/components/mdx/PricingTable.editor",
+          },
+        ],
+      },
+      resolvePropsEditor: async () => null,
+    },
   };
 }
 
@@ -442,6 +465,24 @@ test("ContentDocumentPageView renders guarded schema mismatch recovery controls"
   assert.match(markup, /Server schema hash/);
   assert.match(markup, /server-hash/);
   assert.match(markup, /Sync Schema/);
+});
+
+test("ContentDocumentPageView renders the active MDX component props panel in the sidebar properties tab", () => {
+  const markup = renderPageMarkup(createReadyState(), {
+    context: createMdxMountContext(),
+    activeMdxComponent: {
+      component: createMdxMountContext().mdx!.catalog.components[0]!,
+      componentName: "PricingTable",
+      isVoid: true,
+      props: {},
+      readOnly: false,
+      forbidden: false,
+      onPropsChange: () => {},
+    },
+  });
+
+  assert.match(markup, /data-mdcms-mdx-props-panel="PricingTable"/);
+  assert.match(markup, /MDX component props/);
 });
 
 test("loadContentDocumentPageState applies the schema mismatch guard before returning the ready document state", async () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -40,7 +40,10 @@ import {
 } from "../../document-version-diff.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import { useParams, useRouter } from "../adapters/next-navigation.js";
-import { type MdxPropsPanelSelection } from "../components/editor/mdx-props-panel.js";
+import {
+  MdxPropsPanel,
+  type MdxPropsPanelSelection,
+} from "../components/editor/mdx-props-panel.js";
 import {
   TipTapEditor,
   type TipTapEditorHandle,
@@ -1944,6 +1947,8 @@ export function SidebarInfoTab(props: {
 
 function SidebarPropertiesTab(props: {
   state: ContentDocumentPageReadyState;
+  context?: StudioMountContext;
+  activeMdxComponent?: MdxPropsPanelSelection | null;
   onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
 }) {
   const propertyDescriptors = getPropertyDescriptors(props.state);
@@ -1952,6 +1957,15 @@ function SidebarPropertiesTab(props: {
 
   return (
     <div className="p-4">
+      {props.context ? (
+        <div className="mb-4 border-b border-border pb-4">
+          <MdxPropsPanel
+            context={props.context}
+            selection={props.activeMdxComponent ?? null}
+          />
+        </div>
+      ) : null}
+
       {propertyDescriptors.length > 0 ? (
         <div className="flex flex-col">
           {propertyDescriptors.map((descriptor) => {
@@ -2281,6 +2295,8 @@ function SidebarHistoryTab(props: {
 
 function ContentDocumentPageSidebar(props: {
   state: ContentDocumentPageReadyState;
+  context?: StudioMountContext;
+  activeMdxComponent?: MdxPropsPanelSelection | null;
   onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
@@ -2288,6 +2304,12 @@ function ContentDocumentPageSidebar(props: {
   const [activeTab, setActiveTab] = useState<"properties" | "info" | "history">(
     "properties",
   );
+
+  useEffect(() => {
+    if (props.activeMdxComponent) {
+      setActiveTab("properties");
+    }
+  }, [props.activeMdxComponent]);
 
   return (
     <aside
@@ -2339,6 +2361,8 @@ function ContentDocumentPageSidebar(props: {
         {activeTab === "properties" ? (
           <SidebarPropertiesTab
             state={props.state}
+            context={props.context}
+            activeMdxComponent={props.activeMdxComponent}
             onFrontmatterFieldChange={props.onFrontmatterFieldChange}
           />
         ) : activeTab === "info" ? (
@@ -2678,6 +2702,8 @@ export function ContentDocumentPageView({
           {state.status === "ready" && sidebarOpen ? (
             <ContentDocumentPageSidebar
               state={state}
+              context={context}
+              activeMdxComponent={activeMdxComponent}
               onFrontmatterFieldChange={onFrontmatterFieldChange}
               onViewVersion={onViewVersion}
               onBackToDraft={onBackToDraft}

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1947,8 +1947,6 @@ export function SidebarInfoTab(props: {
 
 function SidebarPropertiesTab(props: {
   state: ContentDocumentPageReadyState;
-  context?: StudioMountContext;
-  activeMdxComponent?: MdxPropsPanelSelection | null;
   onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
 }) {
   const propertyDescriptors = getPropertyDescriptors(props.state);
@@ -1957,15 +1955,6 @@ function SidebarPropertiesTab(props: {
 
   return (
     <div className="p-4">
-      {props.context ? (
-        <div className="mb-4 border-b border-border pb-4">
-          <MdxPropsPanel
-            context={props.context}
-            selection={props.activeMdxComponent ?? null}
-          />
-        </div>
-      ) : null}
-
       {propertyDescriptors.length > 0 ? (
         <div className="flex flex-col">
           {propertyDescriptors.map((descriptor) => {
@@ -2195,6 +2184,20 @@ function SidebarPropertiesTab(props: {
   );
 }
 
+function SidebarComponentTab(props: {
+  context: StudioMountContext;
+  activeMdxComponent: MdxPropsPanelSelection;
+}) {
+  return (
+    <div className="p-4">
+      <MdxPropsPanel
+        context={props.context}
+        selection={props.activeMdxComponent}
+      />
+    </div>
+  );
+}
+
 function SidebarHistoryTab(props: {
   state: ContentDocumentPageReadyState;
   onViewVersion?: (version: number) => void;
@@ -2301,15 +2304,21 @@ function ContentDocumentPageSidebar(props: {
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState<"properties" | "info" | "history">(
-    "properties",
-  );
+  const hasComponentTab = Boolean(props.context && props.activeMdxComponent);
+  const [activeTab, setActiveTab] = useState<
+    "properties" | "component" | "info" | "history"
+  >(() => (hasComponentTab ? "component" : "properties"));
 
   useEffect(() => {
-    if (props.activeMdxComponent) {
-      setActiveTab("properties");
+    if (hasComponentTab) {
+      setActiveTab("component");
+      return;
     }
-  }, [props.activeMdxComponent]);
+
+    setActiveTab((currentTab) =>
+      currentTab === "component" ? "properties" : currentTab,
+    );
+  }, [hasComponentTab]);
 
   return (
     <aside
@@ -2342,6 +2351,20 @@ function ContentDocumentPageSidebar(props: {
         >
           Properties
         </button>
+        {hasComponentTab ? (
+          <button
+            type="button"
+            className={cn(
+              "flex-1 py-2.5 text-center text-xs font-semibold transition-colors",
+              activeTab === "component"
+                ? "border-b-2 border-primary text-primary"
+                : "text-foreground-muted hover:text-foreground",
+            )}
+            onClick={() => setActiveTab("component")}
+          >
+            Component
+          </button>
+        ) : null}
         <button
           type="button"
           className={cn(
@@ -2361,9 +2384,14 @@ function ContentDocumentPageSidebar(props: {
         {activeTab === "properties" ? (
           <SidebarPropertiesTab
             state={props.state}
+            onFrontmatterFieldChange={props.onFrontmatterFieldChange}
+          />
+        ) : activeTab === "component" &&
+          props.context &&
+          props.activeMdxComponent ? (
+          <SidebarComponentTab
             context={props.context}
             activeMdxComponent={props.activeMdxComponent}
-            onFrontmatterFieldChange={props.onFrontmatterFieldChange}
           />
         ) : activeTab === "info" ? (
           <SidebarInfoTab state={props.state} />


### PR DESCRIPTION
## Summary
- add a dedicated wrapper `content-only` props-host state plus clearer panel and node-view guidance for editing nested MDX children
- align review fixtures, mock content, and default editor content with the current `Callout` `tone` prop contract
- update SPEC-007 to document the wrapper-content fallback and inline slash-picker behavior

## Testing
- `bun x prettier --check packages/studio/src/lib/mdx-props-editor-host.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx packages/studio/src/lib/runtime-ui/lib/mock-data.ts packages/studio/src/lib/mdx-props-editor-host.test.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx apps/studio-review/review/scenarios.ts apps/studio-review/review/scenarios.test.ts docs/specs/SPEC-007-editor-mdx-and-collaboration.md`
- `bun test packages/studio/src/lib/mdx-props-editor-host.test.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.test.tsx apps/studio-review/review/scenarios.test.ts`
- `bun run typecheck`

## Notes
- `bun run ci:required` is currently blocked by existing repo-wide Prettier warnings in unrelated files outside this branch.