### PR TITLE
fix(cli): make quality gate pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,16 @@ Upcoming work is focused on live preview (real-time content rendering in the con
 
 ## Repository layout
 
-| Path | What it is |
-| --- | --- |
-| `apps/server` | Elysia HTTP server, the backend for everything |
-| `apps/cli` | CLI binary (`mdcms`) for push/pull/sync workflows |
-| `apps/studio-example` | Next.js app that embeds the Studio component |
-| `apps/studio-review` | Internal app for visual PR review of Studio changes |
-| `packages/shared` | Contracts, types, and schema utilities used everywhere |
-| `packages/sdk` | Client SDK for reading content from applications |
-| `packages/studio` | The embeddable React Studio component |
-| `packages/modules` | First-party module registry |
+| Path                  | What it is                                             |
+| --------------------- | ------------------------------------------------------ |
+| `apps/server`         | Elysia HTTP server, the backend for everything         |
+| `apps/cli`            | CLI binary (`mdcms`) for push/pull/sync workflows      |
+| `apps/studio-example` | Next.js app that embeds the Studio component           |
+| `apps/studio-review`  | Internal app for visual PR review of Studio changes    |
+| `packages/shared`     | Contracts, types, and schema utilities used everywhere |
+| `packages/sdk`        | Client SDK for reading content from applications       |
+| `packages/studio`     | The embeddable React Studio component                  |
+| `packages/modules`    | First-party module registry                            |
 
 Bun workspaces, Nx for task orchestration. Run `bun install` at the root.
 

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -16,10 +16,7 @@ const externalDeps = [
   "node:*",
 ];
 
-const entrypoints = [
-  "src/bin/mdcms.ts",
-  "src/index.ts",
-];
+const entrypoints = ["src/bin/mdcms.ts", "src/index.ts"];
 
 const result = await Bun.build({
   entrypoints,

--- a/apps/cli/src/lib/push.test.ts
+++ b/apps/cli/src/lib/push.test.ts
@@ -564,6 +564,82 @@ test("push exits successfully without API calls when no changed documents are fo
   });
 });
 
+test("push exits successfully without local schema state when no content writes are needed", async () => {
+  await withTempDir(async (cwd) => {
+    const manifestPath = join(
+      cwd,
+      ".mdcms",
+      "manifests",
+      "marketing-site.staging.json",
+    );
+    await mkdir(join(cwd, ".mdcms", "manifests"), { recursive: true });
+    await mkdir(join(cwd, "content", "blog"), { recursive: true });
+
+    const localContent = "# Stable document\n";
+    await writeFile(
+      join(cwd, "content/blog/stable.en.md"),
+      localContent,
+      "utf8",
+    );
+    await writeFile(
+      manifestPath,
+      JSON.stringify(
+        {
+          "doc-stable": {
+            path: "content/blog/stable.en.md",
+            format: "md",
+            draftRevision: 3,
+            publishedVersion: 1,
+            hash: hashRawContent(localContent),
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const restoreTTY = setTTY(false);
+    try {
+      let stdout = "";
+      let requestCount = 0;
+      let confirmCount = 0;
+      const exitCode = await runMdcmsCli(["push"], {
+        cwd,
+        env: {} as NodeJS.ProcessEnv,
+        fetcher: async (input, init) => {
+          if (isSchemaGetRequest(input, init)) {
+            return createSchemaListResponse(BLOG_POST_CONFIG, "staging");
+          }
+          requestCount += 1;
+          throw new Error("fetch should not be called");
+        },
+        loadConfig: async () => ({
+          config: BLOG_POST_CONFIG,
+          configPath: join(cwd, "mdcms.config.ts"),
+        }),
+        stdout: {
+          write: (chunk) => {
+            stdout += chunk;
+          },
+        },
+        stderr: { write: () => undefined },
+        confirm: async () => {
+          confirmCount += 1;
+          return true;
+        },
+      });
+
+      assert.equal(exitCode, 0);
+      assert.equal(requestCount, 0);
+      assert.equal(confirmCount, 0);
+      assert.equal(stdout.includes("No changes to push"), true);
+    } finally {
+      restoreTTY();
+    }
+  });
+});
+
 test("push treats missing manifest hash as changed and repairs hash after success", async () => {
   await withTempDir(async (cwd) => {
     const manifestPath = join(
@@ -1384,7 +1460,10 @@ const DRIFT_CONFIG = parseMdcmsConfig(
   }),
 );
 
-async function seedPushableWorkspace(cwd: string): Promise<void> {
+async function seedPushableWorkspace(
+  cwd: string,
+  options: { writeSchemaState?: boolean } = {},
+): Promise<void> {
   const manifestPath = join(
     cwd,
     ".mdcms",
@@ -1392,7 +1471,9 @@ async function seedPushableWorkspace(cwd: string): Promise<void> {
     "marketing-site.staging.json",
   );
   await mkdir(join(cwd, ".mdcms", "manifests"), { recursive: true });
-  await writeSchemaStateFile(cwd, "marketing-site", "staging");
+  if (options.writeSchemaState !== false) {
+    await writeSchemaStateFile(cwd, "marketing-site", "staging");
+  }
   await writeFile(
     manifestPath,
     JSON.stringify(
@@ -1417,6 +1498,49 @@ async function seedPushableWorkspace(cwd: string): Promise<void> {
     "utf8",
   );
 }
+
+test("push --dry-run does not require local schema state before writes", async () => {
+  await withTempDir(async (cwd) => {
+    await seedPushableWorkspace(cwd, { writeSchemaState: false });
+    const restoreTTY = setTTY(false);
+    try {
+      let schemaGetCalls = 0;
+      let contentWriteCalls = 0;
+      let stdout = "";
+
+      const exitCode = await runMdcmsCli(["push", "--force", "--dry-run"], {
+        cwd,
+        env: {} as NodeJS.ProcessEnv,
+        fetcher: async (input, init) => {
+          if (isSchemaGetRequest(input, init)) {
+            schemaGetCalls += 1;
+            return createSchemaListResponse(BLOG_POST_CONFIG, "staging");
+          }
+          contentWriteCalls += 1;
+          throw new Error("dry run should not write content");
+        },
+        loadConfig: async () => ({
+          config: BLOG_POST_CONFIG,
+          configPath: join(cwd, "mdcms.config.ts"),
+        }),
+        stdout: {
+          write: (chunk: string) => {
+            stdout += chunk;
+          },
+        },
+        stderr: { write: () => undefined },
+        confirm: async () => true,
+      });
+
+      assert.equal(exitCode, 0);
+      assert.equal(schemaGetCalls, 1);
+      assert.equal(contentWriteCalls, 0);
+      assert.ok(stdout.includes("Dry run complete. No changes were pushed."));
+    } finally {
+      restoreTTY();
+    }
+  });
+});
 
 test("preflight: no drift continues to content writes", async () => {
   await withTempDir(async (cwd) => {

--- a/apps/cli/src/lib/push.ts
+++ b/apps/cli/src/lib/push.ts
@@ -1644,12 +1644,11 @@ export async function runPushCommand(
   // Preflight or the missing-state flow may sync schema and update the local
   // state file. Re-read immediately before writes so requests carry the fresh
   // hash, while dry-run/no-work paths never require local schema state.
-  let schemaState =
-    (await readSchemaState({
-      cwd: context.cwd,
-      project: context.project,
-      environment: context.environment,
-    })) ?? initialSchemaState;
+  let schemaState = await readSchemaState({
+    cwd: context.cwd,
+    project: context.project,
+    environment: context.environment,
+  });
 
   if (!schemaState) {
     const isInteractive = process.stdin.isTTY === true;

--- a/apps/cli/src/lib/push.ts
+++ b/apps/cli/src/lib/push.ts
@@ -1450,9 +1450,7 @@ export async function runPushCommand(
           "Sync schema from server before pushing content?",
         );
         if (!accepted) {
-          context.stdout.write(
-            "Sync declined. No content writes performed.\n",
-          );
+          context.stdout.write("Sync declined. No content writes performed.\n");
           return 1;
         }
       }
@@ -1505,15 +1503,6 @@ export async function runPushCommand(
   if (preflight.outcome === "abort") {
     return preflight.exitCode;
   }
-
-  // Preflight may have synced schema and updated the local state file.
-  // Re-read so content writes carry the fresh hash, not the stale one.
-  const schemaState =
-    (await readSchemaState({
-      cwd: context.cwd,
-      project: context.project,
-      environment: context.environment,
-    })) ?? initialSchemaState;
 
   const manifestPath = resolveScopedManifestPath({
     cwd: context.cwd,
@@ -1568,6 +1557,25 @@ export async function runPushCommand(
   if (options.dryRun) {
     context.stdout.write("Dry run complete. No changes were pushed.\n");
     return 0;
+  }
+
+  // Preflight may have synced schema and updated the local state file.
+  // Re-read so content writes carry the fresh hash, not the stale one.
+  const schemaState =
+    (await readSchemaState({
+      cwd: context.cwd,
+      project: context.project,
+      environment: context.environment,
+    })) ?? initialSchemaState;
+  if (!schemaState) {
+    throw new RuntimeError({
+      code: "SCHEMA_STATE_MISSING",
+      message:
+        `No local schema state found for ${context.project}/${context.environment}.\n` +
+        `To sync schema as part of this push, re-run with --sync-schema.\n` +
+        `To sync explicitly without push, run: mdcms schema sync`,
+      statusCode: 400,
+    });
   }
 
   // Interactive selection for new files

--- a/apps/cli/src/lib/push.ts
+++ b/apps/cli/src/lib/push.ts
@@ -1432,72 +1432,11 @@ export async function runPushCommand(
     });
   }
 
-  let initialSchemaState = await readSchemaState({
+  const initialSchemaState = await readSchemaState({
     cwd: context.cwd,
     project: context.project,
     environment: context.environment,
   });
-
-  if (!initialSchemaState) {
-    const isInteractive = process.stdin.isTTY === true;
-
-    if (isInteractive || options.syncSchema) {
-      if (isInteractive && !options.syncSchema) {
-        context.stdout.write(
-          `No local schema state found for ${context.project}/${context.environment}.\n`,
-        );
-        const accepted = await context.confirm(
-          "Sync schema from server before pushing content?",
-        );
-        if (!accepted) {
-          context.stdout.write("Sync declined. No content writes performed.\n");
-          return 1;
-        }
-      }
-
-      if (options.dryRun) {
-        context.stdout.write(
-          "Dry run: skipping schema sync (no local state).\n",
-        );
-      } else {
-        const syncResult = await performSchemaSync({
-          config: context.config as ParsedMdcmsConfig,
-          serverUrl: context.serverUrl,
-          project: context.project,
-          environment: context.environment,
-          apiKey: context.apiKey,
-          cwd: context.cwd,
-          fetcher: context.fetcher,
-        });
-
-        if (syncResult.outcome === "failure") {
-          context.stderr.write(
-            `${syncResult.errorCode}: ${syncResult.message}\n`,
-          );
-          return 1;
-        }
-
-        context.stdout.write(
-          `Schema synced (hash: ${syncResult.schemaHash.slice(0, 12)}...)\n`,
-        );
-
-        initialSchemaState = await readSchemaState({
-          cwd: context.cwd,
-          project: context.project,
-          environment: context.environment,
-        });
-      }
-    } else {
-      throw new RuntimeError({
-        code: "SCHEMA_STATE_MISSING",
-        message:
-          `No local schema state found for ${context.project}/${context.environment}.\n` +
-          `To sync schema as part of this push, re-run with --sync-schema.\n` +
-          `To sync explicitly without push, run: mdcms schema sync`,
-        statusCode: 400,
-      });
-    }
-  }
 
   const preflight = await runSchemaPreflight(context, options);
   if (preflight.outcome === "abort") {
@@ -1557,25 +1496,6 @@ export async function runPushCommand(
   if (options.dryRun) {
     context.stdout.write("Dry run complete. No changes were pushed.\n");
     return 0;
-  }
-
-  // Preflight may have synced schema and updated the local state file.
-  // Re-read so content writes carry the fresh hash, not the stale one.
-  const schemaState =
-    (await readSchemaState({
-      cwd: context.cwd,
-      project: context.project,
-      environment: context.environment,
-    })) ?? initialSchemaState;
-  if (!schemaState) {
-    throw new RuntimeError({
-      code: "SCHEMA_STATE_MISSING",
-      message:
-        `No local schema state found for ${context.project}/${context.environment}.\n` +
-        `To sync schema as part of this push, re-run with --sync-schema.\n` +
-        `To sync explicitly without push, run: mdcms schema sync`,
-      statusCode: 400,
-    });
   }
 
   // Interactive selection for new files
@@ -1719,6 +1639,73 @@ export async function runPushCommand(
         statusCode: 400,
       });
     }
+  }
+
+  // Preflight or the missing-state flow may sync schema and update the local
+  // state file. Re-read immediately before writes so requests carry the fresh
+  // hash, while dry-run/no-work paths never require local schema state.
+  let schemaState =
+    (await readSchemaState({
+      cwd: context.cwd,
+      project: context.project,
+      environment: context.environment,
+    })) ?? initialSchemaState;
+
+  if (!schemaState) {
+    const isInteractive = process.stdin.isTTY === true;
+
+    if (isInteractive) {
+      context.stdout.write(
+        `No local schema state found for ${context.project}/${context.environment}.\n`,
+      );
+      const accepted = await context.confirm(
+        "Sync schema from server before pushing content?",
+      );
+      if (!accepted) {
+        context.stdout.write("Sync declined. No content writes performed.\n");
+        return 1;
+      }
+    }
+
+    if (isInteractive || options.syncSchema) {
+      const syncResult = await performSchemaSync({
+        config: context.config as ParsedMdcmsConfig,
+        serverUrl: context.serverUrl,
+        project: context.project,
+        environment: context.environment,
+        apiKey: context.apiKey,
+        cwd: context.cwd,
+        fetcher: context.fetcher,
+      });
+
+      if (syncResult.outcome === "failure") {
+        context.stderr.write(
+          `${syncResult.errorCode}: ${syncResult.message}\n`,
+        );
+        return 1;
+      }
+
+      context.stdout.write(
+        `Schema synced (hash: ${syncResult.schemaHash.slice(0, 12)}...)\n`,
+      );
+
+      schemaState = await readSchemaState({
+        cwd: context.cwd,
+        project: context.project,
+        environment: context.environment,
+      });
+    }
+  }
+
+  if (!schemaState) {
+    throw new RuntimeError({
+      code: "SCHEMA_STATE_MISSING",
+      message:
+        `No local schema state found for ${context.project}/${context.environment}.\n` +
+        `To sync schema as part of this push, re-run with --sync-schema.\n` +
+        `To sync explicitly without push, run: mdcms schema sync`,
+      statusCode: 400,
+    });
   }
 
   const { results, failures } = await applyPush(

--- a/apps/docs/agent-instructions.mdx
+++ b/apps/docs/agent-instructions.mdx
@@ -17,28 +17,34 @@ Set up MDCMS from scratch — install dependencies, start services, initialize t
 Set up MDCMS in this project. Follow these steps exactly:
 
 1. **Install the MDCMS packages:**
+
    ```bash
    bun add @mdcms/sdk @mdcms/studio
    bun add -D @mdcms/cli
    ```
 
 2. **Start the MDCMS server** (requires Docker):
+
    ```bash
    git clone git@github.com:Blazity/mdcms.git /tmp/mdcms-server
    cd /tmp/mdcms-server
    bun install
    docker compose -f docker-compose.dev.yml up -d
    ```
+
    Server runs at http://localhost:4000. Demo credentials: demo@mdcms.local / Demo12345!
 
 3. **Initialize the project:**
+
    ```bash
    bunx mdcms init
    ```
+
    Follow the interactive wizard: enter server URL (http://localhost:4000), choose a project name, authenticate via browser, select content directories, and generate the config.
 
 4. **Embed Studio** in a Next.js App Router catch-all route:
    Create `app/admin/[[...path]]/page.tsx`:
+
    ```tsx
    import { Studio } from "@mdcms/studio";
 
@@ -54,6 +60,7 @@ Set up MDCMS in this project. Follow these steps exactly:
    ```
 
 5. **Create a content type** in `mdcms.config.ts`:
+
    ```typescript
    import { defineConfig, defineType } from "@mdcms/shared";
    import { z } from "zod";
@@ -75,6 +82,7 @@ Set up MDCMS in this project. Follow these steps exactly:
    ```
 
 6. **Sync the schema:**
+
    ```bash
    bunx mdcms schema sync
    ```
@@ -82,6 +90,7 @@ Set up MDCMS in this project. Follow these steps exactly:
 7. **Start the dev server** and visit /admin to see the Studio.
 
 Verify each step works before proceeding to the next.
+
 </Prompt>
 
 ## Embed Studio in Next.js
@@ -96,16 +105,19 @@ Add the MDCMS Studio visual editor to an existing Next.js application.
 Add the MDCMS Studio visual CMS editor to this Next.js project.
 
 1. **Install:**
+
    ```bash
    bun add @mdcms/studio
    ```
 
 2. **Add environment variables** to `.env.local`:
+
    ```
    NEXT_PUBLIC_MDCMS_SERVER_URL=http://localhost:4000
    ```
 
 3. **Create the Studio route** at `app/admin/[[...path]]/page.tsx`:
+
    ```tsx
    import { Studio } from "@mdcms/studio";
 
@@ -125,6 +137,7 @@ Add the MDCMS Studio visual CMS editor to this Next.js project.
 The Studio component fetches a runtime bundle from the MDCMS server and renders the full CMS UI. It handles authentication, content editing, publishing, and schema browsing.
 
 If the server is unreachable, Studio shows an error with retry option. Make sure the MDCMS server is running at the configured URL.
+
 </Prompt>
 
 ## Configure the SDK
@@ -139,11 +152,13 @@ Set up the `@mdcms/sdk` client for fetching content in your application.
 Set up the MDCMS SDK to fetch content from the CMS in this project.
 
 1. **Install:**
+
    ```bash
    bun add @mdcms/sdk
    ```
 
 2. **Add environment variables** to `.env.local`:
+
    ```
    MDCMS_SERVER_URL=http://localhost:4000
    MDCMS_API_KEY=your_api_key_here
@@ -152,6 +167,7 @@ Set up the MDCMS SDK to fetch content from the CMS in this project.
    ```
 
 3. **Create a shared client** at `lib/mdcms.ts`:
+
    ```typescript
    import { createClient } from "@mdcms/sdk";
 
@@ -164,6 +180,7 @@ Set up the MDCMS SDK to fetch content from the CMS in this project.
    ```
 
 4. **Fetch content** in a Next.js page (App Router):
+
    ```typescript
    import { cms } from "@/lib/mdcms";
    import { notFound } from "next/navigation";
@@ -197,10 +214,12 @@ Set up the MDCMS SDK to fetch content from the CMS in this project.
    ```
 
 The SDK methods are:
+
 - `cms.get(type, { id } | { slug }, options?)` — fetch a single document
 - `cms.list(type, options?)` — fetch a paginated list of documents
 
 Options include: `locale`, `resolve` (array of reference fields to expand), `draft` (boolean), `published`, `limit`, `offset`, `sort`, `order`.
+
 </Prompt>
 
 ## Schema Definition and Sync
@@ -215,11 +234,13 @@ Define content types and sync them to the server.
 Set up MDCMS content type definitions and sync them to the server.
 
 1. **Install CLI** (if not already):
+
    ```bash
    bun add -D @mdcms/cli
    ```
 
 2. **Create or update `mdcms.config.ts`** at the project root:
+
    ```typescript
    import { defineConfig, defineType, reference } from "@mdcms/shared";
    import { z } from "zod";
@@ -260,6 +281,7 @@ Set up MDCMS content type definitions and sync them to the server.
    ```
 
 3. **Sync to server:**
+
    ```bash
    bunx mdcms schema sync
    ```
@@ -267,11 +289,13 @@ Set up MDCMS content type definitions and sync them to the server.
 4. **Verify** in Studio at `/admin/schema` — you should see both content types with their field definitions.
 
 Adapt the type definitions to match your content model. Each type needs:
+
 - `directory` — folder name for local content files
 - `fields` — Zod schemas defining the frontmatter structure
 - `localized` (optional) — set to `true` for multilingual content
 
 Available field types: `z.string()`, `z.number()`, `z.boolean()`, `z.coerce.date()`, `z.enum([...])`, `z.array(...)`, `z.object({...})`, `reference("TypeName")`.
+
 </Prompt>
 
 ## Content Migration
@@ -288,28 +312,35 @@ Run a schema migration for MDCMS. Follow these steps:
 1. **Make schema changes** in `mdcms.config.ts` — modify field types, add/remove fields, rename types as needed.
 
 2. **Check current status:**
+
    ```bash
    bunx mdcms status
    ```
+
    This shows any drift between local schema and server.
 
 3. **For non-breaking changes** (adding optional fields, adding new types):
    Just sync the schema — no migration needed:
+
    ```bash
    bunx mdcms schema sync
    ```
 
 4. **For breaking changes** (renaming types, changing field types, removing fields):
    Generate a migration:
+
    ```bash
    bunx mdcms migrate
    ```
+
    Review the generated migration file in `migrations/`.
 
    Apply the migration:
+
    ```bash
    bunx mdcms migrate --apply
    ```
+
    This transforms existing documents and auto-publishes new versions.
 
 5. **Verify** the migration succeeded:
@@ -319,6 +350,7 @@ Run a schema migration for MDCMS. Follow these steps:
    Should report "in sync" with exit code 0.
 
 IMPORTANT: Back up your database before running migrations in production. Test migrations locally with realistic data first.
+
 </Prompt>
 
 ## CI/CD Pipeline Setup
@@ -337,12 +369,13 @@ Set up GitHub Actions CI/CD for MDCMS schema sync and content deployment.
    - `MDCMS_SERVER_URL` — your MDCMS server URL
 
 2. **Create `.github/workflows/mdcms-schema-sync.yml`:**
+
    ```yaml
    name: Sync MDCMS Schema
    on:
      push:
        branches: [main]
-       paths: ['mdcms.config.ts']
+       paths: ["mdcms.config.ts"]
    jobs:
      sync:
        runs-on: ubuntu-latest
@@ -359,12 +392,13 @@ Set up GitHub Actions CI/CD for MDCMS schema sync and content deployment.
    ```
 
 3. **Create `.github/workflows/mdcms-content-push.yml`:**
+
    ```yaml
    name: Push MDCMS Content
    on:
      push:
        branches: [main]
-       paths: ['content/**']
+       paths: ["content/**"]
    jobs:
      push:
        runs-on: ubuntu-latest
@@ -392,4 +426,5 @@ Set up GitHub Actions CI/CD for MDCMS schema sync and content deployment.
    Exit code 1 means drift detected — use this to block deploys.
 
 Adapt project name, environment, and content paths to match your setup.
+
 </Prompt>

--- a/apps/docs/api-reference/authentication.mdx
+++ b/apps/docs/api-reference/authentication.mdx
@@ -24,7 +24,8 @@ Session-based auth is used by the Studio and browser clients. It requires a CSRF
 ### Login
 
 <ParamField method="POST" path="/api/v1/auth/login">
-  Authenticate with email and password. Returns a session and sets an HTTP-only session cookie.
+  Authenticate with email and password. Returns a session and sets an HTTP-only
+  session cookie.
 </ParamField>
 
 <ParamField body="email" type="string" required>
@@ -101,7 +102,8 @@ curl -X POST "https://cms.example.com/api/v1/auth/logout" \
 ### Initiate OIDC
 
 <ParamField method="POST" path="/api/v1/auth/sso/{provider}">
-  Initiate an OpenID Connect authentication flow with an external identity provider.
+  Initiate an OpenID Connect authentication flow with an external identity
+  provider.
 </ParamField>
 
 <ParamField path="provider" type="string" required>
@@ -134,7 +136,8 @@ Redirect the user to the `redirectUrl`. After successful authentication, the pro
 ### SAML Assertion Consumer
 
 <ParamField method="POST" path="/api/v1/auth/saml/acs">
-  SAML assertion consumer service endpoint. Receives and processes SAML assertions from the identity provider after authentication.
+  SAML assertion consumer service endpoint. Receives and processes SAML
+  assertions from the identity provider after authentication.
 </ParamField>
 
 This endpoint is called by the SAML identity provider, not by client applications directly. On successful assertion validation, a session is established and the user is redirected to the Studio.
@@ -146,7 +149,9 @@ This endpoint is called by the SAML identity provider, not by client application
 ### SAML Metadata
 
 <ParamField method="GET" path="/api/v1/auth/saml/metadata">
-  Returns the SAML service provider metadata XML document. Use this URL when configuring MDCMS as a service provider in your identity provider's admin console.
+  Returns the SAML service provider metadata XML document. Use this URL when
+  configuring MDCMS as a service provider in your identity provider's admin
+  console.
 </ParamField>
 
 **Example request:**
@@ -184,7 +189,8 @@ The CLI uses a device authorization flow to authenticate without exposing creden
 ### Start Challenge
 
 <ParamField method="POST" path="/api/v1/auth/cli/start">
-  Begin a CLI device authorization flow. Returns a challenge ID and a URL for the user to authorize in their browser.
+  Begin a CLI device authorization flow. Returns a challenge ID and a URL for
+  the user to authorize in their browser.
 </ParamField>
 
 <ParamField body="project" type="string" required>
@@ -219,13 +225,15 @@ curl -X POST "https://cms.example.com/api/v1/auth/cli/start" \
 ```
 
 <Warning>
-  The challenge expires after 10 minutes. If the user does not authorize within that window, the CLI must restart the flow.
+  The challenge expires after 10 minutes. If the user does not authorize within
+  that window, the CLI must restart the flow.
 </Warning>
 
 ### Authorize Challenge
 
 <ParamField method="POST" path="/api/v1/auth/cli/authorize">
-  Authorize a pending CLI device challenge. Called from the browser after the user logs in and approves the CLI session.
+  Authorize a pending CLI device challenge. Called from the browser after the
+  user logs in and approves the CLI session.
 </ParamField>
 
 **Example request:**
@@ -254,7 +262,8 @@ curl -X POST "https://cms.example.com/api/v1/auth/cli/authorize" \
 ### Exchange Code
 
 <ParamField method="POST" path="/api/v1/auth/cli/exchange">
-  Exchange the authorization code for an API key. Called by the CLI after the user authorizes the challenge.
+  Exchange the authorization code for an API key. Called by the CLI after the
+  user authorizes the challenge.
 </ParamField>
 
 **Example request:**
@@ -288,7 +297,8 @@ The CLI stores this API key locally and uses it for subsequent requests.
 ### Get Current User
 
 <ParamField method="GET" path="/api/v1/me">
-  Returns the current authenticated principal's identity and capabilities within the active project and environment.
+  Returns the current authenticated principal's identity and capabilities within
+  the active project and environment.
 </ParamField>
 
 **Example request:**
@@ -342,7 +352,13 @@ For session-based authentication, the response includes the user's email and rol
     "role": "admin",
     "capabilities": {
       "schema": { "read": true, "write": true },
-      "content": { "read": true, "readDraft": true, "write": true, "publish": true, "delete": true },
+      "content": {
+        "read": true,
+        "readDraft": true,
+        "write": true,
+        "publish": true,
+        "delete": true
+      },
       "users": { "manage": true },
       "settings": { "manage": true }
     }
@@ -397,5 +413,7 @@ curl "https://cms.example.com/api/v1/environments" \
 ```
 
 <Note>
-  The `X-MDCMS-Environment` header is still required for this endpoint, even though it returns all environments. The header is used for authentication context.
+  The `X-MDCMS-Environment` header is still required for this endpoint, even
+  though it returns all environments. The header is used for authentication
+  context.
 </Note>

--- a/apps/docs/api-reference/content.mdx
+++ b/apps/docs/api-reference/content.mdx
@@ -10,7 +10,8 @@ All content endpoints require the standard [authentication headers](/api-referen
 ## List Documents
 
 <ParamField method="GET" path="/api/v1/content">
-  Retrieve a paginated list of documents, filtered by type and optional criteria.
+  Retrieve a paginated list of documents, filtered by type and optional
+  criteria.
 </ParamField>
 
 **Scope required:** `content:read`. Add `content:read:draft` to include draft documents (when `draft=true`).
@@ -30,11 +31,13 @@ All content endpoints require the standard [authentication headers](/api-referen
 </ParamField>
 
 <ParamField query="slug" type="string">
-  Filter by the `slug` frontmatter field. Requires the type to have a `slug` field.
+  Filter by the `slug` frontmatter field. Requires the type to have a `slug`
+  field.
 </ParamField>
 
 <ParamField query="published" type="boolean">
-  When `true`, only return documents with at least one published version. When `false`, only return never-published documents.
+  When `true`, only return documents with at least one published version. When
+  `false`, only return never-published documents.
 </ParamField>
 
 <ParamField query="isDeleted" type="boolean">
@@ -42,15 +45,18 @@ All content endpoints require the standard [authentication headers](/api-referen
 </ParamField>
 
 <ParamField query="hasUnpublishedChanges" type="boolean">
-  When `true`, only return documents with draft changes ahead of the published version.
+  When `true`, only return documents with draft changes ahead of the published
+  version.
 </ParamField>
 
 <ParamField query="draft" type="boolean">
-  When `true`, return draft content instead of the published version. Requires `content:read:draft` scope.
+  When `true`, return draft content instead of the published version. Requires
+  `content:read:draft` scope.
 </ParamField>
 
 <ParamField query="resolve" type="string">
-  Reference field name to resolve. Can be repeated for multiple fields (e.g., `resolve=author&resolve=category`). Resolution is one level deep.
+  Reference field name to resolve. Can be repeated for multiple fields (e.g.,
+  `resolve=author&resolve=category`). Resolution is one level deep.
 </ParamField>
 
 <ParamField query="limit" type="integer">
@@ -62,7 +68,8 @@ All content endpoints require the standard [authentication headers](/api-referen
 </ParamField>
 
 <ParamField query="sort" type="string">
-  Sort field. Accepted values: `createdAt`, `updatedAt`, `path`. Default `createdAt`.
+  Sort field. Accepted values: `createdAt`, `updatedAt`, `path`. Default
+  `createdAt`.
 </ParamField>
 
 <ParamField query="order" type="string">
@@ -166,7 +173,8 @@ const posts = await client.list("BlogPost", {
 ### Query Parameters
 
 <ParamField query="locale" type="string">
-  Locale override. If the document is localized, returns the variant for this locale.
+  Locale override. If the document is localized, returns the variant for this
+  locale.
 </ParamField>
 
 <ParamField query="resolve" type="string">
@@ -265,7 +273,8 @@ const post = await client.get("BlogPost", {
 </ParamField>
 
 <ParamField body="locale" type="string">
-  BCP 47 locale tag. Required for localized types. Defaults to `__mdcms_default__` for non-localized types.
+  BCP 47 locale tag. Required for localized types. Defaults to
+  `__mdcms_default__` for non-localized types.
 </ParamField>
 
 <ParamField body="format" type="string">
@@ -351,11 +360,11 @@ curl -X POST "https://cms.example.com/api/v1/content" \
 
 **Error cases:**
 
-| Error Code | Cause |
-|------------|-------|
-| `SCHEMA_HASH_MISMATCH` | The `X-MDCMS-Schema-Hash` does not match the server. Run `mdcms schema sync`. |
-| `CONTENT_PATH_CONFLICT` | A document already exists at the given path and locale. |
-| `INVALID_INPUT` | Frontmatter does not pass schema validation. Check `details` for field-level errors. |
+| Error Code              | Cause                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `SCHEMA_HASH_MISMATCH`  | The `X-MDCMS-Schema-Hash` does not match the server. Run `mdcms schema sync`.        |
+| `CONTENT_PATH_CONFLICT` | A document already exists at the given path and locale.                              |
+| `INVALID_INPUT`         | Frontmatter does not pass schema validation. Check `details` for field-level errors. |
 
 ---
 
@@ -378,7 +387,8 @@ curl -X POST "https://cms.example.com/api/v1/content" \
 ### Request Body
 
 <ParamField body="frontmatter" type="object">
-  Updated frontmatter. Partial updates are not supported -- provide the complete frontmatter object.
+  Updated frontmatter. Partial updates are not supported -- provide the complete
+  frontmatter object.
 </ParamField>
 
 <ParamField body="body" type="string">
@@ -386,7 +396,9 @@ curl -X POST "https://cms.example.com/api/v1/content" \
 </ParamField>
 
 <ParamField body="draftRevision" type="integer" required>
-  The `draftRevision` value from the last fetch. Used for optimistic concurrency control. If the server's current revision is higher, the update is rejected with a `CONFLICT` error.
+  The `draftRevision` value from the last fetch. Used for optimistic concurrency
+  control. If the server's current revision is higher, the update is rejected
+  with a `CONFLICT` error.
 </ParamField>
 
 ### Example
@@ -457,11 +469,11 @@ curl -X PUT "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-4466
 
 **Error cases:**
 
-| Error Code | Cause |
-|------------|-------|
-| `CONFLICT` | The `draftRevision` is stale. Another edit was saved after your last fetch. Re-fetch, merge, and retry. |
-| `SCHEMA_HASH_MISMATCH` | Schema is out of date. Run `mdcms schema sync`. |
-| `INVALID_INPUT` | Frontmatter does not pass schema validation. |
+| Error Code             | Cause                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `CONFLICT`             | The `draftRevision` is stale. Another edit was saved after your last fetch. Re-fetch, merge, and retry. |
+| `SCHEMA_HASH_MISMATCH` | Schema is out of date. Run `mdcms schema sync`.                                                         |
+| `INVALID_INPUT`        | Frontmatter does not pass schema validation.                                                            |
 
 ---
 
@@ -482,7 +494,8 @@ curl -X PUT "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-4466
 ### Request Body
 
 <ParamField body="changeSummary" type="string">
-  Optional summary of changes in this version (e.g., "Fixed typos and updated pricing section").
+  Optional summary of changes in this version (e.g., "Fixed typos and updated
+  pricing section").
 </ParamField>
 
 ### Example
@@ -529,7 +542,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ## Unpublish Document
 
 <ParamField method="POST" path="/api/v1/content/{documentId}/unpublish">
-  Remove the published version, reverting the document to draft-only state. The version history is preserved.
+  Remove the published version, reverting the document to draft-only state. The
+  version history is preserved.
 </ParamField>
 
 **Scope required:** `content:publish`
@@ -568,7 +582,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ## List Versions
 
 <ParamField method="GET" path="/api/v1/content/{documentId}/versions">
-  Retrieve the version history of a document. Each entry represents a published snapshot.
+  Retrieve the version history of a document. Each entry represents a published
+  snapshot.
 </ParamField>
 
 **Scope required:** `content:read`
@@ -692,8 +707,13 @@ curl "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-44665544000
 
 ## Restore Version
 
-<ParamField method="POST" path="/api/v1/content/{documentId}/versions/{version}/restore">
-  Restore the document's draft to the state captured in a specific version. This does not delete any version history -- it creates a new draft revision with the content from the specified version.
+<ParamField
+  method="POST"
+  path="/api/v1/content/{documentId}/versions/{version}/restore"
+>
+  Restore the document's draft to the state captured in a specific version. This
+  does not delete any version history -- it creates a new draft revision with
+  the content from the specified version.
 </ParamField>
 
 **Scope required:** `content:write`
@@ -738,7 +758,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ## Delete Document
 
 <ParamField method="DELETE" path="/api/v1/content/{documentId}">
-  Soft-delete a document. The document remains in the database but is excluded from normal queries. It can be restored later.
+  Soft-delete a document. The document remains in the database but is excluded
+  from normal queries. It can be restored later.
 </ParamField>
 
 **Scope required:** `content:delete`
@@ -816,7 +837,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ## Duplicate Document
 
 <ParamField method="POST" path="/api/v1/content/{documentId}/duplicate">
-  Create a copy of a document with a new ID and path. The duplicate starts as a draft with no published version, regardless of the source document's state.
+  Create a copy of a document with a new ID and path. The duplicate starts as a
+  draft with no published version, regardless of the source document's state.
 </ParamField>
 
 **Scope required:** `content:write`
@@ -877,7 +899,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ## Overview Stats
 
 <ParamField method="GET" path="/api/v1/content/overview">
-  Get aggregate counts of documents per content type. Useful for building editorial dashboards.
+  Get aggregate counts of documents per content type. Useful for building
+  editorial dashboards.
 </ParamField>
 
 **Scope required:** `content:read`
@@ -885,7 +908,8 @@ curl -X POST "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-446
 ### Query Parameters
 
 <ParamField query="type" type="string">
-  Filter to specific types. Can be repeated (e.g., `type=BlogPost&type=Author`). When omitted, returns counts for all types.
+  Filter to specific types. Can be repeated (e.g., `type=BlogPost&type=Author`).
+  When omitted, returns counts for all types.
 </ParamField>
 
 **Example request:**
@@ -927,7 +951,8 @@ curl "https://cms.example.com/api/v1/content/overview?type=BlogPost&type=Author"
 ## Get Variants
 
 <ParamField method="GET" path="/api/v1/content/{documentId}/variants">
-  Returns all locale variants for a document, identified by their shared translation group.
+  Returns all locale variants for a document, identified by their shared
+  translation group.
 </ParamField>
 
 **Scope required:** `content:read`
@@ -935,7 +960,8 @@ curl "https://cms.example.com/api/v1/content/overview?type=BlogPost&type=Author"
 ### Path Parameters
 
 <ParamField path="documentId" type="string" required>
-  The document's UUID. Any locale variant can be used -- the server looks up the translation group automatically.
+  The document's UUID. Any locale variant can be used -- the server looks up the
+  translation group automatically.
 </ParamField>
 
 **Example request:**
@@ -984,5 +1010,6 @@ curl "https://cms.example.com/api/v1/content/550e8400-e29b-41d4-a716-44665544000
 ```
 
 <Tip>
-  Non-localized types return a single-element array with the `__mdcms_default__` locale.
+  Non-localized types return a single-element array with the `__mdcms_default__`
+  locale.
 </Tip>

--- a/apps/docs/api-reference/errors.mdx
+++ b/apps/docs/api-reference/errors.mdx
@@ -26,38 +26,40 @@ All errors follow a consistent envelope:
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | string | Always `"error"`. |
-| `code` | string | Machine-readable error code. Use this for programmatic error handling. |
-| `message` | string | Human-readable description of what went wrong. |
+| Field        | Type    | Description                                                             |
+| ------------ | ------- | ----------------------------------------------------------------------- |
+| `status`     | string  | Always `"error"`.                                                       |
+| `code`       | string  | Machine-readable error code. Use this for programmatic error handling.  |
+| `message`    | string  | Human-readable description of what went wrong.                          |
 | `statusCode` | integer | HTTP status code (duplicated from the response status for convenience). |
-| `details` | object | Additional context specific to the error type. May be empty `{}`. |
-| `requestId` | string | Unique identifier for this request. Include this when reporting issues. |
-| `timestamp` | string | ISO 8601 timestamp of when the error occurred. |
+| `details`    | object  | Additional context specific to the error type. May be empty `{}`.       |
+| `requestId`  | string  | Unique identifier for this request. Include this when reporting issues. |
+| `timestamp`  | string  | ISO 8601 timestamp of when the error occurred.                          |
 
 <Note>
-  Every error response includes a `requestId`. When contacting support or filing bug reports, include the `requestId` to help trace the request through server logs.
+  Every error response includes a `requestId`. When contacting support or filing
+  bug reports, include the `requestId` to help trace the request through server
+  logs.
 </Note>
 
 ## Error Codes
 
-| Code | HTTP Status | Description | Common Cause |
-|------|-------------|-------------|--------------|
-| `UNAUTHORIZED` | 401 | Missing or invalid authentication credentials. | Expired API key, missing `Authorization` header, invalid session cookie. |
-| `FORBIDDEN` | 403 | Authenticated but insufficient permissions. | API key lacks the required scope, or user role does not include the needed capability. |
-| `NOT_FOUND` | 404 | The requested resource does not exist. | Invalid document ID, deleted document, or wrong project/environment. |
-| `INVALID_INPUT` | 400 | Request body failed validation. | Missing required fields, wrong data types, or values that violate schema constraints. |
-| `INVALID_QUERY_PARAM` | 400 | A query parameter has an invalid value. | Non-numeric `limit`, unsupported `sort` field, or unknown filter parameter. |
-| `INVALID_CONTENT_SCOPE` | 400 | The content scope in the request is invalid. | Requesting a type that does not exist, or a locale that is not configured for the project. |
-| `SCHEMA_NOT_FOUND` | 404 | The requested schema type does not exist in the registry. | Querying for a type name that has not been synced. |
-| `SCHEMA_HASH_REQUIRED` | 400 | Content write operation attempted without schema hash header. | Missing `X-MDCMS-Schema-Hash` header on a create or update request. |
-| `SCHEMA_HASH_MISMATCH` | 409 | The schema hash provided does not match the server's current schema. | Local schema is out of date. Run `mdcms schema sync` to update. |
-| `SCHEMA_NOT_SYNCED` | 409 | No schema has been synced to the server yet. | The project has no schema registry entries. Run `mdcms schema sync` first. |
-| `CONTENT_PATH_CONFLICT` | 409 | A document already exists at the given path and locale. | Attempting to create a document with a `path` that is already taken. |
-| `CONFLICT` | 409 | Optimistic concurrency conflict on document update. | The `draftRevision` in the request body is stale. Re-fetch the document, merge changes, and retry with the current revision. |
-| `RATE_LIMITED` | 429 | Too many requests. | Exceeding the rate limit for the API key or session. Back off and retry after the `Retry-After` header value. |
-| `INTERNAL_ERROR` | 500 | An unexpected server error occurred. | Server bug or infrastructure issue. Report with the `requestId`. |
+| Code                    | HTTP Status | Description                                                          | Common Cause                                                                                                                 |
+| ----------------------- | ----------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `UNAUTHORIZED`          | 401         | Missing or invalid authentication credentials.                       | Expired API key, missing `Authorization` header, invalid session cookie.                                                     |
+| `FORBIDDEN`             | 403         | Authenticated but insufficient permissions.                          | API key lacks the required scope, or user role does not include the needed capability.                                       |
+| `NOT_FOUND`             | 404         | The requested resource does not exist.                               | Invalid document ID, deleted document, or wrong project/environment.                                                         |
+| `INVALID_INPUT`         | 400         | Request body failed validation.                                      | Missing required fields, wrong data types, or values that violate schema constraints.                                        |
+| `INVALID_QUERY_PARAM`   | 400         | A query parameter has an invalid value.                              | Non-numeric `limit`, unsupported `sort` field, or unknown filter parameter.                                                  |
+| `INVALID_CONTENT_SCOPE` | 400         | The content scope in the request is invalid.                         | Requesting a type that does not exist, or a locale that is not configured for the project.                                   |
+| `SCHEMA_NOT_FOUND`      | 404         | The requested schema type does not exist in the registry.            | Querying for a type name that has not been synced.                                                                           |
+| `SCHEMA_HASH_REQUIRED`  | 400         | Content write operation attempted without schema hash header.        | Missing `X-MDCMS-Schema-Hash` header on a create or update request.                                                          |
+| `SCHEMA_HASH_MISMATCH`  | 409         | The schema hash provided does not match the server's current schema. | Local schema is out of date. Run `mdcms schema sync` to update.                                                              |
+| `SCHEMA_NOT_SYNCED`     | 409         | No schema has been synced to the server yet.                         | The project has no schema registry entries. Run `mdcms schema sync` first.                                                   |
+| `CONTENT_PATH_CONFLICT` | 409         | A document already exists at the given path and locale.              | Attempting to create a document with a `path` that is already taken.                                                         |
+| `CONFLICT`              | 409         | Optimistic concurrency conflict on document update.                  | The `draftRevision` in the request body is stale. Re-fetch the document, merge changes, and retry with the current revision. |
+| `RATE_LIMITED`          | 429         | Too many requests.                                                   | Exceeding the rate limit for the API key or session. Back off and retry after the `Retry-After` header value.                |
+| `INTERNAL_ERROR`        | 500         | An unexpected server error occurred.                                 | Server bug or infrastructure issue. Report with the `requestId`.                                                             |
 
 ### Handling Specific Errors
 
@@ -125,7 +127,11 @@ When you use the `resolve` parameter to expand [references](/guide/concepts#refe
       "title": "Hello World",
       "author": null,
       "relatedPosts": [
-        { "documentId": "...", "type": "BlogPost", "frontmatter": { "title": "Other Post" } },
+        {
+          "documentId": "...",
+          "type": "BlogPost",
+          "frontmatter": { "title": "Other Post" }
+        },
         null
       ]
     },
@@ -147,13 +153,15 @@ When you use the `resolve` parameter to expand [references](/guide/concepts#refe
 
 ### Resolve Error Codes
 
-| Code | Description |
-|------|-------------|
-| `REFERENCE_NOT_FOUND` | The referenced document does not exist in the target project and environment. It may have been deleted permanently or never existed. |
-| `REFERENCE_DELETED` | The referenced document exists but has been soft-deleted. It can be restored via the [restore endpoint](/api-reference/content#restore-deleted). |
-| `REFERENCE_TYPE_MISMATCH` | The referenced document exists but its type does not match the expected target type declared in the schema. This typically indicates a data integrity issue. |
-| `REFERENCE_FORBIDDEN` | The current API key or user does not have `content:read` permission for the referenced document. The reference exists but cannot be resolved with the current credentials. |
+| Code                      | Description                                                                                                                                                                |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REFERENCE_NOT_FOUND`     | The referenced document does not exist in the target project and environment. It may have been deleted permanently or never existed.                                       |
+| `REFERENCE_DELETED`       | The referenced document exists but has been soft-deleted. It can be restored via the [restore endpoint](/api-reference/content#restore-deleted).                           |
+| `REFERENCE_TYPE_MISMATCH` | The referenced document exists but its type does not match the expected target type declared in the schema. This typically indicates a data integrity issue.               |
+| `REFERENCE_FORBIDDEN`     | The current API key or user does not have `content:read` permission for the referenced document. The reference exists but cannot be resolved with the current credentials. |
 
 <Warning>
-  Resolve errors are informational and do not cause the request to fail. Always check the `resolveErrors` field when using resolved references, especially in production applications where referenced content may change independently.
+  Resolve errors are informational and do not cause the request to fail. Always
+  check the `resolveErrors` field when using resolved references, especially in
+  production applications where referenced content may change independently.
 </Warning>

--- a/apps/docs/api-reference/media-and-webhooks.mdx
+++ b/apps/docs/api-reference/media-and-webhooks.mdx
@@ -8,7 +8,8 @@ description: "File upload, media management, and webhook configuration endpoints
 The Media API handles file uploads and media asset management. Media files are stored in S3-compatible object storage and are reusable across all environments within a project.
 
 <Note>
-  The Media API is a post-MVP feature. The endpoints are defined and will be available in an upcoming release.
+  The Media API is a post-MVP feature. The endpoints are defined and will be
+  available in an upcoming release.
 </Note>
 
 ### Upload Media
@@ -54,7 +55,8 @@ curl -X POST "https://cms.example.com/api/v1/media" \
 ### Delete Media
 
 <ParamField method="DELETE" path="/api/v1/media/{id}">
-  Delete a media file. This removes the file from storage and invalidates all URLs.
+  Delete a media file. This removes the file from storage and invalidates all
+  URLs.
 </ParamField>
 
 **Scope required:** `media:delete`
@@ -88,7 +90,8 @@ curl -X DELETE "https://cms.example.com/api/v1/media/med_550e8400-e29b-41d4-a716
 ```
 
 <Warning>
-  Media deletion is permanent and cannot be undone. Ensure no documents reference the file before deleting.
+  Media deletion is permanent and cannot be undone. Ensure no documents
+  reference the file before deleting.
 </Warning>
 
 ---
@@ -98,7 +101,8 @@ curl -X DELETE "https://cms.example.com/api/v1/media/med_550e8400-e29b-41d4-a716
 Webhooks let you receive real-time HTTP notifications when content changes occur in your project. Configure webhook endpoints to trigger builds, invalidate caches, or sync data with external systems.
 
 <Note>
-  The Webhooks API is a post-MVP feature. The endpoints are defined and will be available in an upcoming release.
+  The Webhooks API is a post-MVP feature. The endpoints are defined and will be
+  available in an upcoming release.
 </Note>
 
 ### List Webhooks
@@ -251,7 +255,12 @@ curl -X PUT "https://cms.example.com/api/v1/webhooks/wh_770e8400-e29b-41d4-a716-
   "data": {
     "id": "wh_770e8400-e29b-41d4-a716-446655440002",
     "url": "https://api.example.com/webhooks/mdcms",
-    "events": ["content.published", "content.unpublished", "content.deleted", "content.created"],
+    "events": [
+      "content.published",
+      "content.unpublished",
+      "content.deleted",
+      "content.created"
+    ],
     "active": true,
     "createdAt": "2026-01-20T10:00:00.000Z",
     "updatedAt": "2026-01-20T11:00:00.000Z"
@@ -299,15 +308,15 @@ curl -X DELETE "https://cms.example.com/api/v1/webhooks/wh_770e8400-e29b-41d4-a7
 
 ### Event Types
 
-| Event | Trigger |
-|-------|---------|
-| `content.created` | A new document is created. |
-| `content.updated` | A document's draft is updated (frontmatter or body change). |
-| `content.published` | A document is published, creating a new version. |
-| `content.unpublished` | A published document is unpublished. |
-| `content.deleted` | A document is soft-deleted. |
-| `content.restored` | A soft-deleted document is restored. |
-| `media.uploaded` | A media file is uploaded. |
+| Event                 | Trigger                                                     |
+| --------------------- | ----------------------------------------------------------- |
+| `content.created`     | A new document is created.                                  |
+| `content.updated`     | A document's draft is updated (frontmatter or body change). |
+| `content.published`   | A document is published, creating a new version.            |
+| `content.unpublished` | A published document is unpublished.                        |
+| `content.deleted`     | A document is soft-deleted.                                 |
+| `content.restored`    | A soft-deleted document is restored.                        |
+| `media.uploaded`      | A media file is uploaded.                                   |
 
 ### Webhook Payload
 
@@ -356,13 +365,13 @@ function verifyWebhookSignature(
   rawBody: string,
   signatureHeader: string,
   secret: string,
-  toleranceSeconds = 300
+  toleranceSeconds = 300,
 ): boolean {
   const parts = Object.fromEntries(
     signatureHeader.split(",").map((p) => {
       const [key, value] = p.split("=");
       return [key, value];
-    })
+    }),
   );
 
   const timestamp = parts.t;
@@ -397,5 +406,6 @@ function verifyWebhookSignature(
 - **Timeout** -- Each delivery attempt has a 10-second timeout. If the endpoint does not respond within 10 seconds, the attempt is marked as failed.
 
 <Tip>
-  Return a `200` status code as quickly as possible from your webhook endpoint. Perform any heavy processing asynchronously to avoid timeouts.
+  Return a `200` status code as quickly as possible from your webhook endpoint.
+  Perform any heavy processing asynchronously to avoid timeouts.
 </Tip>

--- a/apps/docs/api-reference/overview.mdx
+++ b/apps/docs/api-reference/overview.mdx
@@ -20,11 +20,13 @@ For a server running at `https://cms.example.com`, the full base URL is `https:/
 Every request to the MDCMS API must include the following headers:
 
 <ParamField header="X-MDCMS-Project" type="string" required>
-  The project slug (e.g., `marketing-site`). Identifies which project the request targets.
+  The project slug (e.g., `marketing-site`). Identifies which project the
+  request targets.
 </ParamField>
 
 <ParamField header="X-MDCMS-Environment" type="string" required>
-  The environment name (e.g., `production`, `staging`). Determines which content space the request operates against.
+  The environment name (e.g., `production`, `staging`). Determines which content
+  space the request operates against.
 </ParamField>
 
 <ParamField header="Authorization" type="string" required>
@@ -32,15 +34,20 @@ Every request to the MDCMS API must include the following headers:
 </ParamField>
 
 <ParamField header="X-MDCMS-CSRF-Token" type="string">
-  CSRF protection token. Required for all mutation requests (POST, PUT, DELETE) when authenticating via session cookie. Not required for API key authentication.
+  CSRF protection token. Required for all mutation requests (POST, PUT, DELETE)
+  when authenticating via session cookie. Not required for API key
+  authentication.
 </ParamField>
 
 <ParamField header="X-MDCMS-Schema-Hash" type="string">
-  Schema hash returned by `mdcms schema sync`. Required for content write operations (create, update) to ensure the client's schema is in sync with the server.
+  Schema hash returned by `mdcms schema sync`. Required for content write
+  operations (create, update) to ensure the client's schema is in sync with the
+  server.
 </ParamField>
 
 <ParamField header="X-MDCMS-Locale" type="string">
-  Locale override (BCP 47 tag, e.g., `en`, `fr`, `ja`). When set, the server uses this locale instead of the default for the project.
+  Locale override (BCP 47 tag, e.g., `en`, `fr`, `ja`). When set, the server
+  uses this locale instead of the default for the project.
 </ParamField>
 
 <ParamField header="Content-Type" type="string">
@@ -131,12 +138,12 @@ See the [Error Handling](/api-reference/errors) page for the full list of error 
 
 List endpoints accept pagination and sorting parameters:
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `limit` | integer | `20` | Number of results per page. Maximum `100`. |
-| `offset` | integer | `0` | Number of results to skip. |
-| `sort` | string | `createdAt` | Field to sort by. Accepted values: `createdAt`, `updatedAt`, `path`. |
-| `order` | string | `desc` | Sort direction. Accepted values: `asc`, `desc`. |
+| Parameter | Type    | Default     | Description                                                          |
+| --------- | ------- | ----------- | -------------------------------------------------------------------- |
+| `limit`   | integer | `20`        | Number of results per page. Maximum `100`.                           |
+| `offset`  | integer | `0`         | Number of results to skip.                                           |
+| `sort`    | string  | `createdAt` | Field to sort by. Accepted values: `createdAt`, `updatedAt`, `path`. |
+| `order`   | string  | `desc`      | Sort direction. Accepted values: `asc`, `desc`.                      |
 
 Example request:
 
@@ -163,5 +170,7 @@ The response includes a `pagination` object so you can iterate through pages:
 When `hasMore` is `true`, increment `offset` by `limit` to fetch the next page.
 
 <Tip>
-  Use the [`@mdcms/sdk`](/api-reference/sdk) package for type-safe access to the API instead of raw HTTP requests. The SDK handles headers, pagination, error parsing, and TypeScript types automatically.
+  Use the [`@mdcms/sdk`](/api-reference/sdk) package for type-safe access to the
+  API instead of raw HTTP requests. The SDK handles headers, pagination, error
+  parsing, and TypeScript types automatically.
 </Tip>

--- a/apps/docs/api-reference/schema.mdx
+++ b/apps/docs/api-reference/schema.mdx
@@ -8,7 +8,8 @@ The Schema API provides access to the content type registry. It lets you introsp
 ## List Types
 
 <ParamField method="GET" path="/api/v1/schema">
-  Returns all content types registered in the current project and environment, including resolved field metadata.
+  Returns all content types registered in the current project and environment,
+  including resolved field metadata.
 </ParamField>
 
 **Scope required:** `schema:read`
@@ -39,9 +40,7 @@ curl "https://cms.example.com/api/v1/schema" \
             "nullable": false,
             "default": null,
             "reference": null,
-            "checks": [
-              { "type": "min", "value": 1 }
-            ]
+            "checks": [{ "type": "min", "value": 1 }]
           },
           "bio": {
             "kind": "string",
@@ -57,9 +56,7 @@ curl "https://cms.example.com/api/v1/schema" \
             "nullable": false,
             "default": null,
             "reference": null,
-            "checks": [
-              { "type": "url" }
-            ]
+            "checks": [{ "type": "url" }]
           }
         }
       },
@@ -85,9 +82,7 @@ curl "https://cms.example.com/api/v1/schema" \
             "nullable": false,
             "default": null,
             "reference": null,
-            "checks": [
-              { "type": "regex", "value": "^[a-z0-9-]+$" }
-            ]
+            "checks": [{ "type": "regex", "value": "^[a-z0-9-]+$" }]
           },
           "author": {
             "kind": "reference",
@@ -131,14 +126,14 @@ curl "https://cms.example.com/api/v1/schema" \
 
 Each field in the response includes the following properties:
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `kind` | string | The field's data type: `string`, `number`, `boolean`, `date`, `array`, `object`, `reference`, `enum`. |
-| `required` | boolean | Whether the field must be present in frontmatter. |
-| `nullable` | boolean | Whether the field accepts `null` as a value. |
-| `default` | any | Default value applied when the field is omitted. `null` means no default. |
-| `reference` | object \| null | For reference fields, contains `targetType`. `null` for non-reference fields. |
-| `checks` | array | Validation constraints derived from the Zod schema (e.g., `min`, `max`, `regex`, `url`, `email`). |
+| Property    | Type           | Description                                                                                           |
+| ----------- | -------------- | ----------------------------------------------------------------------------------------------------- |
+| `kind`      | string         | The field's data type: `string`, `number`, `boolean`, `date`, `array`, `object`, `reference`, `enum`. |
+| `required`  | boolean        | Whether the field must be present in frontmatter.                                                     |
+| `nullable`  | boolean        | Whether the field accepts `null` as a value.                                                          |
+| `default`   | any            | Default value applied when the field is omitted. `null` means no default.                             |
+| `reference` | object \| null | For reference fields, contains `targetType`. `null` for non-reference fields.                         |
+| `checks`    | array          | Validation constraints derived from the Zod schema (e.g., `min`, `max`, `regex`, `url`, `email`).     |
 
 ---
 
@@ -191,9 +186,7 @@ curl "https://cms.example.com/api/v1/schema/BlogPost" \
         "nullable": false,
         "default": null,
         "reference": null,
-        "checks": [
-          { "type": "regex", "value": "^[a-z0-9-]+$" }
-        ]
+        "checks": [{ "type": "regex", "value": "^[a-z0-9-]+$" }]
       },
       "author": {
         "kind": "reference",
@@ -233,8 +226,8 @@ curl "https://cms.example.com/api/v1/schema/BlogPost" \
 
 **Error cases:**
 
-| Error Code | Cause |
-|------------|-------|
+| Error Code         | Cause                                                          |
+| ------------------ | -------------------------------------------------------------- |
 | `SCHEMA_NOT_FOUND` | The requested type name does not exist in the schema registry. |
 
 ---
@@ -242,7 +235,9 @@ curl "https://cms.example.com/api/v1/schema/BlogPost" \
 ## Sync Schema
 
 <ParamField method="PUT" path="/api/v1/schema/sync">
-  Push the current schema definition to the server. This is the endpoint called by `mdcms schema sync`. The operation is idempotent -- syncing the same schema twice produces no changes.
+  Push the current schema definition to the server. This is the endpoint called
+  by `mdcms schema sync`. The operation is idempotent -- syncing the same schema
+  twice produces no changes.
 </ParamField>
 
 **Scope required:** `schema:write`
@@ -250,15 +245,19 @@ curl "https://cms.example.com/api/v1/schema/BlogPost" \
 ### Request Body
 
 <ParamField body="rawConfigSnapshot" type="object" required>
-  The raw configuration object from `mdcms.config.ts`, serialized as JSON. This is stored for audit and debugging purposes.
+  The raw configuration object from `mdcms.config.ts`, serialized as JSON. This
+  is stored for audit and debugging purposes.
 </ParamField>
 
 <ParamField body="resolvedSchema" type="object" required>
-  The fully resolved schema with all field metadata, environment overlays applied, and references validated. This is what the server uses for content validation.
+  The fully resolved schema with all field metadata, environment overlays
+  applied, and references validated. This is what the server uses for content
+  validation.
 </ParamField>
 
 <ParamField body="schemaHash" type="string" required>
-  A deterministic hash of the resolved schema. Used by content write endpoints to verify client-server schema consistency.
+  A deterministic hash of the resolved schema. Used by content write endpoints
+  to verify client-server schema consistency.
 </ParamField>
 
 **Example request:**
@@ -319,9 +318,13 @@ curl -X PUT "https://cms.example.com/api/v1/schema/sync" \
 ```
 
 <Note>
-  In practice, you should never call this endpoint directly. Use `mdcms schema sync` from the CLI, which reads your `mdcms.config.ts`, resolves the schema, computes the hash, and sends the request.
+  In practice, you should never call this endpoint directly. Use `mdcms schema
+  sync` from the CLI, which reads your `mdcms.config.ts`, resolves the schema,
+  computes the hash, and sends the request.
 </Note>
 
 <Warning>
-  Schema sync does not perform destructive migrations. If you remove a field from the schema, existing documents that contain that field are not modified. The field simply stops being validated and stops appearing in Studio forms.
+  Schema sync does not perform destructive migrations. If you remove a field
+  from the schema, existing documents that contain that field are not modified.
+  The field simply stops being validated and stops appearing in Studio forms.
 </Warning>

--- a/apps/docs/api-reference/sdk.mdx
+++ b/apps/docs/api-reference/sdk.mdx
@@ -44,13 +44,13 @@ const client = createClient({
 
 ### Configuration Options
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `serverUrl` | string | Yes | The base URL of your MDCMS server (e.g., `https://cms.example.com`). |
-| `apiKey` | string | Yes | API key with the appropriate scopes (prefixed with `mdcms_key_`). |
-| `project` | string | Yes | Project slug. Sets the `X-MDCMS-Project` header on every request. |
-| `environment` | string | Yes | Environment name. Sets the `X-MDCMS-Environment` header on every request. |
-| `fetch` | function | No | Custom `fetch` implementation. Useful for testing, caching, or request instrumentation. Defaults to the global `fetch`. |
+| Option        | Type     | Required | Description                                                                                                             |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `serverUrl`   | string   | Yes      | The base URL of your MDCMS server (e.g., `https://cms.example.com`).                                                    |
+| `apiKey`      | string   | Yes      | API key with the appropriate scopes (prefixed with `mdcms_key_`).                                                       |
+| `project`     | string   | Yes      | Project slug. Sets the `X-MDCMS-Project` header on every request.                                                       |
+| `environment` | string   | Yes      | Environment name. Sets the `X-MDCMS-Environment` header on every request.                                               |
+| `fetch`       | function | No       | Custom `fetch` implementation. Useful for testing, caching, or request instrumentation. Defaults to the global `fetch`. |
 
 ---
 
@@ -87,17 +87,20 @@ const post = await client.get("BlogPost", {
 
 ### get() Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `id` | string | Document UUID. Mutually exclusive with `slug` and `path`. |
-| `slug` | string | Slug frontmatter value. Mutually exclusive with `id` and `path`. |
-| `path` | string | Document path. Mutually exclusive with `id` and `slug`. |
-| `locale` | string | BCP 47 locale tag. |
-| `resolve` | string[] | Reference field names to resolve (one level deep). |
-| `draft` | boolean | When `true`, return the draft version instead of the published version. |
+| Option    | Type     | Description                                                             |
+| --------- | -------- | ----------------------------------------------------------------------- |
+| `id`      | string   | Document UUID. Mutually exclusive with `slug` and `path`.               |
+| `slug`    | string   | Slug frontmatter value. Mutually exclusive with `id` and `path`.        |
+| `path`    | string   | Document path. Mutually exclusive with `id` and `slug`.                 |
+| `locale`  | string   | BCP 47 locale tag.                                                      |
+| `resolve` | string[] | Reference field names to resolve (one level deep).                      |
+| `draft`   | boolean  | When `true`, return the draft version instead of the published version. |
 
 <Warning>
-  When using `slug` or `path`, the query must match exactly one document. If multiple documents match (e.g., same slug in different locales without specifying `locale`), the SDK throws an `MdcmsClientError` with code `AMBIGUOUS_RESULT`.
+  When using `slug` or `path`, the query must match exactly one document. If
+  multiple documents match (e.g., same slug in different locales without
+  specifying `locale`), the SDK throws an `MdcmsClientError` with code
+  `AMBIGUOUS_RESULT`.
 </Warning>
 
 ---
@@ -121,24 +124,24 @@ for (const post of posts.data) {
 }
 
 // Access pagination metadata
-console.log(posts.pagination.total);    // 42
-console.log(posts.pagination.hasMore);  // true
+console.log(posts.pagination.total); // 42
+console.log(posts.pagination.hasMore); // true
 ```
 
 ### list() Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `locale` | string | BCP 47 locale tag. |
-| `published` | boolean | Filter by publication status. |
-| `isDeleted` | boolean | Include soft-deleted documents. |
-| `hasUnpublishedChanges` | boolean | Filter to documents with pending draft changes. |
-| `draft` | boolean | Return draft content instead of published content. |
-| `resolve` | string[] | Reference field names to resolve. |
-| `limit` | number | Results per page (default 20, max 100). |
-| `offset` | number | Number of results to skip. |
-| `sort` | string | Sort field: `createdAt`, `updatedAt`, or `path`. |
-| `order` | string | Sort direction: `asc` or `desc`. |
+| Option                  | Type     | Description                                        |
+| ----------------------- | -------- | -------------------------------------------------- |
+| `locale`                | string   | BCP 47 locale tag.                                 |
+| `published`             | boolean  | Filter by publication status.                      |
+| `isDeleted`             | boolean  | Include soft-deleted documents.                    |
+| `hasUnpublishedChanges` | boolean  | Filter to documents with pending draft changes.    |
+| `draft`                 | boolean  | Return draft content instead of published content. |
+| `resolve`               | string[] | Reference field names to resolve.                  |
+| `limit`                 | number   | Results per page (default 20, max 100).            |
+| `offset`                | number   | Number of results to skip.                         |
+| `sort`                  | string   | Sort field: `createdAt`, `updatedAt`, or `path`.   |
+| `order`                 | string   | Sort direction: `asc` or `desc`.                   |
 
 ### Return Type
 
@@ -160,28 +163,28 @@ console.log(posts.pagination.hasMore);  // true
 
 Both `get()` and `list()` return `ContentDocumentResponse` objects with the following fields:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `documentId` | string | Stable UUID identifier. |
-| `translationGroupId` | string | UUID linking locale variants of the same content. |
-| `project` | string | Project slug. |
-| `environment` | string | Environment name. |
-| `path` | string | Filesystem-like path (e.g., `content/blog/hello-world`). |
-| `type` | string | Content type name (e.g., `BlogPost`). |
-| `locale` | string | BCP 47 locale tag, or `__mdcms_default__` for non-localized types. |
-| `format` | string | `md` or `mdx`. |
-| `isDeleted` | boolean | Whether the document is soft-deleted. |
-| `hasUnpublishedChanges` | boolean | Whether the draft differs from the published version. |
-| `version` | number | Current version number (incremented on each publish). |
-| `publishedVersion` | number \| null | Version number of the published snapshot, or `null` if never published. |
-| `draftRevision` | number | Incrementing counter for draft saves. Used for optimistic concurrency. |
-| `frontmatter` | object | Structured data matching the content type schema. References are UUIDs unless resolved. |
-| `body` | string | Markdown or MDX content. |
-| `resolveErrors` | object | Map of field paths to [resolve error](/api-reference/errors#resolve-errors) objects. Empty when no resolve errors. |
-| `createdBy` | string | User or API key ID that created the document. |
-| `createdAt` | string | ISO 8601 creation timestamp. |
-| `updatedBy` | string | User or API key ID that last updated the document. |
-| `updatedAt` | string | ISO 8601 last-update timestamp. |
+| Field                   | Type           | Description                                                                                                        |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `documentId`            | string         | Stable UUID identifier.                                                                                            |
+| `translationGroupId`    | string         | UUID linking locale variants of the same content.                                                                  |
+| `project`               | string         | Project slug.                                                                                                      |
+| `environment`           | string         | Environment name.                                                                                                  |
+| `path`                  | string         | Filesystem-like path (e.g., `content/blog/hello-world`).                                                           |
+| `type`                  | string         | Content type name (e.g., `BlogPost`).                                                                              |
+| `locale`                | string         | BCP 47 locale tag, or `__mdcms_default__` for non-localized types.                                                 |
+| `format`                | string         | `md` or `mdx`.                                                                                                     |
+| `isDeleted`             | boolean        | Whether the document is soft-deleted.                                                                              |
+| `hasUnpublishedChanges` | boolean        | Whether the draft differs from the published version.                                                              |
+| `version`               | number         | Current version number (incremented on each publish).                                                              |
+| `publishedVersion`      | number \| null | Version number of the published snapshot, or `null` if never published.                                            |
+| `draftRevision`         | number         | Incrementing counter for draft saves. Used for optimistic concurrency.                                             |
+| `frontmatter`           | object         | Structured data matching the content type schema. References are UUIDs unless resolved.                            |
+| `body`                  | string         | Markdown or MDX content.                                                                                           |
+| `resolveErrors`         | object         | Map of field paths to [resolve error](/api-reference/errors#resolve-errors) objects. Empty when no resolve errors. |
+| `createdBy`             | string         | User or API key ID that created the document.                                                                      |
+| `createdAt`             | string         | ISO 8601 creation timestamp.                                                                                       |
+| `updatedBy`             | string         | User or API key ID that last updated the document.                                                                 |
+| `updatedAt`             | string         | ISO 8601 last-update timestamp.                                                                                    |
 
 ---
 
@@ -198,16 +201,16 @@ try {
   if (error instanceof MdcmsApiError) {
     // Server returned an error response
     console.error(error.statusCode); // 404
-    console.error(error.code);       // "NOT_FOUND"
-    console.error(error.message);    // "Document not found"
-    console.error(error.requestId);  // "req_abc123"
-    console.error(error.timestamp);  // "2026-01-15T09:30:00.000Z"
-    console.error(error.details);    // {}
+    console.error(error.code); // "NOT_FOUND"
+    console.error(error.message); // "Document not found"
+    console.error(error.requestId); // "req_abc123"
+    console.error(error.timestamp); // "2026-01-15T09:30:00.000Z"
+    console.error(error.details); // {}
   }
 
   if (error instanceof MdcmsClientError) {
     // Client-side error (network, parsing, ambiguity)
-    console.error(error.code);    // e.g., "NOT_FOUND"
+    console.error(error.code); // e.g., "NOT_FOUND"
     console.error(error.message); // Human-readable description
   }
 }
@@ -217,24 +220,24 @@ try {
 
 Thrown when the server returns a non-2xx response. Properties:
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `statusCode` | number | HTTP status code (e.g., 404, 409, 500). |
-| `code` | string | Machine-readable error code (e.g., `NOT_FOUND`, `SCHEMA_HASH_MISMATCH`). |
-| `message` | string | Human-readable error description. |
-| `requestId` | string | Server request ID for debugging. |
-| `timestamp` | string | ISO 8601 error timestamp. |
-| `details` | object | Additional context specific to the error. |
+| Property     | Type   | Description                                                              |
+| ------------ | ------ | ------------------------------------------------------------------------ |
+| `statusCode` | number | HTTP status code (e.g., 404, 409, 500).                                  |
+| `code`       | string | Machine-readable error code (e.g., `NOT_FOUND`, `SCHEMA_HASH_MISMATCH`). |
+| `message`    | string | Human-readable error description.                                        |
+| `requestId`  | string | Server request ID for debugging.                                         |
+| `timestamp`  | string | ISO 8601 error timestamp.                                                |
+| `details`    | object | Additional context specific to the error.                                |
 
 ### MdcmsClientError
 
 Thrown for client-side issues that prevent a valid response. Error codes:
 
-| Code | Description |
-|------|-------------|
-| `INVALID_RESPONSE` | The server returned a response that could not be parsed as valid JSON. |
-| `NETWORK_ERROR` | The request failed due to a network issue (DNS failure, connection refused, timeout). |
-| `NOT_FOUND` | A `get()` call matched zero documents. |
+| Code               | Description                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `INVALID_RESPONSE` | The server returned a response that could not be parsed as valid JSON.                               |
+| `NETWORK_ERROR`    | The request failed due to a network issue (DNS failure, connection refused, timeout).                |
+| `NOT_FOUND`        | A `get()` call matched zero documents.                                                               |
 | `AMBIGUOUS_RESULT` | A `get()` call by slug or path matched multiple documents. Add a `locale` parameter to disambiguate. |
 
 ---
@@ -413,5 +416,7 @@ export default async function BlogPost({
 ```
 
 <Tip>
-  The API key used for draft preview must have both `content:read` and `content:read:draft` scopes. Use a separate API key for preview routes with limited scope rather than reusing a production key.
+  The API key used for draft preview must have both `content:read` and
+  `content:read:draft` scopes. Use a separate API key for preview routes with
+  limited scope rather than reusing a production key.
 </Tip>

--- a/apps/docs/architecture/data-model.mdx
+++ b/apps/docs/architecture/data-model.mdx
@@ -38,65 +38,65 @@ The database schema is organized into four domains: authentication, authorizatio
 
 ### Authentication
 
-| Table | Description |
-| --- | --- |
-| `authUsers` (users) | User accounts with name, email, email verification status, and avatar. |
-| `authSessions` (sessions) | Active login sessions with token, expiry, IP address, and user agent. Cascade-deleted when the user is removed. |
-| `authAccounts` (accounts) | OAuth/OIDC provider links (provider id, access/refresh/id tokens, scopes, or password hash for credential accounts). |
-| `authVerifications` (verifications) | Time-limited verification tokens for email confirmation and password reset flows. |
-| `authLoginBackoffs` (auth_login_backoffs) | Progressive login rate limiting. Tracks failure count, timestamps, and next-allowed-at per login key. |
+| Table                                       | Description                                                                                                            |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `authUsers` (users)                         | User accounts with name, email, email verification status, and avatar.                                                 |
+| `authSessions` (sessions)                   | Active login sessions with token, expiry, IP address, and user agent. Cascade-deleted when the user is removed.        |
+| `authAccounts` (accounts)                   | OAuth/OIDC provider links (provider id, access/refresh/id tokens, scopes, or password hash for credential accounts).   |
+| `authVerifications` (verifications)         | Time-limited verification tokens for email confirmation and password reset flows.                                      |
+| `authLoginBackoffs` (auth_login_backoffs)   | Progressive login rate limiting. Tracks failure count, timestamps, and next-allowed-at per login key.                  |
 | `cliLoginChallenges` (cli_login_challenges) | Device-flow login challenges for the CLI. Status transitions: `pending` -> `authorized` -> `exchanged`. 10-minute TTL. |
 
 ### Authorization
 
-| Table | Description |
-| --- | --- |
-| `rbacGrants` (rbac_grants) | Role-based access grants. Each grant binds a user to a role (`owner`, `admin`, `editor`, `viewer`) at a scope (`global`, `project`, or `folder_prefix`). Supports soft revocation via `revokedAt`. |
-| `apiKeys` (api_keys) | API key credentials. Stores a key prefix (for display), a hash (for lookup), an array of operation scopes, and a `contextAllowlist` restricting which project/environment pairs the key can target. |
-| `invites` (invites) | Pending user invitations with pre-defined RBAC grants, token hash, expiry, and acceptance/revocation tracking. |
+| Table                      | Description                                                                                                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rbacGrants` (rbac_grants) | Role-based access grants. Each grant binds a user to a role (`owner`, `admin`, `editor`, `viewer`) at a scope (`global`, `project`, or `folder_prefix`). Supports soft revocation via `revokedAt`.  |
+| `apiKeys` (api_keys)       | API key credentials. Stores a key prefix (for display), a hash (for lookup), an array of operation scopes, and a `contextAllowlist` restricting which project/environment pairs the key can target. |
+| `invites` (invites)        | Pending user invitations with pre-defined RBAC grants, token hash, expiry, and acceptance/revocation tracking.                                                                                      |
 
 ### Project and Environment
 
-| Table | Description |
-| --- | --- |
-| `projects` | Top-level tenants identified by slug. Each project owns all subordinate resources. |
-| `environments` | Named content spaces within a project (e.g., `production`, `staging`). Unique per project. |
-| `schemaSyncs` | Tracks the last schema synchronization per project/environment. Stores the schema hash and a raw config snapshot. |
+| Table                   | Description                                                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `projects`              | Top-level tenants identified by slug. Each project owns all subordinate resources.                                                                                             |
+| `environments`          | Named content spaces within a project (e.g., `production`, `staging`). Unique per project.                                                                                     |
+| `schemaSyncs`           | Tracks the last schema synchronization per project/environment. Stores the schema hash and a raw config snapshot.                                                              |
 | `schemaRegistryEntries` | Per-type schema records. Each entry stores the schema type name, directory, localization flag, schema hash, and the resolved JSON Schema. Unique per project/environment/type. |
 
 ### Content
 
-| Table | Description |
-| --- | --- |
-| `documents` | The mutable head state of every content document. This is the working copy. |
-| `documentVersions` | Immutable publish snapshots. Each row captures the full document state at the moment of publication. |
-| `media` | File metadata for uploaded assets (filename, MIME type, size, S3 key, public URL). Scoped to project. |
-| `migrations` | Records of applied content migrations (name, schema type, documents affected, applied-by/at). |
+| Table              | Description                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `documents`        | The mutable head state of every content document. This is the working copy.                           |
+| `documentVersions` | Immutable publish snapshots. Each row captures the full document state at the moment of publication.  |
+| `media`            | File metadata for uploaded assets (filename, MIME type, size, S3 key, public URL). Scoped to project. |
+| `migrations`       | Records of applied content migrations (name, schema type, documents affected, applied-by/at).         |
 
 ## Document Table Columns
 
 The `documents` table is the central content table. Each row represents the current draft state of a single document.
 
-| Column | Type | Description |
-| --- | --- | --- |
-| `documentId` | UUID (PK) | Stable identifier for the document across its entire lifecycle. |
-| `translationGroupId` | UUID | Links locale variants of the same logical content. All translations share this ID. |
-| `projectId` | UUID (FK) | Owning project. |
-| `environmentId` | UUID (FK) | Owning environment. |
-| `path` | text | Filesystem-relative path (e.g., `content/blog/hello-world`). Unique per project/environment/locale when not deleted. |
-| `schemaType` | text | Content type name matching a `schemaRegistryEntries` record. |
-| `locale` | text | BCP 47 locale code, or `__mdcms_default__` for non-localized types. |
-| `contentFormat` | text | `md` or `mdx`. Constrained by database check. |
-| `body` | text | The Markdown/MDX body content. |
-| `frontmatter` | JSONB | Structured metadata fields defined by the schema type. |
-| `isDeleted` | boolean | Soft-delete flag. Deleted documents are excluded from all active queries via partial indexes. |
-| `hasUnpublishedChanges` | boolean | `true` when the draft diverges from the latest published version. |
-| `publishedVersion` | integer (FK) | Points to the latest `documentVersions.version` for this document, or `null` if never published. |
-| `draftRevision` | bigint | Monotonically increasing revision counter for optimistic concurrency control. |
-| `createdBy` | UUID | User who created the document. |
-| `createdAt` | timestamptz | Creation timestamp. |
-| `updatedBy` | UUID | User who last modified the document. |
-| `updatedAt` | timestamptz | Last modification timestamp. |
+| Column                  | Type         | Description                                                                                                          |
+| ----------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `documentId`            | UUID (PK)    | Stable identifier for the document across its entire lifecycle.                                                      |
+| `translationGroupId`    | UUID         | Links locale variants of the same logical content. All translations share this ID.                                   |
+| `projectId`             | UUID (FK)    | Owning project.                                                                                                      |
+| `environmentId`         | UUID (FK)    | Owning environment.                                                                                                  |
+| `path`                  | text         | Filesystem-relative path (e.g., `content/blog/hello-world`). Unique per project/environment/locale when not deleted. |
+| `schemaType`            | text         | Content type name matching a `schemaRegistryEntries` record.                                                         |
+| `locale`                | text         | BCP 47 locale code, or `__mdcms_default__` for non-localized types.                                                  |
+| `contentFormat`         | text         | `md` or `mdx`. Constrained by database check.                                                                        |
+| `body`                  | text         | The Markdown/MDX body content.                                                                                       |
+| `frontmatter`           | JSONB        | Structured metadata fields defined by the schema type.                                                               |
+| `isDeleted`             | boolean      | Soft-delete flag. Deleted documents are excluded from all active queries via partial indexes.                        |
+| `hasUnpublishedChanges` | boolean      | `true` when the draft diverges from the latest published version.                                                    |
+| `publishedVersion`      | integer (FK) | Points to the latest `documentVersions.version` for this document, or `null` if never published.                     |
+| `draftRevision`         | bigint       | Monotonically increasing revision counter for optimistic concurrency control.                                        |
+| `createdBy`             | UUID         | User who created the document.                                                                                       |
+| `createdAt`             | timestamptz  | Creation timestamp.                                                                                                  |
+| `updatedBy`             | UUID         | User who last modified the document.                                                                                 |
+| `updatedAt`             | timestamptz  | Last modification timestamp.                                                                                         |
 
 ## Content Lifecycle
 
@@ -118,17 +118,18 @@ stateDiagram-v2
 
 ### State Transitions
 
-| Transition | What changes |
-| --- | --- |
-| **Create** | New row in `documents` with `hasUnpublishedChanges = true`, `publishedVersion = null`, `draftRevision = 1`. |
-| **Edit draft** | `documents` row updated: `body`, `frontmatter`, `updatedBy`, `updatedAt` change. `draftRevision` increments. `hasUnpublishedChanges` set to `true`. |
-| **Publish** | New row in `documentVersions` capturing the full document state. `documents.publishedVersion` updated to new version number. `hasUnpublishedChanges` set to `false`. |
-| **Re-publish** | Same as Publish -- a new immutable version row is created. |
-| **Delete** | `documents.isDeleted` set to `true`. The document is excluded from all active-scoped indexes. No data is removed. |
-| **Restore** | `documents.isDeleted` set to `false`. The document re-enters the Draft state with `hasUnpublishedChanges = true`. |
+| Transition     | What changes                                                                                                                                                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Create**     | New row in `documents` with `hasUnpublishedChanges = true`, `publishedVersion = null`, `draftRevision = 1`.                                                          |
+| **Edit draft** | `documents` row updated: `body`, `frontmatter`, `updatedBy`, `updatedAt` change. `draftRevision` increments. `hasUnpublishedChanges` set to `true`.                  |
+| **Publish**    | New row in `documentVersions` capturing the full document state. `documents.publishedVersion` updated to new version number. `hasUnpublishedChanges` set to `false`. |
+| **Re-publish** | Same as Publish -- a new immutable version row is created.                                                                                                           |
+| **Delete**     | `documents.isDeleted` set to `true`. The document is excluded from all active-scoped indexes. No data is removed.                                                    |
+| **Restore**    | `documents.isDeleted` set to `false`. The document re-enters the Draft state with `hasUnpublishedChanges = true`.                                                    |
 
 <Note>
-Published versions are **never modified or deleted**. The `documentVersions` table is append-only, providing a complete audit trail of every publication.
+  Published versions are **never modified or deleted**. The `documentVersions`
+  table is append-only, providing a complete audit trail of every publication.
 </Note>
 
 ### Concurrency Control
@@ -145,7 +146,9 @@ Server: WHERE draftRevision = 4 → 0 rows affected → 409 Conflict ✗
 ```
 
 <Warning>
-The Studio editor automatically handles revision tracking. If you are building a custom integration, always read the current `draftRevision` before writing and include it in update requests.
+  The Studio editor automatically handles revision tracking. If you are building
+  a custom integration, always read the current `draftRevision` before writing
+  and include it in update requests.
 </Warning>
 
 ## Localization Architecture
@@ -174,11 +177,13 @@ MDCMS normalizes all locale values to BCP 47 format (e.g., `en-US`, `fr-FR`, `ja
 
 The CLI maps documents to filesystem paths based on locale:
 
-| Type | File pattern | Example |
-| --- | --- | --- |
-| Localized | `<path>.<locale>.<ext>` | `content/blog/hello.en-US.mdx` |
-| Non-localized | `<path>.<ext>` | `content/authors/jane.md` |
+| Type          | File pattern            | Example                        |
+| ------------- | ----------------------- | ------------------------------ |
+| Localized     | `<path>.<locale>.<ext>` | `content/blog/hello.en-US.mdx` |
+| Non-localized | `<path>.<ext>`          | `content/authors/jane.md`      |
 
 <Tip>
-The `supportedLocales` and `defaultLocale` fields in the Studio mount context control which locales appear in the locale picker and which locale is selected by default when creating new documents.
+  The `supportedLocales` and `defaultLocale` fields in the Studio mount context
+  control which locales appear in the locale picker and which locale is selected
+  by default when creating new documents.
 </Tip>

--- a/apps/docs/architecture/migrations.mdx
+++ b/apps/docs/architecture/migrations.mdx
@@ -9,17 +9,17 @@ As your content model evolves, some changes require explicit migration steps. Th
 
 Not every schema change requires a migration. MDCMS distinguishes between non-breaking changes (handled automatically) and breaking changes (requiring explicit migration).
 
-| Change Type | Migration Required? | Reason |
-| --- | --- | --- |
-| Adding a new optional field | No | Existing documents remain valid -- the field defaults to `undefined`. |
-| Adding a new content type | No | No existing documents are affected. `mdcms schema sync` registers the new type. |
-| Adding a new environment | No | The environment starts empty. |
-| Renaming a content type | **Yes** | Existing documents reference the old type name. |
-| Removing a content type that has documents | **Yes** | Documents of that type must be migrated or deleted. |
-| Changing a field's type (e.g., string to number) | **Yes** | Existing frontmatter values are incompatible with the new type. |
-| Renaming a field | **Yes** | Existing frontmatter uses the old field name. |
-| Making an optional field required | **Yes** | Existing documents may have `undefined` for that field. |
-| Removing a field | **Yes** | The field should be cleaned from existing frontmatter for consistency. |
+| Change Type                                      | Migration Required? | Reason                                                                          |
+| ------------------------------------------------ | ------------------- | ------------------------------------------------------------------------------- |
+| Adding a new optional field                      | No                  | Existing documents remain valid -- the field defaults to `undefined`.           |
+| Adding a new content type                        | No                  | No existing documents are affected. `mdcms schema sync` registers the new type. |
+| Adding a new environment                         | No                  | The environment starts empty.                                                   |
+| Renaming a content type                          | **Yes**             | Existing documents reference the old type name.                                 |
+| Removing a content type that has documents       | **Yes**             | Documents of that type must be migrated or deleted.                             |
+| Changing a field's type (e.g., string to number) | **Yes**             | Existing frontmatter values are incompatible with the new type.                 |
+| Renaming a field                                 | **Yes**             | Existing frontmatter uses the old field name.                                   |
+| Making an optional field required                | **Yes**             | Existing documents may have `undefined` for that field.                         |
+| Removing a field                                 | **Yes**             | The field should be cleaned from existing frontmatter for consistency.          |
 
 ## Non-Breaking Changes
 
@@ -30,15 +30,19 @@ For non-breaking changes, the standard schema sync workflow handles everything a
     Modify your `mdcms.config.ts` to add the new field, type, or environment.
   </Step>
   <Step title="Sync to the server">
-    Run `mdcms schema sync`. The server computes the new schema hash and updates the `schemaRegistryEntries` and `schemaSyncs` tables.
+    Run `mdcms schema sync`. The server computes the new schema hash and updates
+    the `schemaRegistryEntries` and `schemaSyncs` tables.
   </Step>
   <Step title="Continue editing">
-    Existing documents remain valid. New documents will include the updated field definitions in the Studio editor.
+    Existing documents remain valid. New documents will include the updated
+    field definitions in the Studio editor.
   </Step>
 </Steps>
 
 <Tip>
-Schema sync is idempotent. Running it multiple times with the same configuration produces the same result. It is safe to include in CI/CD pipelines.
+  Schema sync is idempotent. Running it multiple times with the same
+  configuration produces the same result. It is safe to include in CI/CD
+  pipelines.
 </Tip>
 
 ## Database Migrations
@@ -47,30 +51,29 @@ Database schema changes (adding tables, columns, or indexes to the PostgreSQL sc
 
 <Steps>
   <Step title="Modify the schema definition">
-    Edit `apps/server/src/lib/db/schema.ts` to add, modify, or remove table definitions.
+    Edit `apps/server/src/lib/db/schema.ts` to add, modify, or remove table
+    definitions.
   </Step>
   <Step title="Generate the migration SQL">
-    Run the Drizzle migration generator:
-    ```bash
-    cd apps/server
-    bun run db:generate
-    ```
-    This produces a timestamped SQL migration file in the migrations directory.
+    Run the Drizzle migration generator: ```bash cd apps/server bun run
+    db:generate ``` This produces a timestamped SQL migration file in the
+    migrations directory.
   </Step>
   <Step title="Review the generated SQL">
-    Always review the generated migration before applying it. Drizzle generates SQL based on the diff between the current schema definition and the last known state. Verify that destructive operations (column drops, type changes) are intentional.
+    Always review the generated migration before applying it. Drizzle generates
+    SQL based on the diff between the current schema definition and the last
+    known state. Verify that destructive operations (column drops, type changes)
+    are intentional.
   </Step>
   <Step title="Apply the migration">
-    Run the migration against the target database:
-    ```bash
-    cd apps/server
-    bun run db:migrate
-    ```
+    Run the migration against the target database: ```bash cd apps/server bun
+    run db:migrate ```
   </Step>
 </Steps>
 
 <Warning>
-Always back up the database before applying migrations in production. Drizzle migrations are forward-only -- there is no automatic rollback mechanism.
+  Always back up the database before applying migrations in production. Drizzle
+  migrations are forward-only -- there is no automatic rollback mechanism.
 </Warning>
 
 ## Content Migrations
@@ -107,7 +110,10 @@ When applied, the migration:
 4. Records the migration in the `migrations` table (name, schema type, documents affected, who applied it, when)
 
 <Warning>
-Always back up the database before running content migrations in production. Content migrations modify document frontmatter in place and auto-publish affected documents. While the operation is logged in the `migrations` table, there is no built-in undo mechanism.
+  Always back up the database before running content migrations in production.
+  Content migrations modify document frontmatter in place and auto-publish
+  affected documents. While the operation is logged in the `migrations` table,
+  there is no built-in undo mechanism.
 </Warning>
 
 ## Breaking Change Scenarios
@@ -142,22 +148,24 @@ When removing a field from a content type:
 3. Run `mdcms migrate --apply` to clean the removed field from existing document frontmatter
 
 <Note>
-Field removal migrations are optional but recommended. Documents with extra frontmatter fields will not cause errors, but removing stale data keeps the content store clean and reduces confusion in API responses.
+  Field removal migrations are optional but recommended. Documents with extra
+  frontmatter fields will not cause errors, but removing stale data keeps the
+  content store clean and reduces confusion in API responses.
 </Note>
 
 ## Migration Records
 
 Every applied migration is recorded in the `migrations` table:
 
-| Column | Description |
-| --- | --- |
-| `id` | UUID primary key |
-| `name` | Human-readable migration name |
-| `projectId` | Target project |
-| `environmentId` | Target environment |
-| `schemaType` | Content type affected |
-| `appliedAt` | Timestamp of execution |
-| `appliedBy` | User who ran the migration |
+| Column              | Description                     |
+| ------------------- | ------------------------------- |
+| `id`                | UUID primary key                |
+| `name`              | Human-readable migration name   |
+| `projectId`         | Target project                  |
+| `environmentId`     | Target environment              |
+| `schemaType`        | Content type affected           |
+| `appliedAt`         | Timestamp of execution          |
+| `appliedBy`         | User who ran the migration      |
 | `documentsAffected` | Number of documents transformed |
 
 This table provides an audit trail for all content transformations and can be queried to verify migration history.

--- a/apps/docs/architecture/module-system.mdx
+++ b/apps/docs/architecture/module-system.mdx
@@ -9,11 +9,11 @@ MDCMS is built on a module system that organizes all server-side functionality i
 
 A module is a self-contained unit that can contribute to one or more runtime surfaces:
 
-| Surface | What it provides |
-| --- | --- |
+| Surface    | What it provides                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
 | **Server** | HTTP route handlers mounted on the Elysia app, plus action catalog entries for discoverable operations. |
-| **CLI** | Action aliases, output formatters, and preflight hooks that extend the `mdcms` command. |
-| **Studio** | UI extension points including routes, navigation items, slot widgets, field kinds, and editor nodes. |
+| **CLI**    | Action aliases, output formatters, and preflight hooks that extend the `mdcms` command.                 |
+| **Studio** | UI extension points including routes, navigation items, slot widgets, field kinds, and editor nodes.    |
 
 Modules declare a manifest with metadata (id, version, API version, dependencies) and one or more surface implementations.
 
@@ -58,13 +58,20 @@ Modules are registered at compile time in `packages/modules/src/index.ts` and lo
 
 <Steps>
   <Step title="Build load report">
-    `buildServerModuleLoadReport()` validates every registered module package against the Zod schema, checks manifest compatibility (API version, core version range), resolves the dependency graph, and produces a `ServerModuleLoadReport`.
+    `buildServerModuleLoadReport()` validates every registered module package
+    against the Zod schema, checks manifest compatibility (API version, core
+    version range), resolves the dependency graph, and produces a
+    `ServerModuleLoadReport`.
   </Step>
   <Step title="Load modules">
-    `loadServerModules()` reads from the `installedModules` compile-time registry and delegates to the build step. If any module fails validation or has unresolvable dependencies, the server refuses to start.
+    `loadServerModules()` reads from the `installedModules` compile-time
+    registry and delegates to the build step. If any module fails validation or
+    has unresolvable dependencies, the server refuses to start.
   </Step>
   <Step title="Mount modules">
-    `mountLoadedServerModules()` iterates the loaded modules in dependency order and calls each module's `server.mount()`, passing the Elysia app instance and shared dependencies (database DAL, auth service, etc.).
+    `mountLoadedServerModules()` iterates the loaded modules in dependency order
+    and calls each module's `server.mount()`, passing the Elysia app instance
+    and shared dependencies (database DAL, auth service, etc.).
   </Step>
 </Steps>
 
@@ -83,12 +90,14 @@ MDCMS ships with two first-party modules:
 **Kind:** `core`
 
 Provides the foundational infrastructure surface: health checks (`/healthz`), Studio bootstrap endpoint, authentication routes, user management, API key management, RBAC grant management, and invite flows.
+
 </Accordion>
 
 <Accordion title="domain.content">
 **Kind:** `domain`
 
 Provides the content domain surface: document CRUD, schema registry sync, media upload and management, webhook dispatch, environment cloning/promotion, search, and content migration execution.
+
 </Accordion>
 
 Both modules implement `server` and `cli` surfaces. The module registry in `packages/modules/src/index.ts` sorts them deterministically by manifest id before exposing them to the loader.
@@ -99,15 +108,15 @@ Every server-side operation is registered as an **action** -- a discoverable, se
 
 ```typescript
 type ActionCatalogItem = {
-  id: string;                        // e.g. "content.documents.list"
-  kind: "command" | "query";         // write vs read
+  id: string; // e.g. "content.documents.list"
+  kind: "command" | "query"; // write vs read
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-  path: string;                      // e.g. "/api/v1/content"
-  permissions: string[];             // required scopes
-  studio?: StudioActionMeta;         // visibility, surface, label, form hints
-  cli?: CliActionMeta;               // visibility, alias, input mode
-  requestSchema?: JsonSchema;        // JSON Schema for request body
-  responseSchema?: JsonSchema;       // JSON Schema for response body
+  path: string; // e.g. "/api/v1/content"
+  permissions: string[]; // required scopes
+  studio?: StudioActionMeta; // visibility, surface, label, form hints
+  cli?: CliActionMeta; // visibility, alias, input mode
+  requestSchema?: JsonSchema; // JSON Schema for request body
+  responseSchema?: JsonSchema; // JSON Schema for response body
 };
 ```
 
@@ -119,35 +128,38 @@ The catalog is queryable at runtime:
 Actions support visibility policies that filter the catalog per-request based on the caller's authentication context and permissions.
 
 <Tip>
-The CLI uses the action catalog to dynamically discover available commands. Run `mdcms actions` to see all actions available for your current credentials.
+  The CLI uses the action catalog to dynamically discover available commands.
+  Run `mdcms actions` to see all actions available for your current credentials.
 </Tip>
 
 ## Studio Extensibility Surfaces
 
 The Studio component exposes several extension points that modules can populate:
 
-| Surface | Description |
-| --- | --- |
-| `routes` | Additional React Router routes mounted inside the Studio shell. |
-| `navItems` | Navigation entries added to the Studio sidebar. |
-| `slotWidgets` | Widgets rendered in named layout slots across Studio pages. |
-| `fieldKinds` | Custom form field renderers for schema-driven frontmatter editing. |
-| `editorNodes` | Custom TipTap/ProseMirror nodes for the MDX editor. |
+| Surface           | Description                                                           |
+| ----------------- | --------------------------------------------------------------------- |
+| `routes`          | Additional React Router routes mounted inside the Studio shell.       |
+| `navItems`        | Navigation entries added to the Studio sidebar.                       |
+| `slotWidgets`     | Widgets rendered in named layout slots across Studio pages.           |
+| `fieldKinds`      | Custom form field renderers for schema-driven frontmatter editing.    |
+| `editorNodes`     | Custom TipTap/ProseMirror nodes for the MDX editor.                   |
 | `actionOverrides` | Replace or wrap default action behaviors (e.g., custom publish flow). |
-| `settingsPanels` | Additional panels on the Studio settings page. |
+| `settingsPanels`  | Additional panels on the Studio settings page.                        |
 
 Standard slot IDs used across Studio pages:
 
-| Slot ID | Location |
-| --- | --- |
-| `dashboard.main` | Main content area of the dashboard page. |
-| `content.list.toolbar` | Toolbar above the content list table. |
+| Slot ID                         | Location                                      |
+| ------------------------------- | --------------------------------------------- |
+| `dashboard.main`                | Main content area of the dashboard page.      |
+| `content.list.toolbar`          | Toolbar above the content list table.         |
 | `content.editor.header.actions` | Action buttons in the document editor header. |
-| `content.editor.sidebar` | Sidebar panels in the document editor. |
-| `settings.general` | General settings section. |
+| `content.editor.sidebar`        | Sidebar panels in the document editor.        |
+| `settings.general`              | General settings section.                     |
 
 <Note>
-In v1, Studio extensibility surfaces are defined but only consumed by first-party modules. The contract is stable and documented for future third-party use.
+  In v1, Studio extensibility surfaces are defined but only consumed by
+  first-party modules. The contract is stable and documented for future
+  third-party use.
 </Note>
 
 ## v1 Limitation
@@ -193,5 +205,7 @@ X-MDCMS-Environment: production
 The server's target routing guard validates these headers before the request reaches any route handler. Routes that require project+environment context (content, schema, media, webhooks, search) reject requests missing either header with a `400` error. Routes that require only project context (environments API) require `X-MDCMS-Project` alone.
 
 <Warning>
-API keys include a `contextAllowlist` that restricts which project/environment pairs they can access. A key scoped to `production` cannot be used to read `staging` content, even if it has `content:read` permission.
+  API keys include a `contextAllowlist` that restricts which project/environment
+  pairs they can access. A key scoped to `production` cannot be used to read
+  `staging` content, even if it has `content:read` permission.
 </Warning>

--- a/apps/docs/architecture/overview.mdx
+++ b/apps/docs/architecture/overview.mdx
@@ -9,13 +9,13 @@ MDCMS is an open-source headless CMS that treats a PostgreSQL database as the so
 
 MDCMS follows a small set of architectural invariants that inform every subsystem.
 
-| Principle | What it means |
-| --- | --- |
-| **Database is source of truth** | Content lives in PostgreSQL, not the filesystem. The CLI syncs files to and from the database via `mdcms push` / `mdcms pull`. |
-| **Schema-driven UI** | Content types are defined in TypeScript with Zod. The schema drives form generation, validation, API behavior, and Studio rendering automatically. |
-| **Explicit target routing** | Every API request carries a project and environment context via `X-MDCMS-Project` and `X-MDCMS-Environment` headers. There is no implicit "current" tenant. |
-| **Code-first configuration** | All configuration lives in `mdcms.config.ts` -- a TypeScript file that is type-checked and version-controlled alongside application code. |
-| **CQRS-lite** | Writes flow through command handlers that enforce validation, authorization, and versioning. Reads flow through query handlers that project data for specific consumers. The same database backs both paths. |
+| Principle                       | What it means                                                                                                                                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Database is source of truth** | Content lives in PostgreSQL, not the filesystem. The CLI syncs files to and from the database via `mdcms push` / `mdcms pull`.                                                                               |
+| **Schema-driven UI**            | Content types are defined in TypeScript with Zod. The schema drives form generation, validation, API behavior, and Studio rendering automatically.                                                           |
+| **Explicit target routing**     | Every API request carries a project and environment context via `X-MDCMS-Project` and `X-MDCMS-Environment` headers. There is no implicit "current" tenant.                                                  |
+| **Code-first configuration**    | All configuration lives in `mdcms.config.ts` -- a TypeScript file that is type-checked and version-controlled alongside application code.                                                                    |
+| **CQRS-lite**                   | Writes flow through command handlers that enforce validation, authorization, and versioning. Reads flow through query handlers that project data for specific consumers. The same database backs both paths. |
 
 ## Deployment Topology
 
@@ -41,30 +41,32 @@ graph TB
 ```
 
 <Note>
-In local development, `docker-compose.dev.yml` starts PostgreSQL, Redis, and MinIO automatically. The server, Studio, and studio-example app run via `bun run dev`.
+  In local development, `docker-compose.dev.yml` starts PostgreSQL, Redis, and
+  MinIO automatically. The server, Studio, and studio-example app run via `bun
+  run dev`.
 </Note>
 
 ## Technology Stack
 
 Every technology choice has a specific justification. The table below documents the role and rationale for each dependency.
 
-| Technology | Version | Role | Why |
-| --- | --- | --- | --- |
-| **Bun** | 1.3+ | Runtime | Fast startup, native TypeScript execution, built-in test runner. |
-| **TypeScript** | 5.9 | Language | End-to-end type safety across server, CLI, SDK, and Studio. |
-| **Nx** | 22.5 | Monorepo orchestration | Task caching, dependency graph, parallel builds. |
-| **Elysia** | 1.4 | HTTP framework | End-to-end type safety with Bun-native performance. |
-| **PostgreSQL** | 15+ | Primary database | JSONB for frontmatter, full-text search, append-only versioning via `documentVersions`. |
-| **Drizzle ORM** | 0.45 | Database access | Schema-as-code migrations, type-safe query builder. |
-| **better-auth** | 1.5 | Authentication | Session management, OIDC/SAML SSO, CSRF protection. |
-| **Redis** | 7 | Cache / rate limiting | Session cache, login backoff tracking. |
-| **S3 (MinIO dev)** | -- | Media storage | Stores uploaded images and files. MinIO provides local S3-compatible development. |
-| **React** | 19 | Studio UI | Component model for the embeddable CMS editor. |
-| **Next.js** | 15.2 | Studio host | Server-rendered Studio example app and review environment. |
-| **TailwindCSS** | 4.2 | Styling | Utility-first CSS for consistent Studio design. |
-| **TipTap** | 3.7 | Rich text editor | Extensible, ProseMirror-based MDX editing with custom node support. |
-| **Radix UI** | -- | Accessible primitives | Headless UI components for dialogs, menus, popovers, and form controls. |
-| **Zod** | 4.3 | Validation | Schema definition with Standard Schema interface for cross-boundary validation. |
+| Technology         | Version | Role                   | Why                                                                                     |
+| ------------------ | ------- | ---------------------- | --------------------------------------------------------------------------------------- |
+| **Bun**            | 1.3+    | Runtime                | Fast startup, native TypeScript execution, built-in test runner.                        |
+| **TypeScript**     | 5.9     | Language               | End-to-end type safety across server, CLI, SDK, and Studio.                             |
+| **Nx**             | 22.5    | Monorepo orchestration | Task caching, dependency graph, parallel builds.                                        |
+| **Elysia**         | 1.4     | HTTP framework         | End-to-end type safety with Bun-native performance.                                     |
+| **PostgreSQL**     | 15+     | Primary database       | JSONB for frontmatter, full-text search, append-only versioning via `documentVersions`. |
+| **Drizzle ORM**    | 0.45    | Database access        | Schema-as-code migrations, type-safe query builder.                                     |
+| **better-auth**    | 1.5     | Authentication         | Session management, OIDC/SAML SSO, CSRF protection.                                     |
+| **Redis**          | 7       | Cache / rate limiting  | Session cache, login backoff tracking.                                                  |
+| **S3 (MinIO dev)** | --      | Media storage          | Stores uploaded images and files. MinIO provides local S3-compatible development.       |
+| **React**          | 19      | Studio UI              | Component model for the embeddable CMS editor.                                          |
+| **Next.js**        | 15.2    | Studio host            | Server-rendered Studio example app and review environment.                              |
+| **TailwindCSS**    | 4.2     | Styling                | Utility-first CSS for consistent Studio design.                                         |
+| **TipTap**         | 3.7     | Rich text editor       | Extensible, ProseMirror-based MDX editing with custom node support.                     |
+| **Radix UI**       | --      | Accessible primitives  | Headless UI components for dialogs, menus, popovers, and form controls.                 |
+| **Zod**            | 4.3     | Validation             | Schema definition with Standard Schema interface for cross-boundary validation.         |
 
 ## Monorepo Structure
 
@@ -121,5 +123,6 @@ graph LR
 ```
 
 <Tip>
-Run `bun nx graph` at the repository root to see the live, interactive dependency graph in your browser.
+  Run `bun nx graph` at the repository root to see the live, interactive
+  dependency graph in your browser.
 </Tip>

--- a/apps/docs/architecture/request-flow.mdx
+++ b/apps/docs/architecture/request-flow.mdx
@@ -39,16 +39,16 @@ sequenceDiagram
     Envelope->>Client: Standard JSON response
 ```
 
-| Stage | Responsibility |
-| --- | --- |
-| **1. CORS** | Validates the `Origin` header against `MDCMS_STUDIO_ALLOWED_ORIGINS`. Handles `OPTIONS` preflight requests for Studio browser routes. Rejects disallowed origins with `403 FORBIDDEN_ORIGIN`. |
-| **2. Request Logging** | Captures request metadata (method, URL, timing) for observability. |
-| **3. CSRF** | For cookie-authenticated mutations, verifies the `X-MDCMS-CSRF-Token` header matches the `mdcms_csrf` cookie. API key requests bypass CSRF since they use `Authorization` headers. |
-| **4. Authentication** | Identifies the calling principal -- either an API key (via `Authorization: Bearer mdcms_key_...`) or a session (via cookie). |
-| **5. Target Routing** | Validates that scoped routes include the required `X-MDCMS-Project` and/or `X-MDCMS-Environment` headers. Returns `400` if headers are missing. |
-| **6. Authorization** | Checks the authenticated principal's permissions against the requirements of the target route (scope, role, resource path). |
-| **7. Route Handler** | Executes the business logic (content CRUD, schema sync, media upload, etc.). |
-| **8. Response Envelope** | Wraps the result in a standard JSON response format with appropriate status codes and CORS headers. |
+| Stage                    | Responsibility                                                                                                                                                                                |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. CORS**              | Validates the `Origin` header against `MDCMS_STUDIO_ALLOWED_ORIGINS`. Handles `OPTIONS` preflight requests for Studio browser routes. Rejects disallowed origins with `403 FORBIDDEN_ORIGIN`. |
+| **2. Request Logging**   | Captures request metadata (method, URL, timing) for observability.                                                                                                                            |
+| **3. CSRF**              | For cookie-authenticated mutations, verifies the `X-MDCMS-CSRF-Token` header matches the `mdcms_csrf` cookie. API key requests bypass CSRF since they use `Authorization` headers.            |
+| **4. Authentication**    | Identifies the calling principal -- either an API key (via `Authorization: Bearer mdcms_key_...`) or a session (via cookie).                                                                  |
+| **5. Target Routing**    | Validates that scoped routes include the required `X-MDCMS-Project` and/or `X-MDCMS-Environment` headers. Returns `400` if headers are missing.                                               |
+| **6. Authorization**     | Checks the authenticated principal's permissions against the requirements of the target route (scope, role, resource path).                                                                   |
+| **7. Route Handler**     | Executes the business logic (content CRUD, schema sync, media upload, etc.).                                                                                                                  |
+| **8. Response Envelope** | Wraps the result in a standard JSON response format with appropriate status codes and CORS headers.                                                                                           |
 
 ## Authentication Flows
 
@@ -84,13 +84,18 @@ The CLI authenticates via a device-authorization-like flow:
 
 <Steps>
   <Step title="Challenge creation">
-    The CLI creates a login challenge with a 10-minute TTL, specifying the target project, environment, redirect URI, and requested scopes.
+    The CLI creates a login challenge with a 10-minute TTL, specifying the
+    target project, environment, redirect URI, and requested scopes.
   </Step>
   <Step title="Browser authorization">
-    The user opens a browser URL, authenticates via session (password/OIDC/SAML), and authorizes the CLI challenge. The challenge status transitions from `pending` to `authorized`.
+    The user opens a browser URL, authenticates via session
+    (password/OIDC/SAML), and authorizes the CLI challenge. The challenge status
+    transitions from `pending` to `authorized`.
   </Step>
   <Step title="Code exchange">
-    The CLI polls for the authorization code, exchanges it for a scoped API key, and stores the credentials locally. The challenge status transitions from `authorized` to `exchanged`.
+    The CLI polls for the authorization code, exchanges it for a scoped API key,
+    and stores the credentials locally. The challenge status transitions from
+    `authorized` to `exchanged`.
   </Step>
 </Steps>
 
@@ -104,67 +109,68 @@ MDCMS implements role-based access control with hierarchical scoping.
 
 Roles form an ordered hierarchy. Higher roles inherit all capabilities of lower roles.
 
-| Role | Level | Scope Restriction |
-| --- | --- | --- |
-| `viewer` | 0 | Global, project, or folder prefix |
-| `editor` | 1 | Global, project, or folder prefix |
-| `admin` | 2 | Global only |
-| `owner` | 3 | Global only |
+| Role     | Level | Scope Restriction                 |
+| -------- | ----- | --------------------------------- |
+| `viewer` | 0     | Global, project, or folder prefix |
+| `editor` | 1     | Global, project, or folder prefix |
+| `admin`  | 2     | Global only                       |
+| `owner`  | 3     | Global only                       |
 
 <Note>
-`admin` and `owner` roles are restricted to global scope by a database check constraint. They cannot be scoped to a specific project or folder prefix.
+  `admin` and `owner` roles are restricted to global scope by a database check
+  constraint. They cannot be scoped to a specific project or folder prefix.
 </Note>
 
 ### Scopes
 
 Each RBAC grant is bound to a scope that determines where the role applies:
 
-| Scope Kind | Fields Required | Meaning |
-| --- | --- | --- |
-| `global` | None | Applies to all projects and environments. |
-| `project` | `project` | Applies to all environments within a specific project. |
+| Scope Kind      | Fields Required                        | Meaning                                                                                                      |
+| --------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `global`        | None                                   | Applies to all projects and environments.                                                                    |
+| `project`       | `project`                              | Applies to all environments within a specific project.                                                       |
 | `folder_prefix` | `project`, `environment`, `pathPrefix` | Applies only to documents whose path starts with the given prefix within a specific project and environment. |
 
 ### Role Capability Matrix
 
-| Capability | `viewer` | `editor` | `admin` | `owner` |
-| --- | --- | --- | --- | --- |
-| `content:read` | Yes | Yes | Yes | Yes |
-| `content:read:draft` | -- | Yes | Yes | Yes |
-| `content:write` | -- | Yes | Yes | Yes |
-| `content:publish` | -- | Yes | Yes | Yes |
-| `content:unpublish` | -- | Yes | Yes | Yes |
-| `content:delete` | -- | Yes | Yes | Yes |
-| `schema:read` | Yes | Yes | Yes | Yes |
-| `schema:write` | -- | -- | Yes | Yes |
-| `projects:read` | Yes | Yes | Yes | Yes |
-| `projects:write` | -- | -- | Yes | Yes |
-| `user:manage` | -- | -- | Yes | Yes |
-| `settings:manage` | -- | -- | Yes | Yes |
+| Capability           | `viewer` | `editor` | `admin` | `owner` |
+| -------------------- | -------- | -------- | ------- | ------- |
+| `content:read`       | Yes      | Yes      | Yes     | Yes     |
+| `content:read:draft` | --       | Yes      | Yes     | Yes     |
+| `content:write`      | --       | Yes      | Yes     | Yes     |
+| `content:publish`    | --       | Yes      | Yes     | Yes     |
+| `content:unpublish`  | --       | Yes      | Yes     | Yes     |
+| `content:delete`     | --       | Yes      | Yes     | Yes     |
+| `schema:read`        | Yes      | Yes      | Yes     | Yes     |
+| `schema:write`       | --       | --       | Yes     | Yes     |
+| `projects:read`      | Yes      | Yes      | Yes     | Yes     |
+| `projects:write`     | --       | --       | Yes     | Yes     |
+| `user:manage`        | --       | --       | Yes     | Yes     |
+| `settings:manage`    | --       | --       | Yes     | Yes     |
 
 ## API Key Scopes
 
 API keys use a fine-grained scope model independent of RBAC roles. Each key declares which operations it is permitted to perform.
 
-| Scope | Description |
-| --- | --- |
-| `content:read` | Read published content documents. |
-| `content:read:draft` | Read draft (unpublished) content documents. |
-| `content:write` | Create and update content documents. |
-| `content:write:draft` | Legacy scope for draft writes (aliases `content:write`). |
-| `content:publish` | Publish documents (create immutable version snapshots). |
-| `content:delete` | Soft-delete and restore content documents. |
-| `schema:read` | Read schema registry entries and sync state. |
-| `schema:write` | Sync schema changes to the server. |
-| `media:upload` | Upload media files to S3 storage. |
-| `media:delete` | Delete media files. |
-| `webhooks:read` | List and inspect webhook configurations. |
-| `webhooks:write` | Create, update, and delete webhook configurations. |
-| `environments:clone` | Clone content between environments. |
-| `environments:promote` | Promote content from one environment to another. |
-| `migrations:run` | Execute content migrations. |
-| `projects:read` | Read project metadata. |
-| `projects:write` | Update project settings. |
+| Scope                  | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `content:read`         | Read published content documents.                        |
+| `content:read:draft`   | Read draft (unpublished) content documents.              |
+| `content:write`        | Create and update content documents.                     |
+| `content:write:draft`  | Legacy scope for draft writes (aliases `content:write`). |
+| `content:publish`      | Publish documents (create immutable version snapshots).  |
+| `content:delete`       | Soft-delete and restore content documents.               |
+| `schema:read`          | Read schema registry entries and sync state.             |
+| `schema:write`         | Sync schema changes to the server.                       |
+| `media:upload`         | Upload media files to S3 storage.                        |
+| `media:delete`         | Delete media files.                                      |
+| `webhooks:read`        | List and inspect webhook configurations.                 |
+| `webhooks:write`       | Create, update, and delete webhook configurations.       |
+| `environments:clone`   | Clone content between environments.                      |
+| `environments:promote` | Promote content from one environment to another.         |
+| `migrations:run`       | Execute content migrations.                              |
+| `projects:read`        | Read project metadata.                                   |
+| `projects:write`       | Update project settings.                                 |
 
 <Warning>
 API keys are scoped to specific project/environment pairs via the `contextAllowlist`. A key with `content:read` scope but an allowlist of `[{project: "docs", environment: "production"}]` cannot read content from any other project or environment.
@@ -243,5 +249,7 @@ MDCMS_STUDIO_ALLOWED_ORIGINS=http://localhost:4173,https://admin.example.com
 The server validates that the `Origin` header matches either the request's own origin (same-origin) or one of the configured allowed origins. Requests from disallowed origins receive a `403 FORBIDDEN_ORIGIN` response. Preflight `OPTIONS` requests are handled automatically with the appropriate `access-control-allow-*` headers.
 
 <Tip>
-In local development, the default docker-compose configuration sets `MDCMS_STUDIO_ALLOWED_ORIGINS` to the studio-example dev server origin. Add additional origins when embedding Studio in a separate application.
+  In local development, the default docker-compose configuration sets
+  `MDCMS_STUDIO_ALLOWED_ORIGINS` to the studio-example dev server origin. Add
+  additional origins when embedding Studio in a separate application.
 </Tip>

--- a/apps/docs/development/contributing.mdx
+++ b/apps/docs/development/contributing.mdx
@@ -14,6 +14,7 @@ This page covers everything you need to know about contributing to MDCMS, from b
     ```bash
     git checkout -b feat/my-feature
     ```
+
   </Step>
   <Step title="Develop with tests">
     Write failing tests first, then implement until they pass. Run unit tests during development for fast feedback:
@@ -21,6 +22,7 @@ This page covers everything you need to know about contributing to MDCMS, from b
     ```bash
     bun run unit
     ```
+
   </Step>
   <Step title="Verify everything passes">
     Before committing, run the full CI gate:
@@ -30,6 +32,7 @@ This page covers everything you need to know about contributing to MDCMS, from b
     ```
 
     This runs format check, typecheck, unit tests, and integration tests sequentially.
+
   </Step>
   <Step title="Commit with conventional commits">
     ```bash
@@ -42,12 +45,12 @@ This page covers everything you need to know about contributing to MDCMS, from b
 
 All branches follow a `type/kebab-case-description` pattern:
 
-| Prefix | Use for |
-|--------|---------|
-| `feat/` | New features |
-| `fix/` | Bug fixes |
-| `chore/` | Maintenance, dependency updates, config changes |
-| `refactor/` | Code restructuring without behavior changes |
+| Prefix      | Use for                                         |
+| ----------- | ----------------------------------------------- |
+| `feat/`     | New features                                    |
+| `fix/`      | Bug fixes                                       |
+| `chore/`    | Maintenance, dependency updates, config changes |
+| `refactor/` | Code restructuring without behavior changes     |
 
 Examples: `feat/media-upload-drag-drop`, `fix/reference-resolution-null`, `chore/bump-elysia`.
 
@@ -59,18 +62,19 @@ Commits follow the conventional commits format:
 type(scope): brief message
 ```
 
-| Type | Use for |
-|------|---------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `chore` | Maintenance task |
-| `refactor` | Code restructuring |
-| `docs` | Documentation changes |
-| `test` | Test additions or modifications |
+| Type       | Use for                         |
+| ---------- | ------------------------------- |
+| `feat`     | New feature                     |
+| `fix`      | Bug fix                         |
+| `chore`    | Maintenance task                |
+| `refactor` | Code restructuring              |
+| `docs`     | Documentation changes           |
+| `test`     | Test additions or modifications |
 
 The **scope** is the package name or area of the codebase (e.g., `server`, `studio`, `cli`, `shared`, `sdk`, `modules`).
 
 Rules:
+
 - First line only -- no body, no footer
 - Keep the message concise and descriptive
 - Use imperative mood ("add feature" not "added feature")
@@ -87,6 +91,7 @@ git commit -m "fixed stuff"
 git commit -m "feat: update"
 git commit -m "WIP"
 ```
+
 </CodeGroup>
 
 ## Code Conventions
@@ -107,12 +112,12 @@ bun run format
 
 ### Naming
 
-| Entity | Convention | Example |
-|--------|-----------|---------|
-| Files | kebab-case | `content-api.ts` |
-| Types / Interfaces | PascalCase | `ContentDocument` |
-| Functions / Variables | camelCase | `getDocument` |
-| Constants | SCREAMING_SNAKE_CASE | `MAX_LIMIT` |
+| Entity                | Convention           | Example           |
+| --------------------- | -------------------- | ----------------- |
+| Files                 | kebab-case           | `content-api.ts`  |
+| Types / Interfaces    | PascalCase           | `ContentDocument` |
+| Functions / Variables | camelCase            | `getDocument`     |
+| Constants             | SCREAMING_SNAKE_CASE | `MAX_LIMIT`       |
 
 - No abbreviations except widely known ones (`id`, `url`, `ctx`)
 - Self-documenting names -- comments explain "why", not "what"
@@ -132,6 +137,7 @@ bun run format
     ```bash
     git push -u origin feat/my-feature
     ```
+
   </Step>
   <Step title="CI runs automatically">
     GitHub Actions runs the full CI pipeline on every PR. All required checks must pass before merge.
@@ -160,9 +166,13 @@ This runs the following checks sequentially:
 4. **Integration tests** -- Runs integration tests (requires Docker services running)
 
 <Warning>
-The pre-push hook blocks the push if any check fails. Fix all failures before pushing. Do not skip the hook with `--no-verify` unless you have a specific reason.
+  The pre-push hook blocks the push if any check fails. Fix all failures before
+  pushing. Do not skip the hook with `--no-verify` unless you have a specific
+  reason.
 </Warning>
 
 <Tip>
-Run `bun run quality` (format + typecheck) as a quick sanity check during development. Save the full `bun run ci:required` for when you are ready to push.
+  Run `bun run quality` (format + typecheck) as a quick sanity check during
+  development. Save the full `bun run ci:required` for when you are ready to
+  push.
 </Tip>

--- a/apps/docs/development/packages.mdx
+++ b/apps/docs/development/packages.mdx
@@ -37,11 +37,11 @@ graph TD
 
 ### apps/server
 
-| | |
-|---|---|
-| **Package** | `@mdcms/server` |
-| **Entry** | `src/index.ts` |
-| **Port** | 4000 |
+|                 |                     |
+| --------------- | ------------------- |
+| **Package**     | `@mdcms/server`     |
+| **Entry**       | `src/index.ts`      |
+| **Port**        | 4000                |
 | **Dev command** | `bun nx dev server` |
 
 The Elysia HTTP server is the core of MDCMS. It exposes the REST API for content CRUD, schema registry, authentication, media uploads, webhooks, and environment management.
@@ -50,36 +50,36 @@ Key dependencies: Elysia, Drizzle ORM, better-auth, `@mdcms/shared`, `@mdcms/mod
 
 ### apps/cli
 
-| | |
-|---|---|
-| **Package** | `@mdcms/cli` |
-| **Binary** | `mdcms` |
+|                 |                  |
+| --------------- | ---------------- |
+| **Package**     | `@mdcms/cli`     |
+| **Binary**      | `mdcms`          |
 | **Dev command** | `bun nx dev cli` |
 
 The command-line tool for managing MDCMS projects from your terminal or CI/CD pipelines.
 
 Available commands:
 
-| Command | Description |
-|---------|-------------|
-| `init` | Interactive project setup wizard |
-| `login` | Authenticate via browser OAuth flow |
-| `logout` | Clear stored credentials |
-| `push` | Push local content to the server |
-| `pull` | Pull content from the server to local files |
-| `schema-sync` | Sync schema definitions to the server |
-| `status` | Show sync status between local and server |
-| `migrate` | Run content migrations |
+| Command       | Description                                 |
+| ------------- | ------------------------------------------- |
+| `init`        | Interactive project setup wizard            |
+| `login`       | Authenticate via browser OAuth flow         |
+| `logout`      | Clear stored credentials                    |
+| `push`        | Push local content to the server            |
+| `pull`        | Pull content from the server to local files |
+| `schema-sync` | Sync schema definitions to the server       |
+| `status`      | Show sync status between local and server   |
+| `migrate`     | Run content migrations                      |
 
 Dependencies: `@mdcms/shared`, `@mdcms/modules`.
 
 ### apps/studio-example
 
-| | |
-|---|---|
-| **Package** | `@mdcms/studio-example` |
-| **Framework** | Next.js 15.2 |
-| **Port** | 4173 |
+|                 |                             |
+| --------------- | --------------------------- |
+| **Package**     | `@mdcms/studio-example`     |
+| **Framework**   | Next.js 15.2                |
+| **Port**        | 4173                        |
 | **Dev command** | `bun nx dev studio-example` |
 
 A demo Next.js application that embeds the `<Studio />` component from `@mdcms/studio`. Used for local development and testing of the Studio UI. Not published to any registry.
@@ -88,10 +88,10 @@ Dependencies: `@mdcms/studio`, `@mdcms/sdk`.
 
 ### apps/studio-review
 
-| | |
-|---|---|
-| **Package** | `@mdcms/studio-review` |
-| **Port** | 3000 |
+|                 |                            |
+| --------------- | -------------------------- |
+| **Package**     | `@mdcms/studio-review`     |
+| **Port**        | 3000                       |
 | **Dev command** | `bun nx dev studio-review` |
 
 An internal visual review application that renders deterministic scenarios for PR review. Deployed as a standalone Vercel deployment, allowing reviewers to see UI changes across predefined states without needing a full local setup.
@@ -102,76 +102,76 @@ Dependencies: `@mdcms/studio`.
 
 ### packages/shared
 
-| | |
-|---|---|
+|             |                 |
+| ----------- | --------------- |
 | **Package** | `@mdcms/shared` |
 
 The foundational package that all other packages depend on. Contains contracts, types, and utilities shared across the entire monorepo.
 
 Key exports:
 
-| Export | Purpose |
-|--------|---------|
-| `defineConfig` | Configuration builder for `mdcms.config.ts` |
-| `defineType` | Content type definition helper |
-| `reference` | Typed reference field helper |
-| `API_V1_BASE_PATH` | API version path constant |
-| `RuntimeError` | Base error class for structured errors |
-| Content response types | TypeScript types for API responses |
-| Schema types | TypeScript types for schema definitions |
+| Export                 | Purpose                                     |
+| ---------------------- | ------------------------------------------- |
+| `defineConfig`         | Configuration builder for `mdcms.config.ts` |
+| `defineType`           | Content type definition helper              |
+| `reference`            | Typed reference field helper                |
+| `API_V1_BASE_PATH`     | API version path constant                   |
+| `RuntimeError`         | Base error class for structured errors      |
+| Content response types | TypeScript types for API responses          |
+| Schema types           | TypeScript types for schema definitions     |
 
 ### packages/sdk
 
-| | |
-|---|---|
+|             |              |
+| ----------- | ------------ |
 | **Package** | `@mdcms/sdk` |
 
 The TypeScript client SDK for querying MDCMS content from your application at build time or runtime.
 
 Key exports:
 
-| Export | Purpose |
-|--------|---------|
-| `createClient` | Factory function to create a configured MDCMS client |
-| `MdcmsApiError` | Error class for API-level errors |
+| Export             | Purpose                                               |
+| ------------------ | ----------------------------------------------------- |
+| `createClient`     | Factory function to create a configured MDCMS client  |
+| `MdcmsApiError`    | Error class for API-level errors                      |
 | `MdcmsClientError` | Error class for client-level errors (network, config) |
 
 Dependencies: `@mdcms/shared`.
 
 ### packages/studio
 
-| | |
-|---|---|
+|             |                 |
+| ----------- | --------------- |
 | **Package** | `@mdcms/studio` |
 
 The embeddable React UI component that provides the full visual editing experience -- dashboard, content editor, media management, and settings.
 
 Built with:
 
-| Library | Purpose |
-|---------|---------|
-| React 19 | UI framework |
-| TipTap 3.7 | Rich text / MDX editor |
-| Radix UI | Accessible component primitives |
-| TailwindCSS | Styling |
-| TanStack React Query | Server state management |
-| Lucide | Icon library |
+| Library              | Purpose                         |
+| -------------------- | ------------------------------- |
+| React 19             | UI framework                    |
+| TipTap 3.7           | Rich text / MDX editor          |
+| Radix UI             | Accessible component primitives |
+| TailwindCSS          | Styling                         |
+| TanStack React Query | Server state management         |
+| Lucide               | Icon library                    |
 
 Dependencies: `@mdcms/shared`.
 
 ### packages/modules
 
-| | |
-|---|---|
+|             |                  |
+| ----------- | ---------------- |
 | **Package** | `@mdcms/modules` |
 
 The module registry that provides extensibility. Modules can register server actions, CLI commands, and Studio UI extensions.
 
 Built-in modules:
 
-| Module | Description |
-|--------|-------------|
-| `core.system` | Core system functionality |
+| Module           | Description               |
+| ---------------- | ------------------------- |
+| `core.system`    | Core system functionality |
 | `domain.content` | Content domain operations |
 
 Dependencies: `@mdcms/shared`.

--- a/apps/docs/development/setup.mdx
+++ b/apps/docs/development/setup.mdx
@@ -6,19 +6,20 @@ description: "Prerequisites, installation, environment variables, and running MD
 This guide walks you through setting up a local MDCMS development environment from scratch for **contributing to MDCMS itself**. By the end, you will have all services running and be ready to develop.
 
 <Note>
-  If you want to use MDCMS in your own project (not contribute to the MDCMS codebase), see the [Quick Start](/guide/quickstart) instead.
+  If you want to use MDCMS in your own project (not contribute to the MDCMS
+  codebase), see the [Quick Start](/guide/quickstart) instead.
 </Note>
 
 ## Prerequisites
 
 Before you begin, install the following tools:
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| **Bun** | 1.3.11+ (pinned in `.bun-version`) | Package manager, runtime, and test runner |
-| **Docker & Docker Compose** | Latest stable | Infrastructure services (PostgreSQL, Redis, MinIO) |
-| **Node.js** | 20+ | Required for Next.js apps (studio-example, studio-review) |
-| **Git** | Latest stable | Source control |
+| Tool                        | Version                            | Purpose                                                   |
+| --------------------------- | ---------------------------------- | --------------------------------------------------------- |
+| **Bun**                     | 1.3.11+ (pinned in `.bun-version`) | Package manager, runtime, and test runner                 |
+| **Docker & Docker Compose** | Latest stable                      | Infrastructure services (PostgreSQL, Redis, MinIO)        |
+| **Node.js**                 | 20+                                | Required for Next.js apps (studio-example, studio-review) |
+| **Git**                     | Latest stable                      | Source control                                            |
 
 <Tabs>
   <Tab title="macOS">
@@ -33,6 +34,7 @@ Before you begin, install the following tools:
     brew install nvm
     nvm install 20
     ```
+
   </Tab>
   <Tab title="Linux">
     ```bash
@@ -46,32 +48,29 @@ Before you begin, install the following tools:
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
     nvm install 20
     ```
+
   </Tab>
 </Tabs>
 
 <Note>
-The repository includes a `.bun-version` file that pins Bun to 1.3.11. If you use a version manager like `mise` or `proto`, it will pick this up automatically.
+  The repository includes a `.bun-version` file that pins Bun to 1.3.11. If you
+  use a version manager like `mise` or `proto`, it will pick this up
+  automatically.
 </Note>
 
 ## Clone & Install
 
 <Steps>
   <Step title="Clone the repository">
-    ```bash
-    git clone git@github.com:Blazity/mdcms.git && cd mdcms
-    ```
+    ```bash git clone git@github.com:Blazity/mdcms.git && cd mdcms ```
   </Step>
   <Step title="Install dependencies">
-    ```bash
-    bun install
-    ```
-    This also sets up the pre-push git hook that runs CI checks before every push.
+    ```bash bun install ``` This also sets up the pre-push git hook that runs CI
+    checks before every push.
   </Step>
   <Step title="Copy environment file">
-    ```bash
-    cp .env.example .env
-    ```
-    Edit `.env` to override any defaults for your local setup. See the environment variables section below.
+    ```bash cp .env.example .env ``` Edit `.env` to override any defaults for
+    your local setup. See the environment variables section below.
   </Step>
 </Steps>
 
@@ -81,47 +80,49 @@ The repository includes a `.bun-version` file that pins Bun to 1.3.11. If you us
 
 These must be set for the server to start.
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://postgres:postgres@localhost:5432/mdcms` |
-| `REDIS_URL` | Redis connection string | `redis://localhost:6379` |
-| `S3_ENDPOINT` | S3-compatible storage endpoint | `http://localhost:9000` |
-| `S3_ACCESS_KEY` | S3 access key | `minioadmin` |
-| `S3_SECRET_KEY` | S3 secret key | `minioadmin` |
-| `S3_BUCKET` | S3 bucket name | `mdcms` |
+| Variable        | Description                    | Example                                               |
+| --------------- | ------------------------------ | ----------------------------------------------------- |
+| `DATABASE_URL`  | PostgreSQL connection string   | `postgresql://postgres:postgres@localhost:5432/mdcms` |
+| `REDIS_URL`     | Redis connection string        | `redis://localhost:6379`                              |
+| `S3_ENDPOINT`   | S3-compatible storage endpoint | `http://localhost:9000`                               |
+| `S3_ACCESS_KEY` | S3 access key                  | `minioadmin`                                          |
+| `S3_SECRET_KEY` | S3 secret key                  | `minioadmin`                                          |
+| `S3_BUCKET`     | S3 bucket name                 | `mdcms`                                               |
 
 ### Server
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `PORT` | Server listen port | `4000` |
-| `NODE_ENV` | Runtime environment | `development` |
-| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `debug` |
+| Variable    | Description                                      | Example       |
+| ----------- | ------------------------------------------------ | ------------- |
+| `PORT`      | Server listen port                               | `4000`        |
+| `NODE_ENV`  | Runtime environment                              | `development` |
+| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `debug`       |
 
 ### Studio
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `MDCMS_STUDIO_ALLOWED_ORIGINS` | CORS allowed origins for Studio | `http://localhost:4173` |
-| `MDCMS_AUTH_INSECURE_COOKIES` | Allow HTTP cookies in dev (no HTTPS) | `true` |
+| Variable                       | Description                          | Example                 |
+| ------------------------------ | ------------------------------------ | ----------------------- |
+| `MDCMS_STUDIO_ALLOWED_ORIGINS` | CORS allowed origins for Studio      | `http://localhost:4173` |
+| `MDCMS_AUTH_INSECURE_COOKIES`  | Allow HTTP cookies in dev (no HTTPS) | `true`                  |
 
 ### Auth Providers (optional)
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `MDCMS_AUTH_OIDC_PROVIDERS` | OIDC provider configuration (JSON) | |
-| `MDCMS_AUTH_SAML_PROVIDERS` | SAML provider configuration (JSON) | |
+| Variable                    | Description                        | Example |
+| --------------------------- | ---------------------------------- | ------- |
+| `MDCMS_AUTH_OIDC_PROVIDERS` | OIDC provider configuration (JSON) |         |
+| `MDCMS_AUTH_SAML_PROVIDERS` | SAML provider configuration (JSON) |         |
 
 ### Demo
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `MDCMS_DEMO_API_KEY` | API key for demo seed data | `mdcms_key_demo_local_compose_seed_2026_read` |
-| `MDCMS_DEMO_PROJECT` | Demo project slug | `marketing-site` |
-| `MDCMS_DEMO_ENVIRONMENT` | Demo environment name | `staging` |
+| Variable                 | Description                | Example                                       |
+| ------------------------ | -------------------------- | --------------------------------------------- |
+| `MDCMS_DEMO_API_KEY`     | API key for demo seed data | `mdcms_key_demo_local_compose_seed_2026_read` |
+| `MDCMS_DEMO_PROJECT`     | Demo project slug          | `marketing-site`                              |
+| `MDCMS_DEMO_ENVIRONMENT` | Demo environment name      | `staging`                                     |
 
 <Tip>
-The Docker Compose dev configuration sets all required variables automatically. You only need to configure `.env` manually if running services outside Docker.
+  The Docker Compose dev configuration sets all required variables
+  automatically. You only need to configure `.env` manually if running services
+  outside Docker.
 </Tip>
 
 ## Start Development
@@ -147,6 +148,7 @@ The Docker Compose dev configuration sets all required variables automatically. 
     ```bash
     docker compose -f docker-compose.dev.yml down
     ```
+
   </Tab>
   <Tab title="Manual">
     Start infrastructure services only, then run apps individually for more control:
@@ -167,6 +169,7 @@ The Docker Compose dev configuration sets all required variables automatically. 
     # Terminal 2: Start the Studio example app
     bun nx dev studio-example
     ```
+
   </Tab>
 </Tabs>
 
@@ -174,38 +177,38 @@ The Docker Compose dev configuration sets all required variables automatically. 
 
 Once running, these services are available:
 
-| Service | URL |
-|---------|-----|
-| Server API | [http://localhost:4000](http://localhost:4000) |
+| Service        | URL                                            |
+| -------------- | ---------------------------------------------- |
+| Server API     | [http://localhost:4000](http://localhost:4000) |
 | Studio Example | [http://localhost:4173](http://localhost:4173) |
-| Studio Review | [http://localhost:3000](http://localhost:3000) |
-| MinIO Console | [http://localhost:9001](http://localhost:9001) |
-| Mailhog | [http://localhost:8025](http://localhost:8025) |
-| PostgreSQL | `localhost:5432` |
-| Redis | `localhost:6379` |
+| Studio Review  | [http://localhost:3000](http://localhost:3000) |
+| MinIO Console  | [http://localhost:9001](http://localhost:9001) |
+| Mailhog        | [http://localhost:8025](http://localhost:8025) |
+| PostgreSQL     | `localhost:5432`                               |
+| Redis          | `localhost:6379`                               |
 
 ## Demo Credentials
 
 The dev seed data creates a demo user you can use to log in to Studio:
 
-| Field | Value |
-|-------|-------|
-| Email | `demo@mdcms.local` |
-| Password | `Demo12345!` |
+| Field    | Value              |
+| -------- | ------------------ |
+| Email    | `demo@mdcms.local` |
+| Password | `Demo12345!`       |
 
 ## Available Commands
 
 These scripts are defined in the root `package.json` and orchestrated by Nx:
 
-| Command | Description |
-|---------|-------------|
-| `bun run dev` | Start the server in development mode |
-| `bun run compose:dev` | Start full dev stack via Docker Compose |
-| `bun run compose:dev:down` | Stop the dev Docker Compose stack |
-| `bun run build` | Build all packages and apps |
-| `bun run typecheck` | Run TypeScript type checking across all packages |
-| `bun run quality` | Run format check + typecheck |
-| `bun run unit` | Run unit tests |
-| `bun run integration` | Run integration tests (requires Docker services) |
-| `bun run ci:required` | Run the full CI gate: format + typecheck + unit + integration |
-| `bun run format` | Format code with Prettier |
+| Command                    | Description                                                   |
+| -------------------------- | ------------------------------------------------------------- |
+| `bun run dev`              | Start the server in development mode                          |
+| `bun run compose:dev`      | Start full dev stack via Docker Compose                       |
+| `bun run compose:dev:down` | Stop the dev Docker Compose stack                             |
+| `bun run build`            | Build all packages and apps                                   |
+| `bun run typecheck`        | Run TypeScript type checking across all packages              |
+| `bun run quality`          | Run format check + typecheck                                  |
+| `bun run unit`             | Run unit tests                                                |
+| `bun run integration`      | Run integration tests (requires Docker services)              |
+| `bun run ci:required`      | Run the full CI gate: format + typecheck + unit + integration |
+| `bun run format`           | Format code with Prettier                                     |

--- a/apps/docs/development/testing.mdx
+++ b/apps/docs/development/testing.mdx
@@ -9,12 +9,12 @@ MDCMS uses Bun's built-in test runner for both unit and integration tests. This 
 
 Unit tests live alongside source files with the `*.test.ts` suffix.
 
-| | |
-|---|---|
-| **Pattern** | `*.test.ts` next to the source file |
-| **Runner** | Bun test (`bun test`) |
-| **Command** | `bun run unit` |
-| **Per-package** | `bun nx test <package>` |
+|                 |                                     |
+| --------------- | ----------------------------------- |
+| **Pattern**     | `*.test.ts` next to the source file |
+| **Runner**      | Bun test (`bun test`)               |
+| **Command**     | `bun run unit`                      |
+| **Per-package** | `bun nx test <package>`             |
 
 Unit tests cover config parsing, validation logic, contracts, SDK methods, and utility functions. They do not require any external services.
 
@@ -31,10 +31,10 @@ bun nx test sdk
 
 Integration tests exercise the full stack -- API endpoints, authentication flows, database operations, and the content lifecycle.
 
-| | |
-|---|---|
+|              |                                                    |
+| ------------ | -------------------------------------------------- |
 | **Requires** | Docker Compose services (PostgreSQL, Redis, MinIO) |
-| **Command** | `bun run integration` |
+| **Command**  | `bun run integration`                              |
 
 <Warning>
 Integration tests require Docker services to be running. Start them before running:
@@ -42,6 +42,7 @@ Integration tests require Docker services to be running. Start them before runni
 ```bash
 docker compose -f docker-compose.dev.yml up -d
 ```
+
 </Warning>
 
 ```bash
@@ -60,6 +61,7 @@ The CI pipeline runs three sequential stages. All must pass before a PR can be m
     ```bash
     bun run quality
     ```
+
   </Step>
   <Step title="Unit tests">
     All unit tests across every package.
@@ -67,6 +69,7 @@ The CI pipeline runs three sequential stages. All must pass before a PR can be m
     ```bash
     bun run unit
     ```
+
   </Step>
   <Step title="Integration tests">
     Full integration test suite. Requires Docker services.
@@ -74,6 +77,7 @@ The CI pipeline runs three sequential stages. All must pass before a PR can be m
     ```bash
     bun run integration
     ```
+
   </Step>
 </Steps>
 
@@ -100,7 +104,10 @@ import { parseConfig } from "./parse-config";
 
 describe("parseConfig", () => {
   test("returns parsed config when input is valid", () => {
-    const result = parseConfig({ project: "my-site", serverUrl: "http://localhost:4000" });
+    const result = parseConfig({
+      project: "my-site",
+      serverUrl: "http://localhost:4000",
+    });
     expect(result.project).toBe("my-site");
   });
 
@@ -111,7 +118,8 @@ describe("parseConfig", () => {
 ```
 
 <Tip>
-Run `bun run unit` during development for fast feedback. Save `bun run integration` for before pushing.
+  Run `bun run unit` during development for fast feedback. Save `bun run
+  integration` for before pushing.
 </Tip>
 
 ## Database Migrations
@@ -125,6 +133,7 @@ MDCMS uses Drizzle ORM for database schema management. Migrations are generated 
     ```
     apps/server/src/lib/db/schema.ts
     ```
+
   </Step>
   <Step title="Generate migration">
     ```bash
@@ -132,6 +141,7 @@ MDCMS uses Drizzle ORM for database schema management. Migrations are generated 
     ```
 
     This creates a new SQL migration file in the `drizzle/` directory.
+
   </Step>
   <Step title="Review the generated SQL">
     Open the generated file in `drizzle/` and verify the SQL matches your intent. Pay attention to destructive operations like column drops or type changes.
@@ -151,9 +161,12 @@ MDCMS uses Drizzle ORM for database schema management. Migrations are generated 
     git add apps/server/src/lib/db/schema.ts drizzle/
     git commit -m "feat(server): add webhook retry columns"
     ```
+
   </Step>
 </Steps>
 
 <Warning>
-Always test migrations against a database with realistic data before deploying to production. A migration that works on an empty database may fail or corrupt data on a populated one.
+  Always test migrations against a database with realistic data before deploying
+  to production. A migration that works on an empty database may fail or corrupt
+  data on a populated one.
 </Warning>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -61,7 +61,13 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["index", "guide/quickstart", "guide/self-hosting", "guide/concepts", "agent-instructions"]
+            "pages": [
+              "index",
+              "guide/quickstart",
+              "guide/self-hosting",
+              "guide/concepts",
+              "agent-instructions"
+            ]
           },
           {
             "group": "Studio",
@@ -128,9 +134,7 @@
           },
           {
             "group": "SDK",
-            "pages": [
-              "api-reference/sdk"
-            ]
+            "pages": ["api-reference/sdk"]
           }
         ]
       },
@@ -139,17 +143,11 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": [
-              "development/setup",
-              "development/packages"
-            ]
+            "pages": ["development/setup", "development/packages"]
           },
           {
             "group": "Contributing",
-            "pages": [
-              "development/contributing",
-              "development/testing"
-            ]
+            "pages": ["development/contributing", "development/testing"]
           }
         ]
       }

--- a/apps/docs/guide/cli/ci-cd.mdx
+++ b/apps/docs/guide/cli/ci-cd.mdx
@@ -9,15 +9,17 @@ The MDCMS CLI is designed for headless operation in CI/CD pipelines. All command
 
 Set these in your CI provider's secret management:
 
-| Variable | Description |
-| --- | --- |
-| `MDCMS_API_KEY` | API key for authentication (replaces `mdcms login`) |
-| `MDCMS_PROJECT` | Target project slug |
-| `MDCMS_ENVIRONMENT` | Target environment name |
-| `MDCMS_SERVER_URL` | MDCMS server URL (overrides `mdcms.config.ts`) |
+| Variable            | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `MDCMS_API_KEY`     | API key for authentication (replaces `mdcms login`) |
+| `MDCMS_PROJECT`     | Target project slug                                 |
+| `MDCMS_ENVIRONMENT` | Target environment name                             |
+| `MDCMS_SERVER_URL`  | MDCMS server URL (overrides `mdcms.config.ts`)      |
 
 <Tip>
-  Create a dedicated API key with minimal scopes for CI use. Schema sync requires `schema:read` and `schema:write`. Content push requires `content:write` and `content:read:draft`.
+  Create a dedicated API key with minimal scopes for CI use. Schema sync
+  requires `schema:read` and `schema:write`. Content push requires
+  `content:write` and `content:read:draft`.
 </Tip>
 
 ## GitHub Actions: Schema sync
@@ -103,7 +105,8 @@ jobs:
 ```
 
 <Note>
-  Schema sync runs before content push to ensure the schema hash is available. Push requires a valid schema hash from a prior sync.
+  Schema sync runs before content push to ensure the schema hash is available.
+  Push requires a valid schema hash from a prior sync.
 </Note>
 
 ## Status check
@@ -158,5 +161,7 @@ jobs:
 ```
 
 <Warning>
-  If `mdcms status` reports drift on a pull request, the author should run `mdcms schema sync` and `mdcms push` locally before merging, or include the schema sync step in the merge workflow.
+  If `mdcms status` reports drift on a pull request, the author should run
+  `mdcms schema sync` and `mdcms push` locally before merging, or include the
+  schema sync step in the merge workflow.
 </Warning>

--- a/apps/docs/guide/cli/commands.mdx
+++ b/apps/docs/guide/cli/commands.mdx
@@ -178,9 +178,11 @@ mdcms push [--force] [--dry-run] [--validate] [--published]
 Push uses optimistic concurrency via the `draftRevision` field. If the server's current revision does not match the manifest's recorded revision, the push for that document is rejected. Run `mdcms pull` to reconcile before retrying.
 
 <Warning>
-  Push requires a valid schema hash from a previous `mdcms schema sync`. If the
-  schema has never been synced or the local hash is missing, the command will
-  fail.
+  Push requires a valid schema hash from a previous `mdcms schema sync` when
+  performing actual writes. If the schema has never been synced or the local
+  hash is missing, write operations will fail. However, dry-run/no-write
+  invocations (e.g., using --dry-run) do not require local schema state and can
+  proceed.
 </Warning>
 
 ---

--- a/apps/docs/guide/cli/commands.mdx
+++ b/apps/docs/guide/cli/commands.mdx
@@ -18,45 +18,52 @@ The wizard runs through the following steps:
     Prompts for the MDCMS server URL and validates it with a health check.
   </Step>
 
-  <Step title="Project selection">
-    Lists existing projects on the server or creates a new one.
-  </Step>
+<Step title="Project selection">
+  Lists existing projects on the server or creates a new one.
+</Step>
 
-  <Step title="OAuth login">
-    Opens a browser window for authentication using the device flow (same mechanism as `mdcms login`).
-  </Step>
+<Step title="OAuth login">
+  Opens a browser window for authentication using the device flow (same
+  mechanism as `mdcms login`).
+</Step>
 
-  <Step title="Environment selection">
-    Choose an existing environment or create one (e.g. `development`, `staging`).
-  </Step>
+<Step title="Environment selection">
+  Choose an existing environment or create one (e.g. `development`, `staging`).
+</Step>
 
-  <Step title="Directory scanning">
-    Recursively scans the repository for `.md` and `.mdx` files and groups them by top-level content directories.
-  </Step>
+<Step title="Directory scanning">
+  Recursively scans the repository for `.md` and `.mdx` files and groups them by
+  top-level content directories.
+</Step>
 
-  <Step title="Locale detection">
-    Analyzes file naming patterns to detect locale suffixes (e.g. `post.en.mdx`, `post.fr.mdx`) and infers default/supported locale configuration.
-  </Step>
+<Step title="Locale detection">
+  Analyzes file naming patterns to detect locale suffixes (e.g. `post.en.mdx`,
+  `post.fr.mdx`) and infers default/supported locale configuration.
+</Step>
 
-  <Step title="Schema inference">
-    Parses frontmatter from discovered files to infer content types and their field schemas using Zod types.
-  </Step>
+<Step title="Schema inference">
+  Parses frontmatter from discovered files to infer content types and their
+  field schemas using Zod types.
+</Step>
 
-  <Step title="Config generation">
-    Writes `mdcms.config.ts` with `defineConfig` and `defineType` calls reflecting all discovered types, directories, and locale settings.
-  </Step>
+<Step title="Config generation">
+  Writes `mdcms.config.ts` with `defineConfig` and `defineType` calls reflecting
+  all discovered types, directories, and locale settings.
+</Step>
 
-  <Step title="Schema sync">
-    Uploads the inferred schema to the server for the selected project/environment.
-  </Step>
+<Step title="Schema sync">
+  Uploads the inferred schema to the server for the selected
+  project/environment.
+</Step>
 
-  <Step title="Content push">
-    Pushes all discovered content files to the server as draft documents and writes the initial manifest.
-  </Step>
+<Step title="Content push">
+  Pushes all discovered content files to the server as draft documents and
+  writes the initial manifest.
+</Step>
 
-  <Step title=".gitignore update">
-    Appends `.mdcms/` and manifest paths to `.gitignore`.
-  </Step>
+<Step title=".gitignore update">
+  Appends `.mdcms/` and manifest paths to `.gitignore`.
+</Step>
 
   <Step title="Untrack managed files">
     Runs `git rm -r --cached` on any managed files that were previously committed to git.
@@ -64,7 +71,8 @@ The wizard runs through the following steps:
 </Steps>
 
 <Note>
-  Running `mdcms init` in a repository that already has an `mdcms.config.ts` will prompt before overwriting.
+  Running `mdcms init` in a repository that already has an `mdcms.config.ts`
+  will prompt before overwriting.
 </Note>
 
 ---
@@ -82,17 +90,19 @@ mdcms login
     The CLI sends a login challenge to the server with a cryptographic state parameter and a loopback redirect URI.
   </Step>
 
-  <Step title="Browser authentication">
-    Your default browser opens the server's authorization page. Complete the login there.
-  </Step>
+<Step title="Browser authentication">
+  Your default browser opens the server's authorization page. Complete the login
+  there.
+</Step>
 
-  <Step title="Receive callback">
-    The CLI listens on a local port for the OAuth callback. The browser redirects back with an authorization code.
-  </Step>
+<Step title="Receive callback">
+  The CLI listens on a local port for the OAuth callback. The browser redirects
+  back with an authorization code.
+</Step>
 
-  <Step title="Exchange for API key">
-    The CLI exchanges the authorization code for a scoped API key.
-  </Step>
+<Step title="Exchange for API key">
+  The CLI exchanges the authorization code for a scoped API key.
+</Step>
 
   <Step title="Store credentials">
     The API key is stored in the local credential store, scoped to the current server/project/environment tuple.
@@ -145,12 +155,12 @@ Upload local content changes to the MDCMS server.
 mdcms push [--force] [--dry-run] [--validate] [--published]
 ```
 
-| Flag | Description |
-| --- | --- |
-| `--force` | Skip all interactive prompts; auto-select all new and deleted files |
-| `--dry-run` | Show the push plan without making any API writes |
-| `--validate` | Validate frontmatter against the local schema before pushing |
-| `--published` | Reserved for future use |
+| Flag          | Description                                                         |
+| ------------- | ------------------------------------------------------------------- |
+| `--force`     | Skip all interactive prompts; auto-select all new and deleted files |
+| `--dry-run`   | Show the push plan without making any API writes                    |
+| `--validate`  | Validate frontmatter against the local schema before pushing        |
+| `--published` | Reserved for future use                                             |
 
 ### How push works
 
@@ -168,7 +178,9 @@ mdcms push [--force] [--dry-run] [--validate] [--published]
 Push uses optimistic concurrency via the `draftRevision` field. If the server's current revision does not match the manifest's recorded revision, the push for that document is rejected. Run `mdcms pull` to reconcile before retrying.
 
 <Warning>
-  Push requires a valid schema hash from a previous `mdcms schema sync`. If the schema has never been synced or the local hash is missing, the command will fail.
+  Push requires a valid schema hash from a previous `mdcms schema sync`. If the
+  schema has never been synced or the local hash is missing, the command will
+  fail.
 </Warning>
 
 ---
@@ -181,29 +193,30 @@ Download content from the MDCMS server to your local filesystem.
 mdcms pull [--published] [--force] [--dry-run]
 ```
 
-| Flag | Description |
-| --- | --- |
-| `--published` | Pull published snapshots instead of draft heads |
-| `--force` | Skip overwrite confirmation for locally modified files |
-| `--dry-run` | Show the pull plan without writing any files |
+| Flag          | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `--published` | Pull published snapshots instead of draft heads        |
+| `--force`     | Skip overwrite confirmation for locally modified files |
+| `--dry-run`   | Show the pull plan without writing any files           |
 
 ### Change categories
 
 The pull command classifies each document into one of these categories:
 
-| Category | Behavior |
-| --- | --- |
-| **Both Modified** | Local and server changes detected. Prompts for confirmation before overwriting |
-| **Server Modified** | Server has newer content. File is updated automatically |
-| **Locally Modified** | Only local changes exist. File is skipped (not overwritten) |
-| **New** | Document exists on server but not locally. File is created |
-| **Moved/Renamed** | Server path differs from manifest path. File is moved to the new location |
+| Category              | Behavior                                                                                  |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| **Both Modified**     | Local and server changes detected. Prompts for confirmation before overwriting            |
+| **Server Modified**   | Server has newer content. File is updated automatically                                   |
+| **Locally Modified**  | Only local changes exist. File is skipped (not overwritten)                               |
+| **New**               | Document exists on server but not locally. File is created                                |
+| **Moved/Renamed**     | Server path differs from manifest path. File is moved to the new location                 |
 | **Deleted on Server** | Document was removed server-side. Prompts for confirmation before deleting the local file |
-| **Unknown Type** | Document type has no matching config entry. Skipped with a warning |
-| **Unchanged** | Content hashes match. No action taken |
+| **Unknown Type**      | Document type has no matching config entry. Skipped with a warning                        |
+| **Unchanged**         | Content hashes match. No action taken                                                     |
 
 <Note>
-  Use `--force` to skip confirmation prompts in non-interactive environments (e.g. CI pipelines). Locally modified files will be overwritten.
+  Use `--force` to skip confirmation prompts in non-interactive environments
+  (e.g. CI pipelines). Locally modified files will be overwritten.
 </Note>
 
 ---
@@ -234,7 +247,9 @@ mdcms schema sync --environment staging
 ```
 
 <Warning>
-  At least one content type must be defined in `mdcms.config.ts` before running schema sync. The command will fail with a `NO_TYPES_DEFINED` error if the `types` array is empty.
+  At least one content type must be defined in `mdcms.config.ts` before running
+  schema sync. The command will fail with a `NO_TYPES_DEFINED` error if the
+  `types` array is empty.
 </Warning>
 
 ---
@@ -254,25 +269,26 @@ The status command reports:
 
 ### Drift categories
 
-| Category | Description |
-| --- | --- |
+| Category             | Description                                              |
+| -------------------- | -------------------------------------------------------- |
 | `modified_on_server` | Server has newer content than the local manifest records |
-| `modified_locally` | Local file has changed since last push/pull |
-| `both_modified` | Both local and server content have diverged |
-| `new_on_server` | Document exists on server but not in the local manifest |
-| `deleted_on_server` | Document is in the manifest but no longer on the server |
-| `moved_renamed` | Server path differs from the manifest path |
-| `unchanged` | Everything is in sync |
+| `modified_locally`   | Local file has changed since last push/pull              |
+| `both_modified`      | Both local and server content have diverged              |
+| `new_on_server`      | Document exists on server but not in the local manifest  |
+| `deleted_on_server`  | Document is in the manifest but no longer on the server  |
+| `moved_renamed`      | Server path differs from the manifest path               |
+| `unchanged`          | Everything is in sync                                    |
 
 ### Exit codes
 
-| Code | Meaning |
-| --- | --- |
-| `0` | Everything is in sync |
-| `1` | Drift detected (content or schema) |
+| Code | Meaning                            |
+| ---- | ---------------------------------- |
+| `0`  | Everything is in sync              |
+| `1`  | Drift detected (content or schema) |
 
 <Tip>
-  Use `mdcms status` in CI pipelines as a gate. A non-zero exit code can block deployments when content or schema is out of sync.
+  Use `mdcms status` in CI pipelines as a gate. A non-zero exit code can block
+  deployments when content or schema is out of sync.
 </Tip>
 
 ---
@@ -285,8 +301,8 @@ Generate and apply content migrations when the schema changes.
 mdcms migrate [--apply]
 ```
 
-| Flag | Description |
-| --- | --- |
+| Flag      | Description                                                   |
+| --------- | ------------------------------------------------------------- |
 | `--apply` | Execute the generated migration instead of just previewing it |
 
 ### How migrations work
@@ -297,5 +313,6 @@ mdcms migrate [--apply]
 4. **Apply** — With `--apply`, each document is transformed and pushed as a new draft revision. If the document was previously published, a new version is auto-published
 
 <Note>
-  Migrations are forward-only. Always review the preview output before running with `--apply`.
+  Migrations are forward-only. Always review the preview output before running
+  with `--apply`.
 </Note>

--- a/apps/docs/guide/cli/configuration.mdx
+++ b/apps/docs/guide/cli/configuration.mdx
@@ -68,34 +68,34 @@ export default defineConfig({
 
 All properties accepted by `defineConfig`:
 
-| Property | Type | Required | Description |
-| --- | --- | --- | --- |
-| `project` | `string` | Yes | Project slug. Must match the project on the server |
-| `serverUrl` | `string` | Yes | Base URL of the MDCMS server |
-| `environment` | `string` | No | Default environment name (e.g. `development`) |
-| `contentDirectories` | `string[]` | No | Directories to scan for content files. Default: `["content"]` |
-| `locales` | `object` | No | Locale configuration (see below) |
-| `types` | `MdcmsTypeDefinition[]` | No | Content type definitions created with `defineType` |
-| `environments` | `Record<string, object>` | No | Per-environment config overlays (can override `serverUrl`, `environment`) |
-| `components` | `object[]` | No | MDX component registrations for the Studio editor |
+| Property             | Type                     | Required | Description                                                               |
+| -------------------- | ------------------------ | -------- | ------------------------------------------------------------------------- |
+| `project`            | `string`                 | Yes      | Project slug. Must match the project on the server                        |
+| `serverUrl`          | `string`                 | Yes      | Base URL of the MDCMS server                                              |
+| `environment`        | `string`                 | No       | Default environment name (e.g. `development`)                             |
+| `contentDirectories` | `string[]`               | No       | Directories to scan for content files. Default: `["content"]`             |
+| `locales`            | `object`                 | No       | Locale configuration (see below)                                          |
+| `types`              | `MdcmsTypeDefinition[]`  | No       | Content type definitions created with `defineType`                        |
+| `environments`       | `Record<string, object>` | No       | Per-environment config overlays (can override `serverUrl`, `environment`) |
+| `components`         | `object[]`               | No       | MDX component registrations for the Studio editor                         |
 
 ### Locale options
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `locales.default` | `string` | The default locale code (e.g. `"en"`) |
-| `locales.supported` | `string[]` | All supported locale codes |
-| `locales.aliases` | `Record<string, string>` | Map alternate locale codes to canonical ones |
+| Property            | Type                     | Description                                  |
+| ------------------- | ------------------------ | -------------------------------------------- |
+| `locales.default`   | `string`                 | The default locale code (e.g. `"en"`)        |
+| `locales.supported` | `string[]`               | All supported locale codes                   |
+| `locales.aliases`   | `Record<string, string>` | Map alternate locale codes to canonical ones |
 
 ### Type definition options
 
 Each `defineType(name, options)` accepts:
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `directory` | `string` | Filesystem directory for this type's content files |
-| `localized` | `boolean` | Whether documents of this type are localized. Default: `false` |
-| `fields` | `Record<string, ZodSchema>` | Frontmatter field definitions using Zod schemas |
+| Property    | Type                        | Description                                                    |
+| ----------- | --------------------------- | -------------------------------------------------------------- |
+| `directory` | `string`                    | Filesystem directory for this type's content files             |
+| `localized` | `boolean`                   | Whether documents of this type are localized. Default: `false` |
+| `fields`    | `Record<string, ZodSchema>` | Frontmatter field definitions using Zod schemas                |
 
 ---
 
@@ -104,7 +104,8 @@ Each `defineType(name, options)` accepts:
 The manifest tracks the mapping between server documents and local files. It is stored at `.mdcms.manifest.json` in the project root, scoped to the current project and environment.
 
 <Warning>
-  The manifest file should be added to `.gitignore`. It contains local state that varies between developers and environments.
+  The manifest file should be added to `.gitignore`. It contains local state
+  that varies between developers and environments.
 </Warning>
 
 ### Structure
@@ -130,13 +131,13 @@ The manifest is a JSON object where each key is a `documentId` and the value des
 }
 ```
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `path` | `string` | Relative path to the content file from project root |
-| `format` | `"md" \| "mdx"` | File format |
-| `draftRevision` | `number` | Current draft revision number on the server |
+| Field              | Type             | Description                                            |
+| ------------------ | ---------------- | ------------------------------------------------------ |
+| `path`             | `string`         | Relative path to the content file from project root    |
+| `format`           | `"md" \| "mdx"`  | File format                                            |
+| `draftRevision`    | `number`         | Current draft revision number on the server            |
 | `publishedVersion` | `number \| null` | Published version number, or `null` if never published |
-| `hash` | `string` | Content hash of the file at last sync |
+| `hash`             | `string`         | Content hash of the file at last sync                  |
 
 ---
 
@@ -167,7 +168,8 @@ For example, `marketing-site` project in the `development` environment produces:
 The `schemaHash` is required by `mdcms push` to validate that content is being pushed against the correct schema version. If this file is missing or the hash is stale, push operations will fail.
 
 <Note>
-  The `.mdcms/` directory should be added to `.gitignore`. The `mdcms init` wizard does this automatically.
+  The `.mdcms/` directory should be added to `.gitignore`. The `mdcms init`
+  wizard does this automatically.
 </Note>
 
 ---

--- a/apps/docs/guide/cli/installation.mdx
+++ b/apps/docs/guide/cli/installation.mdx
@@ -8,7 +8,12 @@ description: "Installing and setting up the MDCMS CLI"
   icon="terminal"
   actions={["copy", "cursor"]}
 >
-Install and configure the MDCMS CLI in this project. Run `npm install --save-dev @mdcms/cli`. Then run `npx mdcms init` to interactively set up the project — it will prompt for server URL (default http://localhost:4000), project name, and environment. After init completes, run `npx mdcms schema sync` to push the generated schema to the server. Verify with `npx mdcms status` (exit code 0 means success).
+  Install and configure the MDCMS CLI in this project. Run `npm install
+  --save-dev @mdcms/cli`. Then run `npx mdcms init` to interactively set up the
+  project — it will prompt for server URL (default http://localhost:4000),
+  project name, and environment. After init completes, run `npx mdcms schema
+  sync` to push the generated schema to the server. Verify with `npx mdcms
+  status` (exit code 0 means success).
 </Prompt>
 
 The MDCMS CLI lets you sync content and schema between your local filesystem and the MDCMS server. It handles authentication, push/pull workflows, and CI/CD integration.
@@ -23,6 +28,7 @@ npm install --save-dev @mdcms/cli
 ```bash bun
 bun add -D @mdcms/cli
 ```
+
 </CodeGroup>
 
 Or install globally to use the `mdcms` command directly:
@@ -55,29 +61,38 @@ The `mdcms init` command walks you through an interactive wizard that configures
     ```
   </Step>
 
-  <Step title="Enter server URL">
-    Provide the URL of your MDCMS server (e.g. `https://cms.example.com`). The CLI validates the connection with a health check before proceeding.
-  </Step>
+<Step title="Enter server URL">
+  Provide the URL of your MDCMS server (e.g. `https://cms.example.com`). The CLI
+  validates the connection with a health check before proceeding.
+</Step>
 
-  <Step title="Choose project and environment">
-    Select an existing project or create a new one, then choose the target environment (e.g. `development`, `staging`, `production`).
-  </Step>
+<Step title="Choose project and environment">
+  Select an existing project or create a new one, then choose the target
+  environment (e.g. `development`, `staging`, `production`).
+</Step>
 
-  <Step title="Authenticate via browser">
-    The CLI opens your default browser for OAuth authentication using a device flow. Complete the login in your browser and the CLI receives credentials automatically.
-  </Step>
+<Step title="Authenticate via browser">
+  The CLI opens your default browser for OAuth authentication using a device
+  flow. Complete the login in your browser and the CLI receives credentials
+  automatically.
+</Step>
 
-  <Step title="Auto-detect content directories and locales">
-    The wizard scans your repository for Markdown and MDX files, groups them by directory, and detects locale patterns from file names (e.g. `post.en.mdx`, `post.fr.mdx`).
-  </Step>
+<Step title="Auto-detect content directories and locales">
+  The wizard scans your repository for Markdown and MDX files, groups them by
+  directory, and detects locale patterns from file names (e.g. `post.en.mdx`,
+  `post.fr.mdx`).
+</Step>
 
-  <Step title="Generate mdcms.config.ts">
-    A configuration file is generated at the project root with your project settings, content type definitions inferred from existing files, and locale configuration.
-  </Step>
+<Step title="Generate mdcms.config.ts">
+  A configuration file is generated at the project root with your project
+  settings, content type definitions inferred from existing files, and locale
+  configuration.
+</Step>
 
-  <Step title="Initial schema sync and content push">
-    The inferred schema is synced to the server, and all discovered content files are pushed as initial draft documents.
-  </Step>
+<Step title="Initial schema sync and content push">
+  The inferred schema is synced to the server, and all discovered content files
+  are pushed as initial draft documents.
+</Step>
 
   <Step title=".gitignore update">
     The wizard appends managed files (manifest, schema state) to your `.gitignore` and untracks them from git with `git rm -r --cached` if they were previously committed.
@@ -88,15 +103,15 @@ The `mdcms init` command walks you through an interactive wizard that configures
 
 Every command accepts these flags:
 
-| Flag | Description |
-| --- | --- |
-| `--project <slug>` | Override the target project slug |
-| `--environment <name>` | Override the target environment name |
-| `--api-key <token>` | Provide an API key directly (useful for CI) |
-| `--server-url <url>` | Override the server URL from config |
-| `--config <path>` | Path to config file (default: `mdcms.config.ts`) |
-| `-V`, `--version` | Print installed CLI version and exit |
-| `-h`, `--help` | Show help text |
+| Flag                   | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| `--project <slug>`     | Override the target project slug                 |
+| `--environment <name>` | Override the target environment name             |
+| `--api-key <token>`    | Provide an API key directly (useful for CI)      |
+| `--server-url <url>`   | Override the server URL from config              |
+| `--config <path>`      | Path to config file (default: `mdcms.config.ts`) |
+| `-V`, `--version`      | Print installed CLI version and exit             |
+| `-h`, `--help`         | Show help text                                   |
 
 ## Resolution order
 
@@ -108,5 +123,6 @@ When the CLI needs a value for project, environment, server URL, or API key, it 
 4. **Stored credentials** — API key from the local credential store (set by `mdcms login`)
 
 <Note>
-  CLI flags always win. This makes it straightforward to override config values in CI pipelines or when working across multiple environments.
+  CLI flags always win. This makes it straightforward to override config values
+  in CI pipelines or when working across multiple environments.
 </Note>

--- a/apps/docs/guide/concepts.mdx
+++ b/apps/docs/guide/concepts.mdx
@@ -64,7 +64,8 @@ Key properties of environments:
 - **Clone & promote** -- You can clone all content from one environment to another, or promote a subset of documents between environments.
 
 <Note>
-The `environment` field in the config selects which environment the CLI operates against by default. If omitted, operations target `production`.
+  The `environment` field in the config selects which environment the CLI
+  operates against by default. If omitted, operations target `production`.
 </Note>
 
 ## Content Types (Schema)
@@ -107,12 +108,12 @@ export default defineConfig({
 
 Each `defineType()` call accepts:
 
-| Parameter | Description |
-|-----------|-------------|
-| `name` | Unique type identifier (first argument). Used in API queries and references. |
-| `directory` | Filesystem directory where documents of this type live (relative to a content directory). |
-| `localized` | When `true`, documents of this type support multiple locale variants. |
-| `fields` | A record of Zod schemas. Each field becomes a frontmatter property and a Studio form field. |
+| Parameter   | Description                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `name`      | Unique type identifier (first argument). Used in API queries and references.                |
+| `directory` | Filesystem directory where documents of this type live (relative to a content directory).   |
+| `localized` | When `true`, documents of this type support multiple locale variants.                       |
+| `fields`    | A record of Zod schemas. Each field becomes a frontmatter property and a Studio form field. |
 
 The schema drives three things:
 
@@ -130,18 +131,20 @@ mdcms schema sync
 
 A **document** is an instance of a content type. It consists of structured frontmatter (validated against the schema) and a Markdown or MDX body.
 
-| Property | Description |
-|----------|-------------|
-| `documentId` | Stable UUID. The true identity of a document -- never changes, even if the path does. |
-| `translationGroupId` | UUID that links locale variants of the same logical content together. |
-| `path` | Mutable, filesystem-like path (e.g., `content/blog/hello-world`). Can be renamed without losing history. |
-| `locale` | BCP 47 language tag (e.g., `en`, `fr`, `ja`). Set to `__mdcms_default__` for non-localized types. |
-| `format` | `md` for standard Markdown, `mdx` for MDX with component support. |
-| `frontmatter` | JSON object containing structured data that matches the content type schema. |
-| `body` | The Markdown or MDX content string. |
+| Property             | Description                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `documentId`         | Stable UUID. The true identity of a document -- never changes, even if the path does.                    |
+| `translationGroupId` | UUID that links locale variants of the same logical content together.                                    |
+| `path`               | Mutable, filesystem-like path (e.g., `content/blog/hello-world`). Can be renamed without losing history. |
+| `locale`             | BCP 47 language tag (e.g., `en`, `fr`, `ja`). Set to `__mdcms_default__` for non-localized types.        |
+| `format`             | `md` for standard Markdown, `mdx` for MDX with component support.                                        |
+| `frontmatter`        | JSON object containing structured data that matches the content type schema.                             |
+| `body`               | The Markdown or MDX content string.                                                                      |
 
 <Tip>
-Because `documentId` is stable, you can safely reference documents by ID in your application code. The `path` is designed for human readability and filesystem mapping, but should not be treated as a permanent identifier.
+  Because `documentId` is stable, you can safely reference documents by ID in
+  your application code. The `path` is designed for human readability and
+  filesystem mapping, but should not be treated as a permanent identifier.
 </Tip>
 
 On disk, a document looks like a standard Markdown file with YAML frontmatter:
@@ -166,24 +169,35 @@ Every document follows a draft/publish lifecycle that tracks changes through imm
 
 <Steps>
   <Step title="Create">
-    A new document starts as a **draft**. It has no published version and is only visible to users with `content:read:draft` permission.
+    A new document starts as a **draft**. It has no published version and is
+    only visible to users with `content:read:draft` permission.
   </Step>
   <Step title="Edit">
-    Edits are auto-saved. Each save increments the `draftRevision` counter. Drafts do not create version history entries -- they represent work in progress.
+    Edits are auto-saved. Each save increments the `draftRevision` counter.
+    Drafts do not create version history entries -- they represent work in
+    progress.
   </Step>
   <Step title="Publish">
-    Publishing creates an **immutable version snapshot**. The `version` number increments and the snapshot captures the full frontmatter and body at that point in time. You can attach an optional change summary to each published version.
+    Publishing creates an **immutable version snapshot**. The `version` number
+    increments and the snapshot captures the full frontmatter and body at that
+    point in time. You can attach an optional change summary to each published
+    version.
   </Step>
   <Step title="Continue Editing">
-    After publishing, further edits create new draft revisions on top of the published version. The published content remains stable and visible to readers.
+    After publishing, further edits create new draft revisions on top of the
+    published version. The published content remains stable and visible to
+    readers.
   </Step>
   <Step title="Re-publish">
-    Publishing again creates a new version snapshot. The full version history is preserved, allowing you to review or compare any previous published state.
+    Publishing again creates a new version snapshot. The full version history is
+    preserved, allowing you to review or compare any previous published state.
   </Step>
 </Steps>
 
 <Note>
-The `hasUnpublishedChanges` flag on a document tells you whether the current draft differs from the latest published version. This is useful for building editorial dashboards that show pending changes.
+  The `hasUnpublishedChanges` flag on a document tells you whether the current
+  draft differs from the latest published version. This is useful for building
+  editorial dashboards that show pending changes.
 </Note>
 
 ## Localization
@@ -229,7 +243,9 @@ How localized documents work:
 - The SDK accepts a `locale` parameter to query content in a specific language.
 
 <Warning>
-Non-localized types (where `localized` is `false` or omitted) operate in implicit single-locale mode. Their documents use the internal locale token `__mdcms_default__` and do not participate in translation groups.
+  Non-localized types (where `localized` is `false` or omitted) operate in
+  implicit single-locale mode. Their documents use the internal locale token
+  `__mdcms_default__` and do not participate in translation groups.
 </Warning>
 
 ## References
@@ -255,15 +271,17 @@ How references are resolved:
 
 Reference resolution error codes:
 
-| Error Code | Meaning |
-|-----------|---------|
-| `REFERENCE_NOT_FOUND` | The referenced document does not exist in the target project/environment. |
-| `REFERENCE_DELETED` | The referenced document has been soft-deleted. |
+| Error Code                | Meaning                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `REFERENCE_NOT_FOUND`     | The referenced document does not exist in the target project/environment.                      |
+| `REFERENCE_DELETED`       | The referenced document has been soft-deleted.                                                 |
 | `REFERENCE_TYPE_MISMATCH` | The referenced document's type does not match the expected target type declared in the schema. |
-| `REFERENCE_FORBIDDEN` | The current API key or user does not have read access to the referenced document. |
+| `REFERENCE_FORBIDDEN`     | The current API key or user does not have read access to the referenced document.              |
 
 <Tip>
-References can be optional (`reference("Author").optional()`) or collected in arrays (`z.array(reference("BlogPost"))`). The resolution engine handles both forms.
+  References can be optional (`reference("Author").optional()`) or collected in
+  arrays (`z.array(reference("BlogPost"))`). The resolution engine handles both
+  forms.
 </Tip>
 
 ## API Keys
@@ -272,12 +290,12 @@ API keys provide scoped, token-based access to the MDCMS API. They are the prima
 
 Each API key has:
 
-| Property | Description |
-|----------|-------------|
-| `label` | Human-readable name (e.g., "Production Read-Only", "CI Deploy Key"). |
-| `scopes` | List of permitted operations. |
-| `contextAllowlist` | Restricts the key to specific project/environment pairs. |
-| `expiresAt` | Optional expiration timestamp. |
+| Property           | Description                                                          |
+| ------------------ | -------------------------------------------------------------------- |
+| `label`            | Human-readable name (e.g., "Production Read-Only", "CI Deploy Key"). |
+| `scopes`           | List of permitted operations.                                        |
+| `contextAllowlist` | Restricts the key to specific project/environment pairs.             |
+| `expiresAt`        | Optional expiration timestamp.                                       |
 
 API keys are prefixed with `mdcms_key_` for easy identification in logs and secret scanners.
 
@@ -285,25 +303,25 @@ API keys are prefixed with `mdcms_key_` for easy identification in logs and secr
 
 <Accordion title="Full list of API key scopes">
 
-| Scope | Description |
-|-------|-------------|
-| `content:read` | Read published content. |
-| `content:read:draft` | Read draft (unpublished) content. |
-| `content:write` | Create and update content. |
-| `content:write:draft` | Create and update draft content. |
-| `content:publish` | Publish documents. |
-| `content:delete` | Delete documents. |
-| `schema:read` | Read schema registry entries. |
-| `schema:write` | Sync schema changes. |
-| `media:upload` | Upload media files. |
-| `media:delete` | Delete media files. |
-| `webhooks:read` | List webhook configurations. |
-| `webhooks:write` | Create, update, and delete webhooks. |
-| `environments:clone` | Clone content between environments. |
+| Scope                  | Description                           |
+| ---------------------- | ------------------------------------- |
+| `content:read`         | Read published content.               |
+| `content:read:draft`   | Read draft (unpublished) content.     |
+| `content:write`        | Create and update content.            |
+| `content:write:draft`  | Create and update draft content.      |
+| `content:publish`      | Publish documents.                    |
+| `content:delete`       | Delete documents.                     |
+| `schema:read`          | Read schema registry entries.         |
+| `schema:write`         | Sync schema changes.                  |
+| `media:upload`         | Upload media files.                   |
+| `media:delete`         | Delete media files.                   |
+| `webhooks:read`        | List webhook configurations.          |
+| `webhooks:write`       | Create, update, and delete webhooks.  |
+| `environments:clone`   | Clone content between environments.   |
 | `environments:promote` | Promote content between environments. |
-| `migrations:run` | Execute content migrations. |
-| `projects:read` | Read project metadata. |
-| `projects:write` | Update project settings. |
+| `migrations:run`       | Execute content migrations.           |
+| `projects:read`        | Read project metadata.                |
+| `projects:write`       | Update project settings.              |
 
 </Accordion>
 
@@ -313,20 +331,20 @@ A typical production frontend key would use only `content:read` and `schema:read
 
 MDCMS uses role-based access control for user permissions. Roles are hierarchical -- each role includes all permissions of the roles below it.
 
-| Permission | Viewer | Editor | Admin | Owner |
-|-----------|--------|--------|-------|-------|
-| `content:read` | Yes | Yes | Yes | Yes |
-| `content:read:draft` | | Yes | Yes | Yes |
-| `content:write` | | Yes | Yes | Yes |
-| `content:publish` | | Yes | Yes | Yes |
-| `content:unpublish` | | Yes | Yes | Yes |
-| `content:delete` | | Yes | Yes | Yes |
-| `schema:read` | Yes | Yes | Yes | Yes |
-| `schema:write` | | | Yes | Yes |
-| `projects:read` | Yes | Yes | Yes | Yes |
-| `projects:write` | | | Yes | Yes |
-| `user:manage` | | | Yes | Yes |
-| `settings:manage` | | | Yes | Yes |
+| Permission           | Viewer | Editor | Admin | Owner |
+| -------------------- | ------ | ------ | ----- | ----- |
+| `content:read`       | Yes    | Yes    | Yes   | Yes   |
+| `content:read:draft` |        | Yes    | Yes   | Yes   |
+| `content:write`      |        | Yes    | Yes   | Yes   |
+| `content:publish`    |        | Yes    | Yes   | Yes   |
+| `content:unpublish`  |        | Yes    | Yes   | Yes   |
+| `content:delete`     |        | Yes    | Yes   | Yes   |
+| `schema:read`        | Yes    | Yes    | Yes   | Yes   |
+| `schema:write`       |        |        | Yes   | Yes   |
+| `projects:read`      | Yes    | Yes    | Yes   | Yes   |
+| `projects:write`     |        |        | Yes   | Yes   |
+| `user:manage`        |        |        | Yes   | Yes   |
+| `settings:manage`    |        |        | Yes   | Yes   |
 
 ### Scope and Constraints
 
@@ -350,12 +368,12 @@ graph LR
     D --> H["S3-Compatible<br/>Object Storage"]
 ```
 
-| Component | Role |
-|-----------|------|
-| **MDCMS Server** | Elysia-based HTTP API running on Bun. Handles content CRUD, schema registry, auth, webhooks, and media. |
-| **@mdcms/cli** | Command-line tool for schema sync, content push/pull, migrations, and project initialization. |
-| **@mdcms/sdk** | TypeScript client for querying content from your application at build time or runtime. |
-| **@mdcms/studio** | Embeddable React component that provides the visual editing interface. Communicates directly with the server. |
-| **PostgreSQL** | Primary data store for all content, schema metadata, users, API keys, and version history. |
-| **Redis** | Used for session management, caching, and real-time features. |
+| Component                 | Role                                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **MDCMS Server**          | Elysia-based HTTP API running on Bun. Handles content CRUD, schema registry, auth, webhooks, and media.                        |
+| **@mdcms/cli**            | Command-line tool for schema sync, content push/pull, migrations, and project initialization.                                  |
+| **@mdcms/sdk**            | TypeScript client for querying content from your application at build time or runtime.                                         |
+| **@mdcms/studio**         | Embeddable React component that provides the visual editing interface. Communicates directly with the server.                  |
+| **PostgreSQL**            | Primary data store for all content, schema metadata, users, API keys, and version history.                                     |
+| **Redis**                 | Used for session management, caching, and real-time features.                                                                  |
 | **S3-Compatible Storage** | Stores uploaded media files (images, documents, etc.). Works with AWS S3, MinIO, Cloudflare R2, or any S3-compatible provider. |

--- a/apps/docs/guide/concepts.mdx
+++ b/apps/docs/guide/concepts.mdx
@@ -135,7 +135,7 @@ A **document** is an instance of a content type. It consists of structured front
 | -------------------- | -------------------------------------------------------------------------------------------------------- |
 | `documentId`         | Stable UUID. The true identity of a document -- never changes, even if the path does.                    |
 | `translationGroupId` | UUID that links locale variants of the same logical content together.                                    |
-| `path`               | Mutable, filesystem-like path (e.g., `content/blog/hello-world`). Can be renamed without losing history. |
+| `path`               | Mutable, filesystem-like path (e.g., `content/blog/hello-world`). It can be renamed without losing history. |
 | `locale`             | BCP 47 language tag (e.g., `en`, `fr`, `ja`). Set to `__mdcms_default__` for non-localized types.        |
 | `format`             | `md` for standard Markdown, `mdx` for MDX with component support.                                        |
 | `frontmatter`        | JSON object containing structured data that matches the content type schema.                             |

--- a/apps/docs/guide/quickstart.mdx
+++ b/apps/docs/guide/quickstart.mdx
@@ -6,11 +6,14 @@ description: "Install MDCMS packages and start managing content in your project"
 Get MDCMS running in your own application. This guide assumes you have an MDCMS server available (self-hosted or managed).
 
 <Tip>
-  Need to set up your own server first? Follow the [Self-Hosting guide](/guide/self-hosting) to get MDCMS running with Docker Compose, then come back here.
+  Need to set up your own server first? Follow the [Self-Hosting
+  guide](/guide/self-hosting) to get MDCMS running with Docker Compose, then
+  come back here.
 </Tip>
 
 <Note>
-  Looking to contribute to MDCMS itself? See [Development Setup](/development/setup).
+  Looking to contribute to MDCMS itself? See [Development
+  Setup](/development/setup).
 </Note>
 
 ## 1. Install the CLI
@@ -23,6 +26,7 @@ npm install --save-dev @mdcms/cli
 ```bash bun
 bun add -D @mdcms/cli
 ```
+
 </CodeGroup>
 
 ## 2. Initialize your project
@@ -34,6 +38,7 @@ npx mdcms init
 ```
 
 It will:
+
 - Ask for your MDCMS server URL
 - Open a browser for authentication
 - Scan your repo for existing Markdown/MDX files
@@ -110,6 +115,7 @@ npm install @mdcms/sdk
 ```bash bun
 bun add @mdcms/sdk
 ```
+
 </CodeGroup>
 
 Query content in your application:
@@ -152,6 +158,7 @@ npm install @mdcms/studio
 ```bash bun
 bun add @mdcms/studio
 ```
+
 </CodeGroup>
 
 ```tsx app/admin/[[...path]]/page.tsx
@@ -171,10 +178,18 @@ See the [Studio Guide](/guide/studio/dashboard) for full embedding and usage ins
   <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
     Push, pull, login, schema sync, and all CLI flags
   </Card>
-  <Card title="Schema Guide" icon="file-code" href="/guide/schema/defining-types">
+  <Card
+    title="Schema Guide"
+    icon="file-code"
+    href="/guide/schema/defining-types"
+  >
     Field types, references, environment overlays, MDX components
   </Card>
-  <Card title="Studio Guide" icon="layout-dashboard" href="/guide/studio/dashboard">
+  <Card
+    title="Studio Guide"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
     Visual content editing, publishing, and version history
   </Card>
   <Card title="SDK Reference" icon="plug" href="/api-reference/sdk">

--- a/apps/docs/guide/schema/defining-types.mdx
+++ b/apps/docs/guide/schema/defining-types.mdx
@@ -33,11 +33,11 @@ export default defineConfig({
 
 Each type accepts the following options:
 
-| Option | Type | Required | Description |
-|---|---|---|---|
-| `directory` | `string` | Yes | Filesystem path where documents of this type are stored. Must be covered by `contentDirectories`. |
-| `localized` | `boolean` | No (default: `false`) | Whether documents of this type support per-locale variants. Requires `locales` config when `true`. |
-| `fields` | `Record<string, ZodSchema>` | Yes | Map of field names to Zod schemas. Each field becomes a frontmatter property and a Studio form control. |
+| Option      | Type                        | Required              | Description                                                                                             |
+| ----------- | --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `directory` | `string`                    | Yes                   | Filesystem path where documents of this type are stored. Must be covered by `contentDirectories`.       |
+| `localized` | `boolean`                   | No (default: `false`) | Whether documents of this type support per-locale variants. Requires `locales` config when `true`.      |
+| `fields`    | `Record<string, ZodSchema>` | Yes                   | Map of field names to Zod schemas. Each field becomes a frontmatter property and a Studio form control. |
 
 ## Field types
 
@@ -45,12 +45,12 @@ Every Zod type maps to a specific Studio form control. MDCMS serializes each fie
 
 ### Primitives
 
-| Zod schema | Registry kind | Studio control | Notes |
-|---|---|---|---|
-| `z.string()` | `string` | Text input | Base type for most text fields |
-| `z.number()` | `number` | Number input | Supports `.int()`, `.min()`, `.max()` checks |
-| `z.boolean()` | `boolean` | Toggle switch | Commonly paired with `.default(false)` |
-| `z.coerce.date()` | `date` | Date picker | Coerces string values to `Date` objects |
+| Zod schema        | Registry kind | Studio control | Notes                                        |
+| ----------------- | ------------- | -------------- | -------------------------------------------- |
+| `z.string()`      | `string`      | Text input     | Base type for most text fields               |
+| `z.number()`      | `number`      | Number input   | Supports `.int()`, `.min()`, `.max()` checks |
+| `z.boolean()`     | `boolean`     | Toggle switch  | Commonly paired with `.default(false)`       |
+| `z.coerce.date()` | `date`        | Date picker    | Coerces string values to `Date` objects      |
 
 ```typescript
 fields: {
@@ -63,13 +63,13 @@ fields: {
 
 ### Complex types
 
-| Zod schema | Registry kind | Studio control | Notes |
-|---|---|---|---|
-| `z.array(z.string())` | `array` (item: `string`) | Tag input | Repeatable string entries |
-| `z.array(z.number())` | `array` (item: `number`) | Repeatable number inputs | |
-| `z.object({...})` | `object` | Nested fieldset | Each property rendered recursively |
-| `z.enum(["a", "b", "c"])` | `enum` | Dropdown select | Options extracted from enum entries |
-| `z.literal("x")` | `literal` | Hidden / read-only | Fixed value, useful for discriminators |
+| Zod schema                | Registry kind            | Studio control           | Notes                                  |
+| ------------------------- | ------------------------ | ------------------------ | -------------------------------------- |
+| `z.array(z.string())`     | `array` (item: `string`) | Tag input                | Repeatable string entries              |
+| `z.array(z.number())`     | `array` (item: `number`) | Repeatable number inputs |                                        |
+| `z.object({...})`         | `object`                 | Nested fieldset          | Each property rendered recursively     |
+| `z.enum(["a", "b", "c"])` | `enum`                   | Dropdown select          | Options extracted from enum entries    |
+| `z.literal("x")`          | `literal`                | Hidden / read-only       | Fixed value, useful for discriminators |
 
 ```typescript
 fields: {
@@ -88,10 +88,10 @@ fields: {
 
 Modifiers control whether fields are required, nullable, or have defaults. They affect both the schema registry snapshot and Studio form behavior.
 
-| Modifier | Effect | Registry impact |
-|---|---|---|
-| `.optional()` | Field can be omitted entirely | `required: false` |
-| `.nullable()` | Field can be explicitly set to `null` | `nullable: true` |
+| Modifier          | Effect                                           | Registry impact                       |
+| ----------------- | ------------------------------------------------ | ------------------------------------- |
+| `.optional()`     | Field can be omitted entirely                    | `required: false`                     |
+| `.nullable()`     | Field can be explicitly set to `null`            | `nullable: true`                      |
 | `.default(value)` | Provides a default value; field becomes optional | `required: false`, `default: <value>` |
 
 ```typescript
@@ -104,7 +104,9 @@ fields: {
 ```
 
 <Note>
-  A field with `.default()` is implicitly optional in the schema registry. The default value is stored in the registry snapshot and applied during validation.
+  A field with `.default()` is implicitly optional in the schema registry. The
+  default value is stored in the registry snapshot and applied during
+  validation.
 </Note>
 
 ## Validation
@@ -126,32 +128,26 @@ fields: {
 ### Available checks by type
 
 <Accordion title="String checks">
-  | Method | Description |
-  |---|---|
-  | `.min(n)` | Minimum length |
-  | `.max(n)` | Maximum length |
-  | `.email()` | Valid email format |
-  | `.url()` | Valid URL format |
-  | `.regex(pattern)` | Matches regular expression (pattern and flags are serialized) |
+  | Method | Description | |---|---| | `.min(n)` | Minimum length | | `.max(n)`
+  | Maximum length | | `.email()` | Valid email format | | `.url()` | Valid URL
+  format | | `.regex(pattern)` | Matches regular expression (pattern and flags
+  are serialized) |
 </Accordion>
 
 <Accordion title="Number checks">
-  | Method | Description |
-  |---|---|
-  | `.min(n)` | Minimum value |
-  | `.max(n)` | Maximum value |
-  | `.int()` | Must be an integer |
+  | Method | Description | |---|---| | `.min(n)` | Minimum value | | `.max(n)` |
+  Maximum value | | `.int()` | Must be an integer |
 </Accordion>
 
 <Accordion title="Array checks">
-  | Method | Description |
-  |---|---|
-  | `.min(n)` | Minimum array length |
-  | `.max(n)` | Maximum array length |
+  | Method | Description | |---|---| | `.min(n)` | Minimum array length | |
+  `.max(n)` | Maximum array length |
 </Accordion>
 
 <Warning>
-  Custom Zod validators (`.refine()`, `.transform()`, `.pipe()`) cannot be serialized to the schema registry and will cause a sync error. Use only built-in Zod checks.
+  Custom Zod validators (`.refine()`, `.transform()`, `.pipe()`) cannot be
+  serialized to the schema registry and will cause a sync error. Use only
+  built-in Zod checks.
 </Warning>
 
 ## Registering types
@@ -184,7 +180,8 @@ Every write operation to the MDCMS API requires an `x-mdcms-schema-hash` header 
 - Re-run `mdcms schema sync` to update after config changes.
 
 <Tip>
-  In CI/CD pipelines, always run `mdcms schema sync` before `mdcms push` to ensure the schema hash is current.
+  In CI/CD pipelines, always run `mdcms schema sync` before `mdcms push` to
+  ensure the schema hash is current.
 </Tip>
 
 ## Environment overlays
@@ -215,12 +212,12 @@ export default defineConfig({
 
 ### Overlay operations
 
-| Operation | Description |
-|---|---|
-| `add` | Add new fields that don't exist on the base type. Errors if the field already exists. |
-| `modify` | Replace the schema for an existing field. Errors if the field doesn't exist. |
-| `omit` | Remove fields by name. Errors if the field doesn't exist. |
-| `extends` | Inherit from another environment instead of the base types. Supports chaining. |
+| Operation | Description                                                                           |
+| --------- | ------------------------------------------------------------------------------------- |
+| `add`     | Add new fields that don't exist on the base type. Errors if the field already exists. |
+| `modify`  | Replace the schema for an existing field. Errors if the field doesn't exist.          |
+| `omit`    | Remove fields by name. Errors if the field doesn't exist.                             |
+| `extends` | Inherit from another environment instead of the base types. Supports chaining.        |
 
 ### Field-level environment targeting
 
@@ -240,7 +237,8 @@ const Post = defineType("post", {
 Fields with `.env()` are only included in the specified environments. This is syntactic sugar that gets expanded into `add` overlays during config parsing.
 
 <Warning>
-  You cannot use `.env()` on fields inside overlay `add`/`modify` maps. Keep environment targeting on the base type only.
+  You cannot use `.env()` on fields inside overlay `add`/`modify` maps. Keep
+  environment targeting on the base type only.
 </Warning>
 
 ## Complete example
@@ -298,5 +296,6 @@ export default defineConfig({
 ```
 
 <Warning>
-  Changing type names or removing types that have existing content requires a migration. Use `mdcms migrate` to handle these changes safely.
+  Changing type names or removing types that have existing content requires a
+  migration. Use `mdcms migrate` to handle these changes safely.
 </Warning>

--- a/apps/docs/guide/schema/mdx-components.mdx
+++ b/apps/docs/guide/schema/mdx-components.mdx
@@ -16,14 +16,15 @@ export default defineConfig({
   project: "marketing-site",
   serverUrl: "http://localhost:4000",
   contentDirectories: ["content"],
-  types: [/* ... */],
+  types: [
+    /* ... */
+  ],
   components: [
     {
       name: "Callout",
       importPath: "./components/mdx/Callout",
       description: "A styled callout box for tips, warnings, or notes",
-      load: () =>
-        import("./components/mdx/Callout").then((m) => m.Callout),
+      load: () => import("./components/mdx/Callout").then((m) => m.Callout),
     },
     {
       name: "VideoEmbed",
@@ -41,34 +42,36 @@ export default defineConfig({
 
 ### Registration options
 
-| Option | Type | Required | Description |
-|---|---|---|---|
-| `name` | `string` | Yes | Component name. Must match the exported React component name. |
-| `importPath` | `string` | Yes | Module path for Studio to resolve the component at runtime. |
-| `description` | `string` | No | Shown in the component catalog to help authors pick the right component. |
-| `load` | `() => Promise<unknown>` | No | Dynamic import function for Studio to load the component at runtime. |
-| `propHints` | `Record<string, PropHint>` | No | Override auto-detected prop types with specific widgets. |
-| `propsEditor` | `string` | No | Module path to a custom props editor component, for complex editing UIs. |
-| `loadPropsEditor` | `() => Promise<unknown>` | No | Dynamic import for the custom props editor. |
+| Option            | Type                       | Required | Description                                                              |
+| ----------------- | -------------------------- | -------- | ------------------------------------------------------------------------ |
+| `name`            | `string`                   | Yes      | Component name. Must match the exported React component name.            |
+| `importPath`      | `string`                   | Yes      | Module path for Studio to resolve the component at runtime.              |
+| `description`     | `string`                   | No       | Shown in the component catalog to help authors pick the right component. |
+| `load`            | `() => Promise<unknown>`   | No       | Dynamic import function for Studio to load the component at runtime.     |
+| `propHints`       | `Record<string, PropHint>` | No       | Override auto-detected prop types with specific widgets.                 |
+| `propsEditor`     | `string`                   | No       | Module path to a custom props editor component, for complex editing UIs. |
+| `loadPropsEditor` | `() => Promise<unknown>`   | No       | Dynamic import for the custom props editor.                              |
 
 ## Prop extraction
 
 MDCMS uses TypeScript's compiler API to extract prop types from your component source files. Each prop is mapped to a form control in Studio based on its type:
 
-| TypeScript type | Extracted type | Studio control |
-|---|---|---|
-| `string` | `string` | Text input |
-| `number` | `number` | Number input |
-| `boolean` | `boolean` | Toggle switch |
-| `Date` | `date` | Date picker |
-| `"a" \| "b" \| "c"` (string literal union) | `enum` | Dropdown select |
-| `string[]` | `array` (items: `string`) | Tag input |
-| `number[]` | `array` (items: `number`) | Repeatable number inputs |
-| `ReactNode` / `children` | `rich-text` | Nested rich-text editor |
-| JSON-serializable object (with `json` hint) | `json` | JSON editor |
+| TypeScript type                             | Extracted type            | Studio control           |
+| ------------------------------------------- | ------------------------- | ------------------------ |
+| `string`                                    | `string`                  | Text input               |
+| `number`                                    | `number`                  | Number input             |
+| `boolean`                                   | `boolean`                 | Toggle switch            |
+| `Date`                                      | `date`                    | Date picker              |
+| `"a" \| "b" \| "c"` (string literal union)  | `enum`                    | Dropdown select          |
+| `string[]`                                  | `array` (items: `string`) | Tag input                |
+| `number[]`                                  | `array` (items: `number`) | Repeatable number inputs |
+| `ReactNode` / `children`                    | `rich-text`               | Nested rich-text editor  |
+| JSON-serializable object (with `json` hint) | `json`                    | JSON editor              |
 
 <Note>
-  Props with function types, ref types, or other non-serializable types are automatically excluded from the form. Only serializable props appear in the Studio editor.
+  Props with function types, ref types, or other non-serializable types are
+  automatically excluded from the form. Only serializable props appear in the
+  Studio editor.
 </Note>
 
 ### Example component
@@ -91,6 +94,7 @@ export function Callout({ type, title, children }: CalloutProps) {
 ```
 
 From this component, MDCMS extracts:
+
 - `type` as `enum` with values `["info", "warning", "error"]` (dropdown)
 - `title` as `string` (text input)
 - `children` as `rich-text` (nested content editor)
@@ -104,92 +108,102 @@ Prop hints override the auto-detected form control for a given prop. Use them wh
 <Accordion title="format: url">
   Renders a text input with URL validation. Only valid for `string` props.
 
-  ```typescript
-  propHints: {
-    imageUrl: { format: "url" },
-  }
-  ```
+```typescript
+propHints: {
+  imageUrl: { format: "url" },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: color-picker">
   Renders a color picker input. Only valid for `string` props.
 
-  ```typescript
-  propHints: {
-    backgroundColor: { widget: "color-picker" },
-  }
-  ```
+```typescript
+propHints: {
+  backgroundColor: { widget: "color-picker" },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: textarea">
   Renders a multi-line textarea instead of a single-line text input. Only valid for `string` props.
 
-  ```typescript
-  propHints: {
-    description: { widget: "textarea" },
-  }
-  ```
+```typescript
+propHints: {
+  description: { widget: "textarea" },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: slider">
   Renders a range slider. Only valid for `number` props. Requires `min` and `max`; `step` is optional.
 
-  ```typescript
-  propHints: {
-    opacity: { widget: "slider", min: 0, max: 100, step: 5 },
-  }
-  ```
+```typescript
+propHints: {
+  opacity: { widget: "slider", min: 0, max: 100, step: 5 },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: image">
   Renders an image picker/uploader. Only valid for `string` props (stores the image URL).
 
-  ```typescript
-  propHints: {
-    thumbnail: { widget: "image" },
-  }
-  ```
+```typescript
+propHints: {
+  thumbnail: { widget: "image" },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: select">
   Renders a dropdown with explicit options. Valid for `string`, `number`, `boolean`, or `enum` props. Options can be simple values or `{ label, value }` objects.
 
-  ```typescript
-  propHints: {
-    size: {
-      widget: "select",
-      options: [
-        { label: "Small", value: "sm" },
-        { label: "Medium", value: "md" },
-        { label: "Large", value: "lg" },
-      ],
-    },
-  }
-  ```
+```typescript
+propHints: {
+  size: {
+    widget: "select",
+    options: [
+      { label: "Small", value: "sm" },
+      { label: "Medium", value: "md" },
+      { label: "Large", value: "lg" },
+    ],
+  },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: hidden">
   Hides the prop from the Studio form entirely. Useful for internal props that should not be edited by content authors.
 
-  ```typescript
-  propHints: {
-    internalId: { widget: "hidden" },
-  }
-  ```
+```typescript
+propHints: {
+  internalId: { widget: "hidden" },
+}
+```
+
 </Accordion>
 
 <Accordion title="widget: json">
   Renders a JSON editor for complex structured data. Only valid for props whose TypeScript type is JSON-serializable.
 
-  ```typescript
-  propHints: {
-    config: { widget: "json" },
-  }
-  ```
+```typescript
+propHints: {
+  config: { widget: "json" },
+}
+```
+
 </Accordion>
 
 <Warning>
-  Prop hints must be compatible with the extracted prop type. For example, applying `widget: "slider"` to a `string` prop will cause a config validation error. The compatibility rules are enforced at build time.
+  Prop hints must be compatible with the extracted prop type. For example,
+  applying `widget: "slider"` to a `string` prop will cause a config validation
+  error. The compatibility rules are enforced at build time.
 </Warning>
 
 ## Inserting components in Studio
@@ -198,13 +212,15 @@ Content authors can insert registered components in two ways:
 
 <Steps>
   <Step title="Slash command">
-    Type `/` in the editor to open the command palette. The component catalog shows all registered components with their names and descriptions.
+    Type `/` in the editor to open the command palette. The component catalog
+    shows all registered components with their names and descriptions.
   </Step>
   <Step title="Toolbar">
     Use the editor toolbar to browse and insert components from the catalog.
   </Step>
   <Step title="Configure props">
-    After insertion, the prop editor panel appears. Fill in the form controls to configure the component.
+    After insertion, the prop editor panel appears. Fill in the form controls to
+    configure the component.
   </Step>
 </Steps>
 
@@ -234,7 +250,7 @@ If your component accepts a `children` prop typed as `ReactNode`, it becomes a *
 type CalloutProps = {
   type: "info" | "warning" | "error";
   title: string;
-  children: React.ReactNode;  // enables nested rich-text editing
+  children: React.ReactNode; // enables nested rich-text editing
 };
 
 export function Callout({ type, title, children }: CalloutProps) {
@@ -269,5 +285,7 @@ For components with complex prop structures that don't map well to auto-generate
 The custom props editor receives the current prop values and a callback to update them. It replaces the auto-generated form entirely for that component.
 
 <Tip>
-  Use custom props editors sparingly. The auto-generated form with prop hints covers most cases. Reserve custom editors for components like data tables, chart builders, or other interactive configuration UIs.
+  Use custom props editors sparingly. The auto-generated form with prop hints
+  covers most cases. Reserve custom editors for components like data tables,
+  chart builders, or other interactive configuration UIs.
 </Tip>

--- a/apps/docs/guide/schema/references.mdx
+++ b/apps/docs/guide/schema/references.mdx
@@ -39,7 +39,9 @@ author: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
 
 <Note>
-  The server validates reference identity on every write. If you supply a documentId that doesn't exist, belongs to a different type, or references a deleted document, the write will fail with an `INVALID_INPUT` error.
+  The server validates reference identity on every write. If you supply a
+  documentId that doesn't exist, belongs to a different type, or references a
+  deleted document, the write will fail with an `INVALID_INPUT` error.
 </Note>
 
 ## Resolving references
@@ -59,6 +61,7 @@ const post = await client.content.get("blog/my-post", {
 });
 // post.frontmatter.author is now the full Author document object
 ```
+
 </CodeGroup>
 
 ### Resolved response structure
@@ -129,15 +132,16 @@ If a reference cannot be resolved, the field value is set to `null` and an entry
 
 ### Error codes
 
-| Code | Description |
-|---|---|
-| `REFERENCE_NOT_FOUND` | The referenced document does not exist in the target project/environment. |
-| `REFERENCE_DELETED` | The referenced document has been soft-deleted. |
+| Code                      | Description                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| `REFERENCE_NOT_FOUND`     | The referenced document does not exist in the target project/environment.                        |
+| `REFERENCE_DELETED`       | The referenced document has been soft-deleted.                                                   |
 | `REFERENCE_TYPE_MISMATCH` | The referenced document exists but belongs to a different type than the reference field expects. |
-| `REFERENCE_FORBIDDEN` | The referenced document exists but is not readable with the current API key scope. |
+| `REFERENCE_FORBIDDEN`     | The referenced document exists but is not readable with the current API key scope.               |
 
 <Tip>
-  Check for the `resolveErrors` key in API responses when using `resolve`. A missing key means all references resolved successfully.
+  Check for the `resolveErrors` key in API responses when using `resolve`. A
+  missing key means all references resolved successfully.
 </Tip>
 
 ## Studio behavior
@@ -149,10 +153,12 @@ In Studio, reference fields render as a **document picker** filtered by the targ
     The document picker opens, showing documents of the target type.
   </Step>
   <Step title="Search or browse">
-    Filter by title or browse the list. Only documents matching the target type are shown.
+    Filter by title or browse the list. Only documents matching the target type
+    are shown.
   </Step>
   <Step title="Select a document">
-    The selected document's ID is stored in frontmatter. Studio displays the document title as a preview.
+    The selected document's ID is stored in frontmatter. Studio displays the
+    document title as a preview.
   </Step>
 </Steps>
 
@@ -176,5 +182,7 @@ curl "http://localhost:4000/api/content/posts/my-post?type=Post&resolve=authors"
 ```
 
 <Warning>
-  Deleting a referenced document does not cascade. Documents that reference the deleted document will get `REFERENCE_DELETED` or `REFERENCE_NOT_FOUND` resolve errors until the reference is updated or removed.
+  Deleting a referenced document does not cascade. Documents that reference the
+  deleted document will get `REFERENCE_DELETED` or `REFERENCE_NOT_FOUND` resolve
+  errors until the reference is updated or removed.
 </Warning>

--- a/apps/docs/guide/self-hosting.mdx
+++ b/apps/docs/guide/self-hosting.mdx
@@ -20,7 +20,14 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
 | Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows                      |
 
 <Tabs>
-  <Tab title="macOS">```bash brew install --cask docker ```</Tab>
+  <Tab title="macOS">
+    Install Docker Desktop with Homebrew:
+
+    ```bash
+    brew install --cask docker
+    ```
+
+  </Tab>
   <Tab title="Linux">
     Follow the [official Docker install
     guide](https://docs.docker.com/engine/install/) for your distribution.

--- a/apps/docs/guide/self-hosting.mdx
+++ b/apps/docs/guide/self-hosting.mdx
@@ -6,29 +6,29 @@ description: "Stand up your own MDCMS server with Docker Compose"
 Run MDCMS on your own infrastructure. This guide walks you through setting up a self-hosted instance from scratch using Docker Compose.
 
 <Note>
-  Already have a server running? Skip to the [Quick Start](/guide/quickstart) to install the CLI and start managing content.
+  Already have a server running? Skip to the [Quick Start](/guide/quickstart) to
+  install the CLI and start managing content.
 </Note>
 
 ## Prerequisites
 
 You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Node.js) is required for running the server.
 
-| Tool | Version | Install |
-|------|---------|---------|
-| Docker | 24+ | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
-| Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows |
+| Tool           | Version                            | Install                                                           |
+| -------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| Docker         | 24+                                | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
+| Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows                      |
 
 <Tabs>
-  <Tab title="macOS">
-    ```bash
-    brew install --cask docker
-    ```
-  </Tab>
+  <Tab title="macOS">```bash brew install --cask docker ```</Tab>
   <Tab title="Linux">
-    Follow the [official Docker install guide](https://docs.docker.com/engine/install/) for your distribution. Docker Compose v2 is included as a Docker plugin.
+    Follow the [official Docker install
+    guide](https://docs.docker.com/engine/install/) for your distribution.
+    Docker Compose v2 is included as a Docker plugin.
   </Tab>
   <Tab title="Windows">
-    Download and install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
+    Download and install [Docker Desktop for
+    Windows](https://docs.docker.com/desktop/install/windows-install/).
   </Tab>
 </Tabs>
 
@@ -50,6 +50,7 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     ```
 
     The defaults work for local evaluation. For production, you should change database credentials, S3 keys, and configure auth providers. See the [environment variables](#environment-variables) section below.
+
   </Step>
 
   <Step title="Start all services">
@@ -65,6 +66,7 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     - **Mailhog** on ports `1025`/`8025` — email capture (dev/staging)
 
     Database migrations run automatically before the server starts.
+
   </Step>
 
   <Step title="Verify the server is healthy">
@@ -73,18 +75,19 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     ```
 
     You should get a `200 OK` response. If the server is still starting, wait a few seconds and try again.
+
   </Step>
 </Steps>
 
 ## Service Endpoints
 
-| Service | URL | Purpose |
-|---------|-----|---------|
-| MDCMS Server API | [http://localhost:4000](http://localhost:4000) | Backend API — all clients connect here |
-| MinIO Console | [http://localhost:9001](http://localhost:9001) | Object storage admin (default: `minioadmin`/`minioadmin`) |
-| Mailhog UI | [http://localhost:8025](http://localhost:8025) | Captured email viewer (auth flows, invites) |
-| PostgreSQL | `localhost:5432` | Direct database access |
-| Redis | `localhost:6379` | Direct cache access |
+| Service          | URL                                            | Purpose                                                   |
+| ---------------- | ---------------------------------------------- | --------------------------------------------------------- |
+| MDCMS Server API | [http://localhost:4000](http://localhost:4000) | Backend API — all clients connect here                    |
+| MinIO Console    | [http://localhost:9001](http://localhost:9001) | Object storage admin (default: `minioadmin`/`minioadmin`) |
+| Mailhog UI       | [http://localhost:8025](http://localhost:8025) | Captured email viewer (auth flows, invites)               |
+| PostgreSQL       | `localhost:5432`                               | Direct database access                                    |
+| Redis            | `localhost:6379`                               | Direct cache access                                       |
 
 ## First Boot
 
@@ -137,50 +140,51 @@ See the [Studio Guide](/guide/studio/dashboard) for full embedding instructions.
 
 These must be set for the server to start. The Docker Compose defaults handle these automatically for local use.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://mdcms:mdcms@postgres:5432/mdcms` |
-| `REDIS_URL` | Redis connection string | `redis://redis:6379` |
-| `S3_ENDPOINT` | S3-compatible storage endpoint | `http://minio:9000` |
-| `S3_ACCESS_KEY` | S3 access key | `minioadmin` |
-| `S3_SECRET_KEY` | S3 secret key | `minioadmin` |
-| `S3_BUCKET` | S3 bucket name | `mdcms-media` |
+| Variable        | Description                    | Default                                        |
+| --------------- | ------------------------------ | ---------------------------------------------- |
+| `DATABASE_URL`  | PostgreSQL connection string   | `postgresql://mdcms:mdcms@postgres:5432/mdcms` |
+| `REDIS_URL`     | Redis connection string        | `redis://redis:6379`                           |
+| `S3_ENDPOINT`   | S3-compatible storage endpoint | `http://minio:9000`                            |
+| `S3_ACCESS_KEY` | S3 access key                  | `minioadmin`                                   |
+| `S3_SECRET_KEY` | S3 secret key                  | `minioadmin`                                   |
+| `S3_BUCKET`     | S3 bucket name                 | `mdcms-media`                                  |
 
 ### Server
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PORT` | Server listen port | `4000` |
-| `NODE_ENV` | Runtime environment | `development` |
-| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `info` |
+| Variable    | Description                                      | Default       |
+| ----------- | ------------------------------------------------ | ------------- |
+| `PORT`      | Server listen port                               | `4000`        |
+| `NODE_ENV`  | Runtime environment                              | `development` |
+| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `info`        |
 
 ### Email
 
-| Variable | Description | Default |
-|----------|-------------|---------|
+| Variable    | Description          | Default   |
+| ----------- | -------------------- | --------- |
 | `SMTP_HOST` | SMTP server hostname | `mailhog` |
-| `SMTP_PORT` | SMTP server port | `1025` |
+| `SMTP_PORT` | SMTP server port     | `1025`    |
 
 <Warning>
-  The default email configuration uses Mailhog, which captures all outgoing email without delivering it. For production, configure a real SMTP provider.
+  The default email configuration uses Mailhog, which captures all outgoing
+  email without delivering it. For production, configure a real SMTP provider.
 </Warning>
 
 ### Studio
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MDCMS_STUDIO_ALLOWED_ORIGINS` | Comma-separated CORS origins for Studio embedding | — |
-| `MDCMS_AUTH_INSECURE_COOKIES` | Allow HTTP cookies (set `true` for local dev without HTTPS) | `false` |
+| Variable                       | Description                                                 | Default |
+| ------------------------------ | ----------------------------------------------------------- | ------- |
+| `MDCMS_STUDIO_ALLOWED_ORIGINS` | Comma-separated CORS origins for Studio embedding           | —       |
+| `MDCMS_AUTH_INSECURE_COOKIES`  | Allow HTTP cookies (set `true` for local dev without HTTPS) | `false` |
 
 ### Auth Providers (optional)
 
 Configure SSO providers for your organization. Providers are enabled by presence — no feature flag is needed.
 
-| Variable | Description |
-|----------|-------------|
-| `MDCMS_AUTH_OIDC_PROVIDERS` | JSON array of OIDC provider configurations |
-| `MDCMS_AUTH_SAML_PROVIDERS` | JSON array of SAML provider configurations |
-| `MDCMS_AUTH_ADMIN_EMAILS` | Comma-separated emails that get admin role on first login |
+| Variable                    | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `MDCMS_AUTH_OIDC_PROVIDERS` | JSON array of OIDC provider configurations                |
+| `MDCMS_AUTH_SAML_PROVIDERS` | JSON array of SAML provider configurations                |
+| `MDCMS_AUTH_ADMIN_EMAILS`   | Comma-separated emails that get admin role on first login |
 
 <Accordion title="Example OIDC provider config">
 ```json
@@ -268,7 +272,11 @@ docker compose down -v
   <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
     Push, pull, login, schema sync, and all CLI flags
   </Card>
-  <Card title="Studio Guide" icon="layout-dashboard" href="/guide/studio/dashboard">
+  <Card
+    title="Studio Guide"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
     Embed the visual content editor in your application
   </Card>
   <Card title="API Reference" icon="plug" href="/api-reference/overview">

--- a/apps/docs/guide/studio/content-editor.mdx
+++ b/apps/docs/guide/studio/content-editor.mdx
@@ -7,13 +7,13 @@ description: "Creating, editing, and managing documents in the Studio"
 
 Each content type has a paginated document table at `/admin/content/:type`. The table includes:
 
-| Column | Description |
-| --- | --- |
-| Title / Path | Document title from frontmatter, with the filesystem path below it |
-| Translations | Locale coverage summary (only for localized types, e.g., "2/4 locales") |
-| Status | **Published**, **Draft**, or **Changed** (published with unpublished edits) |
-| Updated | Relative timestamp (e.g., "5 min ago", "Yesterday") |
-| Author | Avatar and initials of the creator |
+| Column       | Description                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| Title / Path | Document title from frontmatter, with the filesystem path below it          |
+| Translations | Locale coverage summary (only for localized types, e.g., "2/4 locales")     |
+| Status       | **Published**, **Draft**, or **Changed** (published with unpublished edits) |
+| Updated      | Relative timestamp (e.g., "5 min ago", "Yesterday")                         |
+| Author       | Avatar and initials of the creator                                          |
 
 The table supports:
 
@@ -28,22 +28,29 @@ Row actions are available via a dropdown menu on each row: Edit, Publish, Unpubl
 
 <Steps>
   <Step title="Navigate to the content type">
-    Go to **Content** in the sidebar, then select the type you want to create a document for (e.g., `BlogPost`).
+    Go to **Content** in the sidebar, then select the type you want to create a
+    document for (e.g., `BlogPost`).
   </Step>
   <Step title="Click New Document">
-    Click the **New Document** button in the top-right corner. A dialog appears asking for the document path and, for localized types, the locale.
+    Click the **New Document** button in the top-right corner. A dialog appears
+    asking for the document path and, for localized types, the locale.
   </Step>
   <Step title="Fill in the path">
-    Enter a path relative to the type's content directory (e.g., `my-first-post.mdx`). For localized types, select the target locale.
+    Enter a path relative to the type's content directory (e.g.,
+    `my-first-post.mdx`). For localized types, select the target locale.
   </Step>
   <Step title="Edit frontmatter">
-    In the right sidebar under the **Fields** tab, fill in schema-driven frontmatter fields. Required fields are marked with an asterisk.
+    In the right sidebar under the **Fields** tab, fill in schema-driven
+    frontmatter fields. Required fields are marked with an asterisk.
   </Step>
   <Step title="Write the body">
-    Use the TipTap-based MDX editor on the left panel to write your document content. The editor supports standard Markdown formatting and MDX component insertion.
+    Use the TipTap-based MDX editor on the left panel to write your document
+    content. The editor supports standard Markdown formatting and MDX component
+    insertion.
   </Step>
   <Step title="Save">
-    Changes auto-save approximately 5 seconds after your last edit, or immediately when the editor loses focus.
+    Changes auto-save approximately 5 seconds after your last edit, or
+    immediately when the editor loses focus.
   </Step>
 </Steps>
 
@@ -63,18 +70,21 @@ When an MDX component node is selected in the editor, the sidebar also shows the
 
 The Fields tab generates form controls based on your schema field definitions. Each Zod type maps to a specific UI control:
 
-| Schema type | Form control | Notes |
-| --- | --- | --- |
-| `z.string()` | Text input | Supports `.min()` / `.max()` validation |
-| `z.number()` | Number input | |
-| `z.boolean()` | Toggle switch | |
-| `z.enum([...])` | Dropdown select | Options derived from enum values |
-| `z.coerce.date()` | Date picker | Calendar popover with formatted display |
-| `z.array(z.string())` | Tag input | Type and press Enter to add tags; click to remove |
-| `reference("Type")` | Document picker | Select from existing documents of the referenced type |
+| Schema type           | Form control    | Notes                                                 |
+| --------------------- | --------------- | ----------------------------------------------------- |
+| `z.string()`          | Text input      | Supports `.min()` / `.max()` validation               |
+| `z.number()`          | Number input    |                                                       |
+| `z.boolean()`         | Toggle switch   |                                                       |
+| `z.enum([...])`       | Dropdown select | Options derived from enum values                      |
+| `z.coerce.date()`     | Date picker     | Calendar popover with formatted display               |
+| `z.array(z.string())` | Tag input       | Type and press Enter to add tags; click to remove     |
+| `reference("Type")`   | Document picker | Select from existing documents of the referenced type |
 
 <Accordion title="What about unsupported types?">
-  Complex or nested Zod types that don't map to a standard control display a "Not editable yet" message in the form. The underlying data is preserved -- it won't be lost if you save the document. This ensures forward compatibility as more field types gain UI support.
+  Complex or nested Zod types that don't map to a standard control display a
+  "Not editable yet" message in the form. The underlying data is preserved -- it
+  won't be lost if you save the document. This ensures forward compatibility as
+  more field types gain UI support.
 </Accordion>
 
 Required fields show a red asterisk next to their label. Validation errors from Zod constraints (like `min`, `max`, `regex`) are displayed inline below the field.
@@ -108,7 +118,9 @@ When you select an MDX component node in the editor, the sidebar props panel act
 Inline preview renders through the host bridge if your host app provides one. Otherwise, a fallback label with the component name and prop summary is shown.
 
 <Note>
-  The component catalog is sourced from your local `mdcms.config.ts`, not from the server. No backend component sync is required. The server only needs to know about your content schema.
+  The component catalog is sourced from your local `mdcms.config.ts`, not from
+  the server. No backend component sync is required. The server only needs to
+  know about your content schema.
 </Note>
 
 ## Auto-save
@@ -127,5 +139,9 @@ Each auto-save increments the `draftRevision` counter on the document. Auto-save
 The save operation uses `PUT /api/v1/content/:documentId` and includes the active environment's schema hash for conflict detection. If the schema has drifted (e.g., someone ran `mdcms schema sync` with a different schema), the editor switches to read-only mode and shows a schema recovery prompt.
 
 <Warning>
-  Fields that only exist in certain environments (due to schema overlays) are shown with environment badges in the sidebar. For example, a field defined only in your staging environment overlay will display a "staging" badge. Editing these fields in the wrong environment has no effect -- the server validates against the active environment's schema.
+  Fields that only exist in certain environments (due to schema overlays) are
+  shown with environment badges in the sidebar. For example, a field defined
+  only in your staging environment overlay will display a "staging" badge.
+  Editing these fields in the wrong environment has no effect -- the server
+  validates against the active environment's schema.
 </Warning>

--- a/apps/docs/guide/studio/dashboard.mdx
+++ b/apps/docs/guide/studio/dashboard.mdx
@@ -34,18 +34,20 @@ export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
 `createStudioEmbedConfig` strips client-only MDX loader callbacks so the config is safe to pass through the server-to-client boundary. If your config includes MDX component registrations with runtime loaders (`load`, `loadPropsEditor`), keep everything in the client component instead.
 
 <Note>
-  `basePath` is required because the remote runtime cannot infer its subtree root from deep links. Set it to whatever path prefix your catch-all route uses.
+  `basePath` is required because the remote runtime cannot infer its subtree
+  root from deep links. Set it to whatever path prefix your catch-all route
+  uses.
 </Note>
 
 ### Studio props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| `config` | `MdcmsConfig` | Project, environment, server URL, and optional component registrations |
-| `basePath` | `string` | The URL prefix where Studio is mounted (e.g., `/admin`) |
-| `auth` | `{ mode: "cookie" } \| { mode: "token"; token: string }` | Authentication strategy (defaults to cookie) |
-| `hostBridge` | `HostBridgeV1` | Optional bridge for MDX preview rendering from the host app |
-| `fetcher` | `typeof fetch` | Custom fetch implementation |
+| Prop         | Type                                                     | Description                                                            |
+| ------------ | -------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `config`     | `MdcmsConfig`                                            | Project, environment, server URL, and optional component registrations |
+| `basePath`   | `string`                                                 | The URL prefix where Studio is mounted (e.g., `/admin`)                |
+| `auth`       | `{ mode: "cookie" } \| { mode: "token"; token: string }` | Authentication strategy (defaults to cookie)                           |
+| `hostBridge` | `HostBridgeV1`                                           | Optional bridge for MDX preview rendering from the host app            |
+| `fetcher`    | `typeof fetch`                                           | Custom fetch implementation                                            |
 
 ## Dashboard features
 
@@ -82,18 +84,18 @@ If you have create permissions, a **New Document** button appears above the cont
 
 Studio uses a fixed sidebar for navigation. The sidebar contains these items:
 
-| Route | Label | Visibility |
-| --- | --- | --- |
-| `/admin` | Dashboard | Always |
-| `/admin/content` | Content | Always |
-| `/admin/environments` | Environments | Admin/owner only |
-| `/admin/media` | Media | Always |
-| `/admin/schema` | Schema | Users with schema read permission |
-| `/admin/users` | Users | Users with user management permission |
-| `/admin/settings` | Settings | Users with settings management permission |
-| `/admin/workflows` | Workflows | Always |
-| `/admin/api` | API | Always |
-| `/admin/trash` | Trash | Always |
+| Route                 | Label        | Visibility                                |
+| --------------------- | ------------ | ----------------------------------------- |
+| `/admin`              | Dashboard    | Always                                    |
+| `/admin/content`      | Content      | Always                                    |
+| `/admin/environments` | Environments | Admin/owner only                          |
+| `/admin/media`        | Media        | Always                                    |
+| `/admin/schema`       | Schema       | Users with schema read permission         |
+| `/admin/users`        | Users        | Users with user management permission     |
+| `/admin/settings`     | Settings     | Users with settings management permission |
+| `/admin/workflows`    | Workflows    | Always                                    |
+| `/admin/api`          | API          | Always                                    |
+| `/admin/trash`        | Trash        | Always                                    |
 
 The sidebar is collapsible. In collapsed mode, only icons are shown with tooltips on hover.
 
@@ -108,7 +110,11 @@ Fields that exist only in certain environments (due to schema overlays defined i
 ## Bootstrap
 
 <Note>
-  On load, Studio fetches a bootstrap manifest from `GET /api/v1/studio/bootstrap` on the MDCMS server. This manifest identifies the active runtime build, its integrity hash, and compatibility bounds. If the server is unreachable, Studio shows an error screen with the server URL, error details, and a **Retry** button.
+  On load, Studio fetches a bootstrap manifest from `GET
+  /api/v1/studio/bootstrap` on the MDCMS server. This manifest identifies the
+  active runtime build, its integrity hash, and compatibility bounds. If the
+  server is unreachable, Studio shows an error screen with the server URL, error
+  details, and a **Retry** button.
 </Note>
 
 The bootstrap process validates:
@@ -132,6 +138,7 @@ Studio supports two authentication modes, set via the `auth` prop:
     // or explicitly:
     <Studio config={config} basePath="/admin" auth={{ mode: "cookie" }} />
     ```
+
   </Tab>
   <Tab title="Token">
     For headless or non-browser contexts, pass a Bearer API key directly. Studio sends it as an `Authorization: Bearer <token>` header on every request.
@@ -145,5 +152,6 @@ Studio supports two authentication modes, set via the `auth` prop:
     ```
 
     API keys are created in **Settings > API Keys** and use the `mdcms_key_` prefix.
+
   </Tab>
 </Tabs>

--- a/apps/docs/guide/studio/localization.mdx
+++ b/apps/docs/guide/studio/localization.mdx
@@ -38,14 +38,16 @@ export default defineConfig({
 });
 ```
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `default` | `string` | The default locale used when no locale is specified |
-| `supported` | `string[]` | All locales your project supports |
-| `aliases` | `Record<string, string>` | Maps variant codes to canonical locales (e.g., `"en-US"` resolves to `"en"`) |
+| Property    | Type                     | Description                                                                  |
+| ----------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `default`   | `string`                 | The default locale used when no locale is specified                          |
+| `supported` | `string[]`               | All locales your project supports                                            |
+| `aliases`   | `Record<string, string>` | Maps variant codes to canonical locales (e.g., `"en-US"` resolves to `"en"`) |
 
 <Note>
-  Non-localized types ignore the locale configuration entirely. The locale switcher does not appear in their editor, and they are stored under the internal `__mdcms_default__` locale.
+  Non-localized types ignore the locale configuration entirely. The locale
+  switcher does not appear in their editor, and they are stored under the
+  internal `__mdcms_default__` locale.
 </Note>
 
 ## Locale switcher
@@ -70,7 +72,8 @@ The variant list is fetched from `GET /api/v1/content/:documentId/variants`, whi
     Choose a locale that shows a "Create" option.
   </Step>
   <Step title="Create the variant">
-    A new document is created in the target locale. You can optionally prefill it from the default locale to use as a starting point for translation.
+    A new document is created in the target locale. You can optionally prefill
+    it from the default locale to use as a starting point for translation.
   </Step>
 </Steps>
 
@@ -89,7 +92,9 @@ Each locale variant is a fully independent document:
 Changes to one locale variant do not affect any other variant. There is no automatic content synchronization between locales.
 
 <Tip>
-  Locale variants are linked together through a shared `translationGroupId`. This is visible in the document Info tab and is used internally to group variants for the locale switcher and translation coverage reporting.
+  Locale variants are linked together through a shared `translationGroupId`.
+  This is visible in the document Info tab and is used internally to group
+  variants for the locale switcher and translation coverage reporting.
 </Tip>
 
 ## Translation status in content lists

--- a/apps/docs/guide/studio/publishing.mdx
+++ b/apps/docs/guide/studio/publishing.mdx
@@ -12,18 +12,23 @@ Publishing creates an immutable version snapshot that represents the "live" stat
     Make your changes in the document editor. The draft auto-saves as you work.
   </Step>
   <Step title="Click Publish">
-    From the document editor or the content list row actions menu, click **Publish**.
+    From the document editor or the content list row actions menu, click
+    **Publish**.
   </Step>
   <Step title="Add a change summary (optional)">
-    Enter a short description of what changed. This appears in the version history.
+    Enter a short description of what changed. This appears in the version
+    history.
   </Step>
   <Step title="Confirm">
-    The publish request is sent to the server, and a new immutable version is created.
+    The publish request is sent to the server, and a new immutable version is
+    created.
   </Step>
 </Steps>
 
 <Tip>
-  Change summaries are optional but recommended. They make version history useful for teams by providing context about what changed and why, rather than requiring reviewers to read diffs.
+  Change summaries are optional but recommended. They make version history
+  useful for teams by providing context about what changed and why, rather than
+  requiring reviewers to read diffs.
 </Tip>
 
 ## What happens on publish
@@ -70,7 +75,10 @@ Studio includes a diff viewer for comparing any two versions side-by-side. The d
 - **Body** -- Line-by-line diff of the Markdown/MDX content using LCS-based comparison, with lines marked as unchanged, added, removed, or changed
 
 <Note>
-  Version history only tracks published snapshots, not auto-saves. Each auto-save increments the `draftRevision` counter, but these intermediate states are not preserved. Publish whenever you want to create a recoverable checkpoint.
+  Version history only tracks published snapshots, not auto-saves. Each
+  auto-save increments the `draftRevision` counter, but these intermediate
+  states are not preserved. Publish whenever you want to create a recoverable
+  checkpoint.
 </Note>
 
 ## Restoring a version
@@ -81,11 +89,10 @@ You can restore any previous version to make it the current working draft:
   <Step title="Open version history">
     Navigate to the document editor and open the version history in the sidebar.
   </Step>
-  <Step title="Select a version">
-    Find the version you want to restore.
-  </Step>
+  <Step title="Select a version">Find the version you want to restore.</Step>
   <Step title="Restore">
-    Click **Restore**. The version's snapshot (path, frontmatter, body) becomes the new draft content.
+    Click **Restore**. The version's snapshot (path, frontmatter, body) becomes
+    the new draft content.
   </Step>
 </Steps>
 
@@ -106,7 +113,8 @@ The trash page provides:
 When you restore a deleted document, it returns as a draft. If a document already exists at the same path and locale, the restore will fail with a `CONTENT_PATH_CONFLICT` error -- you need to rename or delete the conflicting document first.
 
 <Warning>
-  Restoring a deleted document requires the `content:write` capability. The trash page itself requires read access to deleted content.
+  Restoring a deleted document requires the `content:write` capability. The
+  trash page itself requires read access to deleted content.
 </Warning>
 
 ## Duplicating a document

--- a/apps/docs/guide/studio/settings.mdx
+++ b/apps/docs/guide/studio/settings.mdx
@@ -4,7 +4,8 @@ description: "API keys, users, webhooks, and Studio configuration"
 ---
 
 <Warning>
-  Settings access requires the **admin** or **owner** role. Users without these roles see an "Access denied" message.
+  Settings access requires the **admin** or **owner** role. Users without these
+  roles see an "Access denied" message.
 </Warning>
 
 ## API Keys
@@ -15,36 +16,36 @@ API keys provide programmatic access to the MDCMS API for external integrations,
 
 Click **Create API Key** and configure:
 
-| Field | Description |
-| --- | --- |
-| **Label** | A human-readable name for the key (e.g., "CI Pipeline", "Preview Deploy") |
-| **Scopes** | Which operations the key can perform (see table below) |
-| **Context allowlist** | Restrict the key to specific project/environment pairs |
-| **Expiration** | Optional expiry date; keys without expiration remain active until revoked |
+| Field                 | Description                                                               |
+| --------------------- | ------------------------------------------------------------------------- |
+| **Label**             | A human-readable name for the key (e.g., "CI Pipeline", "Preview Deploy") |
+| **Scopes**            | Which operations the key can perform (see table below)                    |
+| **Context allowlist** | Restrict the key to specific project/environment pairs                    |
+| **Expiration**        | Optional expiry date; keys without expiration remain active until revoked |
 
 After creation, the full key is displayed **once**. Copy it immediately -- it cannot be retrieved again. All keys use the `mdcms_key_` prefix.
 
 ### Available scopes
 
-| Scope | Description |
-| --- | --- |
-| `content:read` | Read published content |
-| `content:read:draft` | Read draft content |
-| `content:write` | Create and update content |
-| `content:write:draft` | Write draft content |
-| `content:publish` | Publish and unpublish documents |
-| `content:delete` | Delete documents |
-| `schema:read` | Read schema definitions |
-| `schema:write` | Sync schema to the server |
-| `media:upload` | Upload media files |
-| `media:delete` | Delete media files |
-| `webhooks:read` | Read webhook configurations |
-| `webhooks:write` | Create and update webhooks |
-| `environments:clone` | Clone environment content |
+| Scope                  | Description                          |
+| ---------------------- | ------------------------------------ |
+| `content:read`         | Read published content               |
+| `content:read:draft`   | Read draft content                   |
+| `content:write`        | Create and update content            |
+| `content:write:draft`  | Write draft content                  |
+| `content:publish`      | Publish and unpublish documents      |
+| `content:delete`       | Delete documents                     |
+| `schema:read`          | Read schema definitions              |
+| `schema:write`         | Sync schema to the server            |
+| `media:upload`         | Upload media files                   |
+| `media:delete`         | Delete media files                   |
+| `webhooks:read`        | Read webhook configurations          |
+| `webhooks:write`       | Create and update webhooks           |
+| `environments:clone`   | Clone environment content            |
 | `environments:promote` | Promote content between environments |
-| `migrations:run` | Run database migrations |
-| `projects:read` | Read project metadata |
-| `projects:write` | Update project settings |
+| `migrations:run`       | Run database migrations              |
+| `projects:read`        | Read project metadata                |
+| `projects:write`       | Update project settings              |
 
 ### Managing keys
 
@@ -66,36 +67,40 @@ Manage team access at **Users** in the sidebar. This page lets you list users, s
     The invitee receives an email with a link to accept the invitation.
   </Step>
   <Step title="Select a role">
-    Choose Admin, Editor, or Viewer. The Owner role cannot be assigned via invitation.
+    Choose Admin, Editor, or Viewer. The Owner role cannot be assigned via
+    invitation.
   </Step>
   <Step title="Set a folder prefix (optional)">
-    For Editor and Viewer roles, you can restrict access to content under a specific path (e.g., `content/blog`). Leave empty for full project access.
+    For Editor and Viewer roles, you can restrict access to content under a
+    specific path (e.g., `content/blog`). Leave empty for full project access.
   </Step>
   <Step title="Send">
-    The invitation appears in the Pending Invitations section until accepted or revoked.
+    The invitation appears in the Pending Invitations section until accepted or
+    revoked.
   </Step>
 </Steps>
 
 ### Role capabilities
 
-| Capability | Viewer | Editor | Admin | Owner |
-| --- | --- | --- | --- | --- |
-| Read published content | Yes | Yes | Yes | Yes |
-| Read draft content | Yes | Yes | Yes | Yes |
-| Create documents | No | Yes | Yes | Yes |
-| Edit documents | No | Yes | Yes | Yes |
-| Publish / Unpublish | No | Yes | Yes | Yes |
-| Delete documents | No | Yes | Yes | Yes |
-| Manage users | No | No | Yes | Yes |
-| Manage settings | No | No | Yes | Yes |
-| Manage environments | No | No | Yes | Yes |
-| Read schema | No | No | Yes | Yes |
-| Transfer ownership | No | No | No | Yes |
+| Capability             | Viewer | Editor | Admin | Owner |
+| ---------------------- | ------ | ------ | ----- | ----- |
+| Read published content | Yes    | Yes    | Yes   | Yes   |
+| Read draft content     | Yes    | Yes    | Yes   | Yes   |
+| Create documents       | No     | Yes    | Yes   | Yes   |
+| Edit documents         | No     | Yes    | Yes   | Yes   |
+| Publish / Unpublish    | No     | Yes    | Yes   | Yes   |
+| Delete documents       | No     | Yes    | Yes   | Yes   |
+| Manage users           | No     | No     | Yes   | Yes   |
+| Manage settings        | No     | No     | Yes   | Yes   |
+| Manage environments    | No     | No     | Yes   | Yes   |
+| Read schema            | No     | No     | Yes   | Yes   |
+| Transfer ownership     | No     | No     | No    | Yes   |
 
 <Accordion title="What about folder-scoped permissions?">
   Editors and Viewers can be scoped to a folder prefix. When a folder prefix is set (e.g., `content/blog`), the user can only access documents whose paths start with that prefix. This is useful for teams where different people own different content sections.
 
-  Admins always have global scope and cannot be restricted to folders.
+Admins always have global scope and cannot be restricted to folders.
+
 </Accordion>
 
 ### Managing existing users
@@ -124,7 +129,8 @@ The Schema Browser at `/admin/schema` provides a read-only view of all content t
 The schema browser is useful for verifying that `mdcms schema sync` applied your latest type definitions correctly.
 
 <Note>
-  The schema is read-only in Studio. To change content type definitions, update your `mdcms.config.ts` file and run `mdcms schema sync` from the CLI.
+  The schema is read-only in Studio. To change content type definitions, update
+  your `mdcms.config.ts` file and run `mdcms schema sync` from the CLI.
 </Note>
 
 ## Webhooks (post-MVP)
@@ -132,18 +138,21 @@ The schema browser is useful for verifying that `mdcms schema sync` applied your
 <Accordion title="Webhook configuration (planned)">
   Webhook support will allow you to configure HTTP endpoints that receive notifications when content events occur.
 
-  Planned configuration per webhook:
+Planned configuration per webhook:
 
-  | Field | Description |
-  | --- | --- |
-  | **URL** | The endpoint to receive POST requests |
-  | **Events** | Filter which events trigger the webhook (e.g., `content.published`, `content.updated`, `content.deleted`) |
-  | **Secret** | A shared secret for HMAC signature verification of webhook payloads |
-  | **Active** | Toggle to enable or disable the webhook without deleting it |
+| Field      | Description                                                                                               |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| **URL**    | The endpoint to receive POST requests                                                                     |
+| **Events** | Filter which events trigger the webhook (e.g., `content.published`, `content.updated`, `content.deleted`) |
+| **Secret** | A shared secret for HMAC signature verification of webhook payloads                                       |
+| **Active** | Toggle to enable or disable the webhook without deleting it                                               |
+
 </Accordion>
 
 ## Media Library (post-MVP)
 
 <Accordion title="Media management (planned)">
-  The Media page at `/admin/media` will provide a library for managing uploaded files (images, documents, etc.) used in your content. This feature is under development.
+  The Media page at `/admin/media` will provide a library for managing uploaded
+  files (images, documents, etc.) used in your content. This feature is under
+  development.
 </Accordion>

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -9,22 +9,31 @@ MDCMS is an open-source, headless CMS for teams managing structured Markdown and
 
 <CardGroup cols={3}>
   <Card title="Schema-First" icon="file-code" href="/guide/concepts">
-    Content types defined in TypeScript with Zod. The schema drives form generation, validation, and API behavior automatically.
+    Content types defined in TypeScript with Zod. The schema drives form
+    generation, validation, and API behavior automatically.
   </Card>
-  <Card title="Visual Studio" icon="layout-dashboard" href="/guide/studio/dashboard">
-    Embeddable React component with a TipTap-based MDX editor, frontmatter editing, and full version history.
+  <Card
+    title="Visual Studio"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
+    Embeddable React component with a TipTap-based MDX editor, frontmatter
+    editing, and full version history.
   </Card>
   <Card title="CLI-Powered Sync" icon="terminal" href="/guide/cli/installation">
-    `mdcms push` and `mdcms pull` sync between your local filesystem and the CMS. Designed for CI/CD pipelines.
+    `mdcms push` and `mdcms pull` sync between your local filesystem and the
+    CMS. Designed for CI/CD pipelines.
   </Card>
   <Card title="Multi-Environment" icon="git-branch" href="/guide/concepts">
-    Isolated content per environment with schema overlays. Clone and promote content between environments.
+    Isolated content per environment with schema overlays. Clone and promote
+    content between environments.
   </Card>
   <Card title="Localization" icon="globe" href="/guide/studio/localization">
     Built-in i18n with translation groups and per-type localization control.
   </Card>
   <Card title="Extensible" icon="puzzle" href="/architecture/module-system">
-    Module system for custom server actions, CLI commands, and Studio UI extensions.
+    Module system for custom server actions, CLI commands, and Studio UI
+    extensions.
   </Card>
 </CardGroup>
 
@@ -32,16 +41,28 @@ MDCMS is an open-source, headless CMS for teams managing structured Markdown and
 
 <CardGroup cols={2}>
   <Card title="I want to use MDCMS" icon="rocket" href="/guide/quickstart">
-    Install the packages, define your schema, and start managing content in your project.
+    Install the packages, define your schema, and start managing content in your
+    project.
   </Card>
-  <Card title="I want to self-host MDCMS" icon="server" href="/guide/self-hosting">
-    Stand up your own MDCMS server with Docker Compose — database, storage, and API in one command.
+  <Card
+    title="I want to self-host MDCMS"
+    icon="server"
+    href="/guide/self-hosting"
+  >
+    Stand up your own MDCMS server with Docker Compose — database, storage, and
+    API in one command.
   </Card>
-  <Card title="I want to integrate the API" icon="plug" href="/api-reference/overview">
-    Explore the REST API, authentication, and the TypeScript SDK for querying content.
+  <Card
+    title="I want to integrate the API"
+    icon="plug"
+    href="/api-reference/overview"
+  >
+    Explore the REST API, authentication, and the TypeScript SDK for querying
+    content.
   </Card>
   <Card title="I want to contribute" icon="code" href="/development/setup">
-    Clone the monorepo, run the dev environment, and start contributing to MDCMS.
+    Clone the monorepo, run the dev environment, and start contributing to
+    MDCMS.
   </Card>
 </CardGroup>
 

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -4327,10 +4327,7 @@ testWithDatabase(
           ?.includes("text/html"),
         true,
       );
-      assert.equal(
-        lockedAuthorizeHtml.includes("Too many attempts"),
-        true,
-      );
+      assert.equal(lockedAuthorizeHtml.includes("Too many attempts"), true);
       assert.equal(lockedAuthorizeHtml.includes("<form"), true);
       assert.equal(lockedAuthorizeResponse.headers.get("retry-after"), "1");
 

--- a/apps/studio-example/README.md
+++ b/apps/studio-example/README.md
@@ -10,14 +10,14 @@ Example Next.js host app demonstrating how to embed `@mdcms/studio` at a catch-a
 
 ## Routes
 
-| Route | Description |
-| --- | --- |
-| `/` | Host app home page |
-| `/admin/*` | Embedded Studio UI (catch-all) |
-| `/demo/content` | Raw content API demo (draft scope) |
-| `/demo/content/:documentId` | Raw content detail |
-| `/demo/sdk-content` | SDK-backed content demo (`@mdcms/sdk`) |
-| `/demo/sdk-content/:documentId` | SDK-backed content detail |
+| Route                           | Description                            |
+| ------------------------------- | -------------------------------------- |
+| `/`                             | Host app home page                     |
+| `/admin/*`                      | Embedded Studio UI (catch-all)         |
+| `/demo/content`                 | Raw content API demo (draft scope)     |
+| `/demo/content/:documentId`     | Raw content detail                     |
+| `/demo/sdk-content`             | SDK-backed content demo (`@mdcms/sdk`) |
+| `/demo/sdk-content/:documentId` | SDK-backed content detail              |
 
 ## Local Run
 
@@ -36,17 +36,18 @@ bun run compose:dev
 ```
 
 Default demo credentials (seeded automatically in `compose:dev`):
+
 - Email: `demo@mdcms.local`
 - Password: `Demo12345!`
 
 ## Environment Variables
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `MDCMS_STUDIO_EXAMPLE_HOST` | `127.0.0.1` | Host address |
-| `MDCMS_STUDIO_EXAMPLE_PORT` | `4173` | Port |
-| `DATABASE_URL` | `postgresql://mdcms:mdcms@localhost:5432/mdcms` | For `server:dev` |
-| `MDCMS_DEMO_API_KEY` | Seeded in compose | API key for demo content pages |
+| Variable                    | Default                                         | Description                    |
+| --------------------------- | ----------------------------------------------- | ------------------------------ |
+| `MDCMS_STUDIO_EXAMPLE_HOST` | `127.0.0.1`                                     | Host address                   |
+| `MDCMS_STUDIO_EXAMPLE_PORT` | `4173`                                          | Port                           |
+| `DATABASE_URL`              | `postgresql://mdcms:mdcms@localhost:5432/mdcms` | For `server:dev`               |
+| `MDCMS_DEMO_API_KEY`        | Seeded in compose                               | API key for demo content pages |
 
 ## Documentation
 

--- a/apps/studio-review/README.md
+++ b/apps/studio-review/README.md
@@ -25,14 +25,14 @@ This command:
 
 ## Scenario Routes
 
-| Route | Description |
-| --- | --- |
-| `/review/editor/admin` | Editor role view |
+| Route                                   | Description          |
+| --------------------------------------- | -------------------- |
+| `/review/editor/admin`                  | Editor role view     |
 | `/review/editor/admin/content/post/:id` | Editor document view |
-| `/review/owner/admin` | Owner role view |
-| `/review/owner/admin/schema` | Owner schema view |
-| `/review/viewer/admin` | Viewer role view |
-| `/review/schema-error/admin/schema` | Schema error state |
+| `/review/owner/admin`                   | Owner role view      |
+| `/review/owner/admin/schema`            | Owner schema view    |
+| `/review/viewer/admin`                  | Viewer role view     |
+| `/review/schema-error/admin/schema`     | Schema error state   |
 
 ## Notes
 

--- a/docs/specs/SPEC-013-mintlify-docs-site.md
+++ b/docs/specs/SPEC-013-mintlify-docs-site.md
@@ -22,10 +22,12 @@ Mintlify `docs.json` configured from `/Users/blazity/dev/mdcms-web/DESIGN_SYSTEM
 User-facing documentation — how to use MDCMS.
 
 **Group: Introduction**
+
 - `index.mdx` — Welcome page with feature cards, quickstart paths, hero section
 - `guide/concepts.mdx` — Key concepts (projects, environments, content types, documents, draft/publish, localization, references, API keys, RBAC)
 
 **Group: Studio**
+
 - `guide/studio/dashboard.mdx` — Dashboard overview with stats, quick actions
 - `guide/studio/content-editor.mdx` — Creating/editing content, frontmatter panel, body editor, MDX component insertion
 - `guide/studio/publishing.mdx` — Draft/publish workflow, version snapshots, change summaries
@@ -34,12 +36,14 @@ User-facing documentation — how to use MDCMS.
 - `guide/studio/settings.mdx` — API keys, webhooks, media, users, role management
 
 **Group: CLI**
+
 - `guide/cli/installation.mdx` — Install methods, prerequisites, shell completion
 - `guide/cli/commands.mdx` — All commands (login, logout, push, pull) with examples
 - `guide/cli/configuration.mdx` — `mdcms.config.ts`, manifest file, defineConfig/defineType
 - `guide/cli/ci-cd.mdx` — GitHub Actions, GitLab CI, environment variable patterns, automation recipes
 
 **Group: Schema**
+
 - `guide/schema/defining-types.mdx` — defineType syntax, type options (directory, localized, fields)
 - `guide/schema/field-types.mdx` — Primitives and complex types with examples for each
 - `guide/schema/modifiers-and-validation.mdx` — Optional, nullable, default, Zod validation chains
@@ -52,18 +56,21 @@ User-facing documentation — how to use MDCMS.
 Technical deep-dives for contributors and evaluators.
 
 **Group: System Design**
+
 - `architecture/overview.mdx` — High-level system architecture with Mermaid diagram
 - `architecture/technology-stack.mdx` — Technology choices with rationale (why Bun, why Elysia, why Drizzle, etc.)
 - `architecture/module-system.mdx` — Compile-time module loading, core vs custom modules, module API
 - `architecture/multi-tenancy.mdx` — Project/environment isolation, API key restrictions, data boundaries
 
 **Group: Data Layer**
+
 - `architecture/data-model.mdx` — ER diagram, core tables, relationships
 - `architecture/content-lifecycle.mdx` — Create > Edit > Publish > Version flow with Mermaid diagram
 - `architecture/localization-model.mdx` — Translation groups, locale independence, query patterns
 - `architecture/migrations.mdx` — Drizzle migration strategy, schema evolution, zero-downtime patterns
 
 **Group: API Layer**
+
 - `architecture/request-flow.mdx` — 8-step middleware chain walkthrough with code snippets
 - `architecture/auth.mdx` — Authentication (API key, session, CLI device flow) and authorization (RBAC, capabilities)
 - `architecture/scopes-and-permissions.mdx` — Operation scopes, role-capability matrix, enforcement points
@@ -73,11 +80,13 @@ Technical deep-dives for contributors and evaluators.
 Developer reference for integrating with MDCMS.
 
 **Group: Getting Started**
+
 - `api-reference/overview.mdx` — Base URL, required headers, response envelope, pagination
 - `api-reference/authentication.mdx` — Auth methods, obtaining API keys, session management
 - `api-reference/errors.mdx` — Error codes, response format, resolve errors
 
 **Group: Content API**
+
 - `api-reference/content/list.mdx` — GET /content with full param docs, examples, filters
 - `api-reference/content/get.mdx` — GET /content/{id}
 - `api-reference/content/create.mdx` — POST /content
@@ -88,21 +97,25 @@ Developer reference for integrating with MDCMS.
 - `api-reference/content/overview-stats.mdx` — GET /content/overview
 
 **Group: Schema API**
+
 - `api-reference/schema/list.mdx` — GET /schema
 - `api-reference/schema/get.mdx` — GET /schema/{type}
 - `api-reference/schema/sync.mdx` — PUT /schema (CLI sync flow)
 
 **Group: Media API**
+
 - `api-reference/media/upload.mdx` — POST /media
 - `api-reference/media/delete.mdx` — DELETE /media/{id}
 
 **Group: Webhooks API**
+
 - `api-reference/webhooks/list.mdx` — GET /webhooks
 - `api-reference/webhooks/create.mdx` — POST /webhooks
 - `api-reference/webhooks/update.mdx` — PUT /webhooks/{id}
 - `api-reference/webhooks/delete.mdx` — DELETE /webhooks/{id}
 
 **Group: SDK**
+
 - `api-reference/sdk/installation.mdx` — Install, peer deps
 - `api-reference/sdk/client-setup.mdx` — createClient, configuration options
 - `api-reference/sdk/querying.mdx` — get, list, filtering, sorting, pagination
@@ -114,11 +127,13 @@ Developer reference for integrating with MDCMS.
 Contributor guide for working on MDCMS itself.
 
 **Group: Getting Started**
+
 - `development/prerequisites.mdx` — Bun, Docker, Node.js, OS-specific notes
 - `development/local-setup.mdx` — Clone, install, Docker Compose, manual setup, service endpoints
 - `development/environment-variables.mdx` — All env vars with descriptions, required vs optional
 
 **Group: Monorepo**
+
 - `development/packages/overview.mdx` — Workspace layout, dependency graph
 - `development/packages/server.mdx` — Elysia server architecture, adding endpoints, testing
 - `development/packages/cli.mdx` — CLI architecture, adding commands
@@ -128,12 +143,14 @@ Contributor guide for working on MDCMS itself.
 - `development/packages/modules.mdx` — Module system, creating custom modules
 
 **Group: Contributing**
+
 - `development/workflow.mdx` — Branch naming, commit conventions, PR process
 - `development/code-conventions.mdx` — TypeScript strict, formatting, naming rules
 - `development/testing.mdx` — Unit tests, integration tests, CI gates, coverage
 - `development/database-migrations.mdx` — Drizzle migration workflow, schema changes
 
 ### Tab 5: Changelog
+
 - `changelog.mdx` — Release notes placeholder
 
 ## Total: ~50 pages
@@ -141,23 +158,27 @@ Contributor guide for working on MDCMS itself.
 ## Content Depth Strategy
 
 ### Guides
+
 - Step-by-step walkthroughs using `<Steps>` component
 - Tips/warnings using `<Note>`, `<Warning>`, `<Tip>` callouts inline
 - "Common Issues" `<AccordionGroup>` at bottom of procedural pages
 - Real configuration examples, not abstract placeholders
 
 ### API Reference
+
 - `<ParamField>` for every parameter on every endpoint
 - Full request/response JSON in `<CodeGroup>` (cURL + SDK)
 - Error cases documented per endpoint
 - Pagination examples for list endpoints
 
 ### Architecture
+
 - Mermaid diagrams for data flow, entity relationships, request pipeline
 - Code snippets from the actual codebase where relevant
 - Decision rationale ("Why X over Y") in callouts
 
 ### Development
+
 - Copy-pasteable commands throughout
 - Platform-specific `<Tabs>` (macOS / Linux)
 - Troubleshooting `<Accordion>` sections
@@ -165,18 +186,18 @@ Contributor guide for working on MDCMS itself.
 
 ## Component Usage Plan
 
-| Component | Usage |
-|-----------|-------|
-| `<Steps>` | All procedural guides (setup, publishing, CLI workflows) |
-| `<CodeGroup>` | Multi-format examples (cURL/SDK, bun/npm, macOS/Linux) |
-| `<Tabs>` | Platform alternatives, install methods |
-| `<Accordion>` | FAQ, troubleshooting, edge cases |
-| `<Card>` | Landing page navigation, feature highlights |
-| `<Note/Warning/Tip/Info>` | Inline callouts throughout |
-| `<ParamField>` | Every API parameter |
-| Mermaid | Architecture diagrams, data flow, ER diagrams |
-| Tables | Technology stacks, permission matrices, env vars |
-| `<Frame>` | Screenshot/diagram containers |
+| Component                 | Usage                                                    |
+| ------------------------- | -------------------------------------------------------- |
+| `<Steps>`                 | All procedural guides (setup, publishing, CLI workflows) |
+| `<CodeGroup>`             | Multi-format examples (cURL/SDK, bun/npm, macOS/Linux)   |
+| `<Tabs>`                  | Platform alternatives, install methods                   |
+| `<Accordion>`             | FAQ, troubleshooting, edge cases                         |
+| `<Card>`                  | Landing page navigation, feature highlights              |
+| `<Note/Warning/Tip/Info>` | Inline callouts throughout                               |
+| `<ParamField>`            | Every API parameter                                      |
+| Mermaid                   | Architecture diagrams, data flow, ER diagrams            |
+| Tables                    | Technology stacks, permission matrices, env vars         |
+| `<Frame>`                 | Screenshot/diagram containers                            |
 
 ## Git Strategy
 

--- a/packages/modules/README.md
+++ b/packages/modules/README.md
@@ -18,10 +18,10 @@ packages/modules/<module-id>/src/
 
 ## Current Modules
 
-| Module | Description |
-| --- | --- |
-| `core.system` | System-level preflight validation and server routes |
-| `domain.content` | Content domain preflight hooks and server routes |
+| Module           | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `core.system`    | System-level preflight validation and server routes |
+| `domain.content` | Content domain preflight hooks and server routes    |
 
 ## How It Works
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -43,12 +43,12 @@ const posts = await cms.list("BlogPost", {
 
 Creates an SDK client instance.
 
-| Option | Required | Description |
-| --- | --- | --- |
-| `serverUrl` | Yes | MDCMS server URL |
-| `apiKey` | Yes | API key for authentication |
-| `project` | Yes | Default project name |
-| `environment` | Yes | Default environment name |
+| Option        | Required | Description                |
+| ------------- | -------- | -------------------------- |
+| `serverUrl`   | Yes      | MDCMS server URL           |
+| `apiKey`      | Yes      | API key for authentication |
+| `project`     | Yes      | Default project name       |
+| `environment` | Yes      | Default environment name   |
 
 ### `client.get(type, options)`
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -50,16 +50,16 @@ The shell handles startup errors (network failures, incompatible versions, disab
 
 Once mounted, Studio provides these routes under your `basePath`:
 
-| Route | Description |
-| --- | --- |
-| `/admin` | Dashboard |
-| `/admin/content` | Content list with type filtering |
+| Route                              | Description                                                   |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `/admin`                           | Dashboard                                                     |
+| `/admin/content`                   | Content list with type filtering                              |
 | `/admin/content/:type/:documentId` | Document editor with draft save, publish, and version history |
-| `/admin/environments` | Environment management |
-| `/admin/schema` | Read-only schema browser |
-| `/admin/users` | User management (admin/owner only) |
-| `/admin/settings` | Settings (admin/owner only) |
-| `/admin/trash` | Deleted content |
+| `/admin/environments`              | Environment management                                        |
+| `/admin/schema`                    | Read-only schema browser                                      |
+| `/admin/users`                     | User management (admin/owner only)                            |
+| `/admin/settings`                  | Settings (admin/owner only)                                   |
+| `/admin/trash`                     | Deleted content                                               |
 
 ## MDX Components
 
@@ -83,13 +83,13 @@ Registered components can be inserted from the toolbar or via `/` slash commands
 
 ## Exports
 
-| Import Path | Description |
-| --- | --- |
-| `@mdcms/studio` | `Studio` component, `PropsEditorComponent` type |
-| `@mdcms/studio/runtime` | `prepareStudioConfig`, `createStudioEmbedConfig`, runtime helpers |
-| `@mdcms/studio/markdown-pipeline` | `parseMarkdownToDocument`, `serializeDocumentToMarkdown` |
-| `@mdcms/studio/document-shell` | `loadStudioDocumentShell` for host-app shell rendering |
-| `@mdcms/studio/action-catalog-adapter` | Typed action catalog client |
+| Import Path                            | Description                                                       |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `@mdcms/studio`                        | `Studio` component, `PropsEditorComponent` type                   |
+| `@mdcms/studio/runtime`                | `prepareStudioConfig`, `createStudioEmbedConfig`, runtime helpers |
+| `@mdcms/studio/markdown-pipeline`      | `parseMarkdownToDocument`, `serializeDocumentToMarkdown`          |
+| `@mdcms/studio/document-shell`         | `loadStudioDocumentShell` for host-app shell rendering            |
+| `@mdcms/studio/action-catalog-adapter` | Typed action catalog client                                       |
 
 ## Documentation
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -301,10 +301,7 @@ export default function DashboardPage() {
         {/* Quick Actions */}
         {canCreateContent && (
           <div className="flex flex-wrap gap-3">
-            <Button
-              variant="default"
-              asChild
-            >
+            <Button variant="default" asChild>
               <Link href="/admin/content">
                 <Plus className="mr-2 h-4 w-4" />
                 New Document

--- a/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/schema-page.tsx
@@ -316,18 +316,23 @@ export function SchemaPageView({ state }: { state: StudioSchemaState }) {
             </p>
           </section>
         ) : (
-          <div data-mdcms-schema-page-state="ready" className="grid gap-4 lg:grid-cols-2">
+          <div
+            data-mdcms-schema-page-state="ready"
+            className="grid gap-4 lg:grid-cols-2"
+          >
             {sortEntries(state.entries).map((entry) => (
-              <Card key={entry.type} data-mdcms-schema-entry-type={entry.type} className="p-0 gap-0">
+              <Card
+                key={entry.type}
+                data-mdcms-schema-entry-type={entry.type}
+                className="p-0 gap-0"
+              >
                 <CardHeader className="gap-2 p-5 pb-3">
                   <div className="space-y-1.5">
                     <div className="flex flex-wrap items-center gap-2">
                       <CardTitle className="text-lg tracking-tight">
                         {entry.type}
                       </CardTitle>
-                      <Badge
-                        variant={entry.localized ? "default" : "outline"}
-                      >
+                      <Badge variant={entry.localized ? "default" : "outline"}>
                         {entry.localized ? "Localized" : "Single locale"}
                       </Badge>
                     </div>

--- a/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/session-context.tsx
@@ -9,7 +9,11 @@ export type StudioSessionState =
   | { status: "authenticated"; session: StudioSessionInfo; csrfToken: string }
   | { status: "unauthenticated" }
   | { status: "error"; message: string }
-  | { status: "token-error"; reason: "missing" | "invalid" | "forbidden"; message: string };
+  | {
+      status: "token-error";
+      reason: "missing" | "invalid" | "forbidden";
+      message: string;
+    };
 
 const DEFAULT_SESSION_STATE: StudioSessionState = { status: "loading" };
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
@@ -132,9 +132,7 @@ export default function SettingsPage({
                     Manage API keys for external integrations
                   </p>
                 </div>
-                <Button
-                  onClick={() => setCreateDialogOpen(true)}
-                >
+                <Button onClick={() => setCreateDialogOpen(true)}>
                   <Plus className="mr-2 h-4 w-4" />
                   Create API Key
                 </Button>

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -683,10 +683,7 @@ export default function UsersPage() {
               >
                 Cancel
               </Button>
-              <Button
-                disabled={isUpdatingGrants}
-                onClick={handleEditRole}
-              >
+              <Button disabled={isUpdatingGrants} onClick={handleEditRole}>
                 {isUpdatingGrants ? "Saving..." : "Save"}
               </Button>
             </DialogFooter>

--- a/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/page-header.tsx
@@ -66,10 +66,7 @@ export function PageHeaderHeading({
   ...props
 }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h1
-      className={cn("text-h5 font-heading font-bold", className)}
-      {...props}
-    >
+    <h1 className={cn("text-h5 font-heading font-bold", className)} {...props}>
       {children}
     </h1>
   );

--- a/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/badge.tsx
@@ -9,20 +9,13 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-muted text-foreground",
-        white:
-          "bg-card text-foreground",
-        grey:
-          "bg-neutral-grey text-foreground",
-        "light-blue":
-          "bg-light-blue text-primary",
-        destructive:
-          "bg-destructive/10 text-destructive",
-        outline:
-          "border-border text-foreground [a&]:hover:bg-muted",
-        tag:
-          "text-tag rounded-pill gap-1.5 px-2.5 py-0.5",
+        default: "bg-muted text-foreground",
+        white: "bg-card text-foreground",
+        grey: "bg-neutral-grey text-foreground",
+        "light-blue": "bg-light-blue text-primary",
+        destructive: "bg-destructive/10 text-destructive",
+        outline: "border-border text-foreground [a&]:hover:bg-muted",
+        tag: "text-tag rounded-pill gap-1.5 px-2.5 py-0.5",
         "tag-accent":
           "text-tag-2 bg-vibrant-green text-foreground rounded-sm px-3 py-1",
       },

--- a/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/ui/card.tsx
@@ -63,11 +63,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      data-slot="card-content"
-      className={cn("", className)}
-      {...props}
-    />
+    <div data-slot="card-content" className={cn("", className)} {...props} />
   );
 }
 

--- a/packages/studio/src/lib/runtime-ui/styles.css
+++ b/packages/studio/src/lib/runtime-ui/styles.css
@@ -9,42 +9,42 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #FCF9F8;
-  --background-subtle: #F6F3F2;
-  --foreground: #1C1B1B;
+  --background: #fcf9f8;
+  --background-subtle: #f6f3f2;
+  --foreground: #1c1b1b;
   --foreground-muted: #444655;
-  --primary: #2F49E5;
-  --primary-foreground: #FFFFFF;
-  --accent: #D6FF4D;
+  --primary: #2f49e5;
+  --primary-foreground: #ffffff;
+  --accent: #d6ff4d;
   --accent-hover: #c8ea3a;
   --accent-subtle: rgba(47, 73, 229, 0.08);
-  --accent-foreground: #1C1B1B;
-  --secondary: #1C1B1B;
-  --secondary-foreground: #FFFFFF;
-  --muted: #F6F3F2;
+  --accent-foreground: #1c1b1b;
+  --secondary: #1c1b1b;
+  --secondary-foreground: #ffffff;
+  --muted: #f6f3f2;
   --muted-foreground: #444655;
-  --border: #C5C5D8;
-  --border-focus: #2F49E5;
-  --input: #C5C5D8;
-  --ring: #2F49E5;
-  --card: #FFFFFF;
-  --card-foreground: #1C1B1B;
-  --popover: #FFFFFF;
-  --popover-foreground: #1C1B1B;
+  --border: #c5c5d8;
+  --border-focus: #2f49e5;
+  --input: #c5c5d8;
+  --ring: #2f49e5;
+  --card: #ffffff;
+  --card-foreground: #1c1b1b;
+  --popover: #ffffff;
+  --popover-foreground: #1c1b1b;
   --destructive: #ef4444;
-  --destructive-foreground: #FFFFFF;
+  --destructive-foreground: #ffffff;
   --success: #22c55e;
   --success-subtle: #f0fdf4;
   --warning: #f59e0b;
   --warning-subtle: #fffbeb;
-  --blue-100: #EAEDFF;
-  --vibrant-green: #CAF240;
-  --neutral-grey: #E5E2E1;
-  --light-blue: #E2E2F1;
-  --code-bg: #F0EDEC;
+  --blue-100: #eaedff;
+  --vibrant-green: #caf240;
+  --neutral-grey: #e5e2e1;
+  --light-blue: #e2e2f1;
+  --code-bg: #f0edec;
   --divider: rgba(197, 197, 216, 0.3);
   --card-border: rgba(197, 197, 216, 0.2);
-  --chart-1: #2F49E5;
+  --chart-1: #2f49e5;
   --chart-2: #22c55e;
   --chart-3: #f59e0b;
   --chart-4: #6366f1;
@@ -54,7 +54,7 @@
   --sidebar: var(--background);
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: var(--accent-subtle);
   --sidebar-accent-foreground: var(--primary);
   --sidebar-border: var(--border);
@@ -62,42 +62,42 @@
 }
 
 .dark {
-  --background: #1C1B1B;
+  --background: #1c1b1b;
   --background-subtle: #242322;
-  --foreground: #FCF9F8;
+  --foreground: #fcf9f8;
   --foreground-muted: #9a9caa;
-  --primary: #6B7FFF;
-  --primary-foreground: #FFFFFF;
-  --accent: #CAF240;
+  --primary: #6b7fff;
+  --primary-foreground: #ffffff;
+  --accent: #caf240;
   --accent-hover: #b8d635;
   --accent-subtle: rgba(107, 127, 255, 0.1);
-  --accent-foreground: #FCF9F8;
-  --secondary: #FCF9F8;
-  --secondary-foreground: #1C1B1B;
+  --accent-foreground: #fcf9f8;
+  --secondary: #fcf9f8;
+  --secondary-foreground: #1c1b1b;
   --muted: #2a2928;
   --muted-foreground: #9a9caa;
   --border: rgba(197, 197, 216, 0.2);
-  --border-focus: #6B7FFF;
+  --border-focus: #6b7fff;
   --input: rgba(197, 197, 216, 0.3);
-  --ring: #6B7FFF;
+  --ring: #6b7fff;
   --card: #242322;
-  --card-foreground: #FCF9F8;
+  --card-foreground: #fcf9f8;
   --popover: #242322;
-  --popover-foreground: #FCF9F8;
+  --popover-foreground: #fcf9f8;
   --destructive: #f87171;
-  --destructive-foreground: #1C1B1B;
+  --destructive-foreground: #1c1b1b;
   --success: #4ade80;
   --success-subtle: #14532d;
   --warning: #fbbf24;
   --warning-subtle: #422006;
   --blue-100: rgba(234, 237, 255, 0.1);
-  --vibrant-green: #CAF240;
+  --vibrant-green: #caf240;
   --neutral-grey: #3a3938;
   --light-blue: rgba(226, 226, 241, 0.15);
   --code-bg: #2a2928;
   --divider: rgba(197, 197, 216, 0.15);
   --card-border: rgba(197, 197, 216, 0.1);
-  --chart-1: #6B7FFF;
+  --chart-1: #6b7fff;
   --chart-2: #4ade80;
   --chart-3: #fbbf24;
   --chart-4: #818cf8;
@@ -106,7 +106,7 @@
   --sidebar: var(--background);
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: var(--accent-subtle);
   --sidebar-accent-foreground: var(--primary);
   --sidebar-border: var(--border);
@@ -115,9 +115,12 @@
 
 @theme inline {
   /* Font families */
-  --font-heading: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
-  --font-body: "Inter Variable", "Inter", "Inter Fallback", system-ui, sans-serif;
-  --font-sans: "Inter Variable", "Inter", "Inter Fallback", system-ui, sans-serif;
+  --font-heading:
+    "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
+  --font-body:
+    "Inter Variable", "Inter", "Inter Fallback", system-ui, sans-serif;
+  --font-sans:
+    "Inter Variable", "Inter", "Inter Fallback", system-ui, sans-serif;
   --font-mono: "Geist Mono Variable", "Geist Mono", monospace;
 
   /* Heading type scale */
@@ -271,7 +274,11 @@
         var(--accent-subtle),
         transparent 24rem
       ),
-      linear-gradient(180deg, var(--background) 0%, var(--background-subtle) 100%);
+      linear-gradient(
+        180deg,
+        var(--background) 0%,
+        var(--background-subtle) 100%
+      );
   }
 
   .mdcms-studio-runtime :is(h1, h2, h3, h4, h5, h6) {

--- a/packages/studio/src/lib/studio-component.tsx
+++ b/packages/studio/src/lib/studio-component.tsx
@@ -50,8 +50,7 @@ export type StudioStartupErrorDescription = {
 };
 
 const LOADING_TITLE = "Loading Studio";
-const LOADING_SUMMARY =
-  "Fetching and validating the runtime bundle.";
+const LOADING_SUMMARY = "Fetching and validating the runtime bundle.";
 const READY_CONTAINER_STYLE = {
   minHeight: "20rem",
 } as const;

--- a/packages/studio/src/lib/studio.test.ts
+++ b/packages/studio/src/lib/studio.test.ts
@@ -627,10 +627,7 @@ test("StudioShellFrame renders loading startup message", () => {
   );
 
   assert.match(markup, /Loading Studio/);
-  assert.match(
-    markup,
-    /Fetching and validating the runtime bundle\./,
-  );
+  assert.match(markup, /Fetching and validating the runtime bundle\./);
   assert.match(markup, /mdcms-studio-shell__/);
   assert.match(markup, /<style>/);
   assert.match(markup, /overflow-y:\s*auto/);


### PR DESCRIPTION
## Summary
- Ran the repo Prettier formatter over the files failing `format:check`.
- Kept the CLI push dry-run/no-work paths from requiring schema state before writes.
- Added an explicit `SCHEMA_STATE_MISSING` failure before real push writes if schema sync does not leave readable local state.

## Verification
- `bun run format:check` initially failed on 58 files.
- `bun nx run cli:build` passes.
- `bun run quality` passes.
- `git diff --check` passes.

## Local ci:required note
- `bun run ci:required` reaches unit tests and fails in `server:test` on existing server-side cases outside this branch scope:
  - `CLI login authorize applies password backoff without authorizing the challenge`
  - `CLI login authorize GET with expired challenge returns styled HTML error page`
  - `CLI login authorize GET with invalid challenge ID returns styled HTML error page`
  - `CLI login authorize POST with invalid credentials returns HTML with error message`
  - `demo:seed completes successfully for a fresh staging scope`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push command now defers schema-state validation until writes, so dry-run/no-op pushes can succeed without a local schema state.

* **Tests**
  * Added tests covering push behavior when local schema state is absent, including dry-run and no-op scenarios.

* **Documentation**
  * Widespread docs reformatting for improved table alignment, wrapping, and readability across guides and API reference.

* **Style**
  * Formatting tweaks across UI markup, styles, and test/assertion formatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->