### PR TITLE
fix: update repository URLs for npm provenance

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,11 +11,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Blazity/mdcms.git",
+    "url": "https://github.com/mdcms-ai/mdcms.git",
     "directory": "apps/cli"
   },
-  "homepage": "https://github.com/Blazity/mdcms#readme",
-  "bugs": "https://github.com/Blazity/mdcms/issues",
+  "homepage": "https://github.com/mdcms-ai/mdcms#readme",
+  "bugs": "https://github.com/mdcms-ai/mdcms/issues",
   "bin": {
     "mdcms": "./dist/bin/mdcms.js"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,11 +11,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Blazity/mdcms.git",
+    "url": "https://github.com/mdcms-ai/mdcms.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://github.com/Blazity/mdcms#readme",
-  "bugs": "https://github.com/Blazity/mdcms/issues",
+  "homepage": "https://github.com/mdcms-ai/mdcms#readme",
+  "bugs": "https://github.com/mdcms-ai/mdcms/issues",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,11 +11,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Blazity/mdcms.git",
+    "url": "https://github.com/mdcms-ai/mdcms.git",
     "directory": "packages/shared"
   },
-  "homepage": "https://github.com/Blazity/mdcms#readme",
-  "bugs": "https://github.com/Blazity/mdcms/issues",
+  "homepage": "https://github.com/mdcms-ai/mdcms#readme",
+  "bugs": "https://github.com/mdcms-ai/mdcms/issues",
   "exports": {
     "./package.json": "./package.json",
     "./mdx": {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -11,11 +11,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Blazity/mdcms.git",
+    "url": "https://github.com/mdcms-ai/mdcms.git",
     "directory": "packages/studio"
   },
-  "homepage": "https://github.com/Blazity/mdcms#readme",
-  "bugs": "https://github.com/Blazity/mdcms/issues",
+  "homepage": "https://github.com/mdcms-ai/mdcms#readme",
+  "bugs": "https://github.com/mdcms-ai/mdcms/issues",
   "exports": {
     "./package.json": "./package.json",
     "./action-catalog-adapter": {


### PR DESCRIPTION
## Summary

Update repository URLs in publishable package.json files from `Blazity/mdcms` to `mdcms-ai/mdcms`.

npm provenance verification rejects publishes when the package.json `repository.url` doesn't match the OIDC token's repository claim from GitHub Actions.

## Test plan

- [ ] Release workflow publishes successfully after merge