### PR TITLE
fix(studio): add "Restore this version" action to version history [CMS-220]

### DIFF
--- a/packages/studio/src/lib/document-route-api.test.ts
+++ b/packages/studio/src/lib/document-route-api.test.ts
@@ -611,6 +611,54 @@ test("restore sends POST /api/v1/content/:documentId/restore with CSRF token", a
   assert.equal(readHeader(restoreCall?.init, "x-mdcms-csrf-token"), "csrf-abc");
 });
 
+test("restoreVersion sends POST /api/v1/content/:documentId/versions/:version/restore", async () => {
+  const { fetcher, calls } = createMockFetcher([
+    sessionResponse("csrf-abc"),
+    new Response(JSON.stringify(validDocumentResponse), { status: 200 }),
+  ]);
+  const api = createNewMethodsApi({ auth: { mode: "cookie" }, fetcher });
+
+  const result = await api.restoreVersion({ documentId: "doc-1", version: 3 });
+
+  assert.equal(result.documentId, "doc-1");
+  const restoreCall = calls[1];
+  assert.ok(
+    String(restoreCall?.input).endsWith(
+      "/api/v1/content/doc-1/versions/3/restore",
+    ),
+  );
+  assert.equal(restoreCall?.init?.method, "POST");
+  assert.equal(readHeader(restoreCall?.init, "x-mdcms-csrf-token"), "csrf-abc");
+  // Default body is empty — server defaults targetStatus to "draft", so the
+  // client deliberately sends no targetStatus when the caller doesn't
+  // override (avoids accidentally re-publishing under content:write).
+  const body = restoreCall?.init?.body;
+  assert.ok(typeof body === "string");
+  assert.deepEqual(JSON.parse(body), {});
+});
+
+test("restoreVersion forwards targetStatus + changeSummary when provided", async () => {
+  const { fetcher, calls } = createMockFetcher([
+    sessionResponse("csrf-abc"),
+    new Response(JSON.stringify(validDocumentResponse), { status: 200 }),
+  ]);
+  const api = createNewMethodsApi({ auth: { mode: "cookie" }, fetcher });
+
+  await api.restoreVersion({
+    documentId: "doc-1",
+    version: 5,
+    targetStatus: "published",
+    changeSummary: "rolled back the broken FeatureGrid copy",
+  });
+
+  const body = calls[1]?.init?.body;
+  assert.ok(typeof body === "string");
+  assert.deepEqual(JSON.parse(body), {
+    targetStatus: "published",
+    changeSummary: "rolled back the broken FeatureGrid copy",
+  });
+});
+
 test("version detail helper validates required fields and rejects malformed payloads", async () => {
   const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
     [];

--- a/packages/studio/src/lib/document-route-api.ts
+++ b/packages/studio/src/lib/document-route-api.ts
@@ -61,6 +61,18 @@ export type StudioDocumentRouteVersionDetailInput =
     resolve?: string | string[];
   };
 
+export type StudioDocumentRouteRestoreVersionInput =
+  StudioDocumentRouteMutationInput & {
+    version: number;
+    // The server defaults this to "draft" (see parseRestoreTargetStatus in
+    // apps/server/src/lib/content-api/parsing.ts), which is the conservative
+    // choice — restoring a published version straight to a new published
+    // version requires `content:publish` rather than `content:write`.
+    targetStatus?: "draft" | "published";
+    changeSummary?: string;
+    actorId?: string;
+  };
+
 export type StudioDocumentRouteCreateInput = {
   type: string;
   path: string;
@@ -133,6 +145,9 @@ export type StudioDocumentRouteApi = {
   ) => Promise<ContentDocumentResponse>;
   restore: (
     input: StudioDocumentRouteRestoreInput,
+  ) => Promise<ContentDocumentResponse>;
+  restoreVersion: (
+    input: StudioDocumentRouteRestoreVersionInput,
   ) => Promise<ContentDocumentResponse>;
   listVariants: (input: {
     documentId: string;
@@ -944,6 +959,31 @@ export function createStudioDocumentRouteApi(
         "POST /api/v1/content/:documentId/restore",
         payload,
         "Failed to restore document.",
+      );
+    },
+    async restoreVersion(input) {
+      const payload = await requestContentMutation(config, options, {
+        method: "POST",
+        path: `/api/v1/content/${encodeURIComponent(
+          input.documentId,
+        )}/versions/${encodeURIComponent(String(input.version))}/restore`,
+        locale: input.locale,
+        signal: input.signal,
+        payload: {
+          ...(input.targetStatus !== undefined
+            ? { targetStatus: input.targetStatus }
+            : {}),
+          ...(input.changeSummary !== undefined
+            ? { changeSummary: input.changeSummary }
+            : {}),
+          ...(input.actorId !== undefined ? { actorId: input.actorId } : {}),
+        },
+      });
+
+      return toContentDocumentResponse(
+        "POST /api/v1/content/:documentId/versions/:version/restore",
+        payload,
+        "Failed to restore document version.",
       );
     },
     async listVariants(input) {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -3743,8 +3743,7 @@ export default function ContentDocumentPage({
       const versionHistoryRefresh =
         await loadContentDocumentVersionHistoryState({
           api,
-          documentId: currentState.documentId,
-          locale: currentState.document.locale,
+          state: currentState,
         });
 
       const afterRestore = stateRef.current;

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -170,6 +170,13 @@ export type ContentDocumentPageReadyState = {
   publishChangeSummary: string;
   publishState: "idle" | "publishing";
   publishError?: string;
+  // While a "Restore this version" action is in flight against the
+  // POST /api/v1/content/:documentId/versions/:version/restore endpoint,
+  // surface the in-flight state so the banner can disable the button and
+  // show a spinner. The error is surfaced inline above the editor on
+  // failure (mirrors the publishError convention).
+  restoreVersionState: "idle" | "restoring";
+  restoreVersionError?: string;
   versionHistory: ContentDocumentVersionHistoryState;
   selectedComparison: ContentDocumentVersionComparison;
   versionDiff: ContentDocumentVersionDiffState;
@@ -266,6 +273,7 @@ type ContentDocumentPageViewProps = {
   editorRef?: React.Ref<TipTapEditorHandle>;
   onViewVersion?: (version: number) => void;
   onBackToDraft?: () => void;
+  onRestoreVersion?: (version: number) => void;
   onLocaleSwitch?: (locale: string) => void;
   onCreateVariant?: (prefill: boolean) => void;
   onCancelVariantCreation?: () => void;
@@ -807,6 +815,7 @@ function createReadyState(input: {
     publishDialogOpen: false,
     publishChangeSummary: "",
     publishState: "idle",
+    restoreVersionState: "idle",
     versionHistory: {
       status: "idle",
       versions: [],
@@ -2530,6 +2539,7 @@ export function ContentDocumentPageView({
   editorRef,
   onViewVersion,
   onBackToDraft,
+  onRestoreVersion,
   onLocaleSwitch,
   onCreateVariant,
   onCancelVariantCreation,
@@ -2760,27 +2770,76 @@ export function ContentDocumentPageView({
                   ) : null}
 
                   {state.viewingVersion ? (
-                    <div className="mb-3 flex items-center justify-between rounded-md border border-primary/30 bg-primary/5 px-4 py-2.5">
+                    <div
+                      data-mdcms-viewing-version={state.viewingVersion.version}
+                      className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-primary/30 bg-primary/5 px-4 py-2.5"
+                    >
                       <p className="text-sm font-medium">
                         Viewing version {state.viewingVersion.version}
                         {state.viewingVersion.status === "loading"
                           ? " — Loading..."
                           : null}
+                        {state.restoreVersionState === "restoring"
+                          ? " — Restoring..."
+                          : null}
                       </p>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-xs"
-                        onClick={() => onBackToDraft?.()}
-                      >
-                        View latest
-                      </Button>
+                      <div className="flex items-center gap-1">
+                        {/* "Restore this version" copies the viewed version's
+                            body + frontmatter back into the document as a
+                            new draft. The edit isn't published until the
+                            user clicks Publish, mirroring the standard
+                            edit-then-publish flow and keeping the
+                            content:write scope sufficient (publish requires
+                            content:publish, which not every editor has). */}
+                        {state.canWrite ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs"
+                            disabled={
+                              state.viewingVersion.status !== "ready" ||
+                              state.restoreVersionState === "restoring"
+                            }
+                            data-mdcms-restore-version={
+                              state.viewingVersion.version
+                            }
+                            onClick={() => {
+                              const v = state.viewingVersion?.version;
+                              if (typeof v === "number") {
+                                onRestoreVersion?.(v);
+                              }
+                            }}
+                          >
+                            {state.restoreVersionState === "restoring"
+                              ? "Restoring..."
+                              : "Restore this version"}
+                          </Button>
+                        ) : null}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs"
+                          disabled={state.restoreVersionState === "restoring"}
+                          onClick={() => onBackToDraft?.()}
+                        >
+                          View latest
+                        </Button>
+                      </div>
                     </div>
                   ) : null}
 
                   {state.viewingVersion?.status === "error" ? (
                     <div className="mb-3 rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
                       {state.viewingVersion.error}
+                    </div>
+                  ) : null}
+
+                  {state.restoreVersionError ? (
+                    <div
+                      data-mdcms-document-restore-version-state="error"
+                      className="mb-3 rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+                    >
+                      {state.restoreVersionError}
                     </div>
                   ) : null}
 
@@ -3631,6 +3690,116 @@ export default function ContentDocumentPage({
     );
   });
 
+  // Restores a historical published version as the current draft. The
+  // server endpoint defaults `targetStatus` to "draft", so the restored
+  // body lands in the draft slot and the user can review + republish via
+  // the normal flow. We exit version-viewing mode on success so the
+  // editor reflects the restored draft, mark the draft as freshly saved
+  // (the server already persisted the new draft revision), and refresh
+  // version history so the new draftRevision shows.
+  const restoreDocumentVersion = useEffectEvent(async (version: number) => {
+    const currentState = stateRef.current;
+    const requestContext = activeContext;
+    const requestRoute = route;
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
+
+    if (
+      !api ||
+      !requestRoute ||
+      currentState.status !== "ready" ||
+      !currentState.canWrite ||
+      currentState.restoreVersionState === "restoring"
+    ) {
+      return;
+    }
+
+    const requestToken = createContentDocumentRouteRequestToken({
+      documentId: currentState.documentId,
+      route: requestRoute,
+    });
+
+    setState((current) =>
+      current.status === "ready"
+        ? {
+            ...current,
+            restoreVersionState: "restoring",
+            restoreVersionError: undefined,
+          }
+        : current,
+    );
+
+    try {
+      const restored = await api.restoreVersion({
+        documentId: currentState.documentId,
+        locale: currentState.document.locale,
+        version,
+      });
+
+      const restoredBody = restored.body ?? "";
+      const restoredFrontmatter = cloneFrontmatter(restored.frontmatter);
+      const versionHistoryRefresh =
+        await loadContentDocumentVersionHistoryState({
+          api,
+          documentId: currentState.documentId,
+          locale: currentState.document.locale,
+        });
+
+      const afterRestore = stateRef.current;
+      if (
+        afterRestore.status !== "ready" ||
+        !matchesContentDocumentRouteRequestToken(requestToken, afterRestore)
+      ) {
+        return;
+      }
+
+      editorRef.current?.setContent(restoredBody);
+
+      setState((current) =>
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current)
+          ? {
+              ...current,
+              document: {
+                ...current.document,
+                ...restored,
+                body: restoredBody,
+                frontmatter: restoredFrontmatter,
+              },
+              draftBody: restoredBody,
+              draftFrontmatter: restoredFrontmatter,
+              saveState: "saved",
+              mutationError: undefined,
+              fieldErrors: undefined,
+              saveRequestBody: undefined,
+              saveRequestFrontmatter: undefined,
+              viewingVersion: undefined,
+              restoreVersionState: "idle",
+              restoreVersionError: undefined,
+              versionHistory: versionHistoryRefresh.versionHistory,
+            }
+          : current,
+      );
+    } catch (error) {
+      const message = toRouteErrorMessage(
+        error,
+        "Failed to restore document version.",
+      );
+      setState((current) =>
+        current.status === "ready" &&
+        matchesContentDocumentRouteRequestToken(requestToken, current)
+          ? {
+              ...current,
+              restoreVersionState: "idle",
+              restoreVersionError: message,
+            }
+          : current,
+      );
+    }
+  });
+
   useEffect(() => {
     void loadDocument();
   }, [activeContext, documentId, route, typeId, typeLabel]);
@@ -3821,6 +3990,9 @@ export default function ContentDocumentPage({
         void handleViewVersion(version);
       }}
       onBackToDraft={handleBackToDraft}
+      onRestoreVersion={(version) => {
+        void restoreDocumentVersion(version);
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes [CMS-220](https://blazity.atlassian.net/browse/CMS-220). The Studio version-history sidebar let users browse old published versions in a read-only "Viewing version N" banner, but the only available action was "View latest" — there was no way to restore a historical version back into the editor without copy/pasting the body manually (which silently dropped frontmatter fields not in the schema).

Server-side, `POST /api/v1/content/:documentId/versions/:version/restore` was already implemented and tested. The client just hadn't been wired up.

## Changes

- **API client** (`document-route-api.ts`): added `StudioDocumentRouteApi.restoreVersion`. Optional `targetStatus`/`changeSummary`/`actorId` passthrough. Default targetStatus is "draft" (server default), so editors with `content:write` but not `content:publish` can still roll back — publishing the restored content uses the existing publish flow and its own scope check.
- **State** (`content-document-page.tsx`): added `restoreVersionState` ("idle" | "restoring") and `restoreVersionError` to `ContentDocumentPageReadyState`.
- **UI**: "Restore this version" button in the version-viewing banner, alongside "View latest". Visible only when `state.canWrite`. Disabled while version is still loading or while a restore is in flight; label switches to "Restoring..." during the request. Inline error surfaces on failure, keeping the editor in viewing mode so the user can retry.
- **Handler** (`restoreDocumentVersion`): mirrors `publishDocument`. Marks in-flight → calls `api.restoreVersion` → loads restored body/frontmatter into the editor → exits viewing mode → refreshes version history → resets save state. On failure: surface error and stay in viewing mode.
- **Tests**: two new API-client tests cover the default empty-body case (server defaults targetStatus to "draft") and explicit forwarding of `targetStatus` + `changeSummary`.

## Test plan

- [x] `bun test --cwd packages/studio ./src` — 522/523 pass (the 1 unrelated pre-existing failure is an untracked-only Button scratch test, not in this change).
- [x] `bun x tsc --noEmit` clean.
- [x] Prettier check clean.
- [ ] **Manual verification**: open a document with multiple published versions in `/admin`. Click an older version in the sidebar — banner shows "Viewing version N" with both "Restore this version" and "View latest" buttons. Click Restore — banner exits viewing mode, editor shows the restored body as a fresh draft, version history refreshes. Click Publish — restored version becomes the new published version.
- [ ] **Read-only check**: open the same document with a `content:read`-only API key — the Restore button is not rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document version restore functionality allowing users to restore a document to a previous version.
  * Includes visual feedback ("Restoring…") during the restoration process and error messages if restoration fails.
  * Feature is available to users with write permissions when viewing a stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->