### PR TITLE
CMS-200 Keep Studio dev cookies cross-origin for loopback login

### DIFF
--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -2225,6 +2225,10 @@ export function createAuthService(
   const baseUrl = resolveAuthBaseUrl(rawEnv);
   const secret = resolveAuthSecret(rawEnv);
   const useSecureCookies = resolveSecureCookiePolicy(rawEnv);
+  // Cookie-mode Studio is allowed to run cross-origin in local loopback dev,
+  // so SameSite must remain None even when Secure is disabled for HTTP.
+  const csrfCookieSameSite = "None" as const;
+  const sessionCookieSameSite = "none" as const;
   const adminAllowlist = resolveAdminAllowlist(rawEnv);
   const staticSamlProviders = buildStaticSamlProviders(
     baseUrl,
@@ -2287,7 +2291,7 @@ export function createAuthService(
         name: CSRF_COOKIE_NAME,
         value: token,
         path: "/",
-        sameSite: useSecureCookies ? "None" : "Lax",
+        sameSite: csrfCookieSameSite,
         secure: useSecureCookies,
         maxAge: SESSION_INACTIVITY_TIMEOUT_SECONDS,
       }),
@@ -2299,7 +2303,7 @@ export function createAuthService(
       name: CSRF_COOKIE_NAME,
       value: "",
       path: "/",
-      sameSite: useSecureCookies ? "None" : "Lax",
+      sameSite: csrfCookieSameSite,
       secure: useSecureCookies,
       maxAge: 0,
     });
@@ -2655,7 +2659,7 @@ export function createAuthService(
       defaultCookieAttributes: {
         path: "/",
         httpOnly: true,
-        sameSite: useSecureCookies ? "none" : "lax",
+        sameSite: sessionCookieSameSite,
         secure: useSecureCookies,
       },
     },


### PR DESCRIPTION
## Summary
- keep Studio session and CSRF cookies at `SameSite=None` even when `MDCMS_AUTH_INSECURE_COOKIES=true`
- preserve the existing `Secure` override behavior for local HTTP dev
- restore the supported local login flow from `http://127.0.0.1:4173` to `http://localhost:4000`

## Verification
- `bun test apps/server/src/lib/auth.test.ts --test-name-pattern "auth login cookie uses None policy and secure-by-default with local override"`
- `bun test apps/server/src/lib/auth.test.ts --test-name-pattern "auth login issues a Studio session cookie and session is retrievable|auth login and session bootstrap issue a CSRF cookie for Studio mutations|auth logout clears the CSRF cookie alongside the session cookie"`
- `bun test packages/studio/src/lib/login-api.test.ts packages/studio/src/lib/session-api.test.ts packages/studio/src/lib/schema-route-api.test.ts --test-name-pattern "login returns success on 200|signOut posts to logout with CSRF token|cookie-authenticated sync bootstraps csrf from auth/session"`

## Notes
- full `apps/server/src/lib/auth.test.ts` still has 4 pre-existing CLI authorize HTML failures, reproduced on an untouched checkout of current `HEAD`