### PR TITLE
fix(studio): wire MDX component drag handle so reorder actually works [CMS-216]

### DIFF
--- a/packages/studio/src/lib/mdx-component-extension.ts
+++ b/packages/studio/src/lib/mdx-component-extension.ts
@@ -721,6 +721,10 @@ export const MdxComponentExtension = Node.create({
   content: "block*",
   isolating: true,
   selectable: true,
+  // Marks the whole node as a ProseMirror drag source. The node view scopes
+  // the drag to a specific child via `[data-drag-handle]` so clicking inside
+  // the wrapper still places a caret rather than starting a drag.
+  draggable: true,
   priority: 1000,
 
   addProseMirrorPlugins() {

--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
@@ -67,15 +67,32 @@ export function MdxComponentNodeFrame(props: {
           : "border-l-primary/20 hover:border-l-primary/50",
       )}
     >
-      {/* Drag handle — decorative, must not accept a caret. */}
+      {/* Drag handle. Tiptap recognizes `[data-drag-handle]` inside a
+          `draggable: true` node view and routes pointer-down to ProseMirror's
+          drag-start, so only this element initiates a drag — clicking
+          anywhere else in the wrapper places a caret. The handle is
+          suppressed in read-only / forbidden modes to match how the props
+          and delete affordances are gated. */}
       <div
         className="absolute -left-7 top-1.5 flex opacity-0 transition-opacity duration-150 group-hover/mdx-block:opacity-100"
         contentEditable={false}
         suppressContentEditableWarning
       >
-        <span className="cursor-grab rounded p-0.5 text-foreground-muted hover:bg-background-subtle hover:text-foreground">
-          <GripVertical className="h-4 w-4" />
-        </span>
+        {props.readOnly || props.forbidden ? (
+          <span className="rounded p-0.5 text-foreground-muted/50">
+            <GripVertical className="h-4 w-4" />
+          </span>
+        ) : (
+          <span
+            data-drag-handle
+            draggable={true}
+            aria-label={`Drag to reorder ${props.componentName}`}
+            title="Drag to reorder"
+            className="cursor-grab rounded p-0.5 text-foreground-muted hover:bg-background-subtle hover:text-foreground active:cursor-grabbing"
+          >
+            <GripVertical className="h-4 w-4" />
+          </span>
+        )}
       </div>
 
       {/* Chip row — the `<Name />` label and the action buttons are chrome,


### PR DESCRIPTION
## Summary

Fixes [CMS-216](https://blazity.atlassian.net/browse/CMS-216). The drag handle (`GripVertical` icon in the gutter of each MDX component block in the Studio editor) was purely decorative — `cursor-grab` styling without any drag wiring. Result: a UX lie where the cursor told the user "you can drag me" but pointer-down did nothing.

## Root cause

`packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx`:
- The grip element had no `data-drag-handle` attribute (Tiptap recognizes this on a child of a `draggable` NodeView to mark the drag source).
- It had no `draggable` attribute.
- It had no drag handlers.

`packages/studio/src/lib/mdx-component-extension.ts`:
- `Node.create({ … })` did not set `draggable: true`, so ProseMirror's drag-and-drop had no node-level drag affordance to bind to.

The chrome was added but the underlying drag wiring never followed.

## Fix

Two surgical changes:

1. **`mdx-component-extension.ts`**: add `draggable: true` to the Node config.
2. **`mdx-component-node-view.tsx`**: scope the drag to the grip element by adding `data-drag-handle draggable={true}`. Tiptap routes pointer-down on `[data-drag-handle]` inside a `draggable` node view to ProseMirror's drag-start, so only the grip starts a drag — clicking elsewhere in the wrapper still places a caret.
3. Read-only / forbidden modes render a dimmed grip without drag attributes, matching how `onEditProps` and `onDelete` are gated.

The existing `mdxComponentNodeGuard` plugin already permits drag-induced moves: a relocation leaves the MDX-node count unchanged, so the guard's early-return at `afterCount >= beforeCount` lets the transaction through. Existing node-guard tests pass (9/9).

## Test plan

- [x] `bun test --cwd packages/studio ./src/lib/mdx-component-node-guard.test.ts` — 9/9 pass
- [x] `bun test --cwd packages/studio ./src` — 518/519 pass (1 unrelated pre-existing failure in untracked local scratch file `button.test.tsx`)
- [x] `bun x tsc --noEmit` clean from `packages/studio`
- [x] `bun nx build studio` succeeds
- [x] Prettier check clean
- [ ] **Manual UI verification**: open Studio editor, hover an MDX block, confirm grip becomes visible. Pointer-down on the grip and drag to a new position — node should lift and a drop indicator should appear between sibling blocks. Drop and confirm reorder persists through markdown serialization.
- [ ] **Read-only check**: open the same document with a read-only API key — grip should render dimmed and not initiate drag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MDX components in the editor are now fully draggable, enabling users to easily reorder components within their content.
  * Drag handle interface enhanced with accessibility labels ("Drag to reorder") for improved usability.
  * Read-only and restricted content modes properly disable dragging while maintaining visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->