### PR TITLE
fix(studio): polish editor chrome and prose palette

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -144,6 +144,7 @@
         "@radix-ui/react-tabs": "1.1.13",
         "@radix-ui/react-tooltip": "1.2.8",
         "@tailwindcss/postcss": "^4.2.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.96.2",
         "@tiptap/core": "^3.7.0",
         "@tiptap/extension-code-block-lowlight": "^3.7.0",
@@ -938,6 +939,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
 
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.96.2", "", {}, "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.96.2", "", { "dependencies": { "@tanstack/query-core": "5.96.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA=="],
@@ -1179,6 +1182,8 @@
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1611,6 +1616,8 @@
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -104,6 +104,7 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-tooltip": "1.2.8",
     "@tailwindcss/postcss": "^4.2.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.96.2",
     "@tiptap/core": "^3.7.0",
     "@tiptap/extension-code-block-lowlight": "^3.7.0",

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.test.tsx
@@ -99,30 +99,3 @@ test("MdxPropsPanel renders an unresolved state when the selected component is m
   assert.match(markup, /UnknownWidget/);
 });
 
-test("MdxPropsPanel explains that wrapper component children are edited inside the canvas", () => {
-  const wrapperComponent = {
-    name: "Callout",
-    importPath: "@/components/mdx/Callout",
-    description: "Wrapper callout",
-    extractedProps: {
-      tone: { type: "enum", required: true, values: ["info", "warning"] },
-      children: { type: "rich-text", required: false },
-    },
-  } satisfies NonNullable<
-    StudioMountContext["mdx"]
-  >["catalog"]["components"][number];
-  const markup = renderToStaticMarkup(
-    createElement(MdxPropsPanel, {
-      context: createContext(),
-      selection: createSelection({
-        component: wrapperComponent,
-        componentName: wrapperComponent.name,
-        isVoid: false,
-        props: { tone: "warning" },
-      }),
-    }),
-  );
-
-  assert.match(markup, /Wrapper content lives in the editor canvas/);
-  assert.match(markup, /data-mdcms-mdx-auto-form="Callout"/);
-});

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-props-panel.tsx
@@ -7,7 +7,6 @@ import {
   type PropsEditorChangeHandler,
   type PropsEditorValue,
 } from "../../../mdx-props-editor-host.js";
-import { getMdxComponentKind } from "./mdx-component-catalog.js";
 
 type MdxCatalogComponent = NonNullable<
   StudioMountContext["mdx"]
@@ -62,7 +61,6 @@ export function MdxPropsPanel({
   }
 
   const component = selection.component;
-  const kind = selection.isVoid ? "void" : getMdxComponentKind(component);
 
   return (
     <section data-mdcms-mdx-props-panel={component.name} className="space-y-3">
@@ -78,16 +76,6 @@ export function MdxPropsPanel({
         {component.description ? (
           <p className="text-xs text-foreground-muted">
             {component.description}
-          </p>
-        ) : null}
-        {kind === "wrapper" ? (
-          <p
-            data-mdcms-mdx-wrapper-guidance={component.name}
-            className="text-xs text-foreground-muted"
-          >
-            Wrapper content lives in the editor canvas. Use the inner content
-            area in the component block to edit nested markdown; this panel only
-            covers top-level props.
           </p>
         ) : null}
       </div>

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -450,7 +450,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
         editorProps: {
           attributes: {
             class:
-              "prose prose-sm max-w-none min-h-[480px] px-4 py-4 focus:outline-none",
+              "prose max-w-none prose-p:leading-relaxed focus:outline-none",
             "data-placeholder": placeholder,
           },
           handleKeyDown: (_view, event) => {
@@ -884,7 +884,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       <div ref={editorWrapperRef} className="relative">
         <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background">
           <div className="border-b border-border bg-background-subtle">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-2.5">
               {toolbar.primaryGroups.map((group, groupIndex) => (
                 <div key={group.id} className="flex items-center gap-1.5">
                   {groupIndex > 0 ? (
@@ -1076,7 +1076,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             ) : null}
           </div>
 
-          <div className="min-h-[480px] bg-transparent">
+          <div className="min-h-[480px] bg-transparent px-8 py-8">
             <EditorContent editor={editor} />
           </div>
         </div>

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -148,7 +148,7 @@ export function AppSidebar({
         </nav>
 
         {/* Bottom Section */}
-        <div className="border-t border-border p-2">
+        <div className="p-2">
           {/* Collapse Toggle */}
           <Tooltip>
             <TooltipTrigger asChild>
@@ -157,7 +157,7 @@ export function AppSidebar({
                 size="sm"
                 onClick={onToggle}
                 className={cn(
-                  "w-full justify-center text-foreground-muted",
+                  "w-full justify-center border-0 text-foreground-muted",
                   !collapsed && "justify-start gap-3 px-3",
                 )}
               >

--- a/packages/studio/src/lib/runtime-ui/styles.css
+++ b/packages/studio/src/lib/runtime-ui/styles.css
@@ -4,6 +4,8 @@
 @import "@fontsource-variable/inter";
 @import "@fontsource-variable/geist-mono";
 
+@plugin "@tailwindcss/typography";
+
 @source "./**/*.{ts,tsx}";
 
 @custom-variant dark (&:is(.dark *));
@@ -293,11 +295,6 @@
 
   /* ── TipTap editor content ────────────────────────────────── */
 
-  .mdcms-studio-runtime .tiptap p {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-  }
-
   .mdcms-studio-runtime .tiptap > *:first-child {
     margin-top: 0;
   }
@@ -306,21 +303,17 @@
     margin-bottom: 0;
   }
 
-  /* Headings */
+  /* Headings — keep display sizes/letter-spacing; spacing comes from prose. */
   .mdcms-studio-runtime .tiptap h1 {
     font-size: 2rem;
     line-height: 1.2;
     letter-spacing: -0.02em;
-    margin-top: 0.75em;
-    margin-bottom: 0.25em;
   }
 
   .mdcms-studio-runtime .tiptap h2 {
     font-size: 1.5rem;
     line-height: 1.25;
     letter-spacing: -0.01em;
-    margin-top: 0.75em;
-    margin-bottom: 0.25em;
   }
 
   /* Inline marks */
@@ -332,14 +325,6 @@
 
   .dark .mdcms-studio-runtime .tiptap mark {
     background-color: rgba(250, 204, 21, 0.3);
-  }
-
-  .mdcms-studio-runtime .tiptap :not(pre) > code {
-    background-color: var(--code-bg);
-    border-radius: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
   }
 
   /* Links */
@@ -355,16 +340,9 @@
     border-radius: 2px;
   }
 
-  /* Unordered list */
+  /* Unordered list — structure only; spacing handled by prose. */
   .mdcms-studio-runtime .tiptap ul:not([data-type="taskList"]) {
     list-style-type: disc;
-    padding-left: 1.5rem;
-    margin-top: 0.25em;
-    margin-bottom: 0.5em;
-  }
-
-  .mdcms-studio-runtime .tiptap ul:not([data-type="taskList"]) li {
-    margin-bottom: 0.125em;
   }
 
   .mdcms-studio-runtime .tiptap ul:not([data-type="taskList"]) li p {
@@ -374,32 +352,22 @@
   /* Ordered list */
   .mdcms-studio-runtime .tiptap ol {
     list-style-type: decimal;
-    padding-left: 1.5rem;
-    margin-top: 0.25em;
-    margin-bottom: 0.5em;
-  }
-
-  .mdcms-studio-runtime .tiptap ol li {
-    margin-bottom: 0.125em;
   }
 
   .mdcms-studio-runtime .tiptap ol li p {
     margin-bottom: 0;
   }
 
-  /* Task list */
+  /* Task list — flex layout for the checkbox/content pair. */
   .mdcms-studio-runtime .tiptap ul[data-type="taskList"] {
     list-style: none;
     padding-left: 0;
-    margin-top: 0.25em;
-    margin-bottom: 0.5em;
   }
 
   .mdcms-studio-runtime .tiptap ul[data-type="taskList"] li {
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
-    margin-bottom: 0.125em;
   }
 
   .mdcms-studio-runtime .tiptap ul[data-type="taskList"] li > label {
@@ -443,53 +411,19 @@
     border-left: 3px solid var(--border);
     padding-left: 1rem;
     margin-left: 0;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
     color: var(--foreground-muted);
-  }
-
-  /* Code block */
-  .mdcms-studio-runtime .tiptap pre {
-    background-color: var(--code-bg);
-    padding: 0.75rem 1rem;
-    overflow-x: auto;
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    line-height: 1.6;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    border: 1px solid var(--border);
-  }
-
-  .mdcms-studio-runtime .tiptap pre code {
-    background: none;
-    padding: 0;
-    border-radius: 0;
-    font-size: inherit;
-    color: inherit;
-  }
-
-  /* Reserve right-side gutter on NodeView code blocks so the language
-     dropdown overlay doesn't sit on top of code. Only applies to the
-     NodeView-rendered <pre>, not other fenced blocks. */
-  .mdcms-studio-runtime .tiptap pre.mdcms-editor-code-block {
-    padding-right: 10rem;
   }
 
   /* Horizontal rule */
   .mdcms-studio-runtime .tiptap hr {
     border: none;
     border-top: 1px solid var(--divider);
-    margin-top: 1em;
-    margin-bottom: 1em;
   }
 
   /* Image */
   .mdcms-studio-runtime .tiptap img {
     max-width: 100%;
     height: auto;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
   }
 
   .mdcms-studio-runtime :is(button, input, textarea, select) {
@@ -560,6 +494,91 @@
   .mdcms-studio-runtime .tiptap pre code.hljs .hljs-strong {
     font-weight: 700;
   }
+}
+
+/* Code-block + inline-code styling. Kept outside @layer base so the
+   `.prose` utility (which lives in the higher-precedence utility layer)
+   does not override our colors/padding. */
+.mdcms-studio-runtime .tiptap :not(pre) > code {
+  background-color: var(--code-bg);
+  color: var(--foreground);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: inherit;
+}
+
+/* Suppress the backticks the typography plugin injects around inline code. */
+.mdcms-studio-runtime .tiptap :not(pre) > code::before,
+.mdcms-studio-runtime .tiptap :not(pre) > code::after {
+  content: none;
+}
+
+.mdcms-studio-runtime .tiptap pre {
+  background-color: var(--code-bg);
+  color: var(--foreground);
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  border: 1px solid var(--border);
+}
+
+.mdcms-studio-runtime .tiptap pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Reserve right-side gutter on NodeView code blocks so the language
+   dropdown overlay doesn't sit on top of code. */
+.mdcms-studio-runtime .tiptap pre.mdcms-editor-code-block {
+  padding-right: 10rem;
+}
+
+/* Rebind @tailwindcss/typography tokens to the Studio theme. Kept outside
+   @layer base so it overrides the `.prose` utility's own variable defaults
+   (utility-layer rules beat base-layer rules). Theme vars already flip in
+   `.dark`, so light/dark follow automatically. Applies to any `.prose`
+   inside the Studio runtime so nested wrapper editors inherit the palette
+   as well. */
+.mdcms-studio-runtime :where(.prose, .tiptap) {
+  --tw-prose-body: var(--foreground);
+  --tw-prose-headings: var(--foreground);
+  --tw-prose-lead: var(--foreground-muted);
+  --tw-prose-links: var(--primary);
+  --tw-prose-bold: var(--foreground);
+  --tw-prose-counters: var(--foreground-muted);
+  --tw-prose-bullets: var(--foreground-muted);
+  --tw-prose-hr: var(--divider);
+  --tw-prose-quotes: var(--foreground-muted);
+  --tw-prose-quote-borders: var(--border);
+  --tw-prose-captions: var(--foreground-muted);
+  --tw-prose-code: var(--foreground);
+  --tw-prose-pre-code: var(--foreground);
+  --tw-prose-pre-bg: var(--code-bg);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border);
+  --tw-prose-invert-body: var(--foreground);
+  --tw-prose-invert-headings: var(--foreground);
+  --tw-prose-invert-lead: var(--foreground-muted);
+  --tw-prose-invert-links: var(--primary);
+  --tw-prose-invert-bold: var(--foreground);
+  --tw-prose-invert-counters: var(--foreground-muted);
+  --tw-prose-invert-bullets: var(--foreground-muted);
+  --tw-prose-invert-hr: var(--divider);
+  --tw-prose-invert-quotes: var(--foreground-muted);
+  --tw-prose-invert-quote-borders: var(--border);
+  --tw-prose-invert-captions: var(--foreground-muted);
+  --tw-prose-invert-code: var(--foreground);
+  --tw-prose-invert-pre-code: var(--foreground);
+  --tw-prose-invert-pre-bg: var(--code-bg);
+  --tw-prose-invert-th-borders: var(--border);
+  --tw-prose-invert-td-borders: var(--border);
 }
 
 .scrollbar-thin::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Clean up the sidebar collapse toggle (drop the button border + section divider)
- Wire `@tailwindcss/typography` into the Studio styles (Tailwind v4 `@plugin`), rebind `--tw-prose-*` to the Studio theme tokens, and broaden the rebinding to any `.prose` so nested wrapper editors pick up the same palette in light + dark
- Pull the code-block / inline-code rules out of `@layer base` so they survive the `.prose` utility; suppress the backticks the typography plugin injects around inline code
- Remove the hardcoded wrapper-guidance paragraph from the MDX props panel (component-level `description` still renders), delete the now-obsolete test
- Let the editor content go full width and bump body text from `prose-sm` to `prose`

## Test plan
- [ ] Collapse toggle: verify the button + section border are gone in both light and dark
- [ ] Light mode editor: paragraphs, headings, lists, blockquotes and code blocks render with the Studio palette (code block keeps the `--code-bg` background, not the plugin's dark gray)
- [ ] Dark mode editor: body text is readable (uses `--foreground`), inline code pill stays on `--code-bg`, and inline code is rendered without backticks
- [ ] Wrapper component (e.g. `Callout`): inner children editor is readable in dark mode; props panel shows the component description but no longer shows the "Wrapper content lives in the editor canvas…" paragraph
- [ ] Content area fills the full width of the canvas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved editor typography and spacing for enhanced readability.
  * Refined sidebar styling and button appearance.

* **Tests**
  * Removed obsolete test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->