### PR TITLE
fix(studio): drag UX polish + instant schema-mismatch banner [CMS-216, CMS-217]

### DIFF
--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -208,6 +208,12 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       useState<SlashTriggerCoords | null>(null);
     const [linkPopoverOpen, setLinkPopoverOpen] = useState(false);
     const [linkInputValue, setLinkInputValue] = useState("");
+    // While the user drags an MDX component handle, the browser's default
+    // pointer behavior would let the cursor paint a text selection over
+    // sibling block content as it sweeps across the editor. Track the drag
+    // explicitly so we can pin `user-select: none` on the editor and run an
+    // auto-scroll loop while the canvas pane is the scrollable ancestor.
+    const [isMdxDragging, setIsMdxDragging] = useState(false);
     const editorWrapperRef = useRef<HTMLDivElement | null>(null);
     const pickerSourceRef = useRef(pickerSource);
     pickerSourceRef.current = pickerSource;
@@ -555,6 +561,105 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
       syncSlashTrigger(editor);
     }, [catalogComponents, editor, forbidden, isEditorReadOnly, readOnly]);
 
+    // Drag lifecycle for MDX component handles. Listening at the wrapper
+    // catches dragstart only when it originates from a `[data-drag-handle]`
+    // inside an MDX node view (Tiptap routes pointer-down on the handle into
+    // a ProseMirror node drag). dragend / drop are listened on the document
+    // because the events fire wherever the pointer lands, which can be
+    // outside the editor wrapper for cancelled drags.
+    useEffect(() => {
+      const wrapper = editorWrapperRef.current;
+      if (!wrapper) {
+        return;
+      }
+
+      const onDragStart = (event: DragEvent) => {
+        const target = event.target as HTMLElement | null;
+        if (!target?.closest("[data-drag-handle]")) {
+          return;
+        }
+        setIsMdxDragging(true);
+      };
+
+      const stopDragging = () => setIsMdxDragging(false);
+
+      wrapper.addEventListener("dragstart", onDragStart);
+      document.addEventListener("dragend", stopDragging);
+      document.addEventListener("drop", stopDragging);
+
+      return () => {
+        wrapper.removeEventListener("dragstart", onDragStart);
+        document.removeEventListener("dragend", stopDragging);
+        document.removeEventListener("drop", stopDragging);
+      };
+    }, []);
+
+    // Auto-scroll the canvas pane while a drag is in flight so the user can
+    // reorder past the visible viewport. The scroll target is the nearest
+    // `[data-mdcms-editor-pane="canvas"]` ancestor; if there is none (e.g.
+    // tests, embedded preview) the effect no-ops. dragover fires
+    // continuously while the pointer moves, so we record the latest Y and
+    // let a rAF loop convert proximity-to-edge into scroll velocity.
+    useEffect(() => {
+      if (!isMdxDragging) {
+        return;
+      }
+
+      const wrapper = editorWrapperRef.current;
+      if (!wrapper) {
+        return;
+      }
+
+      const scrollContainer = wrapper.closest(
+        '[data-mdcms-editor-pane="canvas"]',
+      ) as HTMLElement | null;
+
+      if (!scrollContainer) {
+        return;
+      }
+
+      const SCROLL_ZONE_PX = 72;
+      const MAX_SCROLL_PER_FRAME = 18;
+      let pointerY: number | null = null;
+      let rafId: number | null = null;
+
+      const onDragOver = (event: DragEvent) => {
+        pointerY = event.clientY;
+      };
+
+      const tick = () => {
+        if (pointerY !== null) {
+          const rect = scrollContainer.getBoundingClientRect();
+          const distanceFromTop = pointerY - rect.top;
+          const distanceFromBottom = rect.bottom - pointerY;
+
+          if (distanceFromTop >= 0 && distanceFromTop < SCROLL_ZONE_PX) {
+            const speed =
+              MAX_SCROLL_PER_FRAME * (1 - distanceFromTop / SCROLL_ZONE_PX);
+            scrollContainer.scrollTop -= speed;
+          } else if (
+            distanceFromBottom >= 0 &&
+            distanceFromBottom < SCROLL_ZONE_PX
+          ) {
+            const speed =
+              MAX_SCROLL_PER_FRAME * (1 - distanceFromBottom / SCROLL_ZONE_PX);
+            scrollContainer.scrollTop += speed;
+          }
+        }
+        rafId = requestAnimationFrame(tick);
+      };
+
+      document.addEventListener("dragover", onDragOver);
+      rafId = requestAnimationFrame(tick);
+
+      return () => {
+        document.removeEventListener("dragover", onDragOver);
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+        }
+      };
+    }, [isMdxDragging]);
+
     useEffect(() => {
       if (!slashPickerOpen || !slashPickerCoords || !editor || !slashTrigger) {
         floatingRefs.setReference(null);
@@ -881,7 +986,17 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
     ) : null;
 
     return (
-      <div ref={editorWrapperRef} className="relative">
+      <div
+        ref={editorWrapperRef}
+        // While a drag is in flight, pin selection off across the editor and
+        // its descendants so the pointer doesn't paint a text selection over
+        // sibling block content as it sweeps over them. `pointer-events`
+        // stays on so dragover continues to fire and auto-scroll works.
+        className={cn(
+          "relative",
+          isMdxDragging && "select-none [&_*]:select-none",
+        )}
+      >
         <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background">
           <div className="border-b border-border bg-background-subtle">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-2.5">

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1254,6 +1254,13 @@ export async function loadContentDocumentPageState(input: {
       serverUrl: input.context.apiBaseUrl,
     },
     auth: input.context.auth,
+    // Forward the host-precomputed hash so initial-load mismatch detection
+    // matches the autosave guard's view. Without this the schema-recovery
+    // banner only appears after the first save round-trips through the
+    // server and comes back as SCHEMA_HASH_MISMATCH.
+    ...(route.write.canWrite
+      ? { precomputedLocalSchemaHash: route.write.schemaHash }
+      : {}),
   });
   const readyState = applySchemaStateToReadyState({
     state: nextState,

--- a/packages/studio/src/lib/schema-state.test.ts
+++ b/packages/studio/src/lib/schema-state.test.ts
@@ -565,6 +565,46 @@ test("loadStudioSchemaState uses precomputedLocalSchemaHash so mismatch is detec
   assert.equal(state.canSync, false);
 });
 
+test("loadStudioSchemaState ignores whitespace-only precomputedLocalSchemaHash and falls back to browser-derived", async () => {
+  const api = createSchemaRouteApi(
+    async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            types: [],
+            schemaHash: "server-hash",
+            syncedAt: "2026-03-31T12:00:00.000Z",
+            project: "marketing-site",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+  );
+
+  const state = await loadStudioSchemaState({
+    config: createConfig(),
+    schemaApi: api,
+    capabilitiesApi: createCapabilitiesApi({
+      schema: { read: true, write: true },
+    }),
+    precomputedLocalSchemaHash: "   ",
+  });
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") {
+    throw new Error("Expected ready state.");
+  }
+  // Whitespace-only host value must not override the valid browser-derived
+  // hash, so the state still reports a real local hash and mismatch
+  // detection works against the server hash.
+  assert.notEqual(state.localSchemaHash, undefined);
+  assert.notEqual(state.localSchemaHash, "   ");
+  assert.equal(state.serverSchemaHash, "server-hash");
+});
+
 test("loadStudioSchemaState ignores precomputedLocalSchemaHash when it matches the server", async () => {
   const api = createSchemaRouteApi(
     async () =>

--- a/packages/studio/src/lib/schema-state.test.ts
+++ b/packages/studio/src/lib/schema-state.test.ts
@@ -516,6 +516,94 @@ test("loadStudioSchemaState detects hash mismatch when server project matches co
   assert.equal(state.isMismatch, true);
 });
 
+test("loadStudioSchemaState uses precomputedLocalSchemaHash so mismatch is detected on first paint", async () => {
+  // Browser-side derivation cannot run on a stripped config (no types), so
+  // localSchemaHash would normally be undefined and the recovery banner
+  // would only appear after an autosave failed server-side. Forwarding the
+  // host-precomputed hash detects mismatch immediately.
+  const api = createSchemaRouteApi(
+    async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            types: [],
+            schemaHash: "server-hash",
+            syncedAt: "2026-03-31T12:00:00.000Z",
+            project: "marketing-site",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+  );
+
+  const state = await loadStudioSchemaState({
+    config: {
+      project: "marketing-site",
+      environment: "staging",
+      serverUrl: "http://localhost:4000",
+    },
+    schemaApi: api,
+    capabilitiesApi: createCapabilitiesApi({
+      schema: { read: true, write: true },
+    }),
+    precomputedLocalSchemaHash: "host-precomputed-hash",
+  });
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") {
+    throw new Error("Expected ready state.");
+  }
+  assert.equal(state.localSchemaHash, "host-precomputed-hash");
+  assert.equal(state.serverSchemaHash, "server-hash");
+  assert.equal(state.isMismatch, true);
+  // No browser-side syncPayload available — sync must remain disabled even
+  // when capabilities allow it, since the precomputed hash alone is not
+  // enough to push a sync from the browser.
+  assert.equal(state.canSync, false);
+});
+
+test("loadStudioSchemaState ignores precomputedLocalSchemaHash when it matches the server", async () => {
+  const api = createSchemaRouteApi(
+    async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            types: [],
+            schemaHash: "matching-hash",
+            syncedAt: "2026-03-31T12:00:00.000Z",
+            project: "marketing-site",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+  );
+
+  const state = await loadStudioSchemaState({
+    config: {
+      project: "marketing-site",
+      environment: "staging",
+      serverUrl: "http://localhost:4000",
+    },
+    schemaApi: api,
+    capabilitiesApi: createCapabilitiesApi({
+      schema: { read: true, write: true },
+    }),
+    precomputedLocalSchemaHash: "matching-hash",
+  });
+
+  assert.equal(state.status, "ready");
+  if (state.status !== "ready") {
+    throw new Error("Expected ready state.");
+  }
+  assert.equal(state.isMismatch, false);
+});
+
 test("loadStudioSchemaState falls through to hash comparison when server omits project", async () => {
   const api = createSchemaRouteApi(
     async () =>

--- a/packages/studio/src/lib/schema-state.ts
+++ b/packages/studio/src/lib/schema-state.ts
@@ -286,10 +286,18 @@ export async function loadStudioSchemaState(
     // enough to *detect* mismatch but not to *resolve* it via a sync from
     // the browser, which matches reality (sync requires the full authored
     // config and is owned by the host / CLI anyway).
+    //
+    // Trim before length-checking so a whitespace-only precomputed value
+    // does not override a valid browser-derived hash. This mirrors the
+    // normalization applied to `serverSchemaHash` so the two sides stay
+    // comparable; intentionally not adding `toLowerCase()` or strict hex
+    // validation here because those would be asymmetric with the server
+    // path and would mask producer bugs rather than expose them.
+    const precomputedLocalSchemaHashRaw = input.precomputedLocalSchemaHash;
     const precomputedLocalSchemaHash =
-      typeof input.precomputedLocalSchemaHash === "string" &&
-      input.precomputedLocalSchemaHash.length > 0
-        ? input.precomputedLocalSchemaHash
+      typeof precomputedLocalSchemaHashRaw === "string" &&
+      precomputedLocalSchemaHashRaw.trim().length > 0
+        ? precomputedLocalSchemaHashRaw.trim()
         : undefined;
     const browserDerivedLocalSchemaHash = localDetails.canWrite
       ? localDetails.syncPayload.schemaHash

--- a/packages/studio/src/lib/schema-state.ts
+++ b/packages/studio/src/lib/schema-state.ts
@@ -74,6 +74,15 @@ export type LoadStudioSchemaStateInput = {
   fetcher?: typeof fetch;
   schemaApi?: StudioSchemaRouteApi;
   capabilitiesApi?: StudioCurrentPrincipalCapabilitiesApi;
+  // Optional host-precomputed local schema hash. The host (Next.js page,
+  // bundler script, etc.) typically computes the schema hash server-side
+  // where the full authored config (with Zod types) is available. The
+  // browser-side load is given a stripped config and cannot recompute the
+  // hash itself, so without this hint the initial schema-state load reports
+  // `localSchemaHash: undefined` and a real mismatch is only surfaced after
+  // a write fails server-side. Pass the host hash here to detect mismatch
+  // on first paint.
+  precomputedLocalSchemaHash?: string;
 };
 
 function createSchemaRouteApi(
@@ -269,15 +278,32 @@ export async function loadStudioSchemaState(
       capabilities = createEmptyCurrentPrincipalCapabilities();
     }
 
+    // Prefer the host-derived hash (full config with types is available
+    // server-side / at build time) over a stripped browser-side recompute.
+    // If no host value was supplied and the browser-side derivation
+    // succeeded, fall back to that. The syncPayload is only ever the
+    // browser-side derivation — a precomputed hash without a payload is
+    // enough to *detect* mismatch but not to *resolve* it via a sync from
+    // the browser, which matches reality (sync requires the full authored
+    // config and is owned by the host / CLI anyway).
+    const precomputedLocalSchemaHash =
+      typeof input.precomputedLocalSchemaHash === "string" &&
+      input.precomputedLocalSchemaHash.length > 0
+        ? input.precomputedLocalSchemaHash
+        : undefined;
+    const browserDerivedLocalSchemaHash = localDetails.canWrite
+      ? localDetails.syncPayload.schemaHash
+      : undefined;
+    const localSchemaHash =
+      precomputedLocalSchemaHash ?? browserDerivedLocalSchemaHash;
+
     return createReadyState({
       project: input.config.project,
       environment: input.config.environment,
       capabilities,
+      ...(localSchemaHash ? { localSchemaHash } : {}),
       ...(localDetails.canWrite
-        ? {
-            localSchemaHash: localDetails.syncPayload.schemaHash,
-            syncPayload: localDetails.syncPayload,
-          }
+        ? { syncPayload: localDetails.syncPayload }
         : {}),
       ...(serverSchemaHash ? { serverSchemaHash } : {}),
       entries,


### PR DESCRIPTION
## Summary

Two fixes bundled because they were both surfaced by the same browser session and they don't conflict.

### CMS-216 follow-up — drag handle UX

The MDX drag handle from PR #121 worked, but two rough edges remained:

1. **Text selection during drag**: as the cursor swept across other component blocks, the browser's default pointer behavior painted a text selection over sibling content.
2. **No auto-scroll**: dragging toward the viewport edge would not advance the canvas, so reorder past the fold was impossible.

Fixes in `tiptap-editor.tsx`:

- Track an `isMdxDragging` state via `dragstart` on `[data-drag-handle]` and `dragend` / `drop` on the document. While true, pin `user-select: none` on the editor wrapper and all descendants so no selection can be painted (pointer-events stay on so `dragover` keeps firing for auto-scroll).
- While dragging, run a `requestAnimationFrame` loop that converts the pointer's distance from the canvas pane edges into scroll velocity. 72px scroll zone, max 18px/frame, scaled linearly by proximity. The scroll target is the nearest `[data-mdcms-editor-pane="canvas"]` ancestor; effect no-ops in tests / embeds where the pane is absent.

### [CMS-217](https://blazity.atlassian.net/browse/CMS-217) — schema-mismatch banner appears late

**Symptom**: Studio renders as fully editable for a few seconds, the user types, autosave fires, the server returns `SCHEMA_HASH_MISMATCH`, and *only then* the "Schema changes detected — Studio is read-only until schema sync resolves the mismatch" banner appears mid-edit.

**Root cause**: `loadStudioSchemaState` was called with a stripped config (`{ project, environment, serverUrl }`) that has no types and no `_schemaHash`. The browser-side derivation in `resolveStudioDocumentRouteSchemaDetails` returns `canWrite: false`, so `localSchemaHash` is left undefined and `hasSchemaRecoveryMismatch` returns false — the banner is suppressed even when a real mismatch exists. The mismatch is only discovered later when `createGuardedSchemaRecoveryState` forces `isMismatch: true` from the autosave error.

The host's precomputed hash (computed at build time / server-side, where the full authored config with Zod types is available) sits on `route.write.schemaHash` but the schema-state caller never forwarded it.

**Fix**:

- Add `precomputedLocalSchemaHash?: string` to `LoadStudioSchemaStateInput`.
- In `loadStudioSchemaState`, prefer the precomputed value over the (often impossible) browser-side recompute. The `syncPayload` is still only set when the browser-side derivation succeeded, so `canSync` is correctly false when only the precomputed hash is available — sync remains owned by the host / CLI.
- At the call site in `content-document-page.tsx`, forward `route.write.canWrite ? route.write.schemaHash : undefined`.

Two new tests cover the mismatch and match cases.

## Test plan

- [x] `bun test --cwd packages/studio ./src/lib/schema-state.test.ts` — 13/13 pass (2 new)
- [x] `bun test --cwd packages/studio ./src` — 520/521 pass (1 unrelated pre-existing failure outside this change)
- [x] `bun x tsc --noEmit` clean from `packages/studio`
- [x] Prettier check clean
- [ ] **Manual UI verification**: drag an MDX block — no text selection painted across siblings; pointer near top/bottom of canvas auto-scrolls.
- [ ] **Manual UI verification**: open a document where the deployed precomputed hash differs from the server's hash — banner is visible **on first paint**, before any keystroke. Open one where they match — no banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor improved drag-and-drop for MDX components with auto-scrolling and refined drag behavior (prevents text selection while dragging).

* **Bug Fixes**
  * Schema mismatch detection fixed on initial document load so validation reflects the current schema immediately.

* **Tests**
  * Added unit tests covering schema hash/precomputed-hash handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->