### PR TITLE
fix: restore bun export condition with prepack stripping for npm

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "./package.json": "./package.json",
     ".": {
       "@mdcms/source": "./src/index.ts",
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -40,6 +41,8 @@
     }
   },
   "scripts": {
+    "prepack": "node ../../scripts/strip-dev-export-conditions.js",
+    "postpack": "node ../../scripts/restore-package-json.js",
     "test": "bun test ./src",
     "dev": "bun --conditions @mdcms/source src/bin/mdcms.ts --help"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Blazity/mdcms.git",
@@ -18,6 +20,7 @@
     "./package.json": "./package.json",
     ".": {
       "@mdcms/source": "./src/index.ts",
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -27,6 +30,8 @@
     "name": "sdk"
   },
   "scripts": {
+    "prepack": "node ../../scripts/strip-dev-export-conditions.js",
+    "postpack": "node ../../scripts/restore-package-json.js",
     "test": "bun test ./src"
   },
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,24 +20,28 @@
     "./package.json": "./package.json",
     "./mdx": {
       "@mdcms/source": "./src/lib/mdx/index.ts",
+      "bun": "./src/lib/mdx/index.ts",
       "types": "./dist/lib/mdx/index.d.ts",
       "import": "./dist/lib/mdx/index.js",
       "default": "./dist/lib/mdx/index.js"
     },
     "./action-catalog-contract": {
       "@mdcms/source": "./src/lib/contracts/action-catalog-contract.ts",
+      "bun": "./src/lib/contracts/action-catalog-contract.ts",
       "types": "./dist/lib/contracts/action-catalog-contract.d.ts",
       "import": "./dist/lib/contracts/action-catalog-contract.js",
       "default": "./dist/lib/contracts/action-catalog-contract.js"
     },
     "./server": {
       "@mdcms/source": "./src/lib/contracts/schema-hash.ts",
+      "bun": "./src/lib/contracts/schema-hash.ts",
       "types": "./dist/lib/contracts/schema-hash.d.ts",
       "import": "./dist/lib/contracts/schema-hash.js",
       "default": "./dist/lib/contracts/schema-hash.js"
     },
     ".": {
       "@mdcms/source": "./src/index.ts",
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -47,6 +51,8 @@
     "name": "shared"
   },
   "scripts": {
+    "prepack": "node ../../scripts/strip-dev-export-conditions.js",
+    "postpack": "node ../../scripts/restore-package-json.js",
     "test": "bun test ./src"
   },
   "dependencies": {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,36 +20,42 @@
     "./package.json": "./package.json",
     "./action-catalog-adapter": {
       "@mdcms/source": "./src/lib/action-catalog-adapter.ts",
+      "bun": "./src/lib/action-catalog-adapter.ts",
       "types": "./dist/lib/action-catalog-adapter.d.ts",
       "import": "./dist/lib/action-catalog-adapter.js",
       "default": "./dist/lib/action-catalog-adapter.js"
     },
     "./build-runtime": {
       "@mdcms/source": "./src/lib/build-runtime.ts",
+      "bun": "./src/lib/build-runtime.ts",
       "types": "./dist/lib/build-runtime.d.ts",
       "import": "./dist/lib/build-runtime.js",
       "default": "./dist/lib/build-runtime.js"
     },
     "./document-shell": {
       "@mdcms/source": "./src/lib/document-shell.ts",
+      "bun": "./src/lib/document-shell.ts",
       "types": "./dist/lib/document-shell.d.ts",
       "import": "./dist/lib/document-shell.js",
       "default": "./dist/lib/document-shell.js"
     },
     "./markdown-pipeline": {
       "@mdcms/source": "./src/lib/markdown-pipeline.ts",
+      "bun": "./src/lib/markdown-pipeline.ts",
       "types": "./dist/lib/markdown-pipeline.d.ts",
       "import": "./dist/lib/markdown-pipeline.js",
       "default": "./dist/lib/markdown-pipeline.js"
     },
     "./runtime": {
       "@mdcms/source": "./src/lib/studio.ts",
+      "bun": "./src/lib/studio.ts",
       "types": "./dist/lib/studio.d.ts",
       "import": "./dist/lib/studio.js",
       "default": "./dist/lib/studio.js"
     },
     ".": {
       "@mdcms/source": "./src/index.ts",
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -67,6 +73,8 @@
     }
   },
   "scripts": {
+    "prepack": "node ../../scripts/strip-dev-export-conditions.js",
+    "postpack": "node ../../scripts/restore-package-json.js",
     "dev": "sh -lc 'trap \"kill 0\" INT TERM EXIT; bun x --bun tsc --build tsconfig.lib.json --watch --preserveWatchOutput & bun --conditions @mdcms/source src/lib/dev-runtime-watch.ts & wait'",
     "test": "bun test ./src"
   },

--- a/scripts/restore-package-json.js
+++ b/scripts/restore-package-json.js
@@ -1,0 +1,16 @@
+/**
+ * postpack script for publishable packages.
+ *
+ * Restores the original package.json from the backup created by
+ * strip-dev-export-conditions.js during prepack.
+ */
+
+import { renameSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const pkgPath = join(process.cwd(), "package.json");
+const backupPath = join(process.cwd(), "package.json.prepublish-backup");
+
+if (existsSync(backupPath)) {
+  renameSync(backupPath, pkgPath);
+}

--- a/scripts/strip-dev-export-conditions.js
+++ b/scripts/strip-dev-export-conditions.js
@@ -1,0 +1,50 @@
+/**
+ * prepack script for publishable packages.
+ *
+ * Strips the "bun" and "@mdcms/source" export conditions from package.json
+ * before npm packs the tarball. These conditions point to src/ files that
+ * are not shipped to npm (only dist/ is included).
+ *
+ * The companion postpack script restores the original file.
+ *
+ * Usage in package.json:
+ *   "prepack": "node ../../scripts/strip-dev-export-conditions.js",
+ *   "postpack": "node ../../scripts/restore-package-json.js"
+ */
+
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DEV_CONDITIONS = ["bun", "@mdcms/source"];
+
+const pkgPath = join(process.cwd(), "package.json");
+const backupPath = join(process.cwd(), "package.json.prepublish-backup");
+
+// Save backup before modifying
+copyFileSync(pkgPath, backupPath);
+
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+
+function stripConditions(exports) {
+  if (typeof exports !== "object" || exports === null) return;
+
+  for (const [key, value] of Object.entries(exports)) {
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      let isConditionMap = Object.values(value).some(
+        (v) => typeof v === "string",
+      );
+      if (isConditionMap) {
+        for (const condition of DEV_CONDITIONS) {
+          delete value[condition];
+        }
+      }
+      stripConditions(value);
+    }
+  }
+}
+
+if (pkg.exports) {
+  stripConditions(pkg.exports);
+}
+
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary

Fixes CI test failures caused by removing the `"bun"` export condition in #60.

**Problem:** The `"bun"` condition was removed from publishable packages because it points to `src/` files not shipped to npm. But bun test in the monorepo relies on it to resolve workspace deps to source files without a prior build — CI runs tests on a clean checkout with no `dist/`.

**Solution:** Keep `"bun"` in source `package.json` for local dev, and strip it at publish time via npm lifecycle scripts:
- `prepack` — saves backup, strips `"bun"` and `"@mdcms/source"` from exports
- `postpack` — restores the original `package.json`

This way:
- `bun test` works without building (resolves to source via `"bun"` condition)
- `npm publish` / `changeset publish` ships a clean tarball (no dev conditions)
- No change to the existing dev or build workflow

## Files changed

- `scripts/strip-dev-export-conditions.js` — prepack script (shared)
- `scripts/restore-package-json.js` — postpack script (shared)
- 4 publishable `package.json` files — restored `"bun"` condition, added prepack/postpack

## Test plan

- [x] `bun test` passes without `dist/` (verified locally by removing `packages/shared/dist`)
- [x] `npm pack` tarball has no `"bun"` or `"@mdcms/source"` conditions (verified)
- [x] Source `package.json` restored after pack (verified)
- [x] Full build passes
- [x] Full typecheck passes
- [x] All tests pass (1 pre-existing button test failure on main, unrelated)
- [ ] CI quality gate passes
- [ ] CI unit-tests gate passes