### PR TITLE
fix(studio-example): align loopback api host for admin login

### DIFF
--- a/apps/studio-example/app/admin/[[...path]]/page.tsx
+++ b/apps/studio-example/app/admin/[[...path]]/page.tsx
@@ -1,13 +1,29 @@
 import { resolve } from "node:path";
 
 import { prepareStudioConfig } from "@mdcms/studio/runtime";
+import { headers } from "next/headers";
 
 import config from "../../../mdcms.config";
 import { AdminStudioClient } from "../admin-studio-client";
 import { resolveStudioExampleAppRoot } from "../resolve-studio-example-app-root";
 import { extractPreparedStudioComponentMetadata } from "../studio-config";
 
+async function readRequestHost(): Promise<string | undefined> {
+  try {
+    const requestHeaders = await headers();
+    return (
+      requestHeaders.get("x-forwarded-host") ??
+      requestHeaders.get("host") ??
+      undefined
+    );
+  } catch {
+    // Unit tests can invoke this component without a Next request context.
+    return undefined;
+  }
+}
+
 export default async function AdminCatchAllPage() {
+  const requestHost = await readRequestHost();
   const appRoot = resolveStudioExampleAppRoot();
   const preparedConfig = await prepareStudioConfig(config, {
     cwd: appRoot,
@@ -29,6 +45,7 @@ export default async function AdminCatchAllPage() {
           ? (preparedConfig._schemaHash as string)
           : undefined
       }
+      requestHost={requestHost}
     />
   );
 }

--- a/apps/studio-example/app/admin/admin-studio-client.tsx
+++ b/apps/studio-example/app/admin/admin-studio-client.tsx
@@ -12,11 +12,13 @@ export function AdminStudioClient(props: {
   preparedComponents: PreparedStudioComponentMetadata[];
   schemaHash?: string;
   documentRouteMetadata?: MdcmsConfig["_documentRouteMetadata"];
+  requestHost?: string;
 }) {
   const config = createClientStudioConfig(
     props.preparedComponents,
     props.schemaHash,
     props.documentRouteMetadata ?? undefined,
+    props.requestHost,
   );
 
   return <Studio config={config} basePath="/admin" />;

--- a/apps/studio-example/app/admin/studio-config.test.ts
+++ b/apps/studio-example/app/admin/studio-config.test.ts
@@ -79,3 +79,14 @@ test("createClientStudioConfig preserves explicit locale metadata", () => {
     supported: ["en", "fr"],
   });
 });
+
+test("createClientStudioConfig aligns loopback api host with request host", () => {
+  const config = createClientStudioConfig(
+    [],
+    undefined,
+    undefined,
+    "127.0.0.1:4173",
+  );
+
+  assert.equal(config.serverUrl, "http://127.0.0.1:4000");
+});

--- a/apps/studio-example/app/admin/studio-config.ts
+++ b/apps/studio-example/app/admin/studio-config.ts
@@ -5,7 +5,7 @@ import {
   studioExampleLocales,
   studioExampleMdxComponents,
   studioExampleProject,
-  studioExampleServerUrl,
+  resolveStudioExampleServerUrl,
 } from "../../lib/studio-example-studio-config";
 
 type PreparedStudioConfig = Awaited<ReturnType<typeof prepareStudioConfig>>;
@@ -36,6 +36,7 @@ export function createClientStudioConfig(
   preparedComponents: PreparedStudioComponentMetadata[],
   schemaHash?: string,
   documentRouteMetadata?: PreparedDocumentRouteMetadata,
+  requestHost?: string,
 ): MdcmsConfig {
   const extractedPropsByName = new Map(
     preparedComponents.map((component) => [
@@ -50,7 +51,7 @@ export function createClientStudioConfig(
   return {
     project: studioExampleProject,
     environment: studioExampleEnvironment,
-    serverUrl: studioExampleServerUrl,
+    serverUrl: resolveStudioExampleServerUrl(requestHost),
     locales: studioExampleLocales,
     // Pre-computed schema hash from the server component where the full
     // config (with Zod types/environments) is available for derivation.

--- a/apps/studio-example/lib/studio-example-studio-config.ts
+++ b/apps/studio-example/lib/studio-example-studio-config.ts
@@ -41,3 +41,43 @@ export const studioExampleMdxComponents = [
       ),
   },
 ] as const;
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function normalizeConfiguredServerUrl(url: URL): string {
+  const pathname = url.pathname.replace(/\/$/, "");
+  return `${url.origin}${pathname}`;
+}
+
+function parseHostHeaderHostname(requestHost: string | undefined): string | null {
+  if (!requestHost) {
+    return null;
+  }
+
+  const firstHost = requestHost.split(",")[0]?.trim();
+
+  if (!firstHost) {
+    return null;
+  }
+
+  try {
+    return new URL(`http://${firstHost}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveStudioExampleServerUrl(requestHost?: string): string {
+  const serverUrl = new URL(studioExampleServerUrl);
+  const requestHostname = parseHostHeaderHostname(requestHost);
+
+  if (
+    requestHostname &&
+    LOOPBACK_HOSTNAMES.has(serverUrl.hostname) &&
+    LOOPBACK_HOSTNAMES.has(requestHostname)
+  ) {
+    serverUrl.hostname = requestHostname;
+  }
+
+  return normalizeConfiguredServerUrl(serverUrl);
+}


### PR DESCRIPTION
## Summary
- fix local Studio login/session behavior when host app is opened on `127.0.0.1`
- resolve Studio example API server host from incoming request host for loopback origins (`localhost`, `127.0.0.1`, `::1`)
- thread request host through admin page/client config and add regression coverage

## Root Cause
`apps/studio-example` hardcoded `serverUrl` to `http://localhost:4000`. In local dev with `MDCMS_AUTH_INSECURE_COOKIES=true` (`SameSite=Lax`), opening Studio from `http://127.0.0.1:4173` caused cross-site cookie-mode auth requests (`127.0.0.1` -> `localhost`), breaking login/session bootstrap.

## Testing
- `bun test apps/studio-example/app/admin/studio-config.test.ts`

Jira: CMS-200
