### PR TITLE
chore(skills): rename to mdcms-ai, scope install URL, refine pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Blazity/mdcms/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Blazity/mdcms" alt="License" /></a>
-  <a href="https://github.com/Blazity/mdcms/stargazers"><img src="https://img.shields.io/github/stars/Blazity/mdcms" alt="Stars" /></a>
+  <a href="https://github.com/mdcms-ai/mdcms/blob/main/LICENSE"><img src="https://img.shields.io/github/license/mdcms-ai/mdcms" alt="License" /></a>
+  <a href="https://github.com/mdcms-ai/mdcms/stargazers"><img src="https://img.shields.io/github/stars/mdcms-ai/mdcms" alt="Stars" /></a>
 </p>
 
 <p align="center">
@@ -36,7 +36,7 @@ https://github.com/user-attachments/assets/b0778e3f-c062-4e66-bd6d-87f1dcb41789
 
 ## Quick Start
 
-> **Using an AI coding agent?** Run `npx skills add Blazity/mdcms` to install the [MDCMS Skills Pack](skills/README.md) — your agent will walk through the setup below for you. Supports Claude Code, Cursor, Gemini CLI, Codex, Copilot, and 40+ others via [skills.sh](https://skills.sh).
+> **Using an AI coding agent?** Run `npx skills add mdcms-ai/mdcms/skills` to install the [MDCMS Skills Pack](skills/README.md) — your agent will walk through the setup below for you. Supports Claude Code, Cursor, Gemini CLI, Codex, Copilot, and 40+ others via [skills.sh](https://skills.sh).
 
 ### 1. Install packages
 
@@ -112,7 +112,7 @@ See the [`@mdcms/studio` README](packages/studio) for embedding instructions.
 Run your own MDCMS server with Docker Compose. The only prerequisites are Docker and Docker Compose.
 
 ```bash
-git clone https://github.com/Blazity/mdcms.git
+git clone https://github.com/mdcms-ai/mdcms.git
 cd mdcms
 cp .env.example .env
 docker compose up -d --build
@@ -184,7 +184,7 @@ For architecture decisions and specs, see the [`docs/`](docs) directory.
 To work on MDCMS itself, clone the repo and use [Bun](https://bun.sh/) as the runtime:
 
 ```bash
-git clone https://github.com/Blazity/mdcms.git
+git clone https://github.com/mdcms-ai/mdcms.git
 cd mdcms
 bun install
 docker compose up -d --build   # Start Postgres, Redis, MinIO, Mailhog

--- a/apps/docs/agent-instructions.mdx
+++ b/apps/docs/agent-instructions.mdx
@@ -6,9 +6,9 @@ description: "Copy-pasteable prompts for AI coding agents to set up and configur
 <Tip>
   **Prefer installable skills?** If your agent supports
   [skills.sh](https://skills.sh) (Claude Code, Cursor, Gemini CLI, Codex,
-  Copilot, and 40+ others), run `npx skills add Blazity/mdcms` to install the
-  [MDCMS Skills Pack](/agent-skills) — it walks your agent through the full
-  setup without copy-pasting prompts.
+  Copilot, and 40+ others), run `npx skills add mdcms-ai/mdcms/skills` to
+  install the [MDCMS Skills Pack](/agent-skills) — it walks your agent through
+  the full setup without copy-pasting prompts.
 </Tip>
 
 Copy any of these prompts into [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/index/codex/), or your preferred AI coding agent to automate MDCMS setup tasks hands-free.
@@ -34,7 +34,7 @@ Set up MDCMS in this project. Follow these steps exactly:
 2. **Start the MDCMS server** (requires Docker):
 
    ```bash
-   git clone git@github.com:Blazity/mdcms.git /tmp/mdcms-server
+   git clone git@github.com:mdcms-ai/mdcms.git /tmp/mdcms-server
    cd /tmp/mdcms-server
    bun install
    docker compose -f docker-compose.dev.yml up -d

--- a/apps/docs/agent-skills.mdx
+++ b/apps/docs/agent-skills.mdx
@@ -10,17 +10,17 @@ If you use Claude Code, Cursor, Gemini CLI, Codex, Copilot, OpenCode, or any of 
 ## Install
 
 ```bash
-# Install all nine skills into the current project
-npx skills add Blazity/mdcms
+# Install all skills into the current project
+npx skills add mdcms-ai/mdcms/skills
 
 # Install globally so every project sees them
-npx skills add Blazity/mdcms -g
+npx skills add mdcms-ai/mdcms/skills -g
 
 # Non-interactive (CI / scripted install)
-npx skills add Blazity/mdcms -y
+npx skills add mdcms-ai/mdcms/skills -y
 ```
 
-Installing the whole pack is recommended — the master skill delegates to the focused skills by slug.
+The install URL ends in `/skills` so skills.sh only sees the public MDCMS pack (internal repo skills are skipped). Installing the whole pack is recommended — the master skill delegates to the focused skills by slug.
 
 See the [skills.sh CLI reference](https://github.com/vercel-labs/skills) for `--copy`, `--skill`, `--agent`, and update/remove commands.
 
@@ -36,13 +36,14 @@ See the [skills.sh CLI reference](https://github.com/vercel-labs/skills) for `--
 | `mdcms-studio-embed`          | Mount `<Studio />` at a catch-all route inside the host app.                                   |
 | `mdcms-sdk-integration`       | Fetch content with `@mdcms/sdk`; drafts vs published; SSR.                                     |
 | `mdcms-mdx-components`        | Register custom MDX components so Studio preview and host SSR match.                           |
-| `mdcms-content-sync-workflow` | Day-to-day `pull`/`push`; key rotation; CI automation.                                         |
+| `mdcms-content-editing`       | Edit, author, translate, and bulk-modify documents. Local vs Studio; validation; new docs.     |
+| `mdcms-content-sync-workflow` | Day-to-day `pull`/`push`/login; key rotation; CI automation.                                   |
 
 ## How to use it
 
 Once installed, start any conversation with your agent with an intent like "set up MDCMS in this project" or "add MDCMS here." The master skill (`mdcms-setup`) activates, detects whether you have a running server, existing content, and a host app, then delegates to each focused skill at the right phase.
 
-The full flow diagram and per-skill details live in the [pack's README on GitHub](https://github.com/Blazity/mdcms/blob/main/skills/README.md).
+The full flow diagram and per-skill details live in the [pack's README on GitHub](https://github.com/mdcms-ai/mdcms/blob/main/skills/README.md).
 
 ## When to use skills vs. copy-paste prompts
 

--- a/apps/docs/development/setup.mdx
+++ b/apps/docs/development/setup.mdx
@@ -62,7 +62,7 @@ Before you begin, install the following tools:
 
 <Steps>
   <Step title="Clone the repository">
-    ```bash git clone git@github.com:Blazity/mdcms.git && cd mdcms ```
+    ```bash git clone git@github.com:mdcms-ai/mdcms.git && cd mdcms ```
   </Step>
   <Step title="Install dependencies">
     ```bash bun install ``` This also sets up the pre-push git hook that runs CI

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -34,7 +34,7 @@
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://github.com/Blazity/mdcms"
+    "href": "https://github.com/mdcms-ai/mdcms"
   },
   "navbar": {
     "links": [
@@ -51,7 +51,7 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/Blazity/mdcms"
+      "github": "https://github.com/mdcms-ai/mdcms"
     }
   },
   "navigation": {
@@ -158,7 +158,7 @@
       "anchors": [
         {
           "anchor": "GitHub",
-          "href": "https://github.com/Blazity/mdcms",
+          "href": "https://github.com/mdcms-ai/mdcms",
           "icon": "github"
         }
       ]

--- a/apps/docs/guide/quickstart.mdx
+++ b/apps/docs/guide/quickstart.mdx
@@ -17,8 +17,8 @@ Get MDCMS running in your own application. This guide assumes you have an MDCMS 
 </Note>
 
 <Tip>
-  **Using an AI coding agent?** `npx skills add Blazity/mdcms` installs the
-  [MDCMS Skills Pack](/agent-skills) so your agent can walk through this
+  **Using an AI coding agent?** `npx skills add mdcms-ai/mdcms/skills` installs
+  the [MDCMS Skills Pack](/agent-skills) so your agent can walk through this
   quickstart for you.
 </Tip>
 

--- a/apps/docs/guide/self-hosting.mdx
+++ b/apps/docs/guide/self-hosting.mdx
@@ -37,7 +37,7 @@ You need **Docker** and **Docker Compose** installed. No other runtime (Bun, Nod
 <Steps>
   <Step title="Get the MDCMS source">
     ```bash
-    git clone https://github.com/Blazity/mdcms.git
+    git clone https://github.com/mdcms-ai/mdcms.git
     cd mdcms
     ```
   </Step>

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,24 +6,26 @@ The pack is designed to be installed into any agent environment supported by [sk
 
 ## Install
 
+The install URL ends in `/skills` so skills.sh only sees the public MDCMS pack — internal repo skills under `.ai/skills/` are not surfaced to consumers.
+
 ```bash
 # Browse available skills
-npx skills add Blazity/mdcms --list
+npx skills add mdcms-ai/mdcms/skills --list
 
-# Install all nine skills into the current project
-npx skills add Blazity/mdcms
+# Install all skills into the current project
+npx skills add mdcms-ai/mdcms/skills
 
 # Target a specific agent (default: prompt for agent)
-npx skills add Blazity/mdcms -a claude-code
+npx skills add mdcms-ai/mdcms/skills -a claude-code
 
 # Install globally (~/.<agent>/skills) so every project sees them
-npx skills add Blazity/mdcms -g
+npx skills add mdcms-ai/mdcms/skills -g
 
 # Non-interactive (CI / scripted install)
-npx skills add Blazity/mdcms -y
+npx skills add mdcms-ai/mdcms/skills -y
 ```
 
-The pack is installed into whichever agent directories the user selects (`~/.claude/skills/`, `~/.cursor/skills/`, etc.). All nine skills work best together because the master skill delegates to each of the focused skills by slug. Installing the whole pack is recommended.
+The pack is installed into whichever agent directories the user selects (`~/.claude/skills/`, `~/.cursor/skills/`, etc.). All skills work best together because the master skill delegates to each of the focused skills by slug. Installing the whole pack is recommended.
 
 See the [skills.sh CLI reference](https://github.com/vercel-labs/skills) for more options (`--copy`, `--skill`, `--agent`, update/remove commands).
 
@@ -39,11 +41,17 @@ See the [skills.sh CLI reference](https://github.com/vercel-labs/skills) for mor
 | [`mdcms-studio-embed`](./mdcms-studio-embed/SKILL.md)                   | Mount `<Studio />` at a catch-all route inside the user's host app.                                           |
 | [`mdcms-sdk-integration`](./mdcms-sdk-integration/SKILL.md)             | Fetch content in the host app via `@mdcms/sdk`; drafts vs published; SSR.                                     |
 | [`mdcms-mdx-components`](./mdcms-mdx-components/SKILL.md)               | Register custom MDX components so Studio preview and host SSR match.                                          |
-| [`mdcms-content-sync-workflow`](./mdcms-content-sync-workflow/SKILL.md) | Day-to-day `pull`/`push`; key rotation; CI automation for publishing.                                         |
+| [`mdcms-content-editing`](./mdcms-content-editing/SKILL.md)             | Edit, author, translate, and bulk-modify documents. Local vs Studio; validation; new docs; renames.           |
+| [`mdcms-content-sync-workflow`](./mdcms-content-sync-workflow/SKILL.md) | Day-to-day `pull`/`push`/login; key rotation; CI automation for publishing.                                   |
 
 ## How the skills flow
 
-The master skill (`mdcms-setup`) walks through these phases and delegates at each branch:
+`mdcms-setup` orchestrates first-time onboarding (the flowchart below). After setup, two skills handle ongoing day-to-day work and trigger directly from common phrasings:
+
+- **`mdcms-content-editing`** — "edit my content", "update a post", "add a page", "translate this", "bulk-edit the tags".
+- **`mdcms-content-sync-workflow`** — "push my changes", "pull from MDCMS", "I'm getting 401", "rotate the API key", "add MDCMS to CI".
+
+### Setup flow
 
 ```mermaid
 flowchart TD

--- a/skills/mdcms-content-editing/SKILL.md
+++ b/skills/mdcms-content-editing/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: mdcms-content-editing
+description: Use when the user wants to edit, author, update, translate, fix, or bulk-modify the actual content stored in MDCMS — phrases like "edit my content", "do something with the content", "update a post", "change the body of X", "add a section to my page", "fix typos in this article", "rename a doc", "translate this page to French", "add a new blog post", "make a new page", "bulk-edit a field across all posts", "find a doc with frontmatter X", or "I want to write a draft". For changes to *documents themselves*. Not for schema (that's `mdcms-schema-refine`), not for sync mechanics or auth (that's `mdcms-content-sync-workflow`), not for components (that's `mdcms-mdx-components`).
+---
+
+# MDCMS Content Editing
+
+Make actual edits to MDCMS-managed Markdown/MDX documents — body, frontmatter, locales, new docs, bulk changes — and get them validated and pushed to the server. Assumes init has run and there's a working `mdcms.config.ts`.
+
+## When to use this skill
+
+Use whenever the change is to _a document_:
+
+- Edit body or frontmatter of an existing post/page.
+- Add a new document of an existing type.
+- Translate an existing document to a new locale.
+- Bulk-rename, bulk-replace, or bulk-tag documents with shell tools.
+- Fix validation errors that surface during `mdcms push`.
+
+Don't use for: adding a new content type or field (use **`mdcms-schema-refine`**), pull/push/CI mechanics or auth errors (use **`mdcms-content-sync-workflow`**), registering MDX components (use **`mdcms-mdx-components`**).
+
+## Prerequisites
+
+- `mdcms.config.ts` exists and the schema is in sync. If unsure, run `npx mdcms status` and resolve any drift first.
+- The user is logged in for the target `(server, project, environment)`. If `mdcms status` reports `401`/unauthorized/"Not logged in", route to **`mdcms-content-sync-workflow`** Step 0 (login preflight) before continuing.
+- Pull a fresh copy before editing: `npx mdcms pull`. This avoids overwriting newer Studio edits.
+
+## Local vs Studio — pick the right surface
+
+Editors and developers can both reach content. Pick based on the change:
+
+| Change                                                       | Best surface           | Why                                                                       |
+| ------------------------------------------------------------ | ---------------------- | ------------------------------------------------------------------------- |
+| Multi-line body edit, new component usage, bulk find/replace | **Local files + push** | Real diff, IDE autocompletion, grep/sed.                                  |
+| Single field tweak, image swap, publish toggle               | **Studio**             | Faster, no `pull`/`push` round-trip, lower error surface.                 |
+| New translation of an existing doc                           | **Local files + push** | Frontmatter consistency across locales is easier to enforce in an editor. |
+| Author wants to author end-to-end (no IDE)                   | **Studio**             | Don't push them through CLI tooling.                                      |
+| Validation errors blocking push                              | **Local files**        | Errors print with file paths the user can jump to.                        |
+
+If both surfaces edit the same doc concurrently, `mdcms pull` flags it as "both modified" and asks for resolution. Don't bypass that — fix it.
+
+## Steps
+
+### 1. Locate the document
+
+Documents live in the directories declared in `mdcms.config.ts` under `defineType(..., { directory })`. Each `.md`/`.mdx` file is one document. To find a specific doc:
+
+```bash
+# By slug or filename
+find content -type f \( -name '*.md' -o -name '*.mdx' \) | grep -i <slug>
+
+# By a frontmatter value
+grep -rl 'title: "Hello"' content/
+
+# By type (directory name)
+ls content/posts
+```
+
+For localized types, files for each locale either share a translation group via frontmatter (e.g. `translationGroupId`) or live in locale subdirectories — check the `locales` config and existing files for the project's convention.
+
+### 2. Edit the document
+
+**Frontmatter** is YAML between `---` delimiters at the top. It must satisfy the type's Zod schema in `mdcms.config.ts`. Common pitfalls:
+
+- Required fields can't be empty strings; use `field: "value"` not `field: ""`.
+- Arrays use YAML list syntax (`tags: [a, b]` or block style with `-`).
+- Date fields written as ISO 8601 strings (e.g. `publishedAt: 2026-04-01T10:00:00Z`).
+- Reference fields (declared via `reference("<type>")`) take a document id, not a file path.
+
+**Body** is everything after the closing `---`. Markdown is parsed normally; `.mdx` files can use registered React components — see **`mdcms-mdx-components`** for the registry contract.
+
+**Adding a new document** — create a new file in the type's directory. Either author the frontmatter by hand (read a sibling for the field shape) or let `mdcms push` walk you through the new-document prompt interactively. Either path requires the frontmatter to validate against the schema.
+
+**Renaming a document** — `git mv` (or `mv`) the file. On `mdcms push`, the CLI detects the move via content hash and updates the server's path mapping rather than treating it as a delete+create.
+
+### 3. Validate before pushing
+
+Catch shape errors locally — they surface with file paths and field names:
+
+```bash
+npx mdcms push --validate --dry-run
+```
+
+`--validate` runs frontmatter against the synced schema. `--dry-run` plans the push without writing anything. If validation fails, fix the listed paths and re-run.
+
+### 4. Push the change
+
+```bash
+npx mdcms push
+```
+
+This uploads changed, new, deleted, and renamed local docs as **draft** updates on the server. Drafts are visible in Studio and to authenticated SDK reads with `draft: true`. They are not visible to public readers until published.
+
+For headless / CI runs, see **`mdcms-content-sync-workflow`** for the full flag surface (`--force`, `--sync-schema`).
+
+### 5. Publish (Studio only)
+
+Publishing moves a draft revision to the published view that unauthenticated readers see. There is currently no `mdcms publish` CLI command — publish from Studio:
+
+1. Open Studio (`<server-url>/admin/studio` or your host app's Studio embed).
+2. Navigate to the document.
+3. Use the **Publish** action.
+
+If many docs need to be published together, do it one by one in Studio, or wait for the upcoming bulk-publish action.
+
+### 6. Verify
+
+```bash
+npx mdcms status
+```
+
+Expected: clean status, no drift. Open the doc in Studio (or hit it via SDK with `draft: true`) and confirm it renders.
+
+## Bulk edits
+
+For find-and-replace across many docs, prefer plain shell tools — they leave a normal git diff:
+
+```bash
+# Replace a string everywhere in content/
+grep -rl 'old-link' content/ | xargs sed -i '' 's/old-link/new-link/g'
+
+# Add a frontmatter field to every post (ad-hoc — review the diff before push)
+# For more complex transforms, write a small script that parses YAML rather than regexing it.
+```
+
+After a bulk edit:
+
+1. `git diff` — sanity-check the change is what you intended.
+2. `npx mdcms push --validate --dry-run` — confirm everything still validates.
+3. `npx mdcms push` — apply.
+
+For programmatic bulk authoring (e.g. an AI agent rewriting 500 posts), the same path works: edit files, validate, push. Don't hit the API directly — `push` keeps the manifest, hashes, and rename detection coherent.
+
+## Translations
+
+For a localized type (`localized: true` in `mdcms.config.ts`):
+
+- A document is a _group_ across locales, identified by a translation-group id stored in frontmatter.
+- Adding a new locale: copy an existing locale's file, change the locale-specific frontmatter (slug, title, body), keep the group id the same.
+- Push as usual — the server links the new locale to the group.
+
+If unsure about the project's locale-file convention (subdirectory vs filename suffix), inspect a doc that already has multiple locales before authoring the new one.
+
+## Common gotchas
+
+- **Schema drift mid-edit** — if `mdcms.config.ts` was changed but not synced, `push --validate` validates against stale rules. Run `mdcms status` to see drift; pass `--sync-schema` to push, or run `mdcms schema sync` first (see **`mdcms-schema-refine`**).
+- **Editing in Studio while a local copy is dirty** — round-trips collide. The fix is to `pull` first, edit, then `push`. If both sides changed, the pull's "both modified" prompt is the resolution moment.
+- **Untracked new files** — `mdcms push` treats files not in the manifest as candidates for new documents. In a TTY it prompts; in CI you need `--force` to upload them. Don't add `--force` blindly — it also confirms deletions.
+- **Frontmatter linter doesn't run from your editor** — some IDEs don't parse the project's Zod schema. Trust `mdcms push --validate` over the IDE's hint.
+- **MDX with raw JSX that isn't registered** — Studio shows it as a raw tag. Either register the component (**`mdcms-mdx-components`**) or convert to plain Markdown.
+- **Deletions** — `rm content/posts/old.md` then `mdcms push` removes the doc on the server. In non-interactive runs, deletion candidates are skipped without `--force`. Use `--dry-run` first.
+
+## Related skills
+
+- **`mdcms-content-sync-workflow`** — owns `pull`/`push`/`status`/login mechanics. Cross-link there for auth errors, CI flag surfaces, and rotating keys.
+- **`mdcms-schema-refine`** — when an edit would require a new field or type, switch to this skill.
+- **`mdcms-mdx-components`** — when an edit would introduce a new component in MDX content.
+- **`mdcms-sdk-integration`** — when changes need to surface in the host app and you're verifying via `cms.get`/`cms.list`.
+
+## Assumptions and limitations
+
+- Assumes the current MDCMS CLI surface: `init`, `login`, `logout`, `pull`, `push`, `schema sync`, `status`. There is no `mdcms create` or `mdcms publish` command — new docs are created by writing files; publishing happens in Studio.
+- Bulk-edit examples target Bash + GNU/BSD `sed`. macOS `sed` requires the `''` after `-i` shown above; Linux drops it.
+- Reference field shape (id vs slug) is determined by the schema's `reference()` declaration. When in doubt, look at a sibling document.
+- Frontmatter is YAML; if the project later moves to TOML or JSON frontmatter, this skill's syntax notes need an update.

--- a/skills/mdcms-content-sync-workflow/SKILL.md
+++ b/skills/mdcms-content-sync-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdcms-content-sync-workflow
-description: Use this skill for day-to-day MDCMS CLI usage — `mdcms pull`, `mdcms push`, `mdcms login`, API key rotation, CI automation for publishing, or when the user asks things like "how do I keep my local markdown in sync with MDCMS", "add MDCMS to CI", "rotate the API key", "what's the draft vs publish flow", or "how do I push changes from a GitHub Action". Not about initial setup — this covers operational usage after init.
+description: Use when the user runs day-to-day MDCMS CLI operations — `mdcms pull`, `mdcms push`, `mdcms status`, `mdcms login`, `mdcms logout` — or asks "how do I keep my local markdown in sync with MDCMS", "how do I push changes", "how do I publish from the CLI", "rotate the API key", "what's the draft vs publish flow", "add MDCMS to CI / GitHub Actions". Also triggers on auth-failure symptoms — "I'm getting 401 / unauthorized / 'not logged in' from the CLI", "MDCMS_API_KEY isn't working", "credentials missing", "mdcms login first". Operational usage after init — not for first-time setup.
 ---
 
 # MDCMS Content Sync Workflow
@@ -16,6 +16,27 @@ Anything operational: syncing content, managing credentials, automating publishi
 - **Drafts** live on the server and in local working copies. Editing locally + `mdcms push` updates the draft on the server. Editing in Studio writes directly to the server draft. Drafts are visible only to authenticated consumers (Studio, preview renders, SDK with `draft: true`).
 - **Publishing** is a separate explicit action (via Studio or the CLI's publish surface when applicable). Published documents are what unauthenticated readers of the host app see.
 - **Manifest** — MDCMS tracks per-`(project, environment)` document state in `.mdcms/manifests/<project>.<environment>.json`. The CLI uses it for hash-based change detection. It's not committed; each developer has their own.
+
+## Step 0 — make sure the user is logged in
+
+**Always preflight authentication before any pull/push/status/publish.** Every authenticated CLI command resolves credentials in this order: `--api-key` flag → `MDCMS_API_KEY` env var → stored credential keyed by `(serverUrl, project, environment)`. The first non-empty wins. If none resolves, the CLI exits with an auth error and the user needs to log in.
+
+Quick check:
+
+```bash
+npx mdcms status
+```
+
+- Exit 0 with a normal status report → credentials are fine, proceed.
+- Exit non-zero with `401`, `unauthorized`, `Not logged in`, `No credential found`, or a prompt for an API key → not logged in for this `(serverUrl, project, environment)` tuple.
+
+If the user is not logged in, route based on context:
+
+- **Interactive dev (a real terminal)** — run `npx mdcms login`. It opens a browser, completes an OAuth-style login, and persists an API key in the OS credential store (keychain / libsecret / credential manager). After login, retry the original command.
+- **Non-interactive (CI, container, no TTY)** — `mdcms login` will fail with no browser. Get an API key from Studio → Settings → API Keys (scope it to the target `(project, environment)`), then export `MDCMS_API_KEY` (and `MDCMS_SERVER_URL` / `MDCMS_PROJECT` / `MDCMS_ENVIRONMENT` if not already set) before running the CLI.
+- **Wrong project/environment selected** — credentials are scoped to a tuple. Logging in for `staging` won't authorize a command targeting `production`. Check `mdcms.config.ts` and the `--project` / `--environment` flags or env vars; log in again with the right tuple if needed.
+
+Don't paper over an auth failure with `--force`, `--yes`, or retry loops. Fix credentials first.
 
 ## Daily loop
 

--- a/skills/mdcms-mdx-components/SKILL.md
+++ b/skills/mdcms-mdx-components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdcms-mdx-components
-description: Use this skill when the user wants to register or author custom MDX components for MDCMS — phrases like "add a Callout component", "register custom MDX components", "my content uses custom React components", "make components available in Studio", or "my MDX renders plain text for <Alert>". Covers the `components` entry in `mdcms.config.ts`, the Studio-side registry, and the host-app MDX runtime that has to render them consistently.
+description: Use when the user wants to register, wire up, or author a React/MDX component for MDCMS — phrases like "add a new component", "register this component with MDCMS", "register a component with the CMS", "add a Callout component", "register custom MDX components", "make my React component available in Studio", "wire a component to MDCMS", "my MDX uses custom components", "my MDX renders plain text for <Alert>", "<Callout> shows as a raw tag in Studio", or "the Studio preview doesn't render my component". Triggers on a generic "add a component" intent inside an MDCMS-aware repo (with `mdcms.config.ts`).
 ---
 
 # MDCMS MDX Components

--- a/skills/mdcms-schema-refine/SKILL.md
+++ b/skills/mdcms-schema-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdcms-schema-refine
-description: Use this skill whenever the user wants to add, edit, extend, or fix MDCMS content types, fields, or references — phrases like "make me a new content type", "add an author type", "add a tags field to posts", "link blog posts to authors", "the inferred schema is wrong", "change the schema", or "author the content model". Covers editing `mdcms.config.ts` with `defineType` + Zod validators, adding `reference()` links, and running `mdcms schema sync` to publish the change.
+description: Use when the user wants to add, edit, extend, or fix MDCMS content types, fields, or references — phrases like "add a new content type", "register a new type with MDCMS", "create a content model", "make me an author type", "add a tags field to posts", "add a new field to my CMS", "link blog posts to authors", "edit mdcms.config.ts", "the inferred schema is wrong", "the schema is missing X", "change the schema", or "author the content model". Triggers on any intent to evolve the content schema, including localizing a type or adding a `reference()` between types.
 ---
 
 # MDCMS Schema Refine
@@ -18,7 +18,7 @@ Not for importing content, embedding Studio, or editing individual documents —
 ## Prerequisites
 
 - A working `mdcms.config.ts` and a reachable MDCMS server (run **`mdcms-brownfield-init`** or **`mdcms-greenfield-init`** first if not).
-- Credential for the target `(server, project, environment)` resolvable by the CLI — already true if init ran on this machine.
+- The user must be logged in for the target `(server, project, environment)`. `mdcms schema sync` writes to the server and fails with `401`/`unauthorized` otherwise. If `mdcms status` prints an auth error, run `mdcms login` (interactive) or set `MDCMS_API_KEY` (non-interactive) before continuing — see **`mdcms-content-sync-workflow`** Step 0 for full guidance.
 - Read the current config before editing so you understand the shape you're changing.
 
 ## Core concepts

--- a/skills/mdcms-self-host-setup/SKILL.md
+++ b/skills/mdcms-self-host-setup/SKILL.md
@@ -23,7 +23,7 @@ The user has decided to run MDCMS themselves (local development, staging, or pro
 ### 1. Clone the MDCMS source
 
 ```bash
-git clone https://github.com/Blazity/mdcms.git
+git clone https://github.com/mdcms-ai/mdcms.git
 cd mdcms
 ```
 

--- a/skills/mdcms-setup/SKILL.md
+++ b/skills/mdcms-setup/SKILL.md
@@ -83,7 +83,9 @@ If their content uses (or will use) custom React components in MDX — callouts,
 
 ### Phase 7 — Day-to-day sync + CI
 
-Close the loop: invoke **`mdcms-content-sync-workflow`** so the user understands daily `mdcms pull` / `mdcms push` usage, API key rotation, and CI automation for publishing.
+Close the loop: invoke **`mdcms-content-sync-workflow`** so the user understands daily `mdcms pull` / `mdcms push` usage, API key rotation, login, and CI automation for publishing. That skill owns the login/credential preflight — if the user later asks "why am I getting a 401?" or "I'm not logged in", route there.
+
+If the user is going to be editing content (not just managing the sync flow), also point them at **`mdcms-content-editing`** for the local-vs-Studio editing loop, frontmatter validation, and bulk edits.
 
 ## State-detection cheatsheet
 
@@ -105,6 +107,14 @@ When you decide to invoke a focused skill, hand off cleanly — don't mix your p
 ## If the user only wants one phase
 
 Short-circuit. If they say "I just want to add Studio to an MDCMS-integrated app", skip the diagnosis and invoke `mdcms-studio-embed` directly. The orchestrator is the default path, not a required gate.
+
+Common short-circuit routes:
+
+- "edit my content" / "update a post" / "change this page" → **`mdcms-content-editing`**.
+- "push my changes" / "sync local to server" / "I'm getting 401" → **`mdcms-content-sync-workflow`**.
+- "add a new content type" / "add a field" / "edit mdcms.config.ts" → **`mdcms-schema-refine`**.
+- "register a component with MDCMS" / "add a new component" → **`mdcms-mdx-components`**.
+- "embed Studio" / "mount Studio at /admin" → **`mdcms-studio-embed`**.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- **Repo rename** — `Blazity/mdcms` → `mdcms-ai/mdcms` across README badges, docs.json, guide pages, agent docs, and the self-host clone URL. `LICENSE` copyright is intentionally left untouched.
- **Skills.sh leak fix** — consumers running the README install command saw 23 skills (9 public mdcms-* + 14 internal superpowers). The leak comes from `.claude/skills` / `.cursor/skills` / `.agents/skills` symlinks at the repo root that resolve into `.ai/skills/`, which skills.sh recurses into. Scoping the install source to `mdcms-ai/mdcms/skills` stops discovery at the public pack — verified via `npx skills add mdcms-ai/mdcms/skills --list` → exactly 9 skills.
- **New `mdcms-content-editing` skill** — covers "edit my content", "update a post", "translate this", "bulk-edit tags", new docs, renames, validation, and the Studio-only publish flow. Fills the gap between `mdcms-content-sync-workflow` (sync mechanics) and `mdcms-schema-refine` (model edits).
- **Stronger triggers** — refreshed `description:` frontmatter on `mdcms-mdx-components`, `mdcms-schema-refine`, and `mdcms-content-sync-workflow` per skill authoring guidance: "Use when…" third-person, triggering conditions only (no workflow summary), with the specific phrasings users were hitting ("add a new component", "register with CMS/MDCMS", "add a new field", "401 / not logged in").
- **Login preflight** — new "Step 0" in `mdcms-content-sync-workflow` with credential resolution order and interactive-vs-CI handoff. Cross-linked from `mdcms-schema-refine` and the new content-editing skill so agents stop papering over auth failures with `--force`.
- **Orchestrator updates** — `mdcms-setup` Phase 7 mentions content-editing; new "Common short-circuit routes" section maps the most common post-setup intents directly to focused skills.

## Test plan

- [ ] `bun run format:check` passes locally (verified).
- [ ] `npx skills add mdcms-ai/mdcms/skills --list` returns exactly 9 mdcms-* skills (verified against the existing branch on `Blazity/mdcms` while staging the change; will re-verify post-merge against `mdcms-ai/mdcms`).
- [ ] Manual smoke: triggers fire on the user-reported phrasings — "add a new component, register it with CMS" → `mdcms-mdx-components`; "edit my content" → `mdcms-content-editing`; "I'm getting 401 from the CLI" → `mdcms-content-sync-workflow`.
- [ ] No `Blazity/mdcms` references remain (`grep -r Blazity` shows only `LICENSE`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content-editing skill guide with workflow instructions for editing and managing documents, including bulk-edit patterns and common pitfalls.
  * Enhanced authentication documentation across skill guides, including credential setup and troubleshooting guidance.
  * Updated repository references and installation commands.

* **Chores**
  * Repository moved to new organizational namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->