### PR TITLE
chore(format): apply prettier to server health.test.ts and server.ts

### DIFF
--- a/apps/server/src/lib/health.test.ts
+++ b/apps/server/src/lib/health.test.ts
@@ -859,7 +859,9 @@ test("Studio asset response is marked immutably cacheable", async () => {
   });
 
   const response = await handler(
-    new Request("http://localhost/api/v1/studio/assets/build-cache/runtime.mjs"),
+    new Request(
+      "http://localhost/api/v1/studio/assets/build-cache/runtime.mjs",
+    ),
   );
 
   assert.equal(response.status, 200);
@@ -914,9 +916,12 @@ test("CORS-origin Vary merges with the asset route's Accept-Encoding signal", as
   });
 
   const response = await handler(
-    new Request("http://localhost/api/v1/studio/assets/build-cors/runtime.mjs", {
-      headers: { origin: "https://demo.example" },
-    }),
+    new Request(
+      "http://localhost/api/v1/studio/assets/build-cors/runtime.mjs",
+      {
+        headers: { origin: "https://demo.example" },
+      },
+    ),
   );
 
   assert.equal(response.status, 200);

--- a/apps/server/src/lib/server.ts
+++ b/apps/server/src/lib/server.ts
@@ -118,7 +118,9 @@ function createStudioCorsHeaders(origin: string): Record<string, string> {
   };
 }
 
-function mergeVaryHeaderValues(...values: ReadonlyArray<string | null>): string {
+function mergeVaryHeaderValues(
+  ...values: ReadonlyArray<string | null>
+): string {
   const seen = new Set<string>();
   const tokens: string[] = [];
 
@@ -320,9 +322,7 @@ function pickStudioAssetEncoding(
   // br > gzip (better ratio for our JS bundle).
   const wildcardQ = tokens.get("*");
   const supported: readonly StudioAssetCompressionEncoding[] = ["br", "gzip"];
-  let best:
-    | { encoding: StudioAssetCompressionEncoding; q: number }
-    | undefined;
+  let best: { encoding: StudioAssetCompressionEncoding; q: number } | undefined;
   for (const candidate of supported) {
     const q = tokens.has(candidate) ? tokens.get(candidate) : wildcardQ;
     if (q === undefined || q <= 0) continue;


### PR DESCRIPTION
## Summary

Pure prettier-write pass on `apps/server/src/lib/health.test.ts` and `apps/server/src/lib/server.ts`. Both files landed on main with format warnings via PR #116, which breaks the `quality` CI check on every subsequent PR.

No behavior or logic changes. Diff is 13 insertions / 8 deletions, all whitespace.

## Test plan
- [x] `bun run format:check` passes locally
- [ ] CI `quality` job goes green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test file formatting for improved readability
* **Chores**
  * Improved code formatting and TypeScript type annotation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->