### PR TITLE
fix(studio): keep slash picker within viewport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/cli": {
       "name": "@mdcms/cli",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "bin": {
         "mdcms": "./dist/bin/mdcms.js",
       },
@@ -102,7 +102,7 @@
     },
     "packages/sdk": {
       "name": "@mdcms/sdk",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@mdcms/shared": "workspace:*",
         "tslib": "^2.3.0",
@@ -110,7 +110,7 @@
     },
     "packages/shared": {
       "name": "@mdcms/shared",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "dependencies": {
         "elysia": "^1.4.25",
         "tslib": "^2.3.0",
@@ -120,13 +120,14 @@
     },
     "packages/studio": {
       "name": "@mdcms/studio",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "dependencies": {
         "@elysiajs/eden": "^1.4.8",
+        "@floating-ui/react-dom": "^2.1.8",
         "@fontsource-variable/geist-mono": "^5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/space-grotesk": "^5.2.10",
-        "@mdcms/shared": "workspace:*",
+        "@mdcms/shared": "^0.1.3",
         "@radix-ui/react-avatar": "1.1.11",
         "@radix-ui/react-checkbox": "1.3.3",
         "@radix-ui/react-collapsible": "1.1.12",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@elysiajs/eden": "^1.4.8",
+    "@floating-ui/react-dom": "^2.1.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/space-grotesk": "^5.2.10",

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
@@ -128,12 +128,12 @@ test("getSlashTriggerCoords anchors the picker to the current caret position", (
 test("createSlashPickerVirtualReference exposes a caret rect and keeps the context element", () => {
   const contextElement = {} as Element;
   const reference = createSlashPickerVirtualReference({
-    anchor: {
+    getAnchor: () => ({
       top: 220,
       left: 100,
       cursorTop: 200,
       cursorBottom: 220,
-    },
+    }),
     contextElement,
   });
   const rect = reference.getBoundingClientRect();
@@ -150,4 +150,29 @@ test("createSlashPickerVirtualReference exposes a caret rect and keeps the conte
     height: 20,
     toJSON: rect.toJSON,
   });
+});
+
+test("createSlashPickerVirtualReference reads the latest anchor on each measurement", () => {
+  let anchor = {
+    top: 220,
+    left: 100,
+    cursorTop: 200,
+    cursorBottom: 220,
+  };
+  const reference = createSlashPickerVirtualReference({
+    getAnchor: () => anchor,
+  });
+
+  assert.deepEqual(reference.getBoundingClientRect().left, 100);
+
+  anchor = {
+    top: 300,
+    left: 148,
+    cursorTop: 280,
+    cursorBottom: 300,
+  };
+
+  assert.deepEqual(reference.getBoundingClientRect().left, 148);
+  assert.deepEqual(reference.getBoundingClientRect().top, 280);
+  assert.deepEqual(reference.getBoundingClientRect().bottom, 300);
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
@@ -99,19 +99,27 @@ test("replaceSlashTriggerWithMdxComponent removes the slash token and inserts th
   }
 });
 
-test("getSlashTriggerCoords returns viewport-relative coordinates", () => {
+test("getSlashTriggerCoords anchors the picker to the current caret position", () => {
   const trigger: MdxComponentSlashTrigger = { query: "Cal", from: 5, to: 9 };
+  let positionRequested = -1;
   const coords = getSlashTriggerCoords(
     {
-      coordsAtPos: (_pos: number) => ({ top: 200, left: 100, bottom: 220 }),
+      coordsAtPos: (pos: number) => {
+        positionRequested = pos;
+
+        return pos === trigger.to
+          ? { top: 200, left: 112, bottom: 220 }
+          : { top: 200, left: 100, bottom: 220 };
+      },
     },
     trigger,
     { getBoundingClientRect: () => ({ top: 50, left: 30 }) },
   );
 
+  assert.equal(positionRequested, trigger.to);
   assert.deepEqual(coords, {
     top: 220,
-    left: 100,
+    left: 112,
     cursorTop: 200,
     cursorBottom: 220,
   });

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
@@ -7,6 +7,7 @@ import { extractMarkdownFromEditor } from "../../../markdown-pipeline.js";
 import { createDocumentEditor } from "../../../document-editor.js";
 import {
   getMdxComponentSlashTrigger,
+  getSlashPickerLayout,
   getSlashTriggerCoords,
   replaceSlashTriggerWithMdxComponent,
 } from "./mdx-component-slash.js";
@@ -111,5 +112,69 @@ test("getSlashTriggerCoords returns container-relative coordinates", () => {
   assert.deepEqual(coords, {
     top: 170,
     left: 70,
+    cursorTop: 150,
+    cursorBottom: 170,
+  });
+});
+
+test("getSlashPickerLayout clamps horizontal overflow and flips above the trigger when needed", () => {
+  const layout = getSlashPickerLayout({
+    anchor: {
+      top: 300,
+      left: 260,
+      cursorTop: 280,
+      cursorBottom: 300,
+    },
+    pickerSize: {
+      width: 240,
+      height: 180,
+    },
+    containerRect: {
+      top: 100,
+      left: 40,
+      width: 320,
+      height: 500,
+    },
+    viewportSize: {
+      width: 360,
+      height: 420,
+    },
+  });
+
+  assert.deepEqual(layout, {
+    top: 92,
+    left: 68,
+    maxHeight: 360,
+  });
+});
+
+test("getSlashPickerLayout keeps the picker below the trigger and caps height when neither side fits fully", () => {
+  const layout = getSlashPickerLayout({
+    anchor: {
+      top: 80,
+      left: 40,
+      cursorTop: 60,
+      cursorBottom: 80,
+    },
+    pickerSize: {
+      width: 220,
+      height: 200,
+    },
+    containerRect: {
+      top: 20,
+      left: 20,
+      width: 320,
+      height: 500,
+    },
+    viewportSize: {
+      width: 360,
+      height: 260,
+    },
+  });
+
+  assert.deepEqual(layout, {
+    top: 88,
+    left: 40,
+    maxHeight: 140,
   });
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
@@ -6,8 +6,8 @@ import type { StudioMountContext } from "@mdcms/shared";
 import { extractMarkdownFromEditor } from "../../../markdown-pipeline.js";
 import { createDocumentEditor } from "../../../document-editor.js";
 import {
+  createSlashPickerVirtualReference,
   getMdxComponentSlashTrigger,
-  getSlashPickerLayout,
   getSlashTriggerCoords,
   replaceSlashTriggerWithMdxComponent,
 } from "./mdx-component-slash.js";
@@ -117,52 +117,29 @@ test("getSlashTriggerCoords returns viewport-relative coordinates", () => {
   });
 });
 
-test("getSlashPickerLayout clamps horizontal overflow and flips above the trigger when needed", () => {
-  const layout = getSlashPickerLayout({
+test("createSlashPickerVirtualReference exposes a caret rect and keeps the context element", () => {
+  const contextElement = {} as Element;
+  const reference = createSlashPickerVirtualReference({
     anchor: {
-      top: 320,
-      left: 320,
-      cursorTop: 300,
-      cursorBottom: 320,
+      top: 220,
+      left: 100,
+      cursorTop: 200,
+      cursorBottom: 220,
     },
-    pickerSize: {
-      width: 240,
-      height: 180,
-    },
-    viewportSize: {
-      width: 360,
-      height: 420,
-    },
+    contextElement,
   });
+  const rect = reference.getBoundingClientRect();
 
-  assert.deepEqual(layout, {
-    top: 112,
-    left: 108,
-    maxHeight: 280,
-  });
-});
-
-test("getSlashPickerLayout keeps the picker below the trigger and caps height when neither side fits fully", () => {
-  const layout = getSlashPickerLayout({
-    anchor: {
-      top: 80,
-      left: 40,
-      cursorTop: 60,
-      cursorBottom: 80,
-    },
-    pickerSize: {
-      width: 220,
-      height: 200,
-    },
-    viewportSize: {
-      width: 360,
-      height: 260,
-    },
-  });
-
-  assert.deepEqual(layout, {
-    top: 88,
-    left: 40,
-    maxHeight: 160,
+  assert.equal(reference.contextElement, contextElement);
+  assert.deepEqual(rect, {
+    x: 100,
+    y: 200,
+    top: 200,
+    right: 100,
+    bottom: 220,
+    left: 100,
+    width: 0,
+    height: 20,
+    toJSON: rect.toJSON,
   });
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts
@@ -99,7 +99,7 @@ test("replaceSlashTriggerWithMdxComponent removes the slash token and inserts th
   }
 });
 
-test("getSlashTriggerCoords returns container-relative coordinates", () => {
+test("getSlashTriggerCoords returns viewport-relative coordinates", () => {
   const trigger: MdxComponentSlashTrigger = { query: "Cal", from: 5, to: 9 };
   const coords = getSlashTriggerCoords(
     {
@@ -110,30 +110,24 @@ test("getSlashTriggerCoords returns container-relative coordinates", () => {
   );
 
   assert.deepEqual(coords, {
-    top: 170,
-    left: 70,
-    cursorTop: 150,
-    cursorBottom: 170,
+    top: 220,
+    left: 100,
+    cursorTop: 200,
+    cursorBottom: 220,
   });
 });
 
 test("getSlashPickerLayout clamps horizontal overflow and flips above the trigger when needed", () => {
   const layout = getSlashPickerLayout({
     anchor: {
-      top: 300,
-      left: 260,
-      cursorTop: 280,
-      cursorBottom: 300,
+      top: 320,
+      left: 320,
+      cursorTop: 300,
+      cursorBottom: 320,
     },
     pickerSize: {
       width: 240,
       height: 180,
-    },
-    containerRect: {
-      top: 100,
-      left: 40,
-      width: 320,
-      height: 500,
     },
     viewportSize: {
       width: 360,
@@ -142,9 +136,9 @@ test("getSlashPickerLayout clamps horizontal overflow and flips above the trigge
   });
 
   assert.deepEqual(layout, {
-    top: 92,
-    left: 68,
-    maxHeight: 360,
+    top: 112,
+    left: 108,
+    maxHeight: 280,
   });
 });
 
@@ -160,12 +154,6 @@ test("getSlashPickerLayout keeps the picker below the trigger and caps height wh
       width: 220,
       height: 200,
     },
-    containerRect: {
-      top: 20,
-      left: 20,
-      width: 320,
-      height: 500,
-    },
     viewportSize: {
       width: 360,
       height: 260,
@@ -175,6 +163,6 @@ test("getSlashPickerLayout keeps the picker below the trigger and caps height wh
   assert.deepEqual(layout, {
     top: 88,
     left: 40,
-    maxHeight: 140,
+    maxHeight: 160,
   });
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
@@ -85,7 +85,7 @@ export function getSlashTriggerCoords(
   trigger: MdxComponentSlashTrigger,
   _container?: { getBoundingClientRect: () => { top: number; left: number } },
 ): SlashTriggerCoords {
-  const cursorCoords = view.coordsAtPos(trigger.from);
+  const cursorCoords = view.coordsAtPos(trigger.to);
 
   return {
     top: cursorCoords.bottom,

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
@@ -96,39 +96,38 @@ export function getSlashTriggerCoords(
 }
 
 export function createSlashPickerVirtualReference(input: {
-  anchor: SlashTriggerCoords;
+  getAnchor: () => SlashTriggerCoords;
   contextElement?: Element | null;
 }): SlashPickerVirtualReference {
-  const height = Math.max(
-    input.anchor.cursorBottom - input.anchor.cursorTop,
-    0,
-  );
-  const left = input.anchor.left;
-  const top = input.anchor.cursorTop;
-  const bottom = top + height;
-  const rect = {
-    x: left,
-    y: top,
-    top,
-    right: left,
-    bottom,
-    left,
-    width: 0,
-    height,
-    toJSON: () => ({
-      x: left,
-      y: top,
-      top,
-      right: left,
-      bottom,
-      left,
-      width: 0,
-      height,
-    }),
-  } satisfies DOMRect;
-
   return {
     contextElement: input.contextElement ?? undefined,
-    getBoundingClientRect: () => rect,
+    getBoundingClientRect: () => {
+      const anchor = input.getAnchor();
+      const height = Math.max(anchor.cursorBottom - anchor.cursorTop, 0);
+      const left = anchor.left;
+      const top = anchor.cursorTop;
+      const bottom = top + height;
+
+      return {
+        x: left,
+        y: top,
+        top,
+        right: left,
+        bottom,
+        left,
+        width: 0,
+        height,
+        toJSON: () => ({
+          x: left,
+          y: top,
+          top,
+          right: left,
+          bottom,
+          left,
+          width: 0,
+          height,
+        }),
+      } satisfies DOMRect;
+    },
   };
 }

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
@@ -69,10 +69,23 @@ export function replaceSlashTriggerWithMdxComponent(
 export type SlashTriggerCoords = {
   top: number;
   left: number;
+  cursorTop: number;
+  cursorBottom: number;
 };
 
+export type SlashPickerLayout = {
+  top: number;
+  left: number;
+  maxHeight: number;
+};
+
+const SLASH_PICKER_VIEWPORT_GUTTER = 12;
+const SLASH_PICKER_TRIGGER_GAP = 8;
+
 export function getSlashTriggerCoords(
-  view: { coordsAtPos: (pos: number) => { top: number; left: number; bottom: number } },
+  view: {
+    coordsAtPos: (pos: number) => { top: number; left: number; bottom: number };
+  },
   trigger: MdxComponentSlashTrigger,
   container: { getBoundingClientRect: () => { top: number; left: number } },
 ): SlashTriggerCoords {
@@ -82,5 +95,74 @@ export function getSlashTriggerCoords(
   return {
     top: cursorCoords.bottom - containerRect.top,
     left: cursorCoords.left - containerRect.left,
+    cursorTop: cursorCoords.top - containerRect.top,
+    cursorBottom: cursorCoords.bottom - containerRect.top,
   };
+}
+
+export function getSlashPickerLayout(input: {
+  anchor: SlashTriggerCoords;
+  pickerSize: { width: number; height: number };
+  containerRect: { top: number; left: number; width: number; height: number };
+  viewportSize: { width: number; height: number };
+  gutter?: number;
+  gap?: number;
+}): SlashPickerLayout {
+  const gutter = input.gutter ?? SLASH_PICKER_VIEWPORT_GUTTER;
+  const gap = input.gap ?? SLASH_PICKER_TRIGGER_GAP;
+  const availableBelow = Math.max(
+    input.viewportSize.height -
+      gutter -
+      (input.containerRect.top + input.anchor.cursorBottom + gap),
+    0,
+  );
+  const availableAbove = Math.max(
+    input.containerRect.top + input.anchor.cursorTop - gap - gutter,
+    0,
+  );
+  const minLeft = gutter - input.containerRect.left;
+  const maxLeft =
+    input.viewportSize.width -
+    gutter -
+    input.containerRect.left -
+    input.pickerSize.width;
+  const left =
+    maxLeft >= minLeft ? clamp(input.anchor.left, minLeft, maxLeft) : minLeft;
+
+  if (input.pickerSize.height <= availableBelow) {
+    return {
+      top: input.anchor.cursorBottom + gap,
+      left,
+      maxHeight: availableBelow,
+    };
+  }
+
+  if (input.pickerSize.height <= availableAbove) {
+    return {
+      top: input.anchor.cursorTop - gap - input.pickerSize.height,
+      left,
+      maxHeight: availableAbove,
+    };
+  }
+
+  if (availableBelow >= availableAbove) {
+    return {
+      top: input.anchor.cursorBottom + gap,
+      left,
+      maxHeight: availableBelow,
+    };
+  }
+
+  return {
+    top: Math.max(
+      gutter - input.containerRect.top,
+      input.anchor.cursorTop - gap - availableAbove,
+    ),
+    left,
+    maxHeight: availableAbove,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
@@ -73,14 +73,10 @@ export type SlashTriggerCoords = {
   cursorBottom: number;
 };
 
-export type SlashPickerLayout = {
-  top: number;
-  left: number;
-  maxHeight: number;
+export type SlashPickerVirtualReference = {
+  contextElement?: Element;
+  getBoundingClientRect: () => DOMRect;
 };
-
-const SLASH_PICKER_VIEWPORT_GUTTER = 12;
-const SLASH_PICKER_TRIGGER_GAP = 8;
 
 export function getSlashTriggerCoords(
   view: {
@@ -99,56 +95,40 @@ export function getSlashTriggerCoords(
   };
 }
 
-export function getSlashPickerLayout(input: {
+export function createSlashPickerVirtualReference(input: {
   anchor: SlashTriggerCoords;
-  pickerSize: { width: number; height: number };
-  viewportSize: { width: number; height: number };
-  gutter?: number;
-  gap?: number;
-}): SlashPickerLayout {
-  const gutter = input.gutter ?? SLASH_PICKER_VIEWPORT_GUTTER;
-  const gap = input.gap ?? SLASH_PICKER_TRIGGER_GAP;
-  const availableBelow = Math.max(
-    input.viewportSize.height - gutter - (input.anchor.cursorBottom + gap),
+  contextElement?: Element | null;
+}): SlashPickerVirtualReference {
+  const height = Math.max(
+    input.anchor.cursorBottom - input.anchor.cursorTop,
     0,
   );
-  const availableAbove = Math.max(input.anchor.cursorTop - gap - gutter, 0);
-  const minLeft = gutter;
-  const maxLeft = input.viewportSize.width - gutter - input.pickerSize.width;
-  const left =
-    maxLeft >= minLeft ? clamp(input.anchor.left, minLeft, maxLeft) : minLeft;
-
-  if (input.pickerSize.height <= availableBelow) {
-    return {
-      top: input.anchor.cursorBottom + gap,
+  const left = input.anchor.left;
+  const top = input.anchor.cursorTop;
+  const bottom = top + height;
+  const rect = {
+    x: left,
+    y: top,
+    top,
+    right: left,
+    bottom,
+    left,
+    width: 0,
+    height,
+    toJSON: () => ({
+      x: left,
+      y: top,
+      top,
+      right: left,
+      bottom,
       left,
-      maxHeight: availableBelow,
-    };
-  }
-
-  if (input.pickerSize.height <= availableAbove) {
-    return {
-      top: input.anchor.cursorTop - gap - input.pickerSize.height,
-      left,
-      maxHeight: availableAbove,
-    };
-  }
-
-  if (availableBelow >= availableAbove) {
-    return {
-      top: input.anchor.cursorBottom + gap,
-      left,
-      maxHeight: availableBelow,
-    };
-  }
+      width: 0,
+      height,
+    }),
+  } satisfies DOMRect;
 
   return {
-    top: Math.max(gutter, input.anchor.cursorTop - gap - availableAbove),
-    left,
-    maxHeight: availableAbove,
+    contextElement: input.contextElement ?? undefined,
+    getBoundingClientRect: () => rect,
   };
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
 }

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts
@@ -87,23 +87,21 @@ export function getSlashTriggerCoords(
     coordsAtPos: (pos: number) => { top: number; left: number; bottom: number };
   },
   trigger: MdxComponentSlashTrigger,
-  container: { getBoundingClientRect: () => { top: number; left: number } },
+  _container?: { getBoundingClientRect: () => { top: number; left: number } },
 ): SlashTriggerCoords {
   const cursorCoords = view.coordsAtPos(trigger.from);
-  const containerRect = container.getBoundingClientRect();
 
   return {
-    top: cursorCoords.bottom - containerRect.top,
-    left: cursorCoords.left - containerRect.left,
-    cursorTop: cursorCoords.top - containerRect.top,
-    cursorBottom: cursorCoords.bottom - containerRect.top,
+    top: cursorCoords.bottom,
+    left: cursorCoords.left,
+    cursorTop: cursorCoords.top,
+    cursorBottom: cursorCoords.bottom,
   };
 }
 
 export function getSlashPickerLayout(input: {
   anchor: SlashTriggerCoords;
   pickerSize: { width: number; height: number };
-  containerRect: { top: number; left: number; width: number; height: number };
   viewportSize: { width: number; height: number };
   gutter?: number;
   gap?: number;
@@ -111,21 +109,12 @@ export function getSlashPickerLayout(input: {
   const gutter = input.gutter ?? SLASH_PICKER_VIEWPORT_GUTTER;
   const gap = input.gap ?? SLASH_PICKER_TRIGGER_GAP;
   const availableBelow = Math.max(
-    input.viewportSize.height -
-      gutter -
-      (input.containerRect.top + input.anchor.cursorBottom + gap),
+    input.viewportSize.height - gutter - (input.anchor.cursorBottom + gap),
     0,
   );
-  const availableAbove = Math.max(
-    input.containerRect.top + input.anchor.cursorTop - gap - gutter,
-    0,
-  );
-  const minLeft = gutter - input.containerRect.left;
-  const maxLeft =
-    input.viewportSize.width -
-    gutter -
-    input.containerRect.left -
-    input.pickerSize.width;
+  const availableAbove = Math.max(input.anchor.cursorTop - gap - gutter, 0);
+  const minLeft = gutter;
+  const maxLeft = input.viewportSize.width - gutter - input.pickerSize.width;
   const left =
     maxLeft >= minLeft ? clamp(input.anchor.left, minLeft, maxLeft) : minLeft;
 
@@ -154,10 +143,7 @@ export function getSlashPickerLayout(input: {
   }
 
   return {
-    top: Math.max(
-      gutter - input.containerRect.top,
-      input.anchor.cursorTop - gap - availableAbove,
-    ),
+    top: Math.max(gutter, input.anchor.cursorTop - gap - availableAbove),
     left,
     maxHeight: availableAbove,
   };

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  size,
+  useFloating,
+} from "@floating-ui/react-dom";
+import {
   forwardRef,
   useEffect,
   useEffectEvent,
   useImperativeHandle,
-  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -59,12 +66,11 @@ import {
   updateSelectedMdxComponentProps,
 } from "./mdx-component-selection.js";
 import {
+  createSlashPickerVirtualReference,
   getMdxComponentSlashTrigger,
-  getSlashPickerLayout,
   getSlashTriggerCoords,
   replaceSlashTriggerWithMdxComponent,
   type MdxComponentSlashTrigger,
-  type SlashPickerLayout,
   type SlashTriggerCoords,
 } from "./mdx-component-slash.js";
 import { Button } from "../ui/button.js";
@@ -194,12 +200,36 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       useState<MdxComponentSlashTrigger | null>(null);
     const [slashPickerCoords, setSlashPickerCoords] =
       useState<SlashTriggerCoords | null>(null);
-    const [slashPickerLayout, setSlashPickerLayout] =
-      useState<SlashPickerLayout | null>(null);
     const editorWrapperRef = useRef<HTMLDivElement | null>(null);
-    const slashPickerRef = useRef<HTMLDivElement | null>(null);
     const pickerSourceRef = useRef(pickerSource);
     pickerSourceRef.current = pickerSource;
+    const slashPickerOpen =
+      pickerSource === "slash" &&
+      slashTrigger !== null &&
+      slashPickerCoords !== null;
+    const {
+      refs: floatingRefs,
+      floatingStyles,
+      update: updateFloating,
+    } = useFloating({
+      open: slashPickerOpen,
+      placement: "bottom-start",
+      strategy: "fixed",
+      whileElementsMounted: autoUpdate,
+      middleware: [
+        offset(8),
+        flip({ padding: 12 }),
+        shift({ padding: 12 }),
+        size({
+          padding: 12,
+          apply({ availableHeight, elements }) {
+            Object.assign(elements.floating.style, {
+              maxHeight: `${Math.max(availableHeight, 0)}px`,
+            });
+          },
+        }),
+      ],
+    });
     const lastPublishedSelectionRef =
       useRef<PublishedMdxComponentSelectionSnapshot | null>(null);
     const lastEmittedMarkdownRef = useRef<string | null>(null);
@@ -242,7 +272,6 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
           );
         } else {
           setSlashPickerCoords(null);
-          setSlashPickerLayout(null);
         }
       },
     );
@@ -422,51 +451,19 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
     }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
 
     useEffect(() => {
-      if (pickerSource !== "slash" || !editor) {
+      if (!slashPickerOpen || !slashPickerCoords) {
+        floatingRefs.setReference(null);
         return;
       }
 
-      const syncPosition = () => {
-        syncSlashTrigger(editor);
-      };
-
-      window.addEventListener("resize", syncPosition);
-      document.addEventListener("scroll", syncPosition, true);
-
-      return () => {
-        window.removeEventListener("resize", syncPosition);
-        document.removeEventListener("scroll", syncPosition, true);
-      };
-    }, [editor, pickerSource, syncSlashTrigger]);
-
-    useLayoutEffect(() => {
-      if (
-        pickerSource !== "slash" ||
-        !slashTrigger ||
-        !slashPickerCoords ||
-        !editorWrapperRef.current ||
-        !slashPickerRef.current
-      ) {
-        setSlashPickerLayout(null);
-        return;
-      }
-
-      const pickerRect = slashPickerRef.current.getBoundingClientRect();
-
-      setSlashPickerLayout(
-        getSlashPickerLayout({
+      floatingRefs.setReference(
+        createSlashPickerVirtualReference({
           anchor: slashPickerCoords,
-          pickerSize: {
-            width: pickerRect.width,
-            height: pickerRect.height,
-          },
-          viewportSize: {
-            width: window.innerWidth,
-            height: window.innerHeight,
-          },
-        }),
+          contextElement: editorWrapperRef.current,
+        }) as never,
       );
-    }, [pickerSource, slashPickerCoords, slashTrigger]);
+      updateFloating();
+    }, [floatingRefs, slashPickerCoords, slashPickerOpen, updateFloating]);
 
     const isActive = (name: string, attributes?: Record<string, unknown>) =>
       editor?.isActive(name, attributes) ?? false;
@@ -664,31 +661,25 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       syncSlashTrigger(editor);
     };
 
-    const slashPicker =
-      pickerSource === "slash" && slashTrigger && slashPickerCoords ? (
-        <div
-          ref={slashPickerRef}
-          data-mdcms-mdx-picker-source="slash"
-          style={{
-            position: "fixed",
-            top: (slashPickerLayout ?? slashPickerCoords).top,
-            left: (slashPickerLayout ?? slashPickerCoords).left,
-            width: "min(28rem, calc(100vw - 24px))",
-            maxHeight:
-              slashPickerLayout !== null
-                ? `${slashPickerLayout.maxHeight}px`
-                : "calc(100vh - 24px)",
-          }}
-          className="z-50 overflow-y-auto"
-        >
-          <MdxComponentPicker
-            components={catalogComponents}
-            query={slashTrigger.query}
-            forbidden={isEditorReadOnly}
-            onSelect={insertSelectedComponent}
-          />
-        </div>
-      ) : null;
+    const slashPicker = slashPickerOpen ? (
+      <div
+        ref={floatingRefs.setFloating}
+        data-mdcms-mdx-picker-source="slash"
+        style={{
+          ...floatingStyles,
+          width: "min(28rem, calc(100vw - 24px))",
+          maxHeight: "calc(100vh - 24px)",
+        }}
+        className="z-50 overflow-y-auto"
+      >
+        <MdxComponentPicker
+          components={catalogComponents}
+          query={slashTrigger.query}
+          forbidden={isEditorReadOnly}
+          onSelect={insertSelectedComponent}
+        />
+      </div>
+    ) : null;
 
     return (
       <div ref={editorWrapperRef} className="relative">

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useEffectEvent,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -58,9 +59,11 @@ import {
 } from "./mdx-component-selection.js";
 import {
   getMdxComponentSlashTrigger,
+  getSlashPickerLayout,
   getSlashTriggerCoords,
   replaceSlashTriggerWithMdxComponent,
   type MdxComponentSlashTrigger,
+  type SlashPickerLayout,
   type SlashTriggerCoords,
 } from "./mdx-component-slash.js";
 import { Button } from "../ui/button.js";
@@ -190,7 +193,10 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       useState<MdxComponentSlashTrigger | null>(null);
     const [slashPickerCoords, setSlashPickerCoords] =
       useState<SlashTriggerCoords | null>(null);
+    const [slashPickerLayout, setSlashPickerLayout] =
+      useState<SlashPickerLayout | null>(null);
     const editorWrapperRef = useRef<HTMLDivElement | null>(null);
+    const slashPickerRef = useRef<HTMLDivElement | null>(null);
     const pickerSourceRef = useRef(pickerSource);
     pickerSourceRef.current = pickerSource;
     const lastPublishedSelectionRef =
@@ -235,6 +241,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
           );
         } else {
           setSlashPickerCoords(null);
+          setSlashPickerLayout(null);
         }
       },
     );
@@ -412,6 +419,37 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       publishSelectedMdxComponent(editor);
       syncSlashTrigger(editor);
     }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
+
+    useLayoutEffect(() => {
+      if (
+        pickerSource !== "slash" ||
+        !slashTrigger ||
+        !slashPickerCoords ||
+        !editorWrapperRef.current ||
+        !slashPickerRef.current
+      ) {
+        setSlashPickerLayout(null);
+        return;
+      }
+
+      const pickerRect = slashPickerRef.current.getBoundingClientRect();
+      const wrapperRect = editorWrapperRef.current.getBoundingClientRect();
+
+      setSlashPickerLayout(
+        getSlashPickerLayout({
+          anchor: slashPickerCoords,
+          pickerSize: {
+            width: pickerRect.width,
+            height: pickerRect.height,
+          },
+          containerRect: wrapperRect,
+          viewportSize: {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+        }),
+      );
+    }, [pickerSource, slashPickerCoords, slashTrigger]);
 
     const isActive = (name: string, attributes?: Record<string, unknown>) =>
       editor?.isActive(name, attributes) ?? false;
@@ -715,13 +753,19 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
 
         {pickerSource === "slash" && slashTrigger && slashPickerCoords ? (
           <div
+            ref={slashPickerRef}
             data-mdcms-mdx-picker-source="slash"
             style={{
               position: "absolute",
-              top: slashPickerCoords.top,
-              left: slashPickerCoords.left,
+              top: (slashPickerLayout ?? slashPickerCoords).top,
+              left: (slashPickerLayout ?? slashPickerCoords).left,
+              width: "min(28rem, calc(100vw - 24px))",
+              maxHeight:
+                slashPickerLayout !== null
+                  ? `${slashPickerLayout.maxHeight}px`
+                  : "calc(100vh - 24px)",
             }}
-            className="z-50 w-72 max-h-80 overflow-y-auto rounded-lg border border-border bg-background shadow-lg"
+            className="z-50 overflow-y-auto"
           >
             <MdxComponentPicker
               components={catalogComponents}

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -451,19 +451,42 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
     }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
 
     useEffect(() => {
-      if (!slashPickerOpen || !slashPickerCoords) {
+      if (!slashPickerOpen || !slashPickerCoords || !editor || !slashTrigger) {
         floatingRefs.setReference(null);
         return;
       }
 
+      const editorWrapper = editorWrapperRef.current;
+
+      if (!editorWrapper) {
+        floatingRefs.setReference(null);
+        return;
+      }
+
+      const contextElement =
+        editorWrapper.closest('[data-mdcms-editor-pane="canvas"]') ??
+        editorWrapper;
+
       floatingRefs.setReference(
         createSlashPickerVirtualReference({
-          anchor: slashPickerCoords,
-          contextElement: editorWrapperRef.current,
+          getAnchor: () =>
+            resolveSlashPickerCoordsForEditor({
+              editor,
+              trigger: slashTrigger,
+              container: editorWrapper,
+            }) ?? slashPickerCoords,
+          contextElement,
         }) as never,
       );
       updateFloating();
-    }, [floatingRefs, slashPickerCoords, slashPickerOpen, updateFloating]);
+    }, [
+      editor,
+      floatingRefs,
+      slashPickerCoords,
+      slashPickerOpen,
+      slashTrigger,
+      updateFloating,
+    ]);
 
     const isActive = (name: string, attributes?: Record<string, unknown>) =>
       editor?.isActive(name, attributes) ?? false;

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 
 import type { StudioMountContext } from "@mdcms/shared";
 import {
@@ -420,6 +421,24 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       syncSlashTrigger(editor);
     }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
 
+    useEffect(() => {
+      if (pickerSource !== "slash" || !editor) {
+        return;
+      }
+
+      const syncPosition = () => {
+        syncSlashTrigger(editor);
+      };
+
+      window.addEventListener("resize", syncPosition);
+      document.addEventListener("scroll", syncPosition, true);
+
+      return () => {
+        window.removeEventListener("resize", syncPosition);
+        document.removeEventListener("scroll", syncPosition, true);
+      };
+    }, [editor, pickerSource, syncSlashTrigger]);
+
     useLayoutEffect(() => {
       if (
         pickerSource !== "slash" ||
@@ -433,7 +452,6 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       }
 
       const pickerRect = slashPickerRef.current.getBoundingClientRect();
-      const wrapperRect = editorWrapperRef.current.getBoundingClientRect();
 
       setSlashPickerLayout(
         getSlashPickerLayout({
@@ -442,7 +460,6 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             width: pickerRect.width,
             height: pickerRect.height,
           },
-          containerRect: wrapperRect,
           viewportSize: {
             width: window.innerWidth,
             height: window.innerHeight,
@@ -647,6 +664,32 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       syncSlashTrigger(editor);
     };
 
+    const slashPicker =
+      pickerSource === "slash" && slashTrigger && slashPickerCoords ? (
+        <div
+          ref={slashPickerRef}
+          data-mdcms-mdx-picker-source="slash"
+          style={{
+            position: "fixed",
+            top: (slashPickerLayout ?? slashPickerCoords).top,
+            left: (slashPickerLayout ?? slashPickerCoords).left,
+            width: "min(28rem, calc(100vw - 24px))",
+            maxHeight:
+              slashPickerLayout !== null
+                ? `${slashPickerLayout.maxHeight}px`
+                : "calc(100vh - 24px)",
+          }}
+          className="z-50 overflow-y-auto"
+        >
+          <MdxComponentPicker
+            components={catalogComponents}
+            query={slashTrigger.query}
+            forbidden={isEditorReadOnly}
+            onSelect={insertSelectedComponent}
+          />
+        </div>
+      ) : null;
+
     return (
       <div ref={editorWrapperRef} className="relative">
         <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background">
@@ -751,30 +794,9 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
           </div>
         </div>
 
-        {pickerSource === "slash" && slashTrigger && slashPickerCoords ? (
-          <div
-            ref={slashPickerRef}
-            data-mdcms-mdx-picker-source="slash"
-            style={{
-              position: "absolute",
-              top: (slashPickerLayout ?? slashPickerCoords).top,
-              left: (slashPickerLayout ?? slashPickerCoords).left,
-              width: "min(28rem, calc(100vw - 24px))",
-              maxHeight:
-                slashPickerLayout !== null
-                  ? `${slashPickerLayout.maxHeight}px`
-                  : "calc(100vh - 24px)",
-            }}
-            className="z-50 overflow-y-auto"
-          >
-            <MdxComponentPicker
-              components={catalogComponents}
-              query={slashTrigger.query}
-              forbidden={isEditorReadOnly}
-              onSelect={insertSelectedComponent}
-            />
-          </div>
-        ) : null}
+        {slashPicker && typeof document !== "undefined"
+          ? createPortal(slashPicker, document.body)
+          : null}
       </div>
     );
   },

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -218,10 +218,26 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       whileElementsMounted: autoUpdate,
       middleware: [
         offset(8),
-        flip({ padding: 12 }),
-        shift({ padding: 12 }),
+        flip({
+          padding: 12,
+          boundary:
+            editorWrapperRef.current?.closest(
+              '[data-mdcms-editor-pane="canvas"]',
+            ) ?? undefined,
+        }),
+        shift({
+          padding: 12,
+          boundary:
+            editorWrapperRef.current?.closest(
+              '[data-mdcms-editor-pane="canvas"]',
+            ) ?? undefined,
+        }),
         size({
           padding: 12,
+          boundary:
+            editorWrapperRef.current?.closest(
+              '[data-mdcms-editor-pane="canvas"]',
+            ) ?? undefined,
           apply({ availableHeight, elements }) {
             Object.assign(elements.floating.style, {
               maxHeight: `${Math.max(availableHeight, 0)}px`,
@@ -463,9 +479,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
         return;
       }
 
-      const contextElement =
-        editorWrapper.closest('[data-mdcms-editor-pane="canvas"]') ??
-        editorWrapper;
+      const contextElement = editorWrapper;
 
       floatingRefs.setReference(
         createSlashPickerVirtualReference({


### PR DESCRIPTION
## Summary
- keep the MDX slash picker within the visible viewport instead of letting it overflow the page
- flip the picker above the slash trigger when there is not enough room below
- cap picker height in tight spaces and cover the positioning rules with focused tests

## Verification
- bun test packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
- bun x prettier --check packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.ts packages/studio/src/lib/runtime-ui/components/editor/mdx-component-slash.test.ts packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
- bun nx run studio:typecheck