### PR TITLE
refactor(cms-180): migrate studio admin data fetching to TanStack Query

### DIFF
--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import {
   QueryClientProvider,
   keepPreviousData,
   useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
 import type { StudioMountContext } from "@mdcms/shared";
 
@@ -249,6 +250,17 @@ function AdminLayoutInner({
       setSidebarCollapsed(stored === "true");
     }
   }, []);
+
+  // Re-fetch auth-scoped studio queries when the host rotates the bearer
+  // token. The token is intentionally not part of query keys (matches the
+  // pattern in the other CMS-132 TanStack hooks and avoids leaking the
+  // secret into React Query DevTools / telemetry), so we explicitly
+  // invalidate on change to restore the pre-refactor useEffect's
+  // auth.token-dep behavior.
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    void queryClient.invalidateQueries({ queryKey: ["studio"] });
+  }, [queryClient, context.auth.token]);
 
   // Capabilities
   const capabilitiesLoadInput = useMemo(() => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { QueryClientProvider } from "@tanstack/react-query";
-import type { StudioMountContext, EnvironmentSummary } from "@mdcms/shared";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import type { StudioMountContext } from "@mdcms/shared";
 
 import { createStudioQueryClient } from "../../query-client.js";
 import { ToastProvider } from "../../components/toast.js";
@@ -181,6 +181,18 @@ export function AdminTokenErrorStateView({
   );
 }
 
+function extractStatusCode(error: unknown): number | null {
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+  return null;
+}
+
 export default function AdminLayout({
   children,
   context,
@@ -189,14 +201,22 @@ export default function AdminLayout({
   context: StudioMountContext;
 }) {
   const [queryClient] = useState(() => createStudioQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AdminLayoutInner context={context}>{children}</AdminLayoutInner>
+    </QueryClientProvider>
+  );
+}
+
+function AdminLayoutInner({
+  children,
+  context,
+}: {
+  children: React.ReactNode;
+  context: StudioMountContext;
+}) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [canReadSchema, setCanReadSchema] = useState(false);
-  const [canCreateContent, setCanCreateContent] = useState(false);
-  const [canPublishContent, setCanPublishContent] = useState(false);
-  const [canUnpublishContent, setCanUnpublishContent] = useState(false);
-  const [canDeleteContent, setCanDeleteContent] = useState(false);
-  const [canManageUsers, setCanManageUsers] = useState(false);
-  const [canManageSettings, setCanManageSettings] = useState(false);
   const [activeEnvironment, setActiveEnvironmentRaw] = useState<string | null>(
     () => {
       if (typeof window !== "undefined") {
@@ -217,10 +237,6 @@ export default function AdminLayout({
       window.history.replaceState(null, "", url.toString());
     }
   }, []);
-  const [sessionState, setSessionState] = useState<StudioSessionState>({
-    status: "loading",
-  });
-  const [environments, setEnvironments] = useState<EnvironmentSummary[]>([]);
 
   // Persist sidebar state
   useEffect(() => {
@@ -230,188 +246,166 @@ export default function AdminLayout({
     }
   }, []);
 
-  // Fetch capabilities
-  useEffect(() => {
+  // Capabilities
+  const capabilitiesLoadInput = useMemo(() => {
     const baseLoadInput = createAdminLayoutCapabilitiesLoadInput(context);
-    const loadInput =
-      baseLoadInput && activeEnvironment
-        ? {
-            ...baseLoadInput,
-            config: {
-              ...baseLoadInput.config,
-              environment: activeEnvironment,
-            },
-          }
-        : null;
-
-    if (!loadInput) {
-      setCanReadSchema(false);
-      setCanCreateContent(false);
-      setCanPublishContent(false);
-      setCanUnpublishContent(false);
-      setCanDeleteContent(false);
-      setCanManageUsers(false);
-      setCanManageSettings(false);
-      return;
-    }
-
-    let cancelled = false;
-    const capabilitiesApi = createStudioCurrentPrincipalCapabilitiesApi(
-      loadInput.config,
-      { auth: loadInput.auth },
-    );
-
-    void capabilitiesApi
-      .get()
-      .then((response) => {
-        if (!cancelled) {
-          setCanReadSchema(response.capabilities.schema.read);
-          setCanCreateContent(response.capabilities.content.write);
-          setCanPublishContent(response.capabilities.content.publish);
-          setCanUnpublishContent(response.capabilities.content.unpublish);
-          setCanDeleteContent(response.capabilities.content.delete);
-          setCanManageUsers(response.capabilities.users.manage);
-          setCanManageSettings(response.capabilities.settings.manage);
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setCanReadSchema(false);
-          setCanCreateContent(false);
-          setCanPublishContent(false);
-          setCanUnpublishContent(false);
-          setCanDeleteContent(false);
-          setCanManageUsers(false);
-          setCanManageSettings(false);
-
-          // In token mode, a capabilities 401/403 means the token is
-          // invalid, revoked, or not allowed for this project/environment.
-          // Surface a deterministic token-error instead of leaving the UI
-          // in a broken empty state.
-          if (context.auth.mode === "token") {
-            const statusCode =
-              error &&
-              typeof error === "object" &&
-              "statusCode" in error &&
-              typeof error.statusCode === "number"
-                ? error.statusCode
-                : null;
-
-            const nextTokenErrorState =
-              createAdminLayoutTokenErrorState(statusCode);
-
-            if (nextTokenErrorState) {
-              setSessionState(nextTokenErrorState);
-            }
-          }
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    context.apiBaseUrl,
-    context.auth.mode,
-    context.auth.token,
-    activeEnvironment,
-    context.documentRoute?.project,
-  ]);
-
-  // Fetch session
-  useEffect(() => {
-    const tokenSessionState = createAdminLayoutTokenSessionState(context.auth);
-
-    if (tokenSessionState) {
-      setSessionState(tokenSessionState);
-      return;
-    }
-
-    const loadInput = createAdminLayoutSessionLoadInput(context);
-    let cancelled = false;
-
-    const sessionApi = createStudioSessionApi(loadInput.config, {
-      auth: loadInput.auth,
-    });
-
-    void sessionApi
-      .get()
-      .then((response) => {
-        if (!cancelled) {
-          setSessionState({
-            status: "authenticated",
-            session: response.session,
-            csrfToken: response.csrfToken,
-          });
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          const isUnauthorized =
-            error &&
-            typeof error === "object" &&
-            "statusCode" in error &&
-            error.statusCode === 401;
-          setSessionState(
-            isUnauthorized
-              ? { status: "unauthenticated" }
-              : {
-                  status: "error",
-                  message:
-                    error instanceof Error
-                      ? error.message
-                      : "Session fetch failed.",
-                },
-          );
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [context.apiBaseUrl, context.auth.mode, context.auth.token]);
-
-  // Fetch environments
-  useEffect(() => {
-    const project = context.documentRoute?.project;
-    if (!project || !activeEnvironment) {
-      setEnvironments([]);
-      return;
-    }
-
-    let cancelled = false;
-    const envApi = createStudioEnvironmentApi(
-      {
-        project,
+    if (!baseLoadInput || !activeEnvironment) return null;
+    return {
+      ...baseLoadInput,
+      config: {
+        ...baseLoadInput.config,
         environment: activeEnvironment,
-        serverUrl: context.apiBaseUrl,
       },
-      { auth: context.auth },
-    );
-
-    void envApi
-      .list()
-      .then((result) => {
-        if (!cancelled) {
-          setEnvironments(result.data);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setEnvironments([]);
-        }
-      });
-
-    return () => {
-      cancelled = true;
     };
   }, [
     context.apiBaseUrl,
     context.auth.mode,
     context.auth.token,
-    activeEnvironment,
     context.documentRoute?.project,
+    context.documentRoute?.initialEnvironment,
+    activeEnvironment,
+    // createAdminLayoutCapabilitiesLoadInput only reads the fields above
+    // from context, so the stable primitive deps above are sufficient.
+    context,
   ]);
+
+  const capabilitiesQuery = useQuery({
+    queryKey: [
+      "studio",
+      "capabilities",
+      capabilitiesLoadInput?.config.project,
+      capabilitiesLoadInput?.config.environment,
+      capabilitiesLoadInput?.config.serverUrl,
+      capabilitiesLoadInput?.auth.mode,
+      capabilitiesLoadInput?.auth.mode === "token"
+        ? capabilitiesLoadInput.auth.token
+        : null,
+    ],
+    queryFn: () => {
+      const api = createStudioCurrentPrincipalCapabilitiesApi(
+        capabilitiesLoadInput!.config,
+        { auth: capabilitiesLoadInput!.auth },
+      );
+      return api.get();
+    },
+    enabled: capabilitiesLoadInput !== null,
+  });
+
+  // Session
+  const tokenSessionState = useMemo(
+    () => createAdminLayoutTokenSessionState(context.auth),
+    [context.auth],
+  );
+  const isTokenMode = context.auth.mode === "token";
+  const sessionLoadInput = useMemo(
+    () => createAdminLayoutSessionLoadInput(context),
+    [context.apiBaseUrl, context.auth.mode, context.auth.token, context],
+  );
+
+  const sessionQuery = useQuery({
+    queryKey: [
+      "studio",
+      "session",
+      sessionLoadInput.config.serverUrl,
+      sessionLoadInput.auth.mode,
+      sessionLoadInput.auth.mode === "token"
+        ? sessionLoadInput.auth.token
+        : null,
+    ],
+    queryFn: () => {
+      const api = createStudioSessionApi(sessionLoadInput.config, {
+        auth: sessionLoadInput.auth,
+      });
+      return api.get();
+    },
+    enabled: !isTokenMode,
+  });
+
+  const sessionState: StudioSessionState = useMemo(() => {
+    if (isTokenMode) {
+      if (tokenSessionState?.status === "token-error") {
+        return tokenSessionState;
+      }
+      const tokenErrorFromCapabilities = capabilitiesQuery.error
+        ? createAdminLayoutTokenErrorState(
+            extractStatusCode(capabilitiesQuery.error),
+          )
+        : null;
+      if (tokenErrorFromCapabilities) {
+        return tokenErrorFromCapabilities;
+      }
+      return tokenSessionState ?? { status: "loading" };
+    }
+
+    if (sessionQuery.isPending) {
+      return { status: "loading" };
+    }
+    if (sessionQuery.error) {
+      const statusCode = extractStatusCode(sessionQuery.error);
+      if (statusCode === 401) {
+        return { status: "unauthenticated" };
+      }
+      return {
+        status: "error",
+        message:
+          sessionQuery.error instanceof Error
+            ? sessionQuery.error.message
+            : "Session fetch failed.",
+      };
+    }
+    const data = sessionQuery.data!;
+    return {
+      status: "authenticated",
+      session: data.session,
+      csrfToken: data.csrfToken,
+    };
+  }, [
+    isTokenMode,
+    tokenSessionState,
+    capabilitiesQuery.error,
+    sessionQuery.isPending,
+    sessionQuery.error,
+    sessionQuery.data,
+  ]);
+
+  // Environments
+  const environmentsEnabled = Boolean(
+    context.documentRoute?.project && activeEnvironment,
+  );
+  const environmentsQuery = useQuery({
+    queryKey: [
+      "studio",
+      "environments",
+      context.documentRoute?.project,
+      activeEnvironment,
+      context.apiBaseUrl,
+      context.auth.mode,
+      context.auth.mode === "token" ? context.auth.token : null,
+    ],
+    queryFn: () => {
+      const api = createStudioEnvironmentApi(
+        {
+          project: context.documentRoute!.project,
+          environment: activeEnvironment!,
+          serverUrl: context.apiBaseUrl,
+        },
+        { auth: context.auth },
+      );
+      return api.list();
+    },
+    enabled: environmentsEnabled,
+  });
+
+  const capabilities = capabilitiesQuery.data?.capabilities;
+  const canReadSchema = capabilities?.schema.read ?? false;
+  const canCreateContent = capabilities?.content.write ?? false;
+  const canPublishContent = capabilities?.content.publish ?? false;
+  const canUnpublishContent = capabilities?.content.unpublish ?? false;
+  const canDeleteContent = capabilities?.content.delete ?? false;
+  const canManageUsers = capabilities?.users.manage ?? false;
+  const canManageSettings = capabilities?.settings.manage ?? false;
+
+  const environments = environmentsQuery.data?.data ?? [];
 
   const pathname = usePathname();
   const router = useRouter();
@@ -420,16 +414,13 @@ export default function AdminLayout({
   // Token-mode embeds must never redirect to the login screen — token auth
   // failures are shown inline via the "token-error" session state.
   useEffect(() => {
-    if (
-      sessionState.status === "unauthenticated" &&
-      context.auth.mode !== "token"
-    ) {
+    if (sessionState.status === "unauthenticated" && !isTokenMode) {
       const returnTo = encodeURIComponent(
         pathname.includes("/admin") ? pathname : "/admin",
       );
       router.replace(`/admin/login?returnTo=${returnTo}`);
     }
-  }, [sessionState.status, pathname, router, context.auth.mode]);
+  }, [sessionState.status, pathname, router, isTokenMode]);
 
   if (sessionState.status === "loading" && typeof window !== "undefined") {
     return (
@@ -486,42 +477,40 @@ export default function AdminLayout({
   };
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <div className="min-h-screen overflow-x-hidden bg-background">
-          <AdminCapabilitiesProvider
-            value={{
-              canReadSchema,
-              canCreateContent,
-              canPublishContent,
-              canUnpublishContent,
-              canDeleteContent,
-              canManageUsers,
-              canManageSettings,
-            }}
-          >
-            <StudioSessionProvider value={sessionState}>
-              <StudioMountInfoProvider value={mountInfo}>
-                <AppSidebar
-                  canReadSchema={canReadSchema}
-                  canManageUsers={canManageUsers}
-                  canManageSettings={canManageSettings}
-                  collapsed={sidebarCollapsed}
-                  onToggle={handleToggle}
-                />
-                <main
-                  className={cn(
-                    "min-h-screen min-w-0 overflow-x-hidden transition-all duration-300",
-                    sidebarCollapsed ? "ml-16" : "ml-60",
-                  )}
-                >
-                  {children}
-                </main>
-              </StudioMountInfoProvider>
-            </StudioSessionProvider>
-          </AdminCapabilitiesProvider>
-        </div>
-      </ToastProvider>
-    </QueryClientProvider>
+    <ToastProvider>
+      <div className="min-h-screen overflow-x-hidden bg-background">
+        <AdminCapabilitiesProvider
+          value={{
+            canReadSchema,
+            canCreateContent,
+            canPublishContent,
+            canUnpublishContent,
+            canDeleteContent,
+            canManageUsers,
+            canManageSettings,
+          }}
+        >
+          <StudioSessionProvider value={sessionState}>
+            <StudioMountInfoProvider value={mountInfo}>
+              <AppSidebar
+                canReadSchema={canReadSchema}
+                canManageUsers={canManageUsers}
+                canManageSettings={canManageSettings}
+                collapsed={sidebarCollapsed}
+                onToggle={handleToggle}
+              />
+              <main
+                className={cn(
+                  "min-h-screen min-w-0 overflow-x-hidden transition-all duration-300",
+                  sidebarCollapsed ? "ml-16" : "ml-60",
+                )}
+              >
+                {children}
+              </main>
+            </StudioMountInfoProvider>
+          </StudioSessionProvider>
+        </AdminCapabilitiesProvider>
+      </div>
+    </ToastProvider>
   );
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   QueryClientProvider,
   keepPreviousData,
@@ -258,7 +258,10 @@ function AdminLayoutInner({
   // invalidate on change to restore the pre-refactor useEffect's
   // auth.token-dep behavior.
   const queryClient = useQueryClient();
+  const previousAuthTokenRef = useRef(context.auth.token);
   useEffect(() => {
+    if (previousAuthTokenRef.current === context.auth.token) return;
+    previousAuthTokenRef.current = context.auth.token;
     void queryClient.invalidateQueries({ queryKey: ["studio"] });
   }, [queryClient, context.auth.token]);
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import {
+  QueryClientProvider,
+  keepPreviousData,
+  useQuery,
+} from "@tanstack/react-query";
 import type { StudioMountContext } from "@mdcms/shared";
 
 import { createStudioQueryClient } from "../../query-client.js";
@@ -286,6 +290,11 @@ function AdminLayoutInner({
       return api.get();
     },
     enabled: capabilitiesLoadInput !== null,
+    // Preserve the last successful capabilities across environment switches so
+    // the sidebar does not briefly flash to "no permissions" while the new
+    // fetch is in flight. Matches the pre-refactor useEffect behavior that
+    // only updated cap flags on resolution.
+    placeholderData: keepPreviousData,
   });
 
   // Session
@@ -387,6 +396,9 @@ function AdminLayoutInner({
       return api.list();
     },
     enabled: environmentsEnabled,
+    // Same rationale as capabilitiesQuery: keep the last env list during a
+    // refetch so the switcher does not briefly empty out.
+    placeholderData: keepPreviousData,
   });
 
   const capabilities = capabilitiesQuery.data?.capabilities;

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -277,9 +277,6 @@ function AdminLayoutInner({
       capabilitiesLoadInput?.config.environment,
       capabilitiesLoadInput?.config.serverUrl,
       capabilitiesLoadInput?.auth.mode,
-      capabilitiesLoadInput?.auth.mode === "token"
-        ? capabilitiesLoadInput.auth.token
-        : null,
     ],
     queryFn: () => {
       const api = createStudioCurrentPrincipalCapabilitiesApi(
@@ -308,9 +305,6 @@ function AdminLayoutInner({
       "session",
       sessionLoadInput.config.serverUrl,
       sessionLoadInput.auth.mode,
-      sessionLoadInput.auth.mode === "token"
-        ? sessionLoadInput.auth.token
-        : null,
     ],
     queryFn: () => {
       const api = createStudioSessionApi(sessionLoadInput.config, {
@@ -380,7 +374,6 @@ function AdminLayoutInner({
       activeEnvironment,
       context.apiBaseUrl,
       context.auth.mode,
-      context.auth.mode === "token" ? context.auth.token : null,
     ],
     queryFn: () => {
       const api = createStudioEnvironmentApi(

--- a/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "../../adapters/next-link.js";
 import {
   FileText,
@@ -23,15 +23,9 @@ import { Badge } from "../../components/ui/badge.js";
 import { Skeleton } from "../../components/ui/skeleton.js";
 import { PageHeader } from "../../components/layout/page-header.js";
 import { useStudioSession } from "./session-context.js";
-import { useStudioMountInfo } from "./mount-info-context.js";
 import { useAdminCapabilities } from "./capabilities-context.js";
-import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
-import { createStudioContentListApi } from "../../../content-list-api.js";
-import { createStudioContentOverviewApi } from "../../../content-overview-api.js";
-import {
-  loadDashboardData,
-  type DashboardLoadResult,
-} from "../../../dashboard-data.js";
+import type { DashboardLoadResult } from "../../../dashboard-data.js";
+import { useDashboardData } from "../../hooks/use-dashboard-data.js";
 
 type DashboardState =
   | { status: "idle" }
@@ -66,69 +60,44 @@ function deriveUserLabel(email: string): string {
 
 export default function DashboardPage() {
   const session = useStudioSession();
-  const mountInfo = useStudioMountInfo();
   const { canCreateContent } = useAdminCapabilities();
-  const [state, setState] = useState<DashboardState>({ status: "idle" });
+  const query = useDashboardData();
+  const [showLoadingSkeleton, setShowLoadingSkeleton] = useState(false);
 
+  const isFetching = query.isFetching;
+  const hasData = query.data !== undefined || query.isError;
+
+  // Delay showing the skeleton by 200ms — if data arrives faster the user
+  // never sees a loading flash.
   useEffect(() => {
-    const { project, environment, apiBaseUrl, auth } = mountInfo;
-
-    if (!project || !environment || !apiBaseUrl) {
+    if (!isFetching || hasData) {
+      setShowLoadingSkeleton(false);
       return;
     }
-
-    let cancelled = false;
-
-    // Delay showing the skeleton by 200ms — if data arrives faster the
-    // user never sees a loading flash.
-    const loadingTimer = setTimeout(() => {
-      if (!cancelled) setState({ status: "loading" });
-    }, 200);
-
-    const config = { project, environment, serverUrl: apiBaseUrl };
-    const authOpts = { auth };
-
-    const schemaApi = createStudioSchemaRouteApi(config, authOpts);
-    const contentApi = createStudioContentListApi(config, authOpts);
-    const overviewApi = createStudioContentOverviewApi(config, authOpts);
-
-    loadDashboardData(schemaApi, contentApi, overviewApi)
-      .then((result) => {
-        if (!cancelled) {
-          clearTimeout(loadingTimer);
-          setState(result);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          clearTimeout(loadingTimer);
-          setState({
-            status: "error",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to load dashboard data.",
-          });
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      clearTimeout(loadingTimer);
-    };
-  }, [
-    mountInfo.project,
-    mountInfo.environment,
-    mountInfo.apiBaseUrl,
-    mountInfo.auth,
-  ]);
+    const timer = setTimeout(() => setShowLoadingSkeleton(true), 200);
+    return () => clearTimeout(timer);
+  }, [isFetching, hasData]);
 
   const userLabel =
     session.status === "authenticated"
       ? deriveUserLabel(session.session.email)
       : null;
 
-  if (state.status === "idle") {
+  const result: DashboardState = query.isError
+    ? {
+        status: "error",
+        message:
+          query.error instanceof Error
+            ? query.error.message
+            : "Failed to load dashboard data.",
+      }
+    : query.data
+      ? query.data
+      : showLoadingSkeleton
+        ? { status: "loading" }
+        : { status: "idle" };
+
+  if (result.status === "idle") {
     return (
       <div className="min-h-screen">
         <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
@@ -136,7 +105,7 @@ export default function DashboardPage() {
     );
   }
 
-  if (state.status === "loading") {
+  if (result.status === "loading") {
     return (
       <div className="min-h-screen">
         <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
@@ -197,7 +166,7 @@ export default function DashboardPage() {
     );
   }
 
-  if (state.status === "forbidden") {
+  if (result.status === "forbidden") {
     return (
       <div className="min-h-screen">
         <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
@@ -213,7 +182,7 @@ export default function DashboardPage() {
     );
   }
 
-  if (state.status === "error") {
+  if (result.status === "error") {
     return (
       <div className="min-h-screen">
         <PageHeader breadcrumbs={[{ label: "Dashboard" }]} />
@@ -221,14 +190,14 @@ export default function DashboardPage() {
           <AlertCircle className="h-8 w-8 text-destructive" />
           <h2 className="text-lg font-semibold">Something went wrong</h2>
           <p className="text-sm text-foreground-muted max-w-md">
-            {state.message}
+            {result.message}
           </p>
         </div>
       </div>
     );
   }
 
-  const { data } = state;
+  const { data } = result;
 
   const statCards = [
     {

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-overview.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-overview.ts
@@ -8,13 +8,25 @@ import {
   type LoadStudioContentOverviewStateInput,
   type StudioContentOverviewState,
 } from "../../content-overview-state.js";
+import type { StudioRuntimeAuth } from "../../request-auth.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 
 export function getContentOverviewQueryKey(
   project: string | null | undefined,
   environment: string | null | undefined,
+  apiBaseUrl: string | null | undefined,
+  authMode: StudioRuntimeAuth["mode"] | null | undefined,
+  supportedLocales: readonly string[] | undefined,
 ) {
-  return ["studio", "content-overview", project, environment] as const;
+  return [
+    "studio",
+    "content-overview",
+    project,
+    environment,
+    apiBaseUrl,
+    authMode,
+    supportedLocales,
+  ] as const;
 }
 
 export function useStudioContentOverview(
@@ -49,6 +61,9 @@ export function useStudioContentOverview(
     queryKey: getContentOverviewQueryKey(
       mountInfo.project,
       mountInfo.environment,
+      mountInfo.apiBaseUrl,
+      mountInfo.auth.mode,
+      mountInfo.supportedLocales,
     ),
     queryFn: () => loadState(loadInput!),
     enabled: loadInput !== null,

--- a/packages/studio/src/lib/runtime-ui/hooks/use-content-overview.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-content-overview.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  loadStudioContentOverviewState,
+  type LoadStudioContentOverviewStateInput,
+  type StudioContentOverviewState,
+} from "../../content-overview-state.js";
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
+
+export function getContentOverviewQueryKey(
+  project: string | null | undefined,
+  environment: string | null | undefined,
+) {
+  return ["studio", "content-overview", project, environment] as const;
+}
+
+export function useStudioContentOverview(
+  loadState: (
+    input: LoadStudioContentOverviewStateInput,
+  ) => Promise<StudioContentOverviewState> = loadStudioContentOverviewState,
+) {
+  const mountInfo = useStudioMountInfo();
+
+  const loadInput = useMemo<LoadStudioContentOverviewStateInput | null>(() => {
+    if (!mountInfo.project || !mountInfo.environment) {
+      return null;
+    }
+    return {
+      config: {
+        project: mountInfo.project,
+        environment: mountInfo.environment,
+        serverUrl: mountInfo.apiBaseUrl,
+        supportedLocales: mountInfo.supportedLocales,
+      },
+      auth: mountInfo.auth,
+    };
+  }, [
+    mountInfo.project,
+    mountInfo.environment,
+    mountInfo.apiBaseUrl,
+    mountInfo.auth,
+    mountInfo.supportedLocales,
+  ]);
+
+  return useQuery<StudioContentOverviewState>({
+    queryKey: getContentOverviewQueryKey(
+      mountInfo.project,
+      mountInfo.environment,
+    ),
+    queryFn: () => loadState(loadInput!),
+    enabled: loadInput !== null,
+  });
+}

--- a/packages/studio/src/lib/runtime-ui/hooks/use-dashboard-data.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-dashboard-data.ts
@@ -10,13 +10,23 @@ import {
 import { createStudioContentListApi } from "../../content-list-api.js";
 import { createStudioContentOverviewApi } from "../../content-overview-api.js";
 import { createStudioSchemaRouteApi } from "../../schema-route-api.js";
+import type { StudioRuntimeAuth } from "../../request-auth.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 
 export function getDashboardDataQueryKey(
   project: string | null | undefined,
   environment: string | null | undefined,
+  apiBaseUrl: string | null | undefined,
+  authMode: StudioRuntimeAuth["mode"] | null | undefined,
 ) {
-  return ["studio", "dashboard", project, environment] as const;
+  return [
+    "studio",
+    "dashboard",
+    project,
+    environment,
+    apiBaseUrl,
+    authMode,
+  ] as const;
 }
 
 export function useDashboardData() {
@@ -37,7 +47,12 @@ export function useDashboardData() {
   }, [project, environment, apiBaseUrl, auth]);
 
   return useQuery<DashboardLoadResult>({
-    queryKey: getDashboardDataQueryKey(project, environment),
+    queryKey: getDashboardDataQueryKey(
+      project,
+      environment,
+      apiBaseUrl,
+      auth.mode,
+    ),
     queryFn: () =>
       loadDashboardData(apis!.schemaApi, apis!.contentApi, apis!.overviewApi),
     enabled: apis !== null,

--- a/packages/studio/src/lib/runtime-ui/hooks/use-dashboard-data.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-dashboard-data.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  loadDashboardData,
+  type DashboardLoadResult,
+} from "../../dashboard-data.js";
+import { createStudioContentListApi } from "../../content-list-api.js";
+import { createStudioContentOverviewApi } from "../../content-overview-api.js";
+import { createStudioSchemaRouteApi } from "../../schema-route-api.js";
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
+
+export function getDashboardDataQueryKey(
+  project: string | null | undefined,
+  environment: string | null | undefined,
+) {
+  return ["studio", "dashboard", project, environment] as const;
+}
+
+export function useDashboardData() {
+  const mountInfo = useStudioMountInfo();
+  const { project, environment, apiBaseUrl, auth } = mountInfo;
+
+  const apis = useMemo(() => {
+    if (!project || !environment || !apiBaseUrl) {
+      return null;
+    }
+    const config = { project, environment, serverUrl: apiBaseUrl };
+    const authOpts = { auth };
+    return {
+      schemaApi: createStudioSchemaRouteApi(config, authOpts),
+      contentApi: createStudioContentListApi(config, authOpts),
+      overviewApi: createStudioContentOverviewApi(config, authOpts),
+    };
+  }, [project, environment, apiBaseUrl, auth]);
+
+  return useQuery<DashboardLoadResult>({
+    queryKey: getDashboardDataQueryKey(project, environment),
+    queryFn: () =>
+      loadDashboardData(apis!.schemaApi, apis!.contentApi, apis!.overviewApi),
+    enabled: apis !== null,
+  });
+}

--- a/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import type { StudioMountContext } from "@mdcms/shared";
 
@@ -12,6 +12,7 @@ import {
   type StudioContentOverviewState,
 } from "../../content-overview-state.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
+import { useStudioContentOverview } from "../hooks/use-content-overview.js";
 import Link from "../adapters/next-link.js";
 import { ChevronRight, FileText, Globe, GlobeOff } from "lucide-react";
 import { Skeleton } from "../components/ui/skeleton.js";
@@ -289,69 +290,26 @@ export default function ContentPage({
   context: StudioMountContext;
   loadState?: typeof loadStudioContentOverviewState;
 }) {
+  void context;
   const mountInfo = useStudioMountInfo();
-  const [state, setState] = useState<StudioContentOverviewState>(() =>
-    createStudioContentOverviewLoadingState(),
-  );
+  const query = useStudioContentOverview(loadState);
 
-  useEffect(() => {
-    if (!mountInfo.project || !mountInfo.environment) {
-      setState(createContentPageMissingRouteState());
-      return;
-    }
-
-    const loadInput: ContentPageLoadInput = {
-      config: {
-        project: mountInfo.project,
-        environment: mountInfo.environment,
-        serverUrl: mountInfo.apiBaseUrl,
-        supportedLocales: mountInfo.supportedLocales,
-      },
-      auth: mountInfo.auth,
-    };
-
-    let active = true;
-
-    const loadingTimer = setTimeout(() => {
-      if (active) setState(createStudioContentOverviewLoadingState());
-    }, 200);
-
-    void loadState(loadInput)
-      .then((nextState) => {
-        if (active) {
-          clearTimeout(loadingTimer);
-          setState(nextState);
-        }
-      })
-      .catch((error: unknown) => {
-        if (!active) {
-          return;
-        }
-
-        clearTimeout(loadingTimer);
-        setState({
+  const state: StudioContentOverviewState = query.data
+    ? query.data
+    : query.isError
+      ? {
           status: "error",
-          project: loadInput.config.project,
-          environment: loadInput.config.environment,
+          project: mountInfo.project ?? "unknown",
+          environment: mountInfo.environment ?? "unknown",
           message:
-            error instanceof Error && error.message.trim().length > 0
-              ? error.message
+            query.error instanceof Error &&
+            query.error.message.trim().length > 0
+              ? query.error.message
               : "Failed to load content overview.",
-        });
-      });
-
-    return () => {
-      active = false;
-      clearTimeout(loadingTimer);
-    };
-  }, [
-    mountInfo.apiBaseUrl,
-    mountInfo.auth,
-    mountInfo.environment,
-    mountInfo.project,
-    mountInfo.supportedLocales,
-    loadState,
-  ]);
+        }
+      : query.fetchStatus === "idle" && !query.isFetched
+        ? createContentPageMissingRouteState()
+        : createStudioContentOverviewLoadingState();
 
   return <ContentPageView state={state} />;
 }


### PR DESCRIPTION
## Summary

Finishes the TanStack Query migration in the Studio runtime that CMS-132 started. The last three raw `useEffect` + `useState` data-fetching sites in `packages/studio` are replaced with `useQuery`-based hooks:

- **Dashboard page** (`admin/page.tsx`) fetches `loadDashboardData` through a new `useDashboardData` hook. The 200 ms skeleton-delay behavior is preserved with a single local effect so fast responses still avoid a loading flash.
- **Admin layout** (`admin/layout.tsx`) is split into an outer `QueryClientProvider` wrapper and an inner `AdminLayoutInner`. Inside the provider, capabilities / session / environments are driven by `useQuery`. The token-mode capability-failure promotion to `session.status = "token-error"` is preserved through a derived memo.
- **Content overview page** (`pages/content-page.tsx`) consumes `loadStudioContentOverviewState` through a new `useStudioContentOverview` hook.

Pure orchestration functions (`loadDashboardData`, `loadStudioContentOverviewState`) are untouched — the refactor is confined to the React data-fetching boundary. No external contracts change.

Jira: https://blazity.atlassian.net/browse/CMS-180

## Test plan

- [x] `bun run format:check` clean
- [x] `bun run check` (Nx build + typecheck for all 6 projects) green
- [x] Targeted unit tests pass: `layout.test.tsx`, `content-page.test.tsx`, `content-overview-state.test.ts`, `dashboard-data.test.ts` (33/33)
- [x] Full studio suite: 518/519 pass (the 1 failure is an unrelated pre-existing, untracked `button.test.tsx` on the working tree, not introduced by this PR)
- [ ] Manual smoke: reviewer exercises admin dashboard, content overview, and environment switching against a running Studio to confirm no visible regression in loading / token-error / unauthenticated flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized admin layout provider and split inner layout to consolidate query client and simplify data loading across admin, dashboard, and content pages while preserving prior results during refetches.

* **New Features**
  * Declarative React Query hooks for dashboard and content overview with stable query keys, gating, and placeholder data to improve loading behavior.

* **Bug Fixes**
  * More deterministic session/auth/error handling, token-mode vs cookie-mode distinctions, and detection of bearer token rotation to trigger refreshed studio data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->