### PR TITLE
feat(cms-189): installable MDCMS skill pack + non-interactive mdcms init

### DIFF
--- a/.changeset/quiet-agents-init.md
+++ b/.changeset/quiet-agents-init.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/cli": minor
+---
+
+Add non-interactive mode to `mdcms init` so CI and AI-agent skills can drive setup end-to-end. New flags: `-y` / `--yes` / `--non-interactive` (fully headless), `--directory` (repeatable), `--directories` (comma-separated), `--default-locale`, `--no-import`, `--no-git-cleanup`, `--no-example-post`. Missing required inputs surface as `INIT_MISSING_INPUT` instead of hanging on a prompt. Values resolve from flag → env var → `mdcms.config.ts` → stored credential, in that order. Existing interactive behavior is unchanged.

--- a/apps/cli/src/lib/init.test.ts
+++ b/apps/cli/src/lib/init.test.ts
@@ -781,6 +781,15 @@ test("parseInitOptions throws when flag value is missing", () => {
   assert.throws(() => parseInitOptions(["--directory"]), /requires a value/);
 });
 
+test("parseInitOptions rejects empty inline flag values", () => {
+  assert.throws(() => parseInitOptions(["--directory="]), /requires a value/);
+  assert.throws(() => parseInitOptions(["--directories="]), /requires a value/);
+  assert.throws(
+    () => parseInitOptions(["--default-locale="]),
+    /requires a value/,
+  );
+});
+
 test("init --non-interactive completes without prompting", async () => {
   await withTempDir(async (cwd) => {
     await mkdir(join(cwd, "content", "posts"), { recursive: true });
@@ -993,6 +1002,7 @@ test("init --non-interactive --no-example-post on empty repo skips example.md", 
       credentialStore: createInMemoryCredentialStore(),
     });
 
+    let stdout = "";
     const exitCode = await runMdcmsCli(
       [
         "init",
@@ -1011,7 +1021,11 @@ test("init --non-interactive --no-example-post on empty repo skips example.md", 
           MDCMS_API_KEY: "test-api-key",
         },
         resolveStoredApiKey: async () => undefined,
-        stdout: { write: () => undefined },
+        stdout: {
+          write: (c) => {
+            stdout += c;
+          },
+        },
         stderr: { write: () => undefined },
         fetcher,
       },
@@ -1027,6 +1041,56 @@ test("init --non-interactive --no-example-post on empty repo skips example.md", 
       existsSync(join(cwd, "mdcms.config.ts")),
       "config should still be written",
     );
+    assert.doesNotMatch(
+      stdout,
+      /Example post created/,
+      "outro should not advertise an example.md that was never written",
+    );
+  });
+});
+
+test("init --non-interactive rejects multiple --directory on empty repo", async () => {
+  await withTempDir(async (cwd) => {
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+    const prompter = createMockPrompter({});
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    let stderr = "";
+    const exitCode = await runMdcmsCli(
+      [
+        "init",
+        "--non-interactive",
+        "--directory",
+        "content/posts",
+        "--directory",
+        "content/pages",
+      ],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+          MDCMS_API_KEY: "test-api-key",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: {
+          write: (c) => {
+            stderr += c;
+          },
+        },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /Scaffolding only supports a single starter/i);
   });
 });
 

--- a/apps/cli/src/lib/init.test.ts
+++ b/apps/cli/src/lib/init.test.ts
@@ -4,9 +4,30 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import type { CredentialStore } from "./credentials.js";
 import { runMdcmsCli } from "./framework.js";
-import { createInitCommand } from "./init.js";
+import { createInitCommand, parseInitOptions } from "./init.js";
 import { createMockPrompter } from "./init/prompt.js";
+
+function createInMemoryCredentialStore(): CredentialStore {
+  const profiles = new Map<string, unknown>();
+  const key = (t: {
+    serverUrl: string;
+    project: string;
+    environment: string;
+  }) => `${t.serverUrl}|${t.project}|${t.environment}`;
+  return {
+    async getProfile(tuple) {
+      return profiles.get(key(tuple)) as never;
+    },
+    async setProfile(tuple, profile) {
+      profiles.set(key(tuple), profile);
+    },
+    async deleteProfile(tuple) {
+      return profiles.delete(key(tuple));
+    },
+  };
+}
 
 async function withTempDir(run: (cwd: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), "mdcms-cli-init-"));
@@ -705,5 +726,349 @@ test("init creates new project and generates config", async () => {
       configContent.includes("new-project"),
       "config should contain new project name",
     );
+  });
+});
+
+test("parseInitOptions parses all recognized flags", () => {
+  const opts = parseInitOptions([
+    "--non-interactive",
+    "--directory",
+    "content/posts",
+    "--directory",
+    "content/pages",
+    "--default-locale",
+    "en",
+    "--no-import",
+    "--no-git-cleanup",
+    "--no-example-post",
+  ]);
+
+  assert.equal(opts.nonInteractive, true);
+  assert.deepEqual(opts.directories, ["content/posts", "content/pages"]);
+  assert.equal(opts.defaultLocale, "en");
+  assert.equal(opts.noImport, true);
+  assert.equal(opts.noGitCleanup, true);
+  assert.equal(opts.noExamplePost, true);
+  assert.equal(opts.help, false);
+});
+
+test("parseInitOptions treats -y and --yes as --non-interactive", () => {
+  assert.equal(parseInitOptions(["-y"]).nonInteractive, true);
+  assert.equal(parseInitOptions(["--yes"]).nonInteractive, true);
+  assert.equal(parseInitOptions(["--non-interactive"]).nonInteractive, true);
+});
+
+test("parseInitOptions parses --directories csv and inline =value forms", () => {
+  const viaCsv = parseInitOptions([
+    "--directories",
+    "content/posts,content/pages",
+  ]);
+  assert.deepEqual(viaCsv.directories, ["content/posts", "content/pages"]);
+
+  const viaInline = parseInitOptions([
+    "--directories=content/posts, content/pages",
+    "--default-locale=fr",
+  ]);
+  assert.deepEqual(viaInline.directories, ["content/posts", "content/pages"]);
+  assert.equal(viaInline.defaultLocale, "fr");
+});
+
+test("parseInitOptions throws on unknown flag", () => {
+  assert.throws(() => parseInitOptions(["--not-a-real-flag"]), /Unknown flag/);
+});
+
+test("parseInitOptions throws when flag value is missing", () => {
+  assert.throws(() => parseInitOptions(["--directory"]), /requires a value/);
+});
+
+test("init --non-interactive completes without prompting", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "posts"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "posts", "hello.md"),
+      "---\ntitle: Hello\nslug: hello\n---\nBody\n",
+    );
+
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+
+    // Empty queues — any prompter call throws and fails the test.
+    const prompter = createMockPrompter({});
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    const exitCode = await runMdcmsCli(
+      ["init", "--non-interactive", "--directory", "content/posts"],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+          MDCMS_API_KEY: "test-api-key",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    const configPath = join(cwd, "mdcms.config.ts");
+    assert.ok(existsSync(configPath), "mdcms.config.ts should exist");
+    const manifestPath = join(
+      cwd,
+      ".mdcms",
+      "manifests",
+      "my-project.staging.json",
+    );
+    assert.ok(existsSync(manifestPath), "manifest should exist");
+  });
+});
+
+test("init --non-interactive fails loud when project is missing", async () => {
+  await withTempDir(async (cwd) => {
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+    const prompter = createMockPrompter({});
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    let stderr = "";
+    const exitCode = await runMdcmsCli(["init", "--non-interactive"], {
+      cwd,
+      commands: [command],
+      env: {
+        MDCMS_SERVER_URL: "http://localhost:4000",
+        MDCMS_API_KEY: "test-api-key",
+      },
+      resolveStoredApiKey: async () => undefined,
+      stdout: { write: () => undefined },
+      stderr: {
+        write: (c) => {
+          stderr += c;
+        },
+      },
+      fetcher,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /Project name/i);
+    assert.match(stderr, /--project/);
+  });
+});
+
+test("init --non-interactive fails loud when api-key is missing", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "posts"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "posts", "hello.md"),
+      "---\ntitle: Hello\n---\nBody\n",
+    );
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+    const prompter = createMockPrompter({});
+
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    let stderr = "";
+    const exitCode = await runMdcmsCli(
+      ["init", "--non-interactive", "--directory", "content/posts"],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: {
+          write: (c) => {
+            stderr += c;
+          },
+        },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /API key/i);
+    assert.match(stderr, /--api-key/);
+  });
+});
+
+test("init --non-interactive --no-import skips content import", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "posts"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "posts", "hello.md"),
+      "---\ntitle: Hello\n---\nBody\n",
+    );
+
+    let contentCallCount = 0;
+    const fetcher = createMockFetcher({
+      ...createDefaultFetchHandlers(),
+      "/api/v1/content": (_url: string) => {
+        contentCallCount += 1;
+        return new Response(
+          JSON.stringify({
+            data: {
+              documentId: "doc-1",
+              draftRevision: 1,
+              publishedVersion: null,
+            },
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const prompter = createMockPrompter({});
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    const exitCode = await runMdcmsCli(
+      [
+        "init",
+        "--non-interactive",
+        "--directory",
+        "content/posts",
+        "--no-import",
+      ],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+          MDCMS_API_KEY: "test-api-key",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(contentCallCount, 0, "no content POSTs should be made");
+    const manifestPath = join(
+      cwd,
+      ".mdcms",
+      "manifests",
+      "my-project.staging.json",
+    );
+    assert.equal(
+      existsSync(manifestPath),
+      false,
+      "manifest should not be written when import is skipped",
+    );
+  });
+});
+
+test("init --non-interactive --no-example-post on empty repo skips example.md", async () => {
+  await withTempDir(async (cwd) => {
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+    const prompter = createMockPrompter({});
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    const exitCode = await runMdcmsCli(
+      [
+        "init",
+        "--non-interactive",
+        "--directory",
+        "content/posts",
+        "--no-example-post",
+      ],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+          MDCMS_API_KEY: "test-api-key",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(
+      existsSync(join(cwd, "content", "posts", "example.md")),
+      false,
+      "example.md should not be scaffolded",
+    );
+    assert.ok(
+      existsSync(join(cwd, "mdcms.config.ts")),
+      "config should still be written",
+    );
+  });
+});
+
+test("init --non-interactive rejects --directory that doesn't match any found content", async () => {
+  await withTempDir(async (cwd) => {
+    await mkdir(join(cwd, "content", "posts"), { recursive: true });
+    await writeFile(
+      join(cwd, "content", "posts", "hello.md"),
+      "---\ntitle: Hello\n---\nBody\n",
+    );
+    const fetcher = createMockFetcher(createDefaultFetchHandlers());
+    const prompter = createMockPrompter({});
+    const command = createInitCommand({
+      prompter,
+      fetcher,
+      credentialStore: createInMemoryCredentialStore(),
+    });
+
+    let stderr = "";
+    const exitCode = await runMdcmsCli(
+      ["init", "--non-interactive", "--directory", "content/pages"],
+      {
+        cwd,
+        commands: [command],
+        env: {
+          MDCMS_SERVER_URL: "http://localhost:4000",
+          MDCMS_PROJECT: "my-project",
+          MDCMS_ENVIRONMENT: "staging",
+          MDCMS_API_KEY: "test-api-key",
+        },
+        resolveStoredApiKey: async () => undefined,
+        stdout: { write: () => undefined },
+        stderr: {
+          write: (c) => {
+            stderr += c;
+          },
+        },
+        fetcher,
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /content\/pages/);
   });
 });

--- a/apps/cli/src/lib/init.ts
+++ b/apps/cli/src/lib/init.ts
@@ -7,6 +7,7 @@ import {
   defineConfig,
   defineType,
   parseMdcmsConfig,
+  RuntimeError,
   type MdcmsFieldSchema,
 } from "@mdcms/shared";
 import { buildSchemaSyncPayload } from "@mdcms/shared/server";
@@ -46,6 +47,127 @@ export type InitCommandOptions = {
   skipAuth?: boolean;
   credentialStore?: CredentialStore;
 };
+
+export type InitFlagOptions = {
+  help: boolean;
+  nonInteractive: boolean;
+  noImport: boolean;
+  noGitCleanup: boolean;
+  noExamplePost: boolean;
+  directories?: string[];
+  defaultLocale?: string;
+};
+
+function readInitFlagValue(
+  args: string[],
+  index: number,
+  flag: string,
+): string {
+  const next = args[index + 1];
+  if (!next || next.startsWith("-")) {
+    throw new RuntimeError({
+      code: "INVALID_INPUT",
+      message: `Flag "${flag}" requires a value.`,
+      statusCode: 400,
+      details: { flag },
+    });
+  }
+  return next;
+}
+
+function splitCsv(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+export function parseInitOptions(args: string[]): InitFlagOptions {
+  const opts: InitFlagOptions = {
+    help: false,
+    nonInteractive: false,
+    noImport: false,
+    noGitCleanup: false,
+    noExamplePost: false,
+  };
+  const directories: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i]!;
+
+    if (token === "-h" || token === "--help") {
+      opts.help = true;
+      continue;
+    }
+    if (token === "-y" || token === "--yes" || token === "--non-interactive") {
+      opts.nonInteractive = true;
+      continue;
+    }
+    if (token === "--no-import") {
+      opts.noImport = true;
+      continue;
+    }
+    if (token === "--no-git-cleanup") {
+      opts.noGitCleanup = true;
+      continue;
+    }
+    if (token === "--no-example-post") {
+      opts.noExamplePost = true;
+      continue;
+    }
+    if (token === "--directory") {
+      directories.push(readInitFlagValue(args, i, "--directory"));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--directory=")) {
+      directories.push(token.slice("--directory=".length));
+      continue;
+    }
+    if (token === "--directories") {
+      directories.push(
+        ...splitCsv(readInitFlagValue(args, i, "--directories")),
+      );
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--directories=")) {
+      directories.push(...splitCsv(token.slice("--directories=".length)));
+      continue;
+    }
+    if (token === "--default-locale") {
+      opts.defaultLocale = readInitFlagValue(args, i, "--default-locale");
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--default-locale=")) {
+      opts.defaultLocale = token.slice("--default-locale=".length);
+      continue;
+    }
+
+    throw new RuntimeError({
+      code: "INVALID_INPUT",
+      message: `Unknown flag "${token}" for \`mdcms init\`.`,
+      statusCode: 400,
+      details: { flag: token },
+    });
+  }
+
+  if (directories.length > 0) {
+    opts.directories = directories;
+  }
+
+  return opts;
+}
+
+function missingInitInput(what: string, flag: string): never {
+  throw new RuntimeError({
+    code: "INIT_MISSING_INPUT",
+    message: `${what} is required in non-interactive mode. Pass ${flag} (or set via env/config).`,
+    statusCode: 400,
+    details: { flag },
+  });
+}
 
 function groupFilesByDirectory(
   files: DiscoveredFile[],
@@ -274,19 +396,34 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
     requiresConfig: false,
     requiresTarget: false,
     run: async (context: CliCommandContext): Promise<number> => {
-      if (context.args.includes("--help") || context.args.includes("-h")) {
+      const initOpts = parseInitOptions(context.args);
+
+      if (initOpts.help) {
         context.stdout.write(
           [
-            "Usage: mdcms init",
+            "Usage: mdcms init [options]",
             "",
-            "Interactive wizard to set up MDCMS in an existing project.",
+            "Interactive wizard (or non-interactive CI flow) to set up MDCMS in a project.",
             "",
             "Steps: server URL, login, project creation,",
             "directory scan, schema inference, config generation,",
             "schema sync, content import, and git cleanup.",
             "",
-            "Options:",
-            "  -h, --help   Show this help text",
+            "Init-specific options:",
+            "  -y, --yes, --non-interactive  Run without prompts; fail on missing inputs",
+            "  --directory <dir>             Managed content directory (repeatable)",
+            "  --directories <a,b,c>         Managed content directories (comma-separated)",
+            "  --default-locale <locale>     Preset default locale (skip locale confirm)",
+            "  --no-import                   Skip initial content import",
+            "  --no-git-cleanup              Skip gitignore/untrack step",
+            "  --no-example-post             Skip scaffolded example.md for empty content",
+            "  -h, --help                    Show this help text",
+            "",
+            "Value sources (resolved in this order):",
+            "  --server-url / MDCMS_SERVER_URL / mdcms.config.ts serverUrl",
+            "  --project    / MDCMS_PROJECT    / mdcms.config.ts project",
+            "  --environment / MDCMS_ENVIRONMENT / mdcms.config.ts environment (default: production)",
+            "  --api-key    / MDCMS_API_KEY    (non-interactive only; interactive mode opens OAuth)",
             "",
           ].join("\n"),
         );
@@ -299,9 +436,11 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
 
       const existingConfigPath = join(cwd, "mdcms.config.ts");
       if (existsSync(existingConfigPath)) {
-        const overwrite = await prompter.confirm(
-          "mdcms.config.ts already exists. Re-running init will overwrite it. Continue?",
-        );
+        const overwrite = initOpts.nonInteractive
+          ? true
+          : await prompter.confirm(
+              "mdcms.config.ts already exists. Re-running init will overwrite it. Continue?",
+            );
         if (!overwrite) {
           stdout.write("Init cancelled. Existing config preserved.\n");
           return 0;
@@ -311,10 +450,12 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       prompter.intro("mdcms init");
 
       // ── Step 1: Server URL ──────────────────────────────────────────
-      const serverUrl = await prompter.text(
-        "Server URL",
-        "http://localhost:4000",
-      );
+      const contextServerUrl = context.serverUrl?.trim();
+      const serverUrl = contextServerUrl
+        ? contextServerUrl
+        : initOpts.nonInteractive
+          ? missingInitInput("Server URL", "--server-url")
+          : await prompter.text("Server URL", "http://localhost:4000");
 
       {
         const s = prompter.spinner();
@@ -333,13 +474,29 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       }
 
       // ── Step 2: Project + Environment Names ──────────────────────────
-      const projectName = await prompter.text("Project name");
-      const envName = await prompter.text("Environment name", "production");
+      const contextProject = context.project?.trim();
+      const projectName = contextProject
+        ? contextProject
+        : initOpts.nonInteractive
+          ? missingInitInput("Project name", "--project")
+          : await prompter.text("Project name");
+
+      const contextEnvironment = context.environment?.trim();
+      const envName = contextEnvironment
+        ? contextEnvironment
+        : initOpts.nonInteractive
+          ? "production"
+          : await prompter.text("Environment name", "production");
 
       // ── Step 3: Login ──────────────────────────────────────────────
       let apiKey: string;
+      const contextApiKey = context.apiKey?.trim();
       if (options?.skipAuth) {
         apiKey = "skip-auth-key";
+      } else if (contextApiKey) {
+        apiKey = contextApiKey;
+      } else if (initOpts.nonInteractive) {
+        missingInitInput("API key", "--api-key");
       } else {
         const s = prompter.spinner();
         s.start("Opening browser for login...");
@@ -460,10 +617,14 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       if (dirGroups.size === 0) {
         stdout.write("No content files found.\n");
 
-        const dirName = await prompter.text(
-          "Content directory (e.g. content/posts)",
-          "content/posts",
-        );
+        const dirName = initOpts.directories?.[0]
+          ? initOpts.directories[0]
+          : initOpts.nonInteractive
+            ? "content/posts"
+            : await prompter.text(
+                "Content directory (e.g. content/posts)",
+                "content/posts",
+              );
         selectedDirectories = [dirName];
 
         const lastSegment = dirName.split("/").pop() ?? dirName;
@@ -486,21 +647,44 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
           `Will create type "${typeName}" for directory "${dirName}" with fields: title, slug\n`,
         );
 
-        // Create example post
-        const examplePath = join(cwd, dirName, "example.md");
-        await mkdir(join(cwd, dirName), { recursive: true });
-        await writeFile(
-          examplePath,
-          [
-            "---",
-            "title: Example Post",
-            "slug: example",
-            "---",
-            "",
-            "This is an example post created by `mdcms init`.",
-            "",
-          ].join("\n"),
-          "utf-8",
+        if (!initOpts.noExamplePost) {
+          // Create example post
+          const examplePath = join(cwd, dirName, "example.md");
+          await mkdir(join(cwd, dirName), { recursive: true });
+          await writeFile(
+            examplePath,
+            [
+              "---",
+              "title: Example Post",
+              "slug: example",
+              "---",
+              "",
+              "This is an example post created by `mdcms init`.",
+              "",
+            ].join("\n"),
+            "utf-8",
+          );
+        }
+      } else if (initOpts.directories && initOpts.directories.length > 0) {
+        const known = new Set(dirGroups.keys());
+        const missing = initOpts.directories.filter((dir) => !known.has(dir));
+        if (missing.length > 0) {
+          throw new RuntimeError({
+            code: "INIT_INVALID_DIRECTORY",
+            message: `Requested --directory ${missing
+              .map((d) => `"${d}"`)
+              .join(", ")} not found among content directories (${[...known]
+              .map((d) => `"${d}"`)
+              .join(", ")}).`,
+            statusCode: 400,
+            details: { missing, available: [...known] },
+          });
+        }
+        selectedDirectories = [...initOpts.directories];
+      } else if (initOpts.nonInteractive) {
+        missingInitInput(
+          "Content directory selection",
+          "--directory <dir> (repeatable) or --directories <a,b,c>",
         );
       } else {
         const choices = [...dirGroups.entries()].map(([dir, files]) => ({
@@ -523,22 +707,37 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       const localeConfig = await detectLocaleConfig(
         allFiles,
         inferredTypes,
-        prompter,
+        initOpts.nonInteractive ? undefined : prompter,
       );
 
       if (localeConfig) {
-        const confirmDefault = await prompter.confirm(
-          `Use "${localeConfig.defaultLocale}" as the default locale?`,
-        );
-        if (!confirmDefault) {
-          const choices = localeConfig.supported.map((l) => ({
-            label: l,
-            value: l,
-          }));
-          localeConfig.defaultLocale = await prompter.select(
-            "Select default locale",
-            choices,
+        if (initOpts.defaultLocale) {
+          if (!localeConfig.supported.includes(initOpts.defaultLocale)) {
+            throw new RuntimeError({
+              code: "INIT_INVALID_DEFAULT_LOCALE",
+              message: `--default-locale "${initOpts.defaultLocale}" is not among detected locales [${localeConfig.supported.join(", ")}].`,
+              statusCode: 400,
+              details: {
+                defaultLocale: initOpts.defaultLocale,
+                supported: localeConfig.supported,
+              },
+            });
+          }
+          localeConfig.defaultLocale = initOpts.defaultLocale;
+        } else if (!initOpts.nonInteractive) {
+          const confirmDefault = await prompter.confirm(
+            `Use "${localeConfig.defaultLocale}" as the default locale?`,
           );
+          if (!confirmDefault) {
+            const choices = localeConfig.supported.map((l) => ({
+              label: l,
+              value: l,
+            }));
+            localeConfig.defaultLocale = await prompter.select(
+              "Select default locale",
+              choices,
+            );
+          }
         }
       }
 
@@ -551,8 +750,10 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
           );
         }
 
-        const confirmed = await prompter.confirm("Confirm inferred types?");
-        if (!confirmed) return 0;
+        if (!initOpts.nonInteractive) {
+          const confirmed = await prompter.confirm("Confirm inferred types?");
+          if (!confirmed) return 0;
+        }
       }
 
       // ── Step 7: Generate Config + Sync Schema ───────────────────────
@@ -649,10 +850,12 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
         ),
       );
 
-      if (filesToImport.length > 0) {
-        const shouldImport = await prompter.confirm(
-          `Import ${filesToImport.length} file${filesToImport.length !== 1 ? "s" : ""} to server?`,
-        );
+      if (filesToImport.length > 0 && !initOpts.noImport) {
+        const shouldImport = initOpts.nonInteractive
+          ? true
+          : await prompter.confirm(
+              `Import ${filesToImport.length} file${filesToImport.length !== 1 ? "s" : ""} to server?`,
+            );
 
         if (shouldImport) {
           const manifest: ScopedManifest = {};
@@ -846,15 +1049,17 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       }
 
       // ── Step 9: Git Cleanup ─────────────────────────────────────────
-      if (selectedDirectories.length > 0) {
+      if (selectedDirectories.length > 0 && !initOpts.noGitCleanup) {
         await updateGitignore(cwd, selectedDirectories);
 
         const tracked = detectTrackedFiles(cwd, selectedDirectories);
 
         if (tracked.length > 0) {
-          const shouldUntrack = await prompter.confirm(
-            `Found ${tracked.length} tracked file${tracked.length !== 1 ? "s" : ""} in managed directories. Untrack them?`,
-          );
+          const shouldUntrack = initOpts.nonInteractive
+            ? true
+            : await prompter.confirm(
+                `Found ${tracked.length} tracked file${tracked.length !== 1 ? "s" : ""} in managed directories. Untrack them?`,
+              );
 
           if (shouldUntrack) {
             const removed = untrackFiles(cwd, selectedDirectories);

--- a/apps/cli/src/lib/init.ts
+++ b/apps/cli/src/lib/init.ts
@@ -75,6 +75,20 @@ function readInitFlagValue(
   return next;
 }
 
+function readInitInlineFlagValue(token: string, prefix: string): string {
+  const value = token.slice(prefix.length);
+  if (value.length === 0) {
+    const flag = prefix.replace(/=$/, "");
+    throw new RuntimeError({
+      code: "INVALID_INPUT",
+      message: `Flag "${flag}" requires a value.`,
+      statusCode: 400,
+      details: { flag },
+    });
+  }
+  return value;
+}
+
 function splitCsv(raw: string): string[] {
   return raw
     .split(",")
@@ -121,7 +135,7 @@ export function parseInitOptions(args: string[]): InitFlagOptions {
       continue;
     }
     if (token.startsWith("--directory=")) {
-      directories.push(token.slice("--directory=".length));
+      directories.push(readInitInlineFlagValue(token, "--directory="));
       continue;
     }
     if (token === "--directories") {
@@ -132,7 +146,9 @@ export function parseInitOptions(args: string[]): InitFlagOptions {
       continue;
     }
     if (token.startsWith("--directories=")) {
-      directories.push(...splitCsv(token.slice("--directories=".length)));
+      directories.push(
+        ...splitCsv(readInitInlineFlagValue(token, "--directories=")),
+      );
       continue;
     }
     if (token === "--default-locale") {
@@ -141,7 +157,7 @@ export function parseInitOptions(args: string[]): InitFlagOptions {
       continue;
     }
     if (token.startsWith("--default-locale=")) {
-      opts.defaultLocale = token.slice("--default-locale=".length);
+      opts.defaultLocale = readInitInlineFlagValue(token, "--default-locale=");
       continue;
     }
 
@@ -613,9 +629,23 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
       dirGroups.delete(".");
 
       let scaffoldedType: InferredType | null = null;
+      let exampleCreated = false;
 
       if (dirGroups.size === 0) {
         stdout.write("No content files found.\n");
+
+        if (initOpts.directories && initOpts.directories.length > 1) {
+          throw new RuntimeError({
+            code: "INIT_INVALID_DIRECTORY",
+            message: `Multiple --directory values (${initOpts.directories
+              .map((d) => `"${d}"`)
+              .join(
+                ", ",
+              )}) were passed but no content was found on disk. Scaffolding only supports a single starter directory — pass one --directory, or remove the flag to accept the default.`,
+            statusCode: 400,
+            details: { directories: initOpts.directories },
+          });
+        }
 
         const dirName = initOpts.directories?.[0]
           ? initOpts.directories[0]
@@ -664,6 +694,7 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
             ].join("\n"),
             "utf-8",
           );
+          exampleCreated = true;
         }
       } else if (initOpts.directories && initOpts.directories.length > 0) {
         const known = new Set(dirGroups.keys());
@@ -1074,7 +1105,7 @@ export function createInitCommand(options?: InitCommandOptions): CliCommand {
         }
       }
 
-      if (scaffoldedType) {
+      if (exampleCreated) {
         stdout.write(
           `\nExample post created at ${selectedDirectories[0]}/example.md\n` +
             `Run 'mdcms push' to upload it to the server.\n`,

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -78,21 +78,21 @@ The SDK follows the same reference-resolution contract documented in SPEC-003. R
 
 ### Commands
 
-| Command                      | Description                                                                 |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| `cms init`                   | Interactive wizard to set up MDCMS in an existing project                   |
-| `cms login`                  | Authenticate via browser-based OAuth/email login                            |
-| `cms logout`                 | Clear stored credentials                                                    |
-| `cms pull`                   | Download all content from CMS to local `.md`/`.mdx` files                   |
-| `cms push`                   | Upload local `.md`/`.mdx` files to CMS                                      |
-| `cms push --validate`        | Validate content against schema before pushing                              |
-| `cms push --sync-schema`     | Allow push to sync schema in non-interactive mode on drift (ignored in TTY) |
-| `cms schema sync`            | Sync `mdcms.config.ts` schema to the server registry                        |
-| `cms migrate`                | Generate and apply content migrations for schema changes                    |
-| `cms status`                 | Show content drift and schema drift (local vs server)                       |
-| `cms action list`            | List available backend actions from `/actions` (with permissions metadata). |
-| `cms action run <actionId>`  | Execute a command/query action via the generic action runner.               |
-| `cms <module-defined alias>` | Optional local alias mapped to `actionId` by bundled module CLI surface.    |
+| Command                      | Description                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `cms init`                   | Interactive wizard (or non-interactive CI mode) to set up MDCMS in a project |
+| `cms login`                  | Authenticate via browser-based OAuth/email login                             |
+| `cms logout`                 | Clear stored credentials                                                     |
+| `cms pull`                   | Download all content from CMS to local `.md`/`.mdx` files                    |
+| `cms push`                   | Upload local `.md`/`.mdx` files to CMS                                       |
+| `cms push --validate`        | Validate content against schema before pushing                               |
+| `cms push --sync-schema`     | Allow push to sync schema in non-interactive mode on drift (ignored in TTY)  |
+| `cms schema sync`            | Sync `mdcms.config.ts` schema to the server registry                         |
+| `cms migrate`                | Generate and apply content migrations for schema changes                     |
+| `cms status`                 | Show content drift and schema drift (local vs server)                        |
+| `cms action list`            | List available backend actions from `/actions` (with permissions metadata).  |
+| `cms action run <actionId>`  | Execute a command/query action via the generic action runner.                |
+| `cms <module-defined alias>` | Optional local alias mapped to `actionId` by bundled module CLI surface.     |
 
 All commands that interact with server content resolve a target `(project, environment)` from config defaults and allow per-run overrides via `--project` and `--environment`.
 
@@ -112,9 +112,40 @@ All commands that interact with server content resolve a target `(project, envir
 
 CLI extensibility in v1 is intentionally action-based: aliases, formatters, and preflight hooks are allowed; arbitrary command-tree injection is out of scope.
 
-### `cms init` — Interactive Wizard
+### `cms init` — Interactive Wizard and Non-Interactive Mode
 
-The setup wizard uses `@inquirer/prompts` for the interactive TUI and walks through:
+The setup wizard uses `@inquirer/prompts` for the interactive TUI by default. A non-interactive mode is supported for CI and AI-agent driven setup: the same 13 steps run end-to-end, but every prompt is answered from flags, env vars, or config and any missing required input causes a clear `INIT_MISSING_INPUT` error instead of hanging on a prompt.
+
+#### Init-specific flags
+
+| Flag                               | Description                                                                                                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-y`, `--yes`, `--non-interactive` | Enable non-interactive mode. Auto-accept every confirm, skip every select/text prompt, fail loud on any missing required value.                                     |
+| `--directory <dir>`                | Managed content directory. Repeatable. Each value must match an existing directory when content is found, or is used as the scaffold target when no content exists. |
+| `--directories <a,b,c>`            | Same as repeated `--directory`, comma-separated.                                                                                                                    |
+| `--default-locale <locale>`        | Preset default locale. Must be one of the locales detected from content. Skips the confirm/select for default locale.                                               |
+| `--no-import`                      | Skip the initial content import step, even if matching files are found.                                                                                             |
+| `--no-git-cleanup`                 | Skip the `.gitignore` update and the tracked-file untrack step.                                                                                                     |
+| `--no-example-post`                | When the repo has no content files, still generate `mdcms.config.ts` and scaffold the starter type, but do not write the `example.md` file.                         |
+| `-h`, `--help`                     | Show help.                                                                                                                                                          |
+
+Global flags also contribute to non-interactive resolution (`--server-url`, `--project`, `--environment`, `--api-key`) alongside env vars `MDCMS_SERVER_URL`, `MDCMS_PROJECT`, `MDCMS_ENVIRONMENT`, `MDCMS_API_KEY`.
+
+#### Value resolution order
+
+For each required input the wizard resolves (first match wins):
+
+1. Global flag (e.g. `--server-url`).
+2. Env var (e.g. `MDCMS_SERVER_URL`).
+3. Existing `mdcms.config.ts` field (if present).
+4. Stored credential store entry (API key only).
+5. Interactive prompt (skipped in non-interactive mode; missing value raises `INIT_MISSING_INPUT`).
+
+Environment name falls back to `"production"` in non-interactive mode when not otherwise provided.
+
+In non-interactive mode, `mdcms.config.ts` that already exists is overwritten implicitly (the mode acts as an auto-yes for all confirms). The intent is that automated setup can be re-run idempotently.
+
+The setup wizard still walks through:
 
 1. **Server URL** — Prompt for the MDCMS server URL + health check (`GET /healthz`).
 2. **Project + environment names** — Prompt for project name and environment name (default: `"production"`). These are collected before authentication so the login challenge can scope the API key to `(project, environment)`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,117 @@
+# MDCMS Skills Pack
+
+Installable AI-agent skills that walk developers through adding MDCMS to a project — from bringing up a self-hosted backend to day-to-day `pull`/`push` automation.
+
+The pack is designed to be installed into any agent environment supported by [skills.sh](https://skills.sh): Claude Code, Cursor, Gemini CLI, Codex, Copilot, OpenCode, and 40+ others.
+
+## Install
+
+```bash
+# Browse available skills
+npx skills add Blazity/mdcms --list
+
+# Install all nine skills into the current project
+npx skills add Blazity/mdcms
+
+# Target a specific agent (default: prompt for agent)
+npx skills add Blazity/mdcms -a claude-code
+
+# Install globally (~/.<agent>/skills) so every project sees them
+npx skills add Blazity/mdcms -g
+
+# Non-interactive (CI / scripted install)
+npx skills add Blazity/mdcms -y
+```
+
+The pack is installed into whichever agent directories the user selects (`~/.claude/skills/`, `~/.cursor/skills/`, etc.). All nine skills work best together because the master skill delegates to each of the focused skills by slug. Installing the whole pack is recommended.
+
+See the [skills.sh CLI reference](https://github.com/vercel-labs/skills) for more options (`--copy`, `--skill`, `--agent`, update/remove commands).
+
+## Skills at a glance
+
+| Skill                                                                   | Purpose                                                                                                       |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| [`mdcms-setup`](./mdcms-setup/SKILL.md)                                 | **Master orchestrator.** Detects repo state and routes to the right focused skill for each phase. Start here. |
+| [`mdcms-self-host-setup`](./mdcms-self-host-setup/SKILL.md)             | Stand up the MDCMS backend via Docker Compose. Env, first boot, admin bootstrap.                              |
+| [`mdcms-brownfield-init`](./mdcms-brownfield-init/SKILL.md)             | Import an existing Markdown/MDX repo into MDCMS via `mdcms init --non-interactive`.                           |
+| [`mdcms-greenfield-init`](./mdcms-greenfield-init/SKILL.md)             | Bootstrap MDCMS in an empty repo with a scaffolded starter.                                                   |
+| [`mdcms-schema-refine`](./mdcms-schema-refine/SKILL.md)                 | Add/edit content types, fields, references; `mdcms schema sync`.                                              |
+| [`mdcms-studio-embed`](./mdcms-studio-embed/SKILL.md)                   | Mount `<Studio />` at a catch-all route inside the user's host app.                                           |
+| [`mdcms-sdk-integration`](./mdcms-sdk-integration/SKILL.md)             | Fetch content in the host app via `@mdcms/sdk`; drafts vs published; SSR.                                     |
+| [`mdcms-mdx-components`](./mdcms-mdx-components/SKILL.md)               | Register custom MDX components so Studio preview and host SSR match.                                          |
+| [`mdcms-content-sync-workflow`](./mdcms-content-sync-workflow/SKILL.md) | Day-to-day `pull`/`push`; key rotation; CI automation for publishing.                                         |
+
+## How the skills flow
+
+The master skill (`mdcms-setup`) walks through these phases and delegates at each branch:
+
+```mermaid
+flowchart TD
+    Start([User: set up MDCMS]) --> Master
+    Master[<b>mdcms-setup</b><br/>master — detects state, routes]
+
+    Master --> Q1{Running MDCMS<br/>server reachable?}
+    Q1 -- "No" --> SelfHost[<b>mdcms-self-host-setup</b>]
+    Q1 -- "Yes / skip" --> Q2
+    SelfHost --> Q2
+
+    Q2{Existing Markdown/MDX<br/>content in repo?}
+    Q2 -- "Yes — brownfield" --> Brown[<b>mdcms-brownfield-init</b>]
+    Q2 -- "No — greenfield" --> Green[<b>mdcms-greenfield-init</b>]
+
+    Brown --> BSchemaQ{Inferred schema<br/>correct?}
+    BSchemaQ -- "No / extend" --> BSchema[<b>mdcms-schema-refine</b>]
+    BSchemaQ -- "Yes" --> BSDKQ
+    BSchema --> BSDKQ
+    BSDKQ{Existing code fetches<br/>content from files?}
+    BSDKQ -- "Yes" --> BSDK[<b>mdcms-sdk-integration</b><br/>replace file fetching]
+    BSDKQ -- "No" --> Converge
+    BSDK --> Converge
+
+    Green --> GSchema[<b>mdcms-schema-refine</b><br/>author first models]
+    GSchema --> GSDK[<b>mdcms-sdk-integration</b><br/>write new fetching]
+    GSDK --> Converge
+
+    Converge[paths converge]
+
+    Converge --> EmbedQ{Want visual editor<br/>in host app?}
+    EmbedQ -- "Yes" --> Embed[<b>mdcms-studio-embed</b>]
+    EmbedQ -- "No" --> MDXQ
+    Embed --> MDXQ
+
+    MDXQ{Custom MDX<br/>components?}
+    MDXQ -- "Yes" --> MDX[<b>mdcms-mdx-components</b>]
+    MDXQ -- "No" --> Sync
+    MDX --> Sync
+
+    Sync[<b>mdcms-content-sync-workflow</b>]
+    Sync --> Done([MDCMS integrated])
+```
+
+## Assumptions and limitations
+
+- Assumes the current MDCMS CLI contract. The `mdcms init --non-interactive` surface is required and ships with MDCMS `0.1.x+`.
+- Skills reference `apps/studio-example` in the MDCMS source repo for copy-from patterns (Studio embed, MDX component registration). When the reference implementation changes, the skills defer to the reference.
+- No assumption is made about the user's host framework beyond "React-based". Examples use Next.js App Router because it is the most common target; adapt for Remix, Astro, Vite, etc.
+- The pack does not bundle an MCP server, hooks, or subagents. Claude Code users wanting `/slash` command shortcuts or MCP-backed integrations should install the pack alongside any project-specific `.claude/` config.
+
+## Distribution conventions
+
+- Each skill is a directory under this pack named `<slug>/`, containing a single `SKILL.md` with YAML frontmatter (`name`, `description`) and a markdown body.
+- Skill slugs are stable and used for cross-references. Renaming a skill is a breaking change for consumers of the pack.
+- New skills should follow the patterns already in this pack: pushy description, prerequisites, numbered steps, verification, gotchas, related skills, and a final assumptions/limitations note.
+
+## Updating / removing
+
+```bash
+# Update all installed skills to their latest version
+npx skills update
+
+# Remove one
+npx skills remove mdcms-setup
+
+# Remove everything from this pack
+npx skills remove --all --skill 'mdcms-*'
+```
+
+See `npx skills --help` for the full command surface.

--- a/skills/mdcms-brownfield-init/SKILL.md
+++ b/skills/mdcms-brownfield-init/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: mdcms-brownfield-init
+description: Use this skill when the user wants to import an existing Markdown or MDX project into MDCMS, says things like "I have a bunch of markdown files and I want MDCMS to manage them", "import my existing blog into MDCMS", "adopt MDCMS for this repo's content", or when the `mdcms-setup` orchestrator has detected the repo has pre-existing `.md`/`.mdx` files. Drives `mdcms init --non-interactive` against the existing content, then verifies the inferred schema.
+---
+
+# MDCMS Brownfield Init
+
+Onboard an existing repository whose content already lives as `.md`/`.mdx` files on disk. `mdcms init` is the one-shot command that creates `mdcms.config.ts`, infers a schema from the existing files, syncs that schema to the server, and imports the files as draft documents.
+
+## When to use this skill
+
+The user has:
+
+- an MDCMS backend reachable (if not, run **`mdcms-self-host-setup`** first), and
+- a repo with Markdown/MDX content they want MDCMS to manage.
+
+Do not use this skill for empty repos — use **`mdcms-greenfield-init`** instead.
+
+## Prerequisites
+
+- Server URL (e.g. `http://localhost:4000`).
+- An MDCMS API key with permission to create projects/environments and sync schema. Create one via Studio → Settings → API Keys, or use the demo key from `docker-compose.dev.yml` for local development.
+- A project slug and environment name (defaults to `production` if omitted).
+- Node.js / npm — the CLI is `npx mdcms` (or `bun x mdcms`).
+
+## Steps
+
+### 1. Discover the content directories
+
+```bash
+find . -type f \( -name '*.md' -o -name '*.mdx' \) \
+  -not -path '*/node_modules/*' -not -path '*/.*' \
+  | awk -F/ '{print $2"/"$3}' | sort -u
+```
+
+List the top two directory levels (for example `content/posts`, `docs/blog`). Confirm with the user which of these MDCMS should manage. Those become `--directory` values in step 3.
+
+### 2. Prepare the non-interactive flags
+
+Collect these inputs up front. If any are missing and the user wants headless, stop and ask:
+
+| Flag            | Value                                          |
+| --------------- | ---------------------------------------------- |
+| `--server-url`  | MDCMS API base URL                             |
+| `--project`     | slug to create on the server (e.g. `my-site`)  |
+| `--environment` | environment name (default `production`)        |
+| `--api-key`     | token with project create + schema sync scopes |
+| `--directory`   | one per managed directory, repeatable          |
+
+Alternatively, set the corresponding env vars (`MDCMS_SERVER_URL`, `MDCMS_PROJECT`, `MDCMS_ENVIRONMENT`, `MDCMS_API_KEY`) and omit the flags.
+
+### 3. Run init
+
+```bash
+npx mdcms init --non-interactive \
+  --server-url "$MDCMS_SERVER_URL" \
+  --project "$MDCMS_PROJECT" \
+  --environment "$MDCMS_ENVIRONMENT" \
+  --api-key "$MDCMS_API_KEY" \
+  --directory content/posts \
+  --directory content/pages
+```
+
+What this does in one shot:
+
+1. Pings `/healthz`.
+2. Creates (or joins) the project and environment on the server.
+3. Stores the API key in the credential store, scoped to `(server, project, environment)`.
+4. Scans each `--directory` for `.md`/`.mdx` files, infers types from frontmatter, detects locale patterns in filenames/folders.
+5. Writes `mdcms.config.ts` to the repo root.
+6. Syncs the inferred schema to the server (`PUT /api/v1/schema`).
+7. Imports every discovered file as a draft document. Files already present on the server are updated in place.
+8. Adds the managed directories to `.gitignore` and untracks any tracked files in them (so the server becomes the source of truth).
+
+### 4. Verify the inferred schema
+
+Open the generated `mdcms.config.ts` and walk it with the user:
+
+- Each `defineType` entry names a type (e.g. `post`, `page`) and lists inferred fields as Zod validators.
+- Fields inferred as `z.string()` from frontmatter values are the common case. Check that required vs optional is right and that arrays are typed as `z.array(z.string())` (or whatever element type actually appeared).
+- `localized: true` appears only when two or more locales were detected. Confirm the inferred default locale is right.
+
+If the inferred schema is wrong or incomplete (a field got typed as `z.unknown()`, a type is missing, two types should cross-reference), delegate to **`mdcms-schema-refine`**.
+
+### 5. Verify the server state
+
+```bash
+npx mdcms status
+```
+
+You should see:
+
+- `schema: in sync`
+- content documents equal to the import count reported by `init`
+
+Open Studio (`<server-url>/admin/studio`) and navigate to the imported type — the content should appear there.
+
+### 6. Commit the config
+
+Commit `mdcms.config.ts` and the updates to `.gitignore`. The files that got untracked stay on disk for anyone still doing local edits but the server is now authoritative.
+
+## Common gotchas
+
+- **Files with no frontmatter**: those get imported but with an empty schema-driven frontmatter. Add fields later via `mdcms-schema-refine` if that matters.
+- **Non-BCP47 locale tags in filenames** (e.g. `en_us`): init normalizes them and records the mapping under `locales.aliases`. Confirm the mapping is what the user wants.
+- **Conflicting path + locale combos**: init falls back to an update if a document already exists with the same `(type, path, locale)` identity. Review the import log for any warnings.
+- **Pre-existing `mdcms.config.ts`**: the non-interactive flag implies yes-to-overwrite. If the user does not want to lose the current config, back it up first.
+
+## Related skills
+
+- Needs a server from **`mdcms-self-host-setup`** if the user is self-hosting.
+- Delegate to **`mdcms-schema-refine`** when inferred types are wrong.
+- Continue with **`mdcms-studio-embed`**, **`mdcms-sdk-integration`**, or **`mdcms-content-sync-workflow`** depending on what the user wants next — **`mdcms-setup`** orchestrates that decision.
+
+## Assumptions and limitations
+
+- Requires the non-interactive flag surface on `mdcms init` (shipped with CMS-189).
+- Inferred schema is a starting point, not a final answer. Plan on at least one `schema-refine` pass for production use.
+- `init` makes `.gitignore` changes; review the diff before committing so any existing ignore lines are preserved.
+- Does not cover manual schema authoring from scratch — that path is greenfield + `mdcms-schema-refine`.

--- a/skills/mdcms-brownfield-init/SKILL.md
+++ b/skills/mdcms-brownfield-init/SKILL.md
@@ -64,13 +64,21 @@ npx mdcms init --non-interactive \
 What this does in one shot:
 
 1. Pings `/healthz`.
-2. Creates (or joins) the project and environment on the server.
-3. Stores the API key in the credential store, scoped to `(server, project, environment)`.
-4. Scans each `--directory` for `.md`/`.mdx` files, infers types from frontmatter, detects locale patterns in filenames/folders.
-5. Writes `mdcms.config.ts` to the repo root.
-6. Syncs the inferred schema to the server (`PUT /api/v1/schema`).
-7. Imports every discovered file as a draft document. Files already present on the server are updated in place.
-8. Adds the managed directories to `.gitignore` and untracks any tracked files in them (so the server becomes the source of truth).
+2. Creates the project on the server via `POST /api/v1/projects`. If a project with the same slug already exists, the server returns HTTP 409 and `init` exits with a non-zero status — the wizard does not attach to existing projects. See [Attaching to an existing project](#attaching-to-an-existing-project) below.
+3. Creates the environment if the just-created project does not already have it. If the project-create response reports the environment already exists (common for the auto-created `production`), init skips environment creation.
+4. Stores the API key in the credential store, scoped to `(server, project, environment)`.
+5. Scans each `--directory` for `.md`/`.mdx` files, infers types from frontmatter, detects locale patterns in filenames/folders.
+6. Writes `mdcms.config.ts` to the repo root.
+7. Syncs the inferred schema to the server (`PUT /api/v1/schema`).
+8. Imports every discovered file as a draft document. Documents that already exist at the same `(type, path, locale)` are updated in place (PUT fallback on 409).
+9. Adds the managed directories to `.gitignore` and untracks any tracked files in them (so the server becomes the source of truth).
+
+### Attaching to an existing project
+
+If the target server already has a project with the slug passed to `--project`, `mdcms init` exits with a 409-driven error and does not modify anything. Options:
+
+- **Pick a different slug** — rerun with `--project <new-slug>`; this creates a fresh project.
+- **Use the existing project manually** — hand-author `mdcms.config.ts` pointing at the existing `(project, environment)` tuple, run `mdcms login` to capture a scoped API key, then use `mdcms pull` to fetch the server's state into the repo. `init` is not the right tool for attaching; it's for first-time creation.
 
 ### 4. Verify the inferred schema
 

--- a/skills/mdcms-content-sync-workflow/SKILL.md
+++ b/skills/mdcms-content-sync-workflow/SKILL.md
@@ -117,11 +117,14 @@ jobs:
           MDCMS_PROJECT: ${{ vars.MDCMS_PROJECT }}
           MDCMS_ENVIRONMENT: ${{ vars.MDCMS_ENVIRONMENT }}
           MDCMS_API_KEY: ${{ secrets.MDCMS_API_KEY }}
-        run: npx mdcms push --validate
+        run: npx mdcms push --validate --force --sync-schema
 ```
 
 Notes:
 
+- `--force` is required in non-interactive CI. Without it, `push` skips **new** and **deleted** file candidates (they would otherwise be confirmed via an interactive prompt) and only the changed-in-place documents are uploaded — the CI job would look green while the server drifts silently.
+- `--sync-schema` lets push apply schema drift in the same run. Without it, a change to `mdcms.config.ts` causes push to fail closed when the local schema differs from the server.
+- `--validate` checks frontmatter against the local schema before any API write, so CI catches shape errors before contacting the server.
 - Scope the MDCMS API key to the single environment this workflow touches (e.g., `staging`). A separate key pushes to `production` via a manual workflow or a protected environment.
 - `paths` filter avoids noisy runs when only app code changes.
 - Never echo the API key in logs. GitHub masks secrets but logging them explicitly can defeat that.
@@ -134,8 +137,8 @@ Only needed if the repo treats the filesystem as a mirror (e.g., for static-site
 
 - **Manifest is per-machine** — don't commit `.mdcms/manifests/`. It contains server state that's meaningless to other developers.
 - **Hash drift** — if a local file was edited without a `mdcms push`, then someone edited the same document in Studio, both sides diverge. `mdcms pull` classifies this as "both modified" and requires confirmation to overwrite.
-- **Deleting locally doesn't delete on the server** unless the push flow is explicit about deletions — check `mdcms push --help` for the current deletion flag. Double-check before assuming a local `rm` cascaded.
-- **Schema drift blocks push** — if `mdcms.config.ts` changes locally but schema sync didn't run, push fails. Either run `mdcms schema sync` first, or pass `--sync-schema` in the push call.
+- **Deletions need an interactive confirm or `--force`** — `mdcms push` has no dedicated deletion flag. When a tracked file is missing on disk, push treats it as a deletion candidate and prompts before removing it on the server. In non-interactive mode (no TTY, or in CI), deletion candidates are **skipped** unless `--force` is passed. The full push flag surface is `--force`, `--dry-run`, `--validate`, `--published`, `--sync-schema`. Use `--dry-run` first if you want to see the plan without writes; use `--force` only when you're sure a local `rm` should cascade.
+- **Schema drift blocks push** — if `mdcms.config.ts` changes locally but schema sync didn't run, push fails closed. Either run `mdcms schema sync` first, or pass `--sync-schema` so push applies the schema in the same run.
 - **Multi-environment confusion** — the credential store keys by `(server, project, environment)`. Switching between `staging` and `production` with different keys is fine; forgetting which one is active is where accidents happen. Use `--environment` explicitly in CI.
 
 ## Related skills

--- a/skills/mdcms-content-sync-workflow/SKILL.md
+++ b/skills/mdcms-content-sync-workflow/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: mdcms-content-sync-workflow
+description: Use this skill for day-to-day MDCMS CLI usage — `mdcms pull`, `mdcms push`, `mdcms login`, API key rotation, CI automation for publishing, or when the user asks things like "how do I keep my local markdown in sync with MDCMS", "add MDCMS to CI", "rotate the API key", "what's the draft vs publish flow", or "how do I push changes from a GitHub Action". Not about initial setup — this covers operational usage after init.
+---
+
+# MDCMS Content Sync Workflow
+
+Operate the local↔server content loop day-to-day: pulling fresh content, pushing edits, logging in/rotating keys, and automating publishes in CI. Assumes **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** already ran.
+
+## When to use this skill
+
+Anything operational: syncing content, managing credentials, automating publishing. Not for first-time setup (that's brownfield/greenfield init), not for schema changes (that's `mdcms-schema-refine`).
+
+## Core mental model
+
+- **Drafts** live on the server and in local working copies. Editing locally + `mdcms push` updates the draft on the server. Editing in Studio writes directly to the server draft. Drafts are visible only to authenticated consumers (Studio, preview renders, SDK with `draft: true`).
+- **Publishing** is a separate explicit action (via Studio or the CLI's publish surface when applicable). Published documents are what unauthenticated readers of the host app see.
+- **Manifest** — MDCMS tracks per-`(project, environment)` document state in `.mdcms/manifests/<project>.<environment>.json`. The CLI uses it for hash-based change detection. It's not committed; each developer has their own.
+
+## Daily loop
+
+### Pull the latest drafts
+
+```bash
+npx mdcms pull
+```
+
+Compares local files against the server and applies the plan. Destructive cases (both local and server changed, deletions, renames) prompt for confirmation. Non-destructive cases apply automatically. For headless runs: `mdcms pull --force` skips the confirmation.
+
+Scope: pull always fetches every document the user's credentials can see. There is no path-based filter.
+
+### Push local edits
+
+```bash
+npx mdcms push
+```
+
+Uploads changed, new, and deleted local `.md`/`.mdx` files to the server as draft updates. Untracked files (not yet in the manifest) are presented interactively as new content candidates. Headless: pass all answers via flags (see the CLI's `push --help` for the current surface).
+
+Useful add-ons:
+
+- `mdcms push --validate` — validate against the synced schema before pushing.
+- `mdcms push --sync-schema` — in non-interactive mode, proactively sync schema drift instead of failing.
+
+### Status check
+
+```bash
+npx mdcms status
+```
+
+Shows content drift and schema drift for the current `(project, environment)`. Use this before bigger workflows (before starting editing, before CI cut) to confirm the baseline.
+
+## Credentials
+
+### Initial login (interactive)
+
+```bash
+npx mdcms login
+```
+
+Opens a browser for OAuth-style login against the MDCMS server. On success, stores an API key in the OS credential store (keychain on macOS, libsecret on Linux, credential manager on Windows), keyed by `(serverUrl, project, environment)`.
+
+The CLI resolves keys in this order for every authenticated command: `--api-key` flag → `MDCMS_API_KEY` env var → stored credential. The first non-empty wins.
+
+### Logout
+
+```bash
+npx mdcms logout
+```
+
+Clears the stored credential for the current or specified tuple.
+
+### Rotating an API key
+
+1. In Studio → Settings → API Keys, create a new key with the same scopes.
+2. Re-login with it:
+
+   ```bash
+   MDCMS_API_KEY="<new-key>" npx mdcms status   # quick sanity check
+   ```
+
+   or run `mdcms login` again to rebind.
+
+3. Revoke the old key in Studio once all consumers have switched.
+
+Treat keys as secrets. Do not commit them. Environment-scoped keys (created per `(project, environment)`) make blast radius small on rotation.
+
+## CI automation
+
+### Pushing on merge (GitHub Actions)
+
+```yaml
+# .github/workflows/mdcms-push.yml
+name: MDCMS push
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/**"
+      - "mdcms.config.ts"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: MDCMS push
+        env:
+          MDCMS_SERVER_URL: ${{ vars.MDCMS_SERVER_URL }}
+          MDCMS_PROJECT: ${{ vars.MDCMS_PROJECT }}
+          MDCMS_ENVIRONMENT: ${{ vars.MDCMS_ENVIRONMENT }}
+          MDCMS_API_KEY: ${{ secrets.MDCMS_API_KEY }}
+        run: npx mdcms push --validate
+```
+
+Notes:
+
+- Scope the MDCMS API key to the single environment this workflow touches (e.g., `staging`). A separate key pushes to `production` via a manual workflow or a protected environment.
+- `paths` filter avoids noisy runs when only app code changes.
+- Never echo the API key in logs. GitHub masks secrets but logging them explicitly can defeat that.
+
+### Scheduled pull (optional)
+
+Only needed if the repo treats the filesystem as a mirror (e.g., for static-site build caching). Most consumers fetch via SDK at build/request time and do not need a scheduled `pull`.
+
+## Gotchas
+
+- **Manifest is per-machine** — don't commit `.mdcms/manifests/`. It contains server state that's meaningless to other developers.
+- **Hash drift** — if a local file was edited without a `mdcms push`, then someone edited the same document in Studio, both sides diverge. `mdcms pull` classifies this as "both modified" and requires confirmation to overwrite.
+- **Deleting locally doesn't delete on the server** unless the push flow is explicit about deletions — check `mdcms push --help` for the current deletion flag. Double-check before assuming a local `rm` cascaded.
+- **Schema drift blocks push** — if `mdcms.config.ts` changes locally but schema sync didn't run, push fails. Either run `mdcms schema sync` first, or pass `--sync-schema` in the push call.
+- **Multi-environment confusion** — the credential store keys by `(server, project, environment)`. Switching between `staging` and `production` with different keys is fine; forgetting which one is active is where accidents happen. Use `--environment` explicitly in CI.
+
+## Related skills
+
+- **`mdcms-brownfield-init`** / **`mdcms-greenfield-init`** — produce the project state this skill operates on.
+- **`mdcms-schema-refine`** — when schema drift blocks a push, that's the owner.
+- **`mdcms-setup`** — this skill is Phase 7 of the master orchestrator.
+
+## Assumptions and limitations
+
+- Flag surfaces match the current CLI contract. When in doubt, run `mdcms <command> --help` and trust it over this skill.
+- CI example targets GitHub Actions; other CIs follow the same pattern — checkout, install, set env, run `mdcms push`.
+- Publish automation (from draft to published) depends on whether the repo wants publishing in CI or exclusively via Studio. This skill does not pick that for the user.
+- Does not cover webhooks-driven revalidation of the host app — that is an MDCMS Post-MVP feature.

--- a/skills/mdcms-greenfield-init/SKILL.md
+++ b/skills/mdcms-greenfield-init/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: mdcms-greenfield-init
+description: Use this skill when the user wants to start a new MDCMS project from scratch with no existing Markdown content, says things like "I'm starting a new site and want to use MDCMS", "set up MDCMS in this empty repo", "I want to try MDCMS with fresh content", or when the `mdcms-setup` orchestrator detects no `.md`/`.mdx` files in the repo. Drives `mdcms init --non-interactive` with the scaffolded starter, pushes the example, and optionally proposes first real content types via `mdcms-schema-refine`.
+---
+
+# MDCMS Greenfield Init
+
+Bootstrap MDCMS in a repo that has no content yet. `mdcms init` scaffolds a minimal starter (one content type, one example post, a valid `mdcms.config.ts`) and syncs the schema. A follow-up `mdcms push` uploads the example.
+
+## When to use this skill
+
+The user wants MDCMS for a new project and has no existing Markdown/MDX files to import. If the repo already has content, use **`mdcms-brownfield-init`** instead.
+
+## Prerequisites
+
+- Server URL (self-host with **`mdcms-self-host-setup`** if needed).
+- MDCMS API key with project + schema permissions.
+- Project slug and environment name.
+- Node.js / npm for `npx mdcms`.
+
+## Steps
+
+### 1. Run init
+
+```bash
+npx mdcms init --non-interactive \
+  --server-url "$MDCMS_SERVER_URL" \
+  --project "$MDCMS_PROJECT" \
+  --environment "$MDCMS_ENVIRONMENT" \
+  --api-key "$MDCMS_API_KEY"
+```
+
+With no content on disk, init:
+
+1. Scaffolds `content/posts/` as the managed directory.
+2. Generates a `post` type with `title: z.string()` and `slug: z.string().optional()`.
+3. Writes `mdcms.config.ts`.
+4. Syncs the schema to the server.
+5. Creates `content/posts/example.md` (a placeholder with frontmatter and a short body). Skip this last step with `--no-example-post` if the user does not want it.
+
+If the user prefers a different starter directory, pass `--directory <path>` — the type is named after the last path segment.
+
+### 2. Push the example to the server
+
+```bash
+npx mdcms push
+```
+
+`init` writes the file locally but does not import it. Running `push` uploads it so the user can immediately open Studio and see a real draft document.
+
+### 3. Decide on the content model
+
+At this point the repo has a minimal `post` type with two fields. Ask the user what their real content model looks like (blog posts with authors and tags? marketing pages? campaigns with localized variants?) and either:
+
+- Start drafting directly in the scaffolded directory if the starter shape fits, or
+- Delegate to **`mdcms-schema-refine`** to add the real types, fields, and references.
+
+Nudge the user toward `schema-refine` if they describe more than one content kind — the scaffold is intentionally minimal, not a template.
+
+### 4. Verify
+
+```bash
+npx mdcms status
+```
+
+Expected:
+
+- `schema: in sync`
+- at least one document (the example post) if `push` ran
+
+Open Studio at `<server-url>/admin/studio` and confirm the example post appears under the `Post` type.
+
+### 5. Commit the starter
+
+Commit `mdcms.config.ts` and the `content/posts/example.md` scaffold if the user wants it as a starting point. If the user intends to delete the example and author real content immediately, the file can be dropped — but push again after removal so the server reflects it.
+
+## Common follow-ups
+
+- **More content types** → **`mdcms-schema-refine`**.
+- **Render the content in the host app** → **`mdcms-sdk-integration`**.
+- **Add the Studio UI to the host app** → **`mdcms-studio-embed`**.
+- **Teach the user `pull`/`push` flow** → **`mdcms-content-sync-workflow`**.
+
+## Gotchas
+
+- The scaffolded `post` type is a placeholder. Do not encourage the user to ship real content against it without a schema review.
+- `--no-example-post` still writes the config and syncs the schema, but leaves the directory empty. Only use this when the user will write their own first document immediately.
+- If an `mdcms.config.ts` already exists in the repo, non-interactive mode overwrites it. If the user has a hand-written config they want to keep, back it up first.
+
+## Related skills
+
+- **`mdcms-self-host-setup`** — needed if the user does not yet have a backend.
+- **`mdcms-schema-refine`** — the natural next step to author real content types.
+- **`mdcms-setup`** — master orchestrator; this skill is phase 2 of that flow in the greenfield branch.
+
+## Assumptions and limitations
+
+- Requires the non-interactive flag surface on `mdcms init` (shipped with CMS-189).
+- The starter schema is deliberately simple — one type, two fields. Production projects should refine it.
+- Does not set up Studio embed, SDK fetching, or MDX components — those are separate skills.

--- a/skills/mdcms-mdx-components/SKILL.md
+++ b/skills/mdcms-mdx-components/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: mdcms-mdx-components
+description: Use this skill when the user wants to register or author custom MDX components for MDCMS — phrases like "add a Callout component", "register custom MDX components", "my content uses custom React components", "make components available in Studio", or "my MDX renders plain text for <Alert>". Covers the `components` entry in `mdcms.config.ts`, the Studio-side registry, and the host-app MDX runtime that has to render them consistently.
+---
+
+# MDCMS MDX Components
+
+Register custom React components so they render consistently inside:
+
+1. The author's MDX source files,
+2. The Studio preview (editors see them in the visual editor), and
+3. The host app's SSR / CSR output (production renders them too).
+
+## When to use this skill
+
+The user has MDX content that uses custom components (`<Callout>`, `<CTAButton>`, `<Chart>`, `<Video>`) and wants them to "just work" end to end. Also use when a component renders fine in one place (e.g., the host app) but not another (e.g., Studio shows the raw tag or empty content).
+
+Not for schema changes (`mdcms-schema-refine`) or for regular markdown (no registration needed).
+
+## Prerequisites
+
+- `mdcms.config.ts` exists (run **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** first).
+- Host app already has MDX rendering set up (or is willing to add it — see the target framework's MDX integration).
+- Each custom component is a React component in the host app's source tree.
+
+## How components flow
+
+The MDCMS contract is: components are declared once, in a shared module, and referenced from both `mdcms.config.ts` and the host app's MDX runtime. Studio reads the config to know which components exist and how to render them in preview; the host app reads the same registry to render them in production.
+
+The `apps/studio-example` repo demonstrates the current pattern — treat it as the canonical reference when file paths or export names change.
+
+## Steps
+
+### 1. Create a shared components module
+
+Create a single source of truth for component metadata and implementations:
+
+```ts
+// lib/mdcms-components.ts
+import { Callout } from "@/components/callout";
+import { CTAButton } from "@/components/cta-button";
+
+export const mdcmsComponents = [
+  {
+    name: "Callout",
+    component: Callout,
+  },
+  {
+    name: "CTAButton",
+    component: CTAButton,
+  },
+];
+```
+
+Exact shape (keys like `name`, `component`, `extractedProps`) comes from `@mdcms/studio`'s component contract — check `apps/studio-example/lib/*-studio-config.ts` for the current field set. Do not invent fields; copy from the reference.
+
+### 2. Wire the registry into `mdcms.config.ts`
+
+```ts
+import { defineConfig, defineType } from "@mdcms/cli";
+import { mdcmsComponents } from "./lib/mdcms-components";
+
+export default defineConfig({
+  // ... other config
+  components: [...mdcmsComponents],
+  types: [
+    // ...
+  ],
+});
+```
+
+The `components` array is what Studio uses to show prop editors and prop-aware previews. Without it, the visual editor treats `<Callout>` as an unknown tag.
+
+### 3. Wire the registry into the host app's MDX runtime
+
+For Next.js App Router with `@mdx-js/react`:
+
+```tsx
+import { MDXProvider } from "@mdx-js/react";
+import { mdcmsComponents } from "@/lib/mdcms-components";
+
+const reactComponents = Object.fromEntries(
+  mdcmsComponents.map((c) => [c.name, c.component]),
+);
+
+export default function MdxLayout({ children }) {
+  return <MDXProvider components={reactComponents}>{children}</MDXProvider>;
+}
+```
+
+For frameworks with a different MDX runtime (Remix, Astro, Vite), wire the same map into whatever `components={...}` prop that runtime expects. The key is: the same `name → React component` map the config uses.
+
+### 4. Push the updated config
+
+```bash
+npx mdcms schema sync
+```
+
+Schema sync pushes the updated `components` list to the server so Studio's prepared config picks it up on next load. If the host app serves the prepared config on the `/admin` route (see **`mdcms-studio-embed`**), redeploy or revalidate that route so the fresh config reaches Studio.
+
+### 5. Verify in Studio
+
+1. Open Studio at `<host-app>/admin` (or the standalone `<server>/admin/studio`).
+2. Edit any document that uses the custom component.
+3. The component should preview with its real React output (Studio uses the component from the registry).
+4. The props panel should show editable fields for each extracted prop.
+
+If Studio still shows `<Callout>` as a raw tag, the config wasn't refreshed — restart the host app or rerun `mdcms schema sync`.
+
+### 6. Verify in the host app
+
+Render a page that uses the component. Confirm the DOM output matches the Studio preview. If the component uses interactive state, verify hydration works (no mismatch errors in the console).
+
+## Common gotchas
+
+- **Component name mismatch** — the `name` in the registry must exactly match the JSX tag used in MDX content (`<Callout>` ↔ `name: "Callout"`). Case-sensitive.
+- **Server/client boundary** — in Next App Router, components used in MDX must be either server-safe or wrapped with `"use client"`. Mark interactive components as client components before wiring.
+- **Stale prepared config** — after editing the `components` array, Studio still serves the old list until its prepared config is regenerated. Revalidate or rebuild.
+- **Divergent shape between host and Studio** — if the host app uses one component module and Studio uses another (e.g. two parallel registries), they drift. Keep one file as the source of truth and import from it in both places.
+- **Void components in MDX** — components that render as self-closing need `<Callout />` in MDX, not `<Callout></Callout>`. Studio's editor surfaces this distinction.
+
+## Related skills
+
+- **`mdcms-studio-embed`** is often adjacent — the prepared config that Studio reads is created by the embed setup.
+- **`mdcms-schema-refine`** after registering components, because a prop type or content field may need to change to model the new component.
+- **`mdcms-sdk-integration`** because the host app fetches the content via SDK and must pair with an MDX runtime.
+
+## Assumptions and limitations
+
+- Current MDCMS MDX contract lives in `@mdcms/studio` and the reference app. Field names (`name`, `component`, `extractedProps`) evolve — trust the reference over this skill.
+- Does not cover prop-extraction tooling (`extractedProps`) — MDCMS has its own extraction pipeline that the reference demonstrates. Follow it for complex components.
+- Assumes the host app uses an MDX runtime. Plain Markdown content without MDX components does not need this skill.
+- Does not cover styling or CSS — components ship their own styles or consume the host app's styling system.

--- a/skills/mdcms-schema-refine/SKILL.md
+++ b/skills/mdcms-schema-refine/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: mdcms-schema-refine
+description: Use this skill whenever the user wants to add, edit, extend, or fix MDCMS content types, fields, or references — phrases like "make me a new content type", "add an author type", "add a tags field to posts", "link blog posts to authors", "the inferred schema is wrong", "change the schema", or "author the content model". Covers editing `mdcms.config.ts` with `defineType` + Zod validators, adding `reference()` links, and running `mdcms schema sync` to publish the change.
+---
+
+# MDCMS Schema Refine
+
+Edit `mdcms.config.ts` to shape the content model and push the change to the server. This is the skill for post-init schema work — whether that's correcting a brownfield-inferred schema, extending a greenfield scaffold, or evolving a mature project.
+
+## When to use this skill
+
+- After **`mdcms-brownfield-init`** when the inferred schema needs corrections or additions.
+- After **`mdcms-greenfield-init`** when the scaffolded `post` type is not enough for the real content model.
+- Any time the user asks to add/edit a type, add/edit a field, or link two types via a reference.
+
+Not for importing content, embedding Studio, or editing individual documents — those are different skills.
+
+## Prerequisites
+
+- A working `mdcms.config.ts` and a reachable MDCMS server (run **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** first if not).
+- Credential for the target `(server, project, environment)` resolvable by the CLI — already true if init ran on this machine.
+- Read the current config before editing so you understand the shape you're changing.
+
+## Core concepts
+
+- **Type** — a content kind (e.g. `post`, `page`, `author`). Declared via `defineType(name, { directory, fields, ... })`.
+- **Field** — a Zod validator attached to a frontmatter key. Typical shapes: `z.string().min(1)`, `z.number().optional()`, `z.boolean().default(false)`, `z.array(z.string())`, `z.enum([...])`.
+- **Reference** — `reference("<target-type>")` makes a field point to a document of another type. References are resolved by the SDK and surfaced in Studio as pickers.
+- **Localized type** — `localized: true` on `defineType` makes every document live in multiple locale variants grouped by a shared translation group id.
+- **Environment-scoped fields** — `.env("staging")` chained onto a Zod validator makes a field only apply in that environment. Use sparingly.
+
+## Steps
+
+### 1. Read the current config
+
+```bash
+cat mdcms.config.ts
+```
+
+Make sure you understand:
+
+- What types exist and which directories they map to.
+- Whether each type is localized.
+- What references already link types together.
+
+### 2. Make the edit
+
+Edit `mdcms.config.ts`. Common patterns:
+
+**Add a new type**
+
+```ts
+import { defineType, reference } from "@mdcms/cli";
+import { z } from "zod";
+
+const author = defineType("author", {
+  directory: "content/authors",
+  fields: {
+    name: z.string().min(1),
+    bio: z.string().optional(),
+  },
+});
+```
+
+Then add the new type to the `types: [...]` array passed to `defineConfig(...)`.
+
+**Add a field to an existing type**
+
+```ts
+const post = defineType("post", {
+  directory: "content/posts",
+  fields: {
+    title: z.string().min(1),
+    slug: z.string().min(1),
+    publishedAt: z.string().datetime().optional(), // new
+    tags: z.array(z.string()).default([]), // new
+  },
+});
+```
+
+**Cross-reference two types**
+
+```ts
+const post = defineType("post", {
+  directory: "content/posts",
+  fields: {
+    title: z.string().min(1),
+    author: reference("author").optional(),
+  },
+});
+```
+
+`reference("author")` means the frontmatter value is an author document id. Studio renders a picker; the SDK can resolve the reference to the full document.
+
+**Make a type localized**
+
+```ts
+const campaign = defineType("campaign", {
+  directory: "content/campaigns",
+  localized: true,
+  fields: {
+    title: z.string().min(1),
+    summary: z.string().min(1),
+  },
+});
+```
+
+Localized types require the `locales` config at the root of `defineConfig(...)` to list the supported locales and the default.
+
+### 3. Preview the impact
+
+```bash
+npx mdcms status
+```
+
+This shows local content vs server state and whether the schema is in sync. After a config edit it will say the schema is drifted.
+
+### 4. Sync the schema to the server
+
+```bash
+npx mdcms schema sync
+```
+
+The server validates the new schema and either accepts it or rejects the change with a clear error (for example if a required field is added but existing documents don't satisfy it).
+
+If the change is rejected:
+
+- Make the new field optional, or
+- Give it a `.default(...)`, or
+- Plan a content migration before rerunning.
+
+### 5. Verify
+
+```bash
+npx mdcms status
+```
+
+Expected: `schema: in sync`. Existing documents are unchanged on disk; they just now validate against the new schema.
+
+Open Studio and confirm the new type/field appears in the document editor.
+
+### 6. Author content (optional)
+
+If the refinement added a new type, author the first document by either:
+
+- Creating the file on disk and running `mdcms push`, or
+- Adding it via Studio directly.
+
+If the refinement added a new field to an existing type, go update the affected documents (locally via editor + `mdcms push`, or in Studio).
+
+## Gotchas
+
+- **Removing a field** is a schema-breaking change from the documents' perspective. The CLI surfaces the conflict; plan a migration (populate a default, then remove). Don't just delete it and hope.
+- **Adding a required field to an existing type** without a `.default(...)` will fail schema sync if documents don't already have that frontmatter key. Use `.optional()` or `.default(...)`.
+- **Renaming a type** is not a rename — it's a delete + create. Use the migration flow or keep the old name.
+- **Reference targets must exist** — `reference("author")` requires an `author` type declared in the same config.
+- **Studio-visible labels** come from the type name. Use readable names (`author`, `blogPost`) over cryptic ones.
+
+## Related skills
+
+- **`mdcms-brownfield-init`** / **`mdcms-greenfield-init`** produce the initial config this skill refines.
+- **`mdcms-content-sync-workflow`** covers how `pull`/`push` interacts with schema changes.
+- **`mdcms-mdx-components`** covers registering custom MDX components (not a schema edit, but a sibling config concern).
+
+## Assumptions and limitations
+
+- Schema validators are Zod. The MDCMS CLI currently ships `defineType`, `defineConfig`, and `reference` from `@mdcms/cli` — verify that import path if the repo's packaging has changed.
+- This skill does not write content migrations. For shape-breaking changes (required field, rename), hand off to the user or an MDCMS migration skill when it exists.
+- Every schema change is pushed server-side; make one coherent edit per sync rather than batching many unrelated changes.

--- a/skills/mdcms-sdk-integration/SKILL.md
+++ b/skills/mdcms-sdk-integration/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: mdcms-sdk-integration
+description: Use this skill when the user wants to fetch MDCMS content from their React/Next/Remix app, says things like "render MDCMS content in my app", "replace my filesystem markdown with MDCMS", "use @mdcms/sdk to load posts", "SSR MDCMS content", "fetch drafts in preview mode", or similar. Covers both replacing an existing filesystem-based content layer (brownfield) and writing fresh fetching code (greenfield), plus drafts vs published, SSR patterns, and revalidation.
+---
+
+# MDCMS SDK Integration
+
+Use `@mdcms/sdk` in the host app to fetch MDCMS content at build time or request time, replacing any filesystem-driven content layer, and supporting the draft/published split.
+
+## When to use this skill
+
+The user wants to consume MDCMS content programmatically from a host app — typically to render pages, build a blog index, or hydrate a CMS-driven section. Two sub-paths:
+
+- **Brownfield (replace)** — the app currently imports markdown from the repo (`import about from "../content/about.md"`, `fs.readFile`, `remark`/`mdx-bundler`). Replace that with SDK calls.
+- **Greenfield (write new)** — the app has no content-fetching code yet. Add it fresh.
+
+Not for editing content (use Studio), not for schema changes (use `mdcms-schema-refine`), not for admin embedding (use `mdcms-studio-embed`).
+
+## Prerequisites
+
+- A running MDCMS server and content synced against a schema (via **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`**).
+- A React-based host app.
+- An API key that the host app can read at runtime. For server-side rendering, this is an env var (`MDCMS_API_KEY`). Never ship the API key to the browser.
+
+## Steps
+
+### 1. Install the SDK
+
+```bash
+npm install @mdcms/sdk
+# or: bun add @mdcms/sdk
+```
+
+### 2. Create a client
+
+In a server-only module (for Next: a file without `"use client"`, ideally under `lib/`):
+
+```ts
+import { createClient } from "@mdcms/sdk";
+
+export const cms = createClient({
+  serverUrl: process.env.MDCMS_SERVER_URL!,
+  project: process.env.MDCMS_PROJECT!,
+  environment: process.env.MDCMS_ENVIRONMENT!,
+  apiKey: process.env.MDCMS_API_KEY!,
+});
+```
+
+Keep the import path server-only. If the app leaks it into a client bundle, the API key ships to users.
+
+### 3. Fetch content
+
+Two common shapes:
+
+**Fetch a single document by path**
+
+```ts
+const about = await cms.getDocument({ type: "page", path: "about" });
+```
+
+**List documents of a type**
+
+```ts
+const posts = await cms.listDocuments({ type: "post", limit: 20 });
+```
+
+Return values include the frontmatter fields as declared in `mdcms.config.ts` plus the body. Use them directly in React:
+
+```tsx
+export default async function AboutPage() {
+  const about = await cms.getDocument({ type: "page", path: "about" });
+  return (
+    <article>
+      <h1>{about.title}</h1>
+      {/* render about.body — either as HTML, or via MDX runtime */}
+    </article>
+  );
+}
+```
+
+### 4. Draft vs published
+
+By default the SDK returns **published** content. Preview/draft flows need an explicit opt-in:
+
+```ts
+const draft = await cms.getDocument({
+  type: "page",
+  path: "about",
+  draft: true,
+});
+```
+
+Patterns:
+
+- **Production pages** — omit `draft` or pass `false`. Only published content ships.
+- **Preview routes** — gate `draft: true` behind a preview cookie / query param so only editors see drafts.
+- **In-development** — early in a project, drafts are often all you have. Pass `draft: true` everywhere until content is ready to publish.
+
+### 5. (Brownfield) replace the existing fetching
+
+Typical before/after in a Next App Router page:
+
+**Before**
+
+```tsx
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const raw = await fs.readFile(
+  path.join(process.cwd(), "content/pages/about.md"),
+  "utf-8",
+);
+const about = parseMarkdown(raw);
+```
+
+**After**
+
+```tsx
+import { cms } from "@/lib/cms";
+
+const about = await cms.getDocument({ type: "page", path: "pages/about" });
+```
+
+Delete the old markdown files from disk if they were imported into MDCMS (check `.gitignore` — `mdcms-brownfield-init` likely already added them), or keep them as a local cache if the app's build process benefits from that.
+
+### 6. (Greenfield) add fresh fetching
+
+Generate the route tree from MDCMS. Example for a blog index + detail in Next:
+
+```tsx
+// app/blog/page.tsx
+import { cms } from "@/lib/cms";
+export default async function BlogIndex() {
+  const posts = await cms.listDocuments({ type: "post", limit: 50 });
+  return (
+    <ul>
+      {posts.map((p) => (
+        <li key={p.id}>
+          <a href={`/blog/${p.slug}`}>{p.title}</a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// app/blog/[slug]/page.tsx
+export default async function PostPage({ params }) {
+  const post = await cms.getDocument({
+    type: "post",
+    path: `posts/${params.slug}`,
+  });
+  return <article>{/* ... */}</article>;
+}
+```
+
+### 7. Revalidation / caching
+
+- **Next App Router** — `fetch` calls from the SDK inherit Next's default cache behavior. For frequently updating content, set `revalidate` on the route or tag-invalidate via `revalidateTag` on webhook. Follow Next's caching guide; the SDK does not override it.
+- **Build-time static** — call the SDK inside `generateStaticParams`/`getStaticProps` (Pages Router). Content is frozen at build time; rebuild to pick up changes.
+- **ISR + webhooks** — expose a revalidation endpoint in the host app; call it from an MDCMS webhook on publish. This is Post-MVP on the MDCMS side; design for it but gate behind a feature check.
+
+## Common gotchas
+
+- **API key leaks into the browser** — always import the SDK in server-only modules. In Next, a `"use client"` file or a client component must not import `@/lib/cms`.
+- **Path mismatch** — document paths in MDCMS preserve the full managed directory segment by default (e.g. `pages/about`, not `about`). Check a working call with the actual path the server returns, not an intuition.
+- **Draft leaking to production** — if every page passes `draft: true`, unpublished content goes live. Route preview behind a flag.
+- **Type vs type name** — `mdcms.config.ts` uses a string type name (`"post"`). The SDK call uses the same name; it is case-sensitive.
+- **Locale-aware fetches** — localized types need a `locale` argument on SDK calls. Omit for non-localized types.
+
+## Related skills
+
+- **`mdcms-mdx-components`** — if the content body is MDX with custom components, the host app needs an MDX runtime that knows about the same component registry Studio uses.
+- **`mdcms-schema-refine`** — if the SDK types returned don't include a field the host needs.
+- **`mdcms-content-sync-workflow`** — pair with this to understand when content is pushed vs pulled vs published.
+
+## Assumptions and limitations
+
+- `@mdcms/sdk` is the first-party client. If the codebase uses a hand-rolled `fetch` directly against the API, migrate to the SDK — contract stability lives there.
+- Covers Next.js App Router as the reference target; adapt patterns for Pages Router, Remix, React Router, or a plain React SPA as needed.
+- Does not cover custom resolvers or server-side data transformation pipelines — SDK returns what the server returns.
+- Caching/revalidation examples use Next primitives; the SDK itself does not ship a cache layer.

--- a/skills/mdcms-sdk-integration/SKILL.md
+++ b/skills/mdcms-sdk-integration/SKILL.md
@@ -50,25 +50,45 @@ Keep the import path server-only. If the app leaks it into a client bundle, the 
 
 ### 3. Fetch content
 
-Two common shapes:
+The SDK exposes two read methods: `cms.get(type, input)` and `cms.list(type, input)`. Both accept `locale`, optional per-call `project`/`environment` overrides, and an optional `resolve` array for reference expansion.
 
-**Fetch a single document by path**
+**Fetch a single document by id or slug**
+
+`get` requires either `id` (preferred — stable across renames) or `slug`. There is no `path` parameter on the SDK.
 
 ```ts
-const about = await cms.getDocument({ type: "page", path: "about" });
+// By id (preferred when you already have it)
+const about = await cms.get("page", { id: "doc_01HY…", locale: "en" });
+
+// By slug (convenient for marketing/blog routes)
+const post = await cms.get("post", { slug: "hello-world", locale: "en" });
 ```
+
+`get` returns the document directly (unwrapped from the `{ data }` envelope).
 
 **List documents of a type**
 
 ```ts
-const posts = await cms.listDocuments({ type: "post", limit: 20 });
+const response = await cms.list("post", {
+  locale: "en",
+  limit: 20,
+  sort: "createdAt",
+  order: "desc",
+});
+
+// response has shape { data: Document[], pagination: {...} }
+for (const post of response.data) {
+  // ...
+}
 ```
 
-Return values include the frontmatter fields as declared in `mdcms.config.ts` plus the body. Use them directly in React:
+`list` returns the full paginated envelope — iterate `response.data`, and use `response.pagination` for offset/total/hasMore.
+
+Document return values include the frontmatter fields as declared in `mdcms.config.ts` plus the body. Use them directly in React:
 
 ```tsx
 export default async function AboutPage() {
-  const about = await cms.getDocument({ type: "page", path: "about" });
+  const about = await cms.get("page", { slug: "about", locale: "en" });
   return (
     <article>
       <h1>{about.title}</h1>
@@ -83,9 +103,9 @@ export default async function AboutPage() {
 By default the SDK returns **published** content. Preview/draft flows need an explicit opt-in:
 
 ```ts
-const draft = await cms.getDocument({
-  type: "page",
-  path: "about",
+const draft = await cms.get("page", {
+  slug: "about",
+  locale: "en",
   draft: true,
 });
 ```
@@ -118,7 +138,7 @@ const about = parseMarkdown(raw);
 ```tsx
 import { cms } from "@/lib/cms";
 
-const about = await cms.getDocument({ type: "page", path: "pages/about" });
+const about = await cms.get("page", { slug: "about", locale: "en" });
 ```
 
 Delete the old markdown files from disk if they were imported into MDCMS (check `.gitignore` — `mdcms-brownfield-init` likely already added them), or keep them as a local cache if the app's build process benefits from that.
@@ -131,10 +151,10 @@ Generate the route tree from MDCMS. Example for a blog index + detail in Next:
 // app/blog/page.tsx
 import { cms } from "@/lib/cms";
 export default async function BlogIndex() {
-  const posts = await cms.listDocuments({ type: "post", limit: 50 });
+  const response = await cms.list("post", { locale: "en", limit: 50 });
   return (
     <ul>
-      {posts.map((p) => (
+      {response.data.map((p) => (
         <li key={p.id}>
           <a href={`/blog/${p.slug}`}>{p.title}</a>
         </li>
@@ -145,9 +165,9 @@ export default async function BlogIndex() {
 
 // app/blog/[slug]/page.tsx
 export default async function PostPage({ params }) {
-  const post = await cms.getDocument({
-    type: "post",
-    path: `posts/${params.slug}`,
+  const post = await cms.get("post", {
+    slug: params.slug,
+    locale: "en",
   });
   return <article>{/* ... */}</article>;
 }
@@ -162,10 +182,11 @@ export default async function PostPage({ params }) {
 ## Common gotchas
 
 - **API key leaks into the browser** — always import the SDK in server-only modules. In Next, a `"use client"` file or a client component must not import `@/lib/cms`.
-- **Path mismatch** — document paths in MDCMS preserve the full managed directory segment by default (e.g. `pages/about`, not `about`). Check a working call with the actual path the server returns, not an intuition.
+- **`get` needs `id` or `slug`, not `path`** — the SDK does not take a document path. If you only have the local filesystem path, either look up the slug from frontmatter or issue a `list` with a filter. Prefer `id` for stability across rename/slug changes.
+- **`list` returns a paginated envelope** — iterate `response.data`, not `response` itself. The envelope also carries `response.pagination` for offset/total pagination.
 - **Draft leaking to production** — if every page passes `draft: true`, unpublished content goes live. Route preview behind a flag.
 - **Type vs type name** — `mdcms.config.ts` uses a string type name (`"post"`). The SDK call uses the same name; it is case-sensitive.
-- **Locale-aware fetches** — localized types need a `locale` argument on SDK calls. Omit for non-localized types.
+- **Locale-aware fetches** — the SDK takes `locale` as an explicit argument on every `get`/`list` call. Pass it even for non-localized types so the caller stays explicit.
 
 ## Related skills
 

--- a/skills/mdcms-self-host-setup/SKILL.md
+++ b/skills/mdcms-self-host-setup/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: mdcms-self-host-setup
+description: Use this skill when the user wants to self-host MDCMS, run MDCMS locally, stand up the MDCMS backend, bring up the MDCMS server, or says things like "I need an MDCMS server", "spin up MDCMS in Docker", "run MDCMS on my own infra", or similar. Also use it when another skill (e.g. `mdcms-setup`) has determined the user has no reachable MDCMS server yet. Walks through cloning the repo, configuring env, `docker compose up`, and verifying `/healthz`.
+---
+
+# MDCMS Self-Host Setup
+
+Stand up an MDCMS backend the user can point the CLI, Studio, and SDK at. The official self-hosting story is Docker Compose from the MDCMS source repo.
+
+## When to use this skill
+
+The user has decided to run MDCMS themselves (local development, staging, or production), and there is no existing server URL they can use. If they already have a hosted MDCMS endpoint, skip this skill.
+
+## Prerequisites
+
+- Docker **24+** and Docker Compose **v2+** on the target machine (Docker Desktop covers both on macOS/Windows).
+- Git, to clone the MDCMS source.
+- Outbound network access to `github.com`, `ghcr.io` (or Docker Hub), and any package registries the images pull from.
+- A free TCP port for the server (default `4000`) and dependencies (`5432`, `6379`, `9000`, `9001`, `1025`, `8025`).
+
+## Steps
+
+### 1. Clone the MDCMS source
+
+```bash
+git clone https://github.com/Blazity/mdcms.git
+cd mdcms
+```
+
+The project lives in a monorepo but Docker Compose handles everything — the host does not need Bun or Node.js to run the server.
+
+### 2. Create the env file
+
+```bash
+cp .env.example .env
+```
+
+The example defaults are suitable for local evaluation. For staging or production, change:
+
+- Database credentials (`POSTGRES_PASSWORD`, `DATABASE_URL`).
+- S3/MinIO credentials (`MDCMS_S3_*`) if switching to a real S3 bucket.
+- Auth provider settings if using OIDC/SAML/email.
+- `MDCMS_STUDIO_ALLOWED_ORIGINS` — the list of origins Studio is allowed to embed from. Add the URL(s) of the host apps that will embed `<Studio />`.
+
+Keep the file out of version control.
+
+### 3. Bring up the stack
+
+```bash
+docker compose up -d --build
+```
+
+This starts:
+
+| Service       | Port            | Purpose                      |
+| ------------- | --------------- | ---------------------------- |
+| MDCMS Server  | `4000`          | API backend                  |
+| PostgreSQL 16 | `5432`          | primary database             |
+| Redis 7       | `6379`          | sessions + cache             |
+| MinIO         | `9000` / `9001` | S3-compatible object storage |
+| Mailhog       | `1025` / `8025` | dev email capture            |
+
+Database migrations run automatically before the server starts.
+
+### 4. Smoke-test the backend
+
+```bash
+curl -sf http://localhost:4000/healthz
+```
+
+Expect a `200 OK`. If the server is still booting, wait a few seconds and retry.
+
+### 5. Create the first admin user
+
+Options, in preference order:
+
+1. **Signup endpoint** — if `MDCMS_AUTH_EMAIL_SIGNUPS_ENABLED=true` (default in local dev): POST `/api/v1/auth/signup` with an email and password, then check Mailhog at `http://localhost:8025` for the verification email.
+2. **Preseeded demo user** — `docker compose -f docker-compose.dev.yml up` includes a seeded admin (`demo@mdcms.local` / `Demo12345!`) for instant local dev. Treat this as disposable; delete it before production.
+3. **Custom bootstrap** — for production, run the server's admin-bootstrap command (see `docs/guide/self-hosting.mdx` for the current command name and flags).
+
+### 6. Capture the server URL
+
+For local dev the server URL is usually `http://localhost:4000`. For production, it's whatever origin is exposed to the internet (Studio and the CLI talk to it directly). Save it — all downstream skills need it.
+
+## Verification checklist
+
+Before moving on to `mdcms init` or Studio embed, confirm:
+
+- `curl -sf <server-url>/healthz` returns 200.
+- You can sign in via `/api/v1/auth/login` or the demo credentials and receive a session cookie.
+- Studio can be loaded at `<server-url>/admin/studio` (the standalone Studio mount) and you can log in with the admin user.
+- The Studio settings page shows your admin user listed.
+
+## Related skills
+
+- After the server is up, continue with **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** to bootstrap the CLI + config.
+- If the host app will embed Studio, **`mdcms-studio-embed`** needs `MDCMS_STUDIO_ALLOWED_ORIGINS` set on this server.
+
+## Assumptions and limitations
+
+- Assumes Docker is available and the user has permission to run containers on their machine.
+- Does not cover TLS termination, domain configuration, or container orchestrators (Kubernetes, ECS). Treat those as out of scope.
+- Env var names match the contract in `docs/guide/self-hosting.mdx` and `.env.example`. If the repo's schema changes, trust the source `.env.example` over this skill.
+- Demo user (`demo@mdcms.local`) is for local dev only. Remove it before exposing the instance.

--- a/skills/mdcms-self-host-setup/SKILL.md
+++ b/skills/mdcms-self-host-setup/SKILL.md
@@ -38,7 +38,7 @@ cp .env.example .env
 The example defaults are suitable for local evaluation. For staging or production, change:
 
 - Database credentials (`POSTGRES_PASSWORD`, `DATABASE_URL`).
-- S3/MinIO credentials (`MDCMS_S3_*`) if switching to a real S3 bucket.
+- S3/MinIO credentials (`S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET`) if switching to a real S3 bucket.
 - Auth provider settings if using OIDC/SAML/email.
 - `MDCMS_STUDIO_ALLOWED_ORIGINS` — the list of origins Studio is allowed to embed from. Add the URL(s) of the host apps that will embed `<Studio />`.
 

--- a/skills/mdcms-setup/SKILL.md
+++ b/skills/mdcms-setup/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: mdcms-setup
+description: Use this skill whenever the user wants to set up, install, add, integrate, wire up, or get started with MDCMS in their project, or says things like "get MDCMS running", "add MDCMS to my app", "I want to start using MDCMS", "bring MDCMS into this repo", or anything that sounds like onboarding an MDCMS-based CMS. This is the master orchestrator — it detects what the user already has (running server, existing Markdown/MDX content, a host React/Next app) and delegates to the right focused MDCMS skill at each phase. Always use this first for any MDCMS setup intent, even if the user hasn't named an "orchestrator" or "setup wizard".
+---
+
+# MDCMS Setup (Master Orchestrator)
+
+Walk the user end-to-end through adding MDCMS to their project. Your job is to detect which phase they are in, delegate to the focused skill that owns that phase, and return here for the next decision.
+
+## When to use this skill
+
+Any user intent to add, install, configure, or integrate MDCMS. You are the entry point to the MDCMS skill pack. Do not implement phase work yourself — delegate.
+
+## Phases
+
+Work through these sequentially. For each phase, decide whether the user is done already, then either skip or invoke the focused skill. Always say what you're doing and why before you do it.
+
+### Phase 1 — Is an MDCMS backend reachable?
+
+Ask the user where their MDCMS server lives.
+
+1. If they have a hosted or self-hosted URL they know works: continue.
+2. If they plan to self-host: invoke **`mdcms-self-host-setup`**.
+3. If they have no server and don't want to self-host: stop. MDCMS needs a backend for the rest of the flow to do anything meaningful.
+
+Verify reachability before continuing:
+
+```bash
+curl -sf "$MDCMS_SERVER_URL/healthz" && echo ok
+```
+
+If this fails, fix it before moving on.
+
+### Phase 2 — Greenfield or brownfield?
+
+Check whether the user's repo already has Markdown or MDX content:
+
+```bash
+find . -type f \( -name '*.md' -o -name '*.mdx' \) \
+  -not -path '*/node_modules/*' -not -path '*/.*' | head
+```
+
+- **Existing content** → invoke **`mdcms-brownfield-init`**. That skill runs `mdcms init --non-interactive` against the existing files, verifies the inferred schema, and imports content on first push.
+- **No content** → invoke **`mdcms-greenfield-init`**. That skill runs `mdcms init --non-interactive` with a scaffolded starter, pushes the example, and can delegate to `mdcms-schema-refine` for first real content models.
+
+After either init path, the user has a working `mdcms.config.ts`, a synced schema on the server, a stored credential, and content reachable from the Studio API.
+
+### Phase 3 — Is the schema adequate?
+
+Ask the user to sanity-check the inferred (brownfield) or scaffolded (greenfield) schema in `mdcms.config.ts`. If fields are missing, new types are needed, or types should reference each other: invoke **`mdcms-schema-refine`**. Otherwise skip.
+
+### Phase 4 — Fetching MDCMS content in the host app
+
+Ask whether the user wants to render MDCMS content in their own React, Next, or Remix app.
+
+- If yes (either replacing existing filesystem-backed fetching or writing it fresh): invoke **`mdcms-sdk-integration`**. That skill covers both the brownfield "replace" path and the greenfield "write new" path.
+- If the user only consumes MDCMS through Studio and the raw API: skip.
+
+### Phase 5 — Visual editor (Studio) in the host app
+
+Ask whether the user wants editors to work inside their own app via the embedded Studio UI.
+
+- Yes → invoke **`mdcms-studio-embed`**.
+- No → skip. They can still run Studio standalone against the same server.
+
+### Phase 6 — Custom MDX components
+
+If their content uses (or will use) custom React components in MDX — callouts, embedded forms, interactive widgets, charts: invoke **`mdcms-mdx-components`**. Skip for plain Markdown only.
+
+### Phase 7 — Day-to-day sync + CI
+
+Close the loop: invoke **`mdcms-content-sync-workflow`** so the user understands daily `mdcms pull` / `mdcms push` usage, API key rotation, and CI automation for publishing.
+
+## State-detection cheatsheet
+
+Before asking the user a phase question, check what you can already see in the repo:
+
+| Signal                                                                     | Implication                                                                |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `curl <url>/healthz` returns 200                                           | Skip Phase 1.                                                              |
+| Repo has `.md`/`.mdx` files outside `node_modules`/`.*`                    | Brownfield path in Phase 2.                                                |
+| Repo has `mdcms.config.ts`                                                 | Init already ran. Skip to Phase 3 and confirm schema is good.              |
+| `package.json` lists `@mdcms/studio`                                       | Studio embed probably already done. Confirm before skipping Phase 5.       |
+| `package.json` lists `@mdcms/sdk` or any `from "@mdcms/sdk"` import exists | SDK integration likely in place. Confirm before skipping Phase 4.          |
+| Repo has a `components` array in `mdcms.config.ts`                         | Custom MDX components already registered. Confirm before skipping Phase 6. |
+
+## How to delegate
+
+When you decide to invoke a focused skill, hand off cleanly — don't mix your prose with its prose. When it returns, come back here and advance to the next phase.
+
+## If the user only wants one phase
+
+Short-circuit. If they say "I just want to add Studio to an MDCMS-integrated app", skip the diagnosis and invoke `mdcms-studio-embed` directly. The orchestrator is the default path, not a required gate.
+
+## Out of scope
+
+- Don't implement phase work yourself. Each focused skill knows its domain and stays aligned with the current MDCMS contract.
+- Don't make product decisions for the user ("you probably don't want Studio"). Ask, then delegate.
+- Don't skip a phase silently. State what you're doing.
+
+## Assumptions and limitations
+
+- Requires a Node.js/npm environment on the developer's machine for `npx mdcms`.
+- Assumes the user can either reach a hosted MDCMS instance or run Docker locally for self-host.
+- Assumes the MDCMS server exposes `/healthz` on the same origin as the API (current contract).
+- The flowchart walks a typical adoption path. Real repos can be more tangled — ask, don't guess.

--- a/skills/mdcms-setup/SKILL.md
+++ b/skills/mdcms-setup/SKILL.md
@@ -33,15 +33,29 @@ If this fails, fix it before moving on.
 
 ### Phase 2 — Greenfield or brownfield?
 
-Check whether the user's repo already has Markdown or MDX content:
+Check whether the user's repo already has Markdown or MDX content that MDCMS should manage. Exclude the places where markdown commonly appears but is **not** user content — repo-level docs, skill packs (including this one), issue/PR templates, and dependency directories:
 
 ```bash
 find . -type f \( -name '*.md' -o -name '*.mdx' \) \
-  -not -path '*/node_modules/*' -not -path '*/.*' | head
+  -not -path '*/node_modules/*' \
+  -not -path '*/.*' \
+  -not -path './skills/*' \
+  -not -path './docs/*' \
+  -not -path './apps/docs/*' \
+  -not -path './.github/*' \
+  -not -name 'README*' \
+  -not -name 'CHANGELOG*' \
+  -not -name 'LICENSE*' \
+  -not -name 'SKILL.md' \
+  | head
 ```
 
-- **Existing content** → invoke **`mdcms-brownfield-init`**. That skill runs `mdcms init --non-interactive` against the existing files, verifies the inferred schema, and imports content on first push.
-- **No content** → invoke **`mdcms-greenfield-init`**. That skill runs `mdcms init --non-interactive` with a scaffolded starter, pushes the example, and can delegate to `mdcms-schema-refine` for first real content models.
+If this surfaces files, ask the user which of the top-level directories (`content/`, `pages/`, `posts/`, or a project-specific path) are actually editorial content vs. product docs. Only editorial content belongs in MDCMS.
+
+- **Editorial content exists** → invoke **`mdcms-brownfield-init`**. That skill runs `mdcms init --non-interactive` against the existing files, verifies the inferred schema, and imports content on first push.
+- **No editorial content** → invoke **`mdcms-greenfield-init`**. That skill runs `mdcms init --non-interactive` with a scaffolded starter, pushes the example, and can delegate to `mdcms-schema-refine` for first real content models.
+
+When in doubt, ask — don't assume a `README.md` at the repo root or a `docs/guide.md` is editorial content that should move into MDCMS.
 
 After either init path, the user has a working `mdcms.config.ts`, a synced schema on the server, a stored credential, and content reachable from the Studio API.
 
@@ -78,7 +92,7 @@ Before asking the user a phase question, check what you can already see in the r
 | Signal                                                                     | Implication                                                                |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | `curl <url>/healthz` returns 200                                           | Skip Phase 1.                                                              |
-| Repo has `.md`/`.mdx` files outside `node_modules`/`.*`                    | Brownfield path in Phase 2.                                                |
+| Repo has `.md`/`.mdx` editorial content (see Phase 2 exclusions)           | Brownfield path in Phase 2.                                                |
 | Repo has `mdcms.config.ts`                                                 | Init already ran. Skip to Phase 3 and confirm schema is good.              |
 | `package.json` lists `@mdcms/studio`                                       | Studio embed probably already done. Confirm before skipping Phase 5.       |
 | `package.json` lists `@mdcms/sdk` or any `from "@mdcms/sdk"` import exists | SDK integration likely in place. Confirm before skipping Phase 4.          |

--- a/skills/mdcms-studio-embed/SKILL.md
+++ b/skills/mdcms-studio-embed/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: mdcms-studio-embed
+description: Use this skill when the user wants to embed the MDCMS Studio UI inside their own React/Next/Remix app, says things like "add the Studio to my app", "mount Studio at /admin", "give my editors a visual editor in the host app", "embed MDCMS editor", or similar. Walks through installing `@mdcms/studio`, adding a catch-all route, wiring the prepared Studio config, setting `MDCMS_STUDIO_ALLOWED_ORIGINS` on the server, and verifying login.
+---
+
+# MDCMS Studio Embed
+
+Mount the MDCMS Studio UI inside the user's own host app so editors work alongside product code. The canonical reference is `apps/studio-example` in the MDCMS repo — use it as the copy-from template for route structure, config preparation, and client bootstrap.
+
+## When to use this skill
+
+The user wants a Studio UI under their own domain (e.g. `app.example.com/admin/...`) instead of running Studio standalone. If they only need the API and use Studio at the server's own `/admin/studio` route, skip.
+
+## Prerequisites
+
+- A reachable MDCMS server and a working `mdcms.config.ts` (run **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** first).
+- A React app, ideally Next.js App Router. Other frameworks work but the reference implementation is Next.
+- Ability to set server-side env vars on the MDCMS backend (for `MDCMS_STUDIO_ALLOWED_ORIGINS`).
+
+## Steps
+
+### 1. Install the Studio package in the host app
+
+```bash
+npm install @mdcms/studio
+# or: bun add @mdcms/studio
+```
+
+### 2. Add a catch-all route
+
+Studio is a single page app embedded at a catch-all route. The reference uses `/admin/[[...path]]` so every Studio route is served from one Next page. Copy the pattern from `apps/studio-example/app/admin/[[...path]]` in the MDCMS repo:
+
+```
+app/
+  admin/
+    [[...path]]/
+      page.tsx        # server component that prepares Studio config
+      layout.tsx      # minimal layout (Studio brings its own chrome)
+    admin-studio-client.tsx   # client wrapper that mounts <Studio />
+    studio-config.ts          # prepareStudioConfig + client-serialized subset
+```
+
+The server component calls `prepareStudioConfig` from `@mdcms/studio/runtime` against the full `mdcms.config.ts`, extracts a client-safe subset (component metadata, schema hash, route metadata), and passes it to the client wrapper.
+
+### 3. Wire the prepared config to `<Studio />`
+
+The client wrapper uses the `<Studio />` component and the prepared config:
+
+```tsx
+"use client";
+import { Studio } from "@mdcms/studio";
+import type { MdcmsConfig } from "@mdcms/studio";
+
+export function AdminStudioClient({ config }: { config: MdcmsConfig }) {
+  return <Studio config={config} />;
+}
+```
+
+Mirror the split the reference uses: the server component reads env + prepared config, the client wrapper renders Studio.
+
+### 4. Set the host app env
+
+The host app needs to know:
+
+- The MDCMS server URL (so Studio's fetch calls resolve).
+- Its own public URL (some flows need it for redirects).
+
+Set these as either server env (Next: `process.env.MDCMS_SERVER_URL`) or `NEXT_PUBLIC_*` vars that are safe to expose to the browser, depending on where they're read. Follow the reference for the exact split — `apps/studio-example/lib/studio-example-studio-config.ts` shows a current, working pattern.
+
+### 5. Allowlist the host app origin on the server
+
+On the MDCMS server, update `.env` (or equivalent config) so the host app's origin is in the allowlist:
+
+```env
+MDCMS_STUDIO_ALLOWED_ORIGINS=https://app.example.com,http://localhost:3000
+```
+
+Without this, Studio's session/CSRF cookies won't be sent on cross-origin XHR requests and login will silently fail. Include every origin that embeds Studio (production, staging, localhost port).
+
+Restart the server after updating the allowlist.
+
+### 6. Verify login
+
+1. Run the host app: `npm run dev` (or framework equivalent).
+2. Open `http://localhost:3000/admin` (or whatever path the catch-all covers).
+3. You should be redirected to the MDCMS login flow, and after logging in land on the Studio dashboard under the host app's URL.
+4. Open a document. Edit a field. Save. Confirm the change appears in the MDCMS server when you run `mdcms pull` locally.
+
+## Common gotchas
+
+- **`127.0.0.1` vs `localhost`**: browser cookies treat them as different sites. Use `localhost` for local dev unless you have a specific reason to use `127.0.0.1` (and then add it to the allowlist).
+- **Stale prepared config**: the prepared config includes a schema hash. After a schema change, redeploy the host app (or revalidate the server component that prepared the config) so the client carries the fresh hash. Otherwise Studio may reject writes.
+- **Next.js layouts that add their own chrome**: Studio expects a minimal layout. The reference uses `apps/studio-example/app/admin/layout.tsx` which is mostly empty. Don't wrap Studio with site navigation — it has its own.
+- **Auth cookie SameSite in dev**: if cookies aren't being sent on XHRs, check the server's cookie SameSite policy. The current contract is `SameSite=None` for Studio cookies, even on HTTP in local dev.
+
+## Related skills
+
+- **`mdcms-self-host-setup`** — only if the user needs a server first.
+- **`mdcms-mdx-components`** — if the content uses custom MDX components, those need to be registered so Studio can preview them.
+- **`mdcms-sdk-integration`** — Studio embed is independent of SDK fetching; they can both exist, or either one alone.
+
+## Assumptions and limitations
+
+- Reference implementation is Next.js App Router. React Router, Remix, or Vite SPAs can embed Studio but need to adapt the server/client split themselves.
+- `prepareStudioConfig` and the client `MdcmsConfig` shape are owned by `@mdcms/studio`; if the package surface changes, trust the source over this skill.
+- Does not cover SSO/OIDC provider configuration for Studio's login — that belongs with the MDCMS auth setup.
+- Copy the patterns from `apps/studio-example/app/admin/*` directly — file names, exports, and props evolve faster than this skill.


### PR DESCRIPTION
## Summary

- Ships a 9-skill installable pack under `skills/<slug>/SKILL.md`, distributed via [skills.sh](https://skills.sh) — `npx skills add Blazity/mdcms`. Works cross-agent (Claude Code, Cursor, Gemini, Codex, Copilot, and 40+ others).
- Master skill (`mdcms-setup`) detects repo state and routes to the focused skill for each phase: self-host, brownfield vs greenfield init, schema refine, Studio embed, SDK integration, MDX components, day-to-day sync.
- `mdcms init` gains a non-interactive mode so AI agents (and CI) can drive it end-to-end: `-y` / `--yes` / `--non-interactive`, plus `--directory`, `--directories`, `--default-locale`, `--no-import`, `--no-git-cleanup`, `--no-example-post`. Missing required input surfaces as `INIT_MISSING_INPUT` instead of hanging on a TTY prompt.
- Existing interactive `mdcms init` behavior is unchanged. Value resolution order: flag → env var → config → stored credential → prompt (skipped in non-interactive).

## Skills in the pack

| Skill | Purpose |
| --- | --- |
| `mdcms-setup` | master orchestrator; phases 1–7 |
| `mdcms-self-host-setup` | Docker Compose backend, env, first boot |
| `mdcms-brownfield-init` | import existing MD/MDX repo via `mdcms init --non-interactive` |
| `mdcms-greenfield-init` | empty-repo scaffold + first push |
| `mdcms-schema-refine` | `defineType` / Zod / `reference()` + `schema sync` |
| `mdcms-studio-embed` | `<Studio />` catch-all route in host app |
| `mdcms-sdk-integration` | `@mdcms/sdk` fetch, drafts vs published, SSR |
| `mdcms-mdx-components` | register custom MDX components for Studio + host |
| `mdcms-content-sync-workflow` | daily `pull`/`push` + CI automation |

## Spec delta

- `docs/specs/SPEC-008` — documents the non-interactive surface (flag table, value resolution order, `INIT_MISSING_INPUT` error) alongside the existing interactive wizard. No Studio / backend contract changes; no `apps/studio-review` impact.

## Test plan

- [x] `bun test --cwd apps/cli ./src/lib/init.test.ts` — 18/18 pass (11 new, 7 pre-existing).
- [x] `bun test --cwd apps/cli ./src` — 203/203 pass.
- [x] `bun x prettier --check <changed paths>` — clean.
- [ ] `bun run check` — CLI typecheck clean; `packages/studio` has a pre-existing `@tiptap/pm` type-resolution failure reproducible on untouched `origin/main`, unrelated to this PR.
- [ ] Manual: run `mdcms init --non-interactive --server-url … --project … --environment … --api-key … --directory …` against a dev backend and confirm config + schema + import complete without any prompt.
- [ ] Manual: `npx skills add` from a local checkout into `~/.claude/skills/` and verify the master orchestrator triggers on "set up MDCMS".

## Notes for reviewers

- Skill descriptions lean "pushy" on purpose to avoid undertriggering. Happy to tone them down.
- Skills reference `apps/studio-example` as the source of truth for Studio embed / MDX component wiring rather than inlining possibly-drifting code snippets. Corrections welcome if I've mis-stated any current contract detail.
- No Claude-Code-specific plugin bundle in this PR. The pack stays cross-agent; a plugin wrapper can land later when we have an MCP server / hooks / subagents worth bundling.

Closes CMS-189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non‑interactive/CI mode for init (-y/--non-interactive) with flags for directories, default locale, and toggles: --no-import, --no-git-cleanup, --no-example-post; help text updated.

* **Behavior Changes / Error Handling**
  * Non‑interactive runs fail fast on missing required inputs; directories and flag values are validated; config overwrite and confirmations auto-resolve (production defaults where applicable).

* **Tests**
  * Expanded unit and integration tests around flag parsing and headless init flows.

* **Documentation**
  * Added a Skills Pack and detailed guides for init, schema, SDK, sync, Studio embed, and self‑hosting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->