### PR TITLE
fix(studio): allow MDX block drops at the very top/bottom of the document [CMS-216]

### DIFF
--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -455,8 +455,16 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
         }),
         editorProps: {
           attributes: {
+            // Padding lives on `.ProseMirror` itself rather than the outer
+            // wrapper so the entire visible editor surface — including the
+            // gutter above the first block and below the last — emits
+            // dragover events that prosemirror-dropcursor binds to. Without
+            // this, the cursor near the document edges falls in wrapper
+            // dead space and the drop indicator (and the drop itself)
+            // silently no-ops, so users dragging an MDX block to the very
+            // top of the document saw nothing happen.
             class:
-              "prose max-w-none prose-p:leading-relaxed focus:outline-none",
+              "prose max-w-none prose-p:leading-relaxed focus:outline-none px-8 py-8 min-h-[480px]",
             "data-placeholder": placeholder,
           },
           handleKeyDown: (_view, event) => {
@@ -1191,7 +1199,7 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
             ) : null}
           </div>
 
-          <div className="min-h-[480px] bg-transparent px-8 py-8">
+          <div className="bg-transparent">
             <EditorContent editor={editor} />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Drop indicator + drop itself didn't fire when dragging an MDX block to the very top of the document (or very bottom). Between sibling blocks worked fine; only the document edges no-oped.

## Root cause

prosemirror-dropcursor binds dragover listeners to `.ProseMirror`. The editor's vertical padding lived on the *outer* wrapper div (`<div className="min-h-[480px] bg-transparent px-8 py-8">`), so dragover events near the top of the visible editor landed in wrapper dead space the cursor never sees. `view.posAtCoords` was never called for the cursor's actual location at the document edge.

## Fix

Move the padding + min-height onto the `.ProseMirror` attributes via `editorProps.attributes.class`. The entire visible editor surface — including the gutter above the first block and below the last — now emits dragover events, so drops at the edges register as "before first node" and "after last node" positions.

## Test plan

- [x] `bun test --cwd packages/studio` editor tests — 58/58 pass
- [x] `bun x tsc --noEmit` clean
- [x] Prettier check clean
- [ ] **Manual UI verification**: drag an MDX component to the very first position (above all other blocks) — drop indicator visible, drop sticks. Same for the very last position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted editor layout and padding to improve drag-and-drop interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->