### PR TITLE
fix(studio): avoid shell theme hydration mismatch on SSR

### DIFF
--- a/packages/studio/src/lib/studio-component.tsx
+++ b/packages/studio/src/lib/studio-component.tsx
@@ -641,20 +641,7 @@ export function resolveShellAppliedTheme(input: {
 }
 
 function useResolvedShellTheme(): ShellAppliedTheme {
-  const [applied, setApplied] = useState<ShellAppliedTheme>(() => {
-    if (typeof window === "undefined") {
-      return "light";
-    }
-
-    const storage = window.localStorage ?? null;
-    const stored = readStoredThemePreference(storage);
-    const systemPrefersDark =
-      typeof window.matchMedia === "function"
-        ? window.matchMedia("(prefers-color-scheme: dark)").matches
-        : false;
-
-    return resolveAppliedTheme(stored ?? "system", systemPrefersDark);
-  });
+  const [applied, setApplied] = useState<ShellAppliedTheme>("light");
 
   useEffect(() => {
     if (

--- a/packages/studio/src/lib/studio-component.tsx
+++ b/packages/studio/src/lib/studio-component.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState, type RefObject } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 
 import {
   isRuntimeErrorLike,
@@ -16,7 +22,13 @@ import {
 import {
   readStoredThemePreference,
   resolveAppliedTheme,
+  STUDIO_THEME_STORAGE_KEY,
 } from "./runtime-ui/adapters/next-themes.js";
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export const SHELL_THEME_INLINE_SCRIPT = `(function(){try{var el=document.currentScript&&document.currentScript.parentElement;if(!el)return;var s=null;try{s=window.localStorage&&window.localStorage.getItem(${JSON.stringify(STUDIO_THEME_STORAGE_KEY)});}catch(_){}var p=s==="light"||s==="dark"||s==="system"?s:"system";var r=p==="light"||p==="dark"?p:(window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");if(el.getAttribute("data-mdcms-theme")!==r){el.setAttribute("data-mdcms-theme",r);}}catch(_){}})();`;
 
 export type { MdcmsConfig } from "./studio-loader.js";
 
@@ -643,7 +655,7 @@ export function resolveShellAppliedTheme(input: {
 function useResolvedShellTheme(): ShellAppliedTheme {
   const [applied, setApplied] = useState<ShellAppliedTheme>("light");
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (
       typeof window === "undefined" ||
       typeof window.matchMedia !== "function"
@@ -656,7 +668,13 @@ function useResolvedShellTheme(): ShellAppliedTheme {
 
     const recompute = () => {
       const stored = readStoredThemePreference(storage);
-      setApplied(resolveAppliedTheme(stored ?? "system", mediaQuery.matches));
+      setApplied((prev) => {
+        const next = resolveAppliedTheme(
+          stored ?? "system",
+          mediaQuery.matches,
+        );
+        return prev === next ? prev : next;
+      });
     };
 
     recompute();
@@ -700,7 +718,11 @@ export function StudioShellFrame({
       data-mdcms-brand="MDCMS"
       data-mdcms-theme={shellTheme}
       className={startupState === "ready" ? undefined : "mdcms-studio-shell"}
+      suppressHydrationWarning
     >
+      <script
+        dangerouslySetInnerHTML={{ __html: SHELL_THEME_INLINE_SCRIPT }}
+      />
       <div
         ref={containerRef}
         data-mdcms-runtime-container="true"

--- a/packages/studio/src/lib/studio.test.ts
+++ b/packages/studio/src/lib/studio.test.ts
@@ -682,6 +682,25 @@ test("StudioShellFrame loading markup embeds a dark-mode palette override", () =
   assert.match(markup, /data-mdcms-theme="dark"/);
 });
 
+test("StudioShellFrame emits a pre-hydration theme script that targets the shell root", () => {
+  const markup = renderToStaticMarkup(
+    StudioShellFrame({
+      config: {
+        project: "marketing-site",
+        environment: "staging",
+        serverUrl: "http://localhost:4000",
+      },
+      basePath: "/admin",
+      startupState: "loading",
+    }),
+  );
+
+  assert.match(markup, /<script>\(function\(\)\{/);
+  assert.match(markup, /mdcms-studio-theme/);
+  assert.match(markup, /prefers-color-scheme: dark/);
+  assert.match(markup, /setAttribute\("data-mdcms-theme"/);
+});
+
 test("resolveShellAppliedTheme returns dark when system prefers dark and no theme is stored", () => {
   assert.equal(
     resolveShellAppliedTheme({


### PR DESCRIPTION
## Summary

Two-part fix for the studio shell theme hydration.

**1. Hydration mismatch (first commit).** `useResolvedShellTheme` read `window.localStorage` / `window.matchMedia` inside its `useState` initializer. SSR produced `data-mdcms-theme="light"` while the first client render produced `"dark"`, so React logged a hydration mismatch on the shell root and refused to patch the attribute. The hook now initializes to a stable `"light"` so SSR and first client render agree.

**2. Dark-theme flash (second commit).** Fix #1 alone leaves dark-mode users looking at light styles until `useEffect` runs post-paint. We now:

- Emit an inline `<script>` as the first child of the shell root that reads the stored preference and system media query synchronously during HTML parsing and mutates `data-mdcms-theme` before the browser paints (the same pattern `next-themes` uses for `<html>`, scoped to the shell).
- Add `suppressHydrationWarning` on the root so React tolerates the pre-hydration DOM mutation.
- Use an isomorphic layout effect (`useLayoutEffect` on client, `useEffect` fallback for SSR) so client-only mounts — e.g., SPA navigation into Studio — also resolve the theme before paint rather than after.

No regression for explicit `shellTheme` prop callers (tests asserting `data-mdcms-theme="light"` / `"dark"` still pass).

## Test plan

- [x] `bun test --cwd packages/studio ./src/lib/studio.test.ts` (38 pass, including new inline-script assertion)
- [x] `bunx nx typecheck studio`
- [ ] Load Studio route with `prefers-color-scheme: dark` and no stored preference: confirm no hydration error and no white flash on initial load
- [ ] Same with stored `"light"` preference while system is dark: confirm light theme renders without flicker
- [ ] Toggle system theme at runtime: shell updates live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * More reliable theme initialization on startup to avoid incorrect theme flashes.

* **Refactor**
  * Theme syncing now runs earlier in the render lifecycle to apply the correct theme sooner.

* **New Features**
  * Injects an early inline theme initializer to align DOM theme before hydration.

* **Tests**
  * Added a unit test confirming the pre-hydration theme initialization script is rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->