### PR TITLE
docs: add end-user integration guide for embedding MDCMS

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -61,7 +61,14 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": ["index", "guide/quickstart", "guide/self-hosting", "guide/concepts", "agent-instructions"]
+            "pages": [
+              "index",
+              "guide/quickstart",
+              "guide/self-hosting",
+              "guide/integration",
+              "guide/concepts",
+              "agent-instructions"
+            ]
           },
           {
             "group": "Studio",
@@ -128,9 +135,7 @@
           },
           {
             "group": "SDK",
-            "pages": [
-              "api-reference/sdk"
-            ]
+            "pages": ["api-reference/sdk"]
           }
         ]
       },
@@ -139,17 +144,11 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": [
-              "development/setup",
-              "development/packages"
-            ]
+            "pages": ["development/setup", "development/packages"]
           },
           {
             "group": "Contributing",
-            "pages": [
-              "development/contributing",
-              "development/testing"
-            ]
+            "pages": ["development/contributing", "development/testing"]
           }
         ]
       }

--- a/apps/docs/guide/integration.mdx
+++ b/apps/docs/guide/integration.mdx
@@ -68,10 +68,12 @@ const BlogPost = defineType("BlogPost", {
 });
 
 export default defineConfig({
-  // These four fields are used by Studio at runtime:
+  // Core runtime fields used by StudioEmbedConfig:
   project: "my-site",
   environment: "production",
   serverUrl: "https://cms.example.com",
+  // Optional — locales are not part of StudioEmbedConfig but are
+  // used by Studio when available on the full MdcmsConfig:
   locales: {
     default: "en",
     supported: ["en", "fr"],

--- a/apps/docs/guide/integration.mdx
+++ b/apps/docs/guide/integration.mdx
@@ -1,0 +1,381 @@
+---
+title: "Integrating MDCMS"
+description: "Embed MDCMS Studio and the content SDK into your own application"
+---
+
+Wire MDCMS into a real application you own. This guide covers host app responsibilities, Studio embedding, authentication, and production configuration.
+
+<Tip>
+  Need a running server first? See [Self-Hosting](/guide/self-hosting). Need to
+  install the CLI and define your schema? See the [Quick
+  Start](/guide/quickstart).
+</Tip>
+
+## Prerequisites
+
+Before integrating, you need:
+
+1. **A running MDCMS server** — self-hosted via Docker Compose or a managed instance
+2. **The CLI installed and a project initialized** — `npx mdcms init` creates your `mdcms.config.ts` and syncs your schema
+3. **A React application** — Next.js App Router is the primary example below; any React framework with catch-all routing works
+
+## Host app responsibilities
+
+MDCMS handles content storage, the Studio UI, authentication flows, and the API. Your host app provides the mount point and configuration.
+
+| Your app provides                                           | MDCMS handles                              |
+| ----------------------------------------------------------- | ------------------------------------------ |
+| A catch-all route where Studio mounts                       | Studio UI, runtime, and in-app navigation  |
+| `MDCMS_STUDIO_ALLOWED_ORIGINS` includes your app's origin   | Authentication flow and session management |
+| `mdcms.config.ts` with project, environment, and server URL | Content storage, versioning, and media     |
+| Optional: custom MDX component registrations                | Schema validation and API serving          |
+| Optional: SDK queries for rendering content                 | Published content delivery                 |
+
+## Installing packages
+
+Install `@mdcms/studio` to embed the visual editor. Add `@mdcms/sdk` if you also query content for rendering.
+
+<CodeGroup>
+```bash npm
+npm install @mdcms/studio
+# Optional: content SDK
+npm install @mdcms/sdk
+```
+
+```bash bun
+bun add @mdcms/studio
+# Optional: content SDK
+bun add @mdcms/sdk
+```
+
+</CodeGroup>
+
+## Project configuration
+
+Your `mdcms.config.ts` (created by `mdcms init`) drives both CLI sync and Studio embedding. The fields that matter for integration:
+
+```typescript mdcms.config.ts
+import { defineConfig, defineType } from "@mdcms/cli";
+import { z } from "zod";
+
+const BlogPost = defineType("BlogPost", {
+  directory: "content/blog",
+  localized: true,
+  fields: {
+    title: z.string().min(1),
+    slug: z.string().regex(/^[a-z0-9-]+$/),
+  },
+});
+
+export default defineConfig({
+  // These four fields are used by Studio at runtime:
+  project: "my-site",
+  environment: "production",
+  serverUrl: "https://cms.example.com",
+  locales: {
+    default: "en",
+    supported: ["en", "fr"],
+  },
+  // Schema and sync config:
+  contentDirectories: ["content"],
+  types: [BlogPost],
+});
+```
+
+See the [Schema Guide](/guide/schema/defining-types) for field types, references, and environment overlays.
+
+## Embedding Studio
+
+Studio is a React component that owns all rendering under a catch-all route (e.g., `/admin/*`). The recommended pattern splits server and client concerns so the config can be safely serialized across the boundary.
+
+### Basic setup
+
+Use this when you do not register custom MDX components.
+
+<Steps>
+  <Step title="Create the server component">
+    The server component imports your config, strips non-serializable values via `createStudioEmbedConfig`, and passes the result to the client component.
+
+    ```tsx app/admin/[[...path]]/page.tsx
+    import { createStudioEmbedConfig } from "@mdcms/studio/runtime";
+    import config from "../../../mdcms.config";
+    import { AdminStudioClient } from "./admin-studio-client";
+
+    export default async function AdminPage() {
+      return <AdminStudioClient config={createStudioEmbedConfig(config)} />;
+    }
+    ```
+
+  </Step>
+
+  <Step title="Create the client component">
+    The client component renders Studio. The `basePath` prop tells Studio which URL prefix it owns.
+
+    ```tsx app/admin/[[...path]]/admin-studio-client.tsx
+    "use client";
+
+    import { Studio, type MdcmsConfig } from "@mdcms/studio";
+
+    export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
+      return <Studio config={config} basePath="/admin" />;
+    }
+    ```
+
+  </Step>
+</Steps>
+
+<Note>
+  `basePath` is required. Studio cannot infer its mount prefix from deep links
+  like `/admin/content/posts/abc`. Set it to the path prefix your catch-all
+  route uses.
+</Note>
+
+<Note>
+  **Other React frameworks:** The pattern is the same for any framework — create a catch-all route that renders the `<Studio>` component. In Remix, use a splat route (`admin.$.tsx`). In Vite with React Router, use a wildcard route (`/admin/*`). The key requirement is that Studio receives all sub-paths under its mount point.
+</Note>
+
+### Setup with MDX components
+
+If your app registers custom MDX components for the Studio editor (e.g., `<Chart>`, `<Callout>`, `<PricingTable>`), use `prepareStudioConfig` on the server to extract TypeScript prop metadata at build time.
+
+<Steps>
+  <Step title="Register components in your config">
+    Add component registrations to your `mdcms.config.ts`. Each component needs a `name`, `importPath`, and a `load` function. Optional: `propHints` for widget customization, `propsEditor`/`loadPropsEditor` for fully custom prop editing UI.
+
+    ```typescript mdcms.config.ts
+    import { defineConfig, defineType } from "@mdcms/cli";
+
+    export const mdxComponents = [
+      {
+        name: "Chart",
+        importPath: "./components/mdx/Chart",
+        description: "Inline data chart.",
+        load: () => import("./components/mdx/Chart").then((m) => m.Chart),
+        propHints: {
+          color: { widget: "color-picker" },
+        },
+      },
+      {
+        name: "Callout",
+        importPath: "./components/mdx/Callout",
+        description: "Styled callout block with nested content.",
+        load: () => import("./components/mdx/Callout").then((m) => m.Callout),
+      },
+    ] as const;
+
+    export default defineConfig({
+      project: "my-site",
+      environment: "production",
+      serverUrl: "https://cms.example.com",
+      contentDirectories: ["content"],
+      components: [...mdxComponents],
+      types: [/* your types */],
+    });
+    ```
+
+  </Step>
+
+  <Step title="Prepare config on the server">
+    `prepareStudioConfig` reads your component source files and extracts TypeScript prop types so the Studio editor can generate form controls automatically.
+
+    ```tsx app/admin/[[...path]]/page.tsx
+    import { resolve } from "node:path";
+    import { prepareStudioConfig } from "@mdcms/studio/runtime";
+    import config from "../../../mdcms.config";
+    import { AdminStudioClient } from "./admin-studio-client";
+
+    export default async function AdminPage() {
+      const appRoot = process.cwd();
+      const prepared = await prepareStudioConfig(config, {
+        cwd: appRoot,
+        tsconfigPath: resolve(appRoot, "tsconfig.json"),
+      });
+
+      // Extract only the serializable metadata for the client
+      const componentMeta = prepared.components?.map((c) => ({
+        name: c.name,
+        ...(c.extractedProps ? { extractedProps: c.extractedProps } : {}),
+      })) ?? [];
+
+      return (
+        <AdminStudioClient
+          preparedComponents={componentMeta}
+          schemaHash={
+            "_schemaHash" in prepared
+              ? (prepared._schemaHash as string)
+              : undefined
+          }
+        />
+      );
+    }
+    ```
+
+  </Step>
+
+  <Step title="Build the client config">
+    The client component merges extracted prop metadata back onto the component registrations (which include the runtime `load` callbacks).
+
+    ```tsx app/admin/[[...path]]/admin-studio-client.tsx
+    "use client";
+
+    import { Studio, type MdcmsConfig } from "@mdcms/studio";
+    import { mdxComponents } from "../../../mdcms.config";
+
+    type ComponentMeta = { name: string; extractedProps?: Record<string, unknown> };
+
+    export function AdminStudioClient(props: {
+      preparedComponents: ComponentMeta[];
+      schemaHash?: string;
+    }) {
+      const extractedByName = new Map(
+        props.preparedComponents.map((c) => [c.name, c.extractedProps]),
+      );
+
+      const config: MdcmsConfig = {
+        project: "my-site",
+        environment: "production",
+        serverUrl: "https://cms.example.com",
+        ...(props.schemaHash ? { _schemaHash: props.schemaHash } : {}),
+        components: [...mdxComponents].map((component) => {
+          const extracted = extractedByName.get(component.name);
+          return extracted ? { ...component, extractedProps: extracted } : component;
+        }),
+      };
+
+      return <Studio config={config} basePath="/admin" />;
+    }
+    ```
+
+  </Step>
+</Steps>
+
+<Warning>
+  `prepareStudioConfig` reads your TypeScript source files at build time. It
+  requires `cwd` pointing to your project root and `tsconfigPath` to your
+  `tsconfig.json`. If your components are in a separate package, adjust these
+  paths accordingly.
+</Warning>
+
+## Authentication and CORS
+
+Studio communicates directly with the MDCMS server API. Authentication determines how Studio identifies the current user.
+
+<Tabs>
+  <Tab title="Cookie (default)">
+    The default mode. Studio sends requests with `credentials: "include"` and the server manages session cookies. CSRF protection is automatic via the `x-mdcms-csrf-token` header.
+
+    ```tsx
+    <Studio config={config} basePath="/admin" />
+    ```
+
+    **Required server config:** The MDCMS server must allow your host app's origin for CORS and cookie delivery:
+
+    ```bash
+    MDCMS_STUDIO_ALLOWED_ORIGINS=https://myapp.example.com
+    ```
+
+    For local development with HTTP:
+
+    ```bash
+    MDCMS_STUDIO_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+    MDCMS_AUTH_INSECURE_COOKIES=true
+    ```
+
+  </Tab>
+  <Tab title="Token">
+    For headless or non-browser contexts, pass a Bearer API key directly:
+
+    ```tsx
+    <Studio
+      config={config}
+      basePath="/admin"
+      auth={{ mode: "token", token: process.env.MDCMS_API_KEY! }}
+    />
+    ```
+
+    API keys are created in **Settings > API Keys** inside Studio and use the `mdcms_key_` prefix.
+
+  </Tab>
+</Tabs>
+
+### Studio props reference
+
+| Prop         | Type                                                     | Description                                                            |
+| ------------ | -------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `config`     | `MdcmsConfig`                                            | Project, environment, server URL, and optional component registrations |
+| `basePath`   | `string`                                                 | URL prefix where Studio is mounted (e.g., `/admin`)                    |
+| `auth`       | `{ mode: "cookie" } \| { mode: "token"; token: string }` | Authentication strategy (defaults to cookie)                           |
+| `hostBridge` | `HostBridgeV1`                                           | Optional bridge for MDX preview rendering from the host app            |
+| `fetcher`    | `typeof fetch`                                           | Custom fetch implementation                                            |
+
+## Fetching content with the SDK
+
+If your app renders MDCMS content (blog posts, pages, etc.), use `@mdcms/sdk` to query the API:
+
+```typescript
+import { createClient } from "@mdcms/sdk";
+
+const cms = createClient({
+  serverUrl: "https://cms.example.com",
+  apiKey: process.env.MDCMS_API_KEY!,
+  project: "my-site",
+  environment: "production",
+});
+
+// List published posts
+const { data: posts } = await cms.list("BlogPost", {
+  locale: "en",
+  published: true,
+  limit: 10,
+});
+
+// Get a single post by slug
+const post = await cms.get("BlogPost", {
+  slug: "hello-world",
+  resolve: ["author"],
+});
+```
+
+See the [SDK reference](/api-reference/sdk) for filtering, pagination, error handling, and Next.js patterns.
+
+## Production checklist
+
+Before going live, verify each item:
+
+1. **HTTPS everywhere** — both the MDCMS server and your host app serve over HTTPS
+2. **Secure cookies** — `MDCMS_AUTH_INSECURE_COOKIES` is removed or set to `false`
+3. **CORS locked down** — `MDCMS_STUDIO_ALLOWED_ORIGINS` lists only your production origin, not `localhost`
+4. **Production mode** — `NODE_ENV=production` on the MDCMS server
+5. **Strong credentials** — database, S3, and Redis credentials are unique and not defaults
+6. **API keys scoped** — keys are scoped to the minimum required permissions and rotated periodically
+7. **Real email provider** — SMTP is configured with a production provider, not Mailhog
+
+<Tip>
+  See the [Self-Hosting guide](/guide/self-hosting#production-considerations)
+  for detailed server-side production hardening.
+</Tip>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Studio Guide"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
+    Dashboard overview, navigation, and all Studio features
+  </Card>
+  <Card
+    title="Schema Guide"
+    icon="file-code"
+    href="/guide/schema/defining-types"
+  >
+    Field types, references, environment overlays, and MDX components
+  </Card>
+  <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
+    Push, pull, login, schema sync, and all CLI flags
+  </Card>
+  <Card title="SDK Reference" icon="plug" href="/api-reference/sdk">
+    Full typed client API for content reads
+  </Card>
+</CardGroup>

--- a/apps/docs/guide/quickstart.mdx
+++ b/apps/docs/guide/quickstart.mdx
@@ -6,11 +6,14 @@ description: "Install MDCMS packages and start managing content in your project"
 Get MDCMS running in your own application. This guide assumes you have an MDCMS server available (self-hosted or managed).
 
 <Tip>
-  Need to set up your own server first? Follow the [Self-Hosting guide](/guide/self-hosting) to get MDCMS running with Docker Compose, then come back here.
+  Need to set up your own server first? Follow the [Self-Hosting
+  guide](/guide/self-hosting) to get MDCMS running with Docker Compose, then
+  come back here.
 </Tip>
 
 <Note>
-  Looking to contribute to MDCMS itself? See [Development Setup](/development/setup).
+  Looking to contribute to MDCMS itself? See [Development
+  Setup](/development/setup).
 </Note>
 
 ## 1. Install the CLI
@@ -23,6 +26,7 @@ npm install --save-dev @mdcms/cli
 ```bash bun
 bun add -D @mdcms/cli
 ```
+
 </CodeGroup>
 
 ## 2. Initialize your project
@@ -34,6 +38,7 @@ npx mdcms init
 ```
 
 It will:
+
 - Ask for your MDCMS server URL
 - Open a browser for authentication
 - Scan your repo for existing Markdown/MDX files
@@ -110,6 +115,7 @@ npm install @mdcms/sdk
 ```bash bun
 bun add @mdcms/sdk
 ```
+
 </CodeGroup>
 
 Query content in your application:
@@ -142,28 +148,19 @@ See the [SDK reference](/api-reference/sdk) for the full API.
 
 ## 6. Embed the Studio UI (optional)
 
-Add a visual editing interface to your app:
-
-<CodeGroup>
-```bash npm
-npm install @mdcms/studio
-```
-
-```bash bun
-bun add @mdcms/studio
-```
-</CodeGroup>
+Add a visual editing interface to your app by installing `@mdcms/studio` and mounting it on a catch-all route:
 
 ```tsx app/admin/[[...path]]/page.tsx
-// Next.js example — catch-all route for Studio
-import { Studio } from "@mdcms/studio";
+import { createStudioEmbedConfig } from "@mdcms/studio/runtime";
+import config from "../../../mdcms.config";
+import { AdminStudioClient } from "./admin-studio-client";
 
-export default function AdminPage() {
-  return <Studio config={config} basePath="/admin" />;
+export default async function AdminPage() {
+  return <AdminStudioClient config={createStudioEmbedConfig(config)} />;
 }
 ```
 
-See the [Studio Guide](/guide/studio/dashboard) for full embedding and usage instructions.
+For the full setup — including MDX component registration, authentication, CORS configuration, and production hardening — see the [Integration Guide](/guide/integration).
 
 ## Next steps
 
@@ -171,10 +168,18 @@ See the [Studio Guide](/guide/studio/dashboard) for full embedding and usage ins
   <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
     Push, pull, login, schema sync, and all CLI flags
   </Card>
-  <Card title="Schema Guide" icon="file-code" href="/guide/schema/defining-types">
+  <Card
+    title="Schema Guide"
+    icon="file-code"
+    href="/guide/schema/defining-types"
+  >
     Field types, references, environment overlays, MDX components
   </Card>
-  <Card title="Studio Guide" icon="layout-dashboard" href="/guide/studio/dashboard">
+  <Card
+    title="Studio Guide"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
     Visual content editing, publishing, and version history
   </Card>
   <Card title="SDK Reference" icon="plug" href="/api-reference/sdk">

--- a/apps/docs/guide/self-hosting.mdx
+++ b/apps/docs/guide/self-hosting.mdx
@@ -6,29 +6,29 @@ description: "Stand up your own MDCMS server with Docker Compose"
 Run MDCMS on your own infrastructure. This guide walks you through setting up a self-hosted instance from scratch using Docker Compose.
 
 <Note>
-  Already have a server running? Skip to the [Quick Start](/guide/quickstart) to install the CLI and start managing content.
+  Already have a server running? Skip to the [Quick Start](/guide/quickstart) to
+  install the CLI and start managing content.
 </Note>
 
 ## Prerequisites
 
 You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Node.js) is required for running the server.
 
-| Tool | Version | Install |
-|------|---------|---------|
-| Docker | 24+ | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
-| Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows |
+| Tool           | Version                            | Install                                                           |
+| -------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| Docker         | 24+                                | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
+| Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows                      |
 
 <Tabs>
-  <Tab title="macOS">
-    ```bash
-    brew install --cask docker
-    ```
-  </Tab>
+  <Tab title="macOS">```bash brew install --cask docker ```</Tab>
   <Tab title="Linux">
-    Follow the [official Docker install guide](https://docs.docker.com/engine/install/) for your distribution. Docker Compose v2 is included as a Docker plugin.
+    Follow the [official Docker install
+    guide](https://docs.docker.com/engine/install/) for your distribution.
+    Docker Compose v2 is included as a Docker plugin.
   </Tab>
   <Tab title="Windows">
-    Download and install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
+    Download and install [Docker Desktop for
+    Windows](https://docs.docker.com/desktop/install/windows-install/).
   </Tab>
 </Tabs>
 
@@ -50,6 +50,7 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     ```
 
     The defaults work for local evaluation. For production, you should change database credentials, S3 keys, and configure auth providers. See the [environment variables](#environment-variables) section below.
+
   </Step>
 
   <Step title="Start all services">
@@ -65,6 +66,7 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     - **Mailhog** on ports `1025`/`8025` — email capture (dev/staging)
 
     Database migrations run automatically before the server starts.
+
   </Step>
 
   <Step title="Verify the server is healthy">
@@ -73,18 +75,19 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
     ```
 
     You should get a `200 OK` response. If the server is still starting, wait a few seconds and try again.
+
   </Step>
 </Steps>
 
 ## Service Endpoints
 
-| Service | URL | Purpose |
-|---------|-----|---------|
-| MDCMS Server API | [http://localhost:4000](http://localhost:4000) | Backend API — all clients connect here |
-| MinIO Console | [http://localhost:9001](http://localhost:9001) | Object storage admin (default: `minioadmin`/`minioadmin`) |
-| Mailhog UI | [http://localhost:8025](http://localhost:8025) | Captured email viewer (auth flows, invites) |
-| PostgreSQL | `localhost:5432` | Direct database access |
-| Redis | `localhost:6379` | Direct cache access |
+| Service          | URL                                            | Purpose                                                   |
+| ---------------- | ---------------------------------------------- | --------------------------------------------------------- |
+| MDCMS Server API | [http://localhost:4000](http://localhost:4000) | Backend API — all clients connect here                    |
+| MinIO Console    | [http://localhost:9001](http://localhost:9001) | Object storage admin (default: `minioadmin`/`minioadmin`) |
+| Mailhog UI       | [http://localhost:8025](http://localhost:8025) | Captured email viewer (auth flows, invites)               |
+| PostgreSQL       | `localhost:5432`                               | Direct database access                                    |
+| Redis            | `localhost:6379`                               | Direct cache access                                       |
 
 ## First Boot
 
@@ -112,24 +115,7 @@ The init wizard walks you through project creation, environment selection, conte
 
 ### Embed the Studio UI
 
-Add the visual content editor to your application:
-
-```bash
-npm install @mdcms/studio
-```
-
-```tsx
-// app/admin/[[...path]]/page.tsx (Next.js example)
-import { createStudioEmbedConfig } from "@mdcms/studio/runtime";
-import config from "../../../mdcms.config";
-import { AdminStudioClient } from "./admin-studio-client";
-
-export default async function AdminPage() {
-  return <AdminStudioClient config={createStudioEmbedConfig(config)} />;
-}
-```
-
-See the [Studio Guide](/guide/studio/dashboard) for full embedding instructions.
+Add the visual content editor to your application. Install `@mdcms/studio` and mount it on a catch-all route in your app. See the [Integration Guide](/guide/integration) for full step-by-step instructions covering Studio embedding, MDX components, authentication, and CORS setup.
 
 ## Environment Variables
 
@@ -137,50 +123,51 @@ See the [Studio Guide](/guide/studio/dashboard) for full embedding instructions.
 
 These must be set for the server to start. The Docker Compose defaults handle these automatically for local use.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://mdcms:mdcms@postgres:5432/mdcms` |
-| `REDIS_URL` | Redis connection string | `redis://redis:6379` |
-| `S3_ENDPOINT` | S3-compatible storage endpoint | `http://minio:9000` |
-| `S3_ACCESS_KEY` | S3 access key | `minioadmin` |
-| `S3_SECRET_KEY` | S3 secret key | `minioadmin` |
-| `S3_BUCKET` | S3 bucket name | `mdcms-media` |
+| Variable        | Description                    | Default                                        |
+| --------------- | ------------------------------ | ---------------------------------------------- |
+| `DATABASE_URL`  | PostgreSQL connection string   | `postgresql://mdcms:mdcms@postgres:5432/mdcms` |
+| `REDIS_URL`     | Redis connection string        | `redis://redis:6379`                           |
+| `S3_ENDPOINT`   | S3-compatible storage endpoint | `http://minio:9000`                            |
+| `S3_ACCESS_KEY` | S3 access key                  | `minioadmin`                                   |
+| `S3_SECRET_KEY` | S3 secret key                  | `minioadmin`                                   |
+| `S3_BUCKET`     | S3 bucket name                 | `mdcms-media`                                  |
 
 ### Server
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PORT` | Server listen port | `4000` |
-| `NODE_ENV` | Runtime environment | `development` |
-| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `info` |
+| Variable    | Description                                      | Default       |
+| ----------- | ------------------------------------------------ | ------------- |
+| `PORT`      | Server listen port                               | `4000`        |
+| `NODE_ENV`  | Runtime environment                              | `development` |
+| `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `info`        |
 
 ### Email
 
-| Variable | Description | Default |
-|----------|-------------|---------|
+| Variable    | Description          | Default   |
+| ----------- | -------------------- | --------- |
 | `SMTP_HOST` | SMTP server hostname | `mailhog` |
-| `SMTP_PORT` | SMTP server port | `1025` |
+| `SMTP_PORT` | SMTP server port     | `1025`    |
 
 <Warning>
-  The default email configuration uses Mailhog, which captures all outgoing email without delivering it. For production, configure a real SMTP provider.
+  The default email configuration uses Mailhog, which captures all outgoing
+  email without delivering it. For production, configure a real SMTP provider.
 </Warning>
 
 ### Studio
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MDCMS_STUDIO_ALLOWED_ORIGINS` | Comma-separated CORS origins for Studio embedding | — |
-| `MDCMS_AUTH_INSECURE_COOKIES` | Allow HTTP cookies (set `true` for local dev without HTTPS) | `false` |
+| Variable                       | Description                                                 | Default |
+| ------------------------------ | ----------------------------------------------------------- | ------- |
+| `MDCMS_STUDIO_ALLOWED_ORIGINS` | Comma-separated CORS origins for Studio embedding           | —       |
+| `MDCMS_AUTH_INSECURE_COOKIES`  | Allow HTTP cookies (set `true` for local dev without HTTPS) | `false` |
 
 ### Auth Providers (optional)
 
 Configure SSO providers for your organization. Providers are enabled by presence — no feature flag is needed.
 
-| Variable | Description |
-|----------|-------------|
-| `MDCMS_AUTH_OIDC_PROVIDERS` | JSON array of OIDC provider configurations |
-| `MDCMS_AUTH_SAML_PROVIDERS` | JSON array of SAML provider configurations |
-| `MDCMS_AUTH_ADMIN_EMAILS` | Comma-separated emails that get admin role on first login |
+| Variable                    | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `MDCMS_AUTH_OIDC_PROVIDERS` | JSON array of OIDC provider configurations                |
+| `MDCMS_AUTH_SAML_PROVIDERS` | JSON array of SAML provider configurations                |
+| `MDCMS_AUTH_ADMIN_EMAILS`   | Comma-separated emails that get admin role on first login |
 
 <Accordion title="Example OIDC provider config">
 ```json
@@ -268,7 +255,11 @@ docker compose down -v
   <Card title="CLI Commands" icon="terminal" href="/guide/cli/commands">
     Push, pull, login, schema sync, and all CLI flags
   </Card>
-  <Card title="Studio Guide" icon="layout-dashboard" href="/guide/studio/dashboard">
+  <Card
+    title="Studio Guide"
+    icon="layout-dashboard"
+    href="/guide/studio/dashboard"
+  >
     Embed the visual content editor in your application
   </Card>
   <Card title="API Reference" icon="plug" href="/api-reference/overview">

--- a/apps/docs/guide/self-hosting.mdx
+++ b/apps/docs/guide/self-hosting.mdx
@@ -20,7 +20,11 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
 | Docker Compose | v2+ (included with Docker Desktop) | Bundled with Docker Desktop on macOS/Windows                      |
 
 <Tabs>
-  <Tab title="macOS">```bash brew install --cask docker ```</Tab>
+  <Tab title="macOS">
+    ```bash
+    brew install --cask docker
+    ```
+  </Tab>
   <Tab title="Linux">
     Follow the [official Docker install
     guide](https://docs.docker.com/engine/install/) for your distribution.

--- a/apps/docs/guide/studio/dashboard.mdx
+++ b/apps/docs/guide/studio/dashboard.mdx
@@ -5,6 +5,12 @@ description: "Studio dashboard overview, navigation, and embedding setup"
 
 ## Embedding Studio
 
+<Tip>
+  For a complete walkthrough of integrating MDCMS into your application —
+  including MDX components, authentication, and production setup — see the
+  [Integration Guide](/guide/integration).
+</Tip>
+
 MDCMS Studio is an embeddable React component from the `@mdcms/studio` package. You mount it inside a Next.js catch-all route so it owns all `/admin/*` paths.
 
 Studio is a client component. The recommended setup splits server and client concerns:
@@ -34,18 +40,20 @@ export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
 `createStudioEmbedConfig` strips client-only MDX loader callbacks so the config is safe to pass through the server-to-client boundary. If your config includes MDX component registrations with runtime loaders (`load`, `loadPropsEditor`), keep everything in the client component instead.
 
 <Note>
-  `basePath` is required because the remote runtime cannot infer its subtree root from deep links. Set it to whatever path prefix your catch-all route uses.
+  `basePath` is required because the remote runtime cannot infer its subtree
+  root from deep links. Set it to whatever path prefix your catch-all route
+  uses.
 </Note>
 
 ### Studio props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| `config` | `MdcmsConfig` | Project, environment, server URL, and optional component registrations |
-| `basePath` | `string` | The URL prefix where Studio is mounted (e.g., `/admin`) |
-| `auth` | `{ mode: "cookie" } \| { mode: "token"; token: string }` | Authentication strategy (defaults to cookie) |
-| `hostBridge` | `HostBridgeV1` | Optional bridge for MDX preview rendering from the host app |
-| `fetcher` | `typeof fetch` | Custom fetch implementation |
+| Prop         | Type                                                     | Description                                                            |
+| ------------ | -------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `config`     | `MdcmsConfig`                                            | Project, environment, server URL, and optional component registrations |
+| `basePath`   | `string`                                                 | The URL prefix where Studio is mounted (e.g., `/admin`)                |
+| `auth`       | `{ mode: "cookie" } \| { mode: "token"; token: string }` | Authentication strategy (defaults to cookie)                           |
+| `hostBridge` | `HostBridgeV1`                                           | Optional bridge for MDX preview rendering from the host app            |
+| `fetcher`    | `typeof fetch`                                           | Custom fetch implementation                                            |
 
 ## Dashboard features
 
@@ -82,18 +90,18 @@ If you have create permissions, a **New Document** button appears above the cont
 
 Studio uses a fixed sidebar for navigation. The sidebar contains these items:
 
-| Route | Label | Visibility |
-| --- | --- | --- |
-| `/admin` | Dashboard | Always |
-| `/admin/content` | Content | Always |
-| `/admin/environments` | Environments | Admin/owner only |
-| `/admin/media` | Media | Always |
-| `/admin/schema` | Schema | Users with schema read permission |
-| `/admin/users` | Users | Users with user management permission |
-| `/admin/settings` | Settings | Users with settings management permission |
-| `/admin/workflows` | Workflows | Always |
-| `/admin/api` | API | Always |
-| `/admin/trash` | Trash | Always |
+| Route                 | Label        | Visibility                                |
+| --------------------- | ------------ | ----------------------------------------- |
+| `/admin`              | Dashboard    | Always                                    |
+| `/admin/content`      | Content      | Always                                    |
+| `/admin/environments` | Environments | Admin/owner only                          |
+| `/admin/media`        | Media        | Always                                    |
+| `/admin/schema`       | Schema       | Users with schema read permission         |
+| `/admin/users`        | Users        | Users with user management permission     |
+| `/admin/settings`     | Settings     | Users with settings management permission |
+| `/admin/workflows`    | Workflows    | Always                                    |
+| `/admin/api`          | API          | Always                                    |
+| `/admin/trash`        | Trash        | Always                                    |
 
 The sidebar is collapsible. In collapsed mode, only icons are shown with tooltips on hover.
 
@@ -108,7 +116,11 @@ Fields that exist only in certain environments (due to schema overlays defined i
 ## Bootstrap
 
 <Note>
-  On load, Studio fetches a bootstrap manifest from `GET /api/v1/studio/bootstrap` on the MDCMS server. This manifest identifies the active runtime build, its integrity hash, and compatibility bounds. If the server is unreachable, Studio shows an error screen with the server URL, error details, and a **Retry** button.
+  On load, Studio fetches a bootstrap manifest from `GET
+  /api/v1/studio/bootstrap` on the MDCMS server. This manifest identifies the
+  active runtime build, its integrity hash, and compatibility bounds. If the
+  server is unreachable, Studio shows an error screen with the server URL, error
+  details, and a **Retry** button.
 </Note>
 
 The bootstrap process validates:
@@ -132,6 +144,7 @@ Studio supports two authentication modes, set via the `auth` prop:
     // or explicitly:
     <Studio config={config} basePath="/admin" auth={{ mode: "cookie" }} />
     ```
+
   </Tab>
   <Tab title="Token">
     For headless or non-browser contexts, pass a Bearer API key directly. Studio sends it as an `Authorization: Bearer <token>` header on every request.
@@ -145,5 +158,6 @@ Studio supports two authentication modes, set via the `auth` prop:
     ```
 
     API keys are created in **Settings > API Keys** and use the `mdcms_key_` prefix.
+
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- Adds `guide/integration.mdx` — a comprehensive guide for embedding MDCMS into a user-owned application, covering host app responsibilities, Studio embed wiring (basic + advanced with MDX components), authentication/CORS, SDK content fetching, and a production checklist
- Updates quickstart, self-hosting, and Studio dashboard pages to cross-reference the new integration guide
- Adds the new page to the docs navigation in the Introduction group

Closes CMS-196

## Test plan

- [ ] Verify `guide/integration.mdx` renders correctly in the Mintlify docs site
- [ ] Verify all internal links resolve (`/guide/self-hosting`, `/guide/quickstart`, `/guide/schema/defining-types`, `/api-reference/sdk`, `/guide/studio/dashboard`, `/guide/cli/commands`)
- [ ] Verify cross-references from quickstart, self-hosting, and dashboard pages link correctly to `/guide/integration`
- [ ] Verify the new page appears in the Introduction nav group after "Self-Hosting"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Integration guide covering Studio embedding, authentication, CORS, MDX component flows, SDK examples, and production checklist.
  * Updated Quick Start to a streamlined embedding approach using a custom Studio client.
  * Reorganized navigation to surface integration content and adjusted page ordering.
  * Improved formatting and clarity across Self‑hosting and Studio Dashboard guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->