### PR TITLE
fix(shared): make schema hash deterministic across deployment contexts [CMS-218]

### DIFF
--- a/packages/shared/src/lib/contracts/schema.test.ts
+++ b/packages/shared/src/lib/contracts/schema.test.ts
@@ -378,11 +378,12 @@ test("serializeResolvedEnvironmentSchema rejects unsupported executable validato
   );
 });
 
-test("toRawConfigSnapshot includes project, serverUrl and omits implicit locales", () => {
+test("toRawConfigSnapshot includes project, omits deployment context, and omits implicit locales", () => {
   const parsed = parseMdcmsConfig(
     defineConfig({
       project: "my-site",
       serverUrl: "http://localhost:4000",
+      environment: "production",
       contentDirectories: ["content"],
       types: [
         defineType("Post", {
@@ -397,12 +398,67 @@ test("toRawConfigSnapshot includes project, serverUrl and omits implicit locales
   const snapshot = toRawConfigSnapshot(parsed);
 
   assert.equal(snapshot.project, "my-site");
-  assert.equal(snapshot.serverUrl, "http://localhost:4000");
+  // `serverUrl` and the active `environment` are deployment-time wiring,
+  // not schema content; they must not appear in the snapshot or the schema
+  // hash starts depending on whoever happens to be computing it.
+  assert.equal(snapshot.serverUrl, undefined);
+  assert.equal(snapshot.environment, undefined);
   assert.deepEqual(snapshot.contentDirectories, ["content"]);
   assert.deepEqual(snapshot.environments, {
     production: {},
   });
   assert.equal(snapshot.locales, undefined);
+});
+
+test("toRawConfigSnapshot is identical for configs differing only in serverUrl", () => {
+  const buildParsed = (serverUrl: string) =>
+    parseMdcmsConfig(
+      defineConfig({
+        project: "my-site",
+        serverUrl,
+        environment: "production",
+        contentDirectories: ["content"],
+        types: [
+          defineType("Post", {
+            directory: "content/posts",
+            fields: { title: z.string() },
+          }),
+        ],
+        environments: { production: {} },
+      }),
+    );
+
+  const local = toRawConfigSnapshot(buildParsed("http://localhost:4000"));
+  const railway = toRawConfigSnapshot(buildParsed("https://api.example.com"));
+
+  assert.deepEqual(local, railway);
+});
+
+test("toRawConfigSnapshot is identical for configs differing only in active environment", () => {
+  const buildParsed = (environment: string) =>
+    parseMdcmsConfig(
+      defineConfig({
+        project: "my-site",
+        serverUrl: "http://localhost:4000",
+        environment,
+        contentDirectories: ["content"],
+        types: [
+          defineType("Post", {
+            directory: "content/posts",
+            fields: { title: z.string() },
+          }),
+        ],
+        environments: {
+          production: {},
+          staging: { extends: "production" },
+        },
+      }),
+    );
+
+  const fromStagingShell = toRawConfigSnapshot(buildParsed("staging"));
+  const fromProductionShell = toRawConfigSnapshot(buildParsed("production"));
+
+  assert.deepEqual(fromStagingShell, fromProductionShell);
 });
 
 test("toRawConfigSnapshot includes environment topology definitions", () => {
@@ -589,6 +645,52 @@ test("buildSchemaSyncPayload produces the same hash for the same inputs", () => 
   const second = buildSchemaSyncPayload(parsed, "production");
 
   assert.equal(first.schemaHash, second.schemaHash);
+});
+
+test("buildSchemaSyncPayload hash for env X is independent of serverUrl and active environment", () => {
+  // Regression for CMS-218: same target environment + same schema content
+  // must hash identically regardless of which server the local config
+  // happens to point at, or which environment the host process happens to
+  // have selected as the "active" one. Otherwise the CLI sync (often run
+  // from a default shell with localhost / staging defaults) and a deployed
+  // host (production-tuned env vars baked at build time) compute different
+  // hashes for the same target env and the editor goes read-only forever.
+  const buildParsed = (input: { serverUrl: string; environment: string }) =>
+    parseMdcmsConfig(
+      defineConfig({
+        project: "marketing-site",
+        serverUrl: input.serverUrl,
+        environment: input.environment,
+        contentDirectories: ["content"],
+        types: [
+          defineType("Post", {
+            directory: "content/posts",
+            fields: { title: z.string() },
+          }),
+        ],
+        environments: {
+          production: {},
+          staging: { extends: "production" },
+        },
+      }),
+    );
+
+  const cliShell = buildSchemaSyncPayload(
+    buildParsed({
+      serverUrl: "http://localhost:4000",
+      environment: "staging",
+    }),
+    "production",
+  );
+  const buildShell = buildSchemaSyncPayload(
+    buildParsed({
+      serverUrl: "https://api.example.com",
+      environment: "production",
+    }),
+    "production",
+  );
+
+  assert.equal(cliShell.schemaHash, buildShell.schemaHash);
 });
 
 test("buildSchemaSyncPayload produces different hashes for different environments", () => {

--- a/packages/shared/src/lib/contracts/schema.ts
+++ b/packages/shared/src/lib/contracts/schema.ts
@@ -878,10 +878,18 @@ export function toRawConfigSnapshot(config: ParsedMdcmsConfig): JsonObject {
       ]),
   ) as JsonObject;
 
+  // Deliberately exclude `serverUrl` and `config.environment` (the host's
+  // currently-active environment): both are deployment-time wiring rather
+  // than schema content. Including them made the same `mdcms.config.ts`
+  // hash differently when the CLI synced from a shell with default env vars
+  // vs. when the demo's Docker build computed the hash with the live
+  // Railway URL and `NEXT_PUBLIC_MDCMS_ENVIRONMENT=production` set.
+  // `buildSchemaRegistrySyncPayloadBase` already takes the *target* env as
+  // its second argument; the snapshot stays a function of structural
+  // schema/config only, so a hash for env X is identical regardless of who
+  // is computing it or where they happen to be pointing at the time.
   return {
     project: config.project,
-    serverUrl: config.serverUrl,
-    ...(config.environment ? { environment: config.environment } : {}),
     environments,
     ...(config.contentDirectories.length > 0
       ? { contentDirectories: config.contentDirectories }

--- a/packages/studio/src/lib/document-route-schema.test.ts
+++ b/packages/studio/src/lib/document-route-schema.test.ts
@@ -114,10 +114,14 @@ test("derived schema details expose the local sync payload pieces", async () => 
   }
 
   assert.equal(details.environment, "staging");
+  // `serverUrl` and the active `environment` are deliberately omitted — they
+  // are deployment-time wiring rather than schema content. Including them
+  // made the same `mdcms.config.ts` hash differently when the CLI synced
+  // from a default shell vs. when the host computed the hash with live
+  // env vars set, so the snapshot now stays a function of structural
+  // schema/config only.
   assert.deepEqual(details.syncPayload.rawConfigSnapshot, {
     project: "marketing-site",
-    serverUrl: "http://localhost:4000",
-    environment: "staging",
     environments: {
       production: {},
       staging: {


### PR DESCRIPTION
## Summary

Fixes [CMS-218](https://blazity.atlassian.net/browse/CMS-218). The schema hash was leaking deployment-time wiring (`serverUrl` and the host's currently-active `config.environment`) into its input. Two callers computing the same schema for the same target environment produced different hashes whenever their shells differed, so a deployed Studio's baked `_schemaHash` would never match a hash synced via the CLI from a default shell.

Concrete failure caught on the demo deployment:

| Caller | NEXT_PUBLIC_MDCMS_ENVIRONMENT | NEXT_PUBLIC_MDCMS_SERVER_URL | Hash for `production` |
|---|---|---|---|
| `mdcms schema sync` from local with default env | unset → defaults to `staging` | unset → defaults to `http://localhost:4000` | `27987b…` |
| Demo Docker build on Railway | `production` | the Railway URL | `0a1fd9…` |

Same `mdcms.config.ts`, same target environment, two hashes that never reconcile. Editor goes read-only forever; "Sync Schema" from Studio doesn't help because the in-browser path lacks the type definitions to recompute.

## Root cause

`packages/shared/src/lib/contracts/schema.ts:869-901` — `toRawConfigSnapshot` was including:

1. **`serverUrl`** — the URL of the MDCMS server the host happened to be pointing at. Pure deployment wiring.
2. **`config.environment`** — the *active* environment, despite `buildSchemaRegistrySyncPayloadBase(config, environmentName)` already taking the *target* env as its second argument. Embedding the active one made the hash depend on (config, active env, target env) instead of (config, target env).

Both fields are runtime/build context, not schema definition.

## Fix

Drop both from the snapshot. The hash for target environment X is now a pure function of (resolved schema for X, structural config — `project`, `environments` topology, `contentDirectories`, `locales`, target env name passed alongside).

Three new determinism tests pin this property:

- `toRawConfigSnapshot is identical for configs differing only in serverUrl`
- `toRawConfigSnapshot is identical for configs differing only in active environment`
- `buildSchemaSyncPayload hash for env X is independent of serverUrl and active environment`

Updated:
- The existing `toRawConfigSnapshot` "includes project, serverUrl" test to assert the absence of those two fields.
- The studio `document-route-schema.test.ts` test that deep-equals the snapshot shape.

## Migration / blast radius

This is a contract change for the hash *value*. Existing synced servers have hashes stored under the old shape; consumers upgrading will see a one-time `SCHEMA_HASH_MISMATCH` until operators re-run `mdcms schema sync`. Callers with baked `_schemaHash` or `_documentRouteMetadata.schemaHashesByEnvironment` values (e.g. demo deployments) will need to rebuild.

Operator workflow after deploy:

```bash
mdcms schema sync --project <project> --environment <env>
```

…from the project's repo. The new hash is independent of which shell you run it from.

## Test plan

- [x] `bun test --cwd packages/shared ./src` — 150/150 pass (3 new determinism tests)
- [x] `bun test --cwd packages/studio ./src` — 517/518 pass (1 unrelated pre-existing failure outside this change)
- [x] `bun test --cwd apps/cli ./src` — 205/205 pass
- [x] `bun test --cwd apps/server ./src` — 165/165 pass (133 skip)
- [x] `bun test --cwd packages/sdk ./src` — 11/11 pass
- [x] `bun nx build shared` succeeds
- [x] Prettier check clean
- [ ] **Operator action after merge + deploy**: re-sync each affected project/environment so the new hash matches the server-stored hash.