### PR TITLE
fix(studio): thicker, accent-colored dropcursor for MDX block drag [CMS-216]

### DIFF
--- a/packages/studio/src/lib/editor-extensions.ts
+++ b/packages/studio/src/lib/editor-extensions.ts
@@ -97,7 +97,18 @@ export function createEditorExtensions(options?: {
   codeBlock?: Extensions[number];
 }): Extensions {
   return [
-    StarterKit.configure({ codeBlock: false }),
+    StarterKit.configure({
+      codeBlock: false,
+      // The default dropcursor is a 1px `currentColor` line, which is
+      // almost invisible on the editor's typical white background and
+      // makes it hard to tell where a dragged MDX block will land. Use
+      // a thicker bar in the theme's primary accent so the drop target
+      // reads at a glance during reorder.
+      dropcursor: {
+        width: 4,
+        color: "var(--color-primary, #2563eb)",
+      },
+    }),
     Underline,
     Highlight,
     BlurSelectionPreserver,


### PR DESCRIPTION
## Summary

Final follow-up on CMS-216. Drag-to-reorder works, but the drop indicator was the default Tiptap dropcursor — a 1px `currentColor` line that on a white editor background reads as an almost-invisible hair between blocks. Several user reports of "drag doesn't work" turned out to be "I couldn't see where it was going to land." Bump the cursor to a 4px primary-accent bar so the drop target reads at a glance during reorder.

## Test plan

- [x] `bun test --cwd packages/studio` editor tests — 58/58 pass
- [x] `bun x tsc --noEmit` clean
- [x] Prettier check clean
- [ ] **Manual UI verification**: drag an MDX block — drop indicator is a clearly visible blue bar at the candidate insertion position, not a thin hair.