### PR TITLE
fix(studio): isolate MDX preview surface from editor's prose styles [CMS-216]

### DIFF
--- a/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/mdx-component-node-view.tsx
@@ -319,7 +319,19 @@ export function MdxComponentNodeView(
           <div
             ref={previewContainerRef}
             data-mdcms-mdx-preview-surface={componentName}
-            className={previewState === "ready" ? "min-h-[3rem]" : "hidden"}
+            // `not-prose` opts the host-rendered component out of the
+            // editor's surrounding `.prose` typography rules. Without this,
+            // selectors like `.prose h1`, `.prose h2`, `.prose p` win on
+            // specificity (0,1,1) over the host component's own utility
+            // classes (0,1,0) — so a marketing component using
+            // `text-dark` on a light section would silently render with
+            // the editor's dark-mode prose heading color (light/white) and
+            // appear white-on-light. Resetting prose at the preview
+            // boundary lets the host component own its own typography.
+            className={cn(
+              "not-prose",
+              previewState === "ready" ? "min-h-[3rem]" : "hidden",
+            )}
           />
         }
         readOnly={props.readOnly}


### PR DESCRIPTION
## Summary

Host marketing components rendered inside the MDX block preview were silently inheriting the surrounding editor's `.prose` heading colors. On the demo, `<FeatureGrid>`'s section heading uses `text-dark` (`#1c1b1b`), but `.prose h2` has higher specificity (`(0,1,1)` vs the utility's `(0,1,0)`), so the prose color won. In dark mode that resolves to a light cream, producing the white-on-cream invisible heading the user reported.

## Fix

Add `not-prose` to the preview surface container in `MdxComponentNodeView`. Prose styles stop at the preview boundary and the host component's own typography utilities own the cascade.

The live `/` rendering of the same component already worked because it has no enclosing `.prose` ancestor — only the Studio editor preview was affected.

## Test plan

- [x] `bun test --cwd packages/studio` editor tests — 58/58 pass
- [x] `bun x tsc --noEmit` clean
- [x] Prettier check clean
- [ ] **Manual UI verification**: open `/admin`, edit a page document, scroll to a `<FeatureGrid />` block — heading reads dark-on-cream as intended. Same for `<Hero />` and other heading-bearing demo components.