### PR TITLE
chore(deploy): drop demo:seed from Railway preDeployCommand [CMS-212]

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "apps/server/Dockerfile"
   },
   "deploy": {
-    "preDeployCommand": "sh -c 'bun run db:migrate && bun run demo:seed'",
+    "preDeployCommand": "bun run db:migrate",
     "healthcheckPath": "/healthz",
     "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary

- Replace `preDeployCommand: \"sh -c 'bun run db:migrate && bun run demo:seed'\"` with `preDeployCommand: \"bun run db:migrate\"` in `railway.json`.
- Demo seed becomes a one-shot bootstrap (run manually via `bun run --cwd apps/server demo:seed` or `railway run`), not a recurring step on every deploy.

## Why

The previous config wired `demo:seed` into every Railway deploy of the server. That made demo-deployment-specific behavior the default for the main MDCMS server config — anyone reusing this `railway.json` would seed demo content on every release.

The closed PR #117 tried to handle this from the wrong direction by adding scope tags + opt-out skip flags (`MDCMS_DEMO_SKIP_SCHEMA_SYNC`, `MDCMS_DEMO_SKIP_CONTENT_SEED`) so the demo deployment could opt out of its own seed. The cleaner inversion is: don't seed by default at all. Seeding is a bootstrap, not a deploy step.

## Test plan
- [ ] CI passes (`bun run ci:required`)
- [ ] Railway demo redeploys successfully with only `db:migrate` running pre-deploy
- [ ] Existing demo user, API key, and home page document survive the redeploy (DB-resident, not code-resident)
- [ ] Studio still loads and login still works on the demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment configuration updated to run only database migrations during deploy; automatic demo data seeding will no longer run as part of the deployment process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->