### PR TITLE
feat(environments): clone & promote workflows end-to-end [CMS-153]

### DIFF
--- a/.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md
+++ b/.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md
@@ -1,0 +1,163 @@
+# CMS-153 Clone & Promote End-to-End — Implementation Plan
+
+Branch: `feat/cms-153-clone-promote-end-to-end`
+Tickets in scope: CMS-94, CMS-95, CMS-96, CMS-97, CMS-98 (Epic CMS-153).
+
+## Spec delta
+
+Owning spec is `docs/specs/SPEC-009-i18n-and-environments.md`. The clone and promote contracts, atomic-remap rule, default values (`includeDrafts=true`), reduced MVP payload (no media), and endpoint table (auth mode, scope, errors) are already specified there. **No spec delta required.** Implementation follows the spec verbatim.
+
+## Affected files (new + modified)
+
+- `apps/server/src/lib/environments-api.ts` — extend `EnvironmentStore` with `clone` and `promote`, mount `POST /:id/clone` + `POST /:targetId/promote`.
+- `apps/server/src/lib/environments-clone-promote.ts` (new) — clone and promote orchestration; uses the remap helper.
+- `apps/server/src/lib/environments-reference-remap.ts` (new) — atomic reference remap walker (CMS-96).
+- `apps/server/src/lib/environments-api.test.ts` — extend with clone/promote routes + scope/CSRF coverage.
+- `apps/server/src/lib/environments-clone-promote.integration.test.ts` (new) — full DB integration matrix for CMS-97.
+- `apps/server/src/lib/runtime-with-modules.ts` — wire `authorizeWriteScope` + scope gates for the new routes.
+- `packages/shared/src/lib/contracts/environments.ts` — request/response types + Zod schemas for clone/promote.
+- `packages/studio/src/lib/environment-api.ts` — client methods `clone` and `promote`.
+- `packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx` — "Clone" action per env card with payload-options dialog.
+- `packages/studio/src/lib/runtime-ui/app/admin/promote-page.tsx` (new) — per-document promote workflow.
+- `packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx` and `promote-page.test.tsx` — view tests.
+
+## Architecture
+
+### Single shared transaction for both flows
+
+Both clone and promote run inside a single `db.transaction` so any reference-remap failure rolls the whole operation back. Drizzle transactions throwing aborts and propagates the error.
+
+### Reference remap module (`environments-reference-remap.ts`)
+
+Pure function, no I/O of its own — receives:
+- `frontmatter: Record<string, unknown>`
+- `schema: SchemaRegistryTypeSnapshot`
+- `referenceLookup: (sourceDocumentId) => { translationGroupId, locale } | undefined`
+- `targetDocumentResolver: (translationGroupId, locale) => targetDocumentId | undefined`
+
+Walks fields the same way `content-api/reference-validation.ts` does (objects + arrays + nested), and for every `field.reference` value:
+1. Look up source by `documentId` to get `(translationGroupId, locale)`.
+2. Resolve the target by `(translationGroupId, locale)`.
+3. If missing, throw `RuntimeError { code: "REFERENCE_REMAP_FAILED", statusCode: 409 }` with details `{ sourceDocumentId, fieldPath, targetType, translationGroupId, locale }`.
+4. Otherwise, replace the value (deep-cloning along the way).
+
+Returns the rewritten `frontmatter`. The same module is used by clone (when copying head + latest published) and promote (when overwriting target draft + auto-publishing).
+
+### Clone (CMS-94)
+
+`POST /api/v1/environments/:id/clone` — `:id` is the **target** environment id (already created via `POST /environments`).
+
+Steps inside one transaction:
+1. Resolve `(project, sourceEnvId, targetEnvId)`. Validate target ≠ source, both belong to routed project.
+2. Load all non-deleted source documents (filter by `includeDrafts === false ⇒ skip rows where publishedVersion is null`).
+3. Pre-compute target documentIds (`new uuid()` per source) keyed by `(translationGroupId, locale)`.
+4. Build the source-doc lookup `documentId ⇒ (translationGroupId, locale)` over all source docs.
+5. For every source document:
+   - Remap frontmatter via the helper using the target id map.
+   - Insert the new `documents` row with the new `documentId`, preserved `translationGroupId`, target env. `path` is preserved (spec says `preservePaths` is in the payload — we already preserve paths, so the flag controls whether *path conflicts* against the target env are tolerated; for MVP we treat target env as initially empty, so `preservePaths` is informational and surfaced in details).
+   - If a `publishedVersion` exists on the source, also insert a `document_versions` row at version 1 in the target with the remapped frontmatter, then update the inserted target row's `publishedVersion = 1` and `hasUnpublishedChanges = false`.
+6. `include.settings: true` — copy the latest `schema_syncs` row + `schema_registry_entries` for the source env to the target env (best-effort; if no source sync, no-op). This lets the target environment be queryable immediately.
+7. Return `{ data: { targetEnvironmentId, documentsCloned } }`.
+
+Notes:
+- `include.content: false` ⇒ skip step 5 entirely.
+- Media is explicitly deferred (spec rule). The clone request schema rejects `include.media` to make the deferral observable.
+- Target env can be non-empty: in that case the unique constraint `(projectId, environmentId, translationGroupId, locale)` and `(projectId, environmentId, locale, path)` will refuse the insert, surfaced as `CONFLICT` (target environment already populated). Matches "clone creates a new environment with copies", spec implication.
+
+### Promote (CMS-95)
+
+`POST /api/v1/environments/:targetId/promote` — `:targetId` is the target env id.
+
+Steps inside one transaction:
+1. Resolve `(project, sourceEnvId, targetEnvId)`. Validate target ≠ source, both belong to routed project.
+2. Load each source document by `documentIds`. Reject if any id is unknown or in another env (`NOT_FOUND`).
+3. If `includeUnpublished !== true`, filter to docs with `publishedVersion !== null`. (Other docs are skipped silently in dry-run output, surfaced as `skipped: "unpublished"`.)
+4. Build source lookup over **all** documents that could be referenced by the promoted set. We resolve dependencies lazily — the remap helper requests `(translationGroupId, locale)` per documentId, served from a memoized SQL query. Forward references to documents *not* in the promoted set still need a target match (matched by `translationGroupId + locale` in the target env). The helper fails atomically if a target match is missing.
+5. For each promoted document, find target by `(translationGroupId, locale)`:
+   - **Match found:** overwrite `body`, `frontmatter (post-remap)`, `path`, `contentFormat`. `draftRevision := draftRevision + 1`. Then auto-publish: insert `document_versions` row at next version, set `publishedVersion = nextVersion`, `hasUnpublishedChanges = false`.
+   - **No match:** insert new `documents` row (new `documentId`, preserved `translationGroupId`, target env). Then auto-publish version 1, same as above.
+6. If `dryRun === true`, run all of the above except the actual writes — produce `DocumentPromotionResult[]` describing planned actions. We achieve this by performing the writes inside the transaction and then `throw`ing a sentinel (`DryRunRollbackSentinel`) at the end so Drizzle aborts and we still return the planned diff cleanly. (Alternative: collect plans via pure compute first; we do that to avoid spurious version increments. Final design: pure compute path that does the resolution and remap but doesn't issue writes — same code path, conditional `tx.execute` calls.)
+7. Return `{ data: { promoted: DocumentPromotionResult[] } }`.
+
+`DocumentPromotionResult` fields (per spec table requires it; design here):
+```ts
+type DocumentPromotionResult = {
+  sourceDocumentId: string;
+  targetDocumentId: string | null;
+  status: "overwrote" | "created" | "skipped_unpublished";
+  path: string;
+  locale: string;
+  type: string;
+  publishedVersion: number | null;
+  remappedReferences: number;
+};
+```
+
+### Atomic remap (CMS-96)
+
+Concentrates in `environments-reference-remap.ts`. Atomicity is the natural consequence of the surrounding `db.transaction` — the helper throws `REFERENCE_REMAP_FAILED`, the route handler lets it bubble, the transaction rolls back. No partial inserts can survive.
+
+Test plan covers:
+- Frontmatter top-level reference, nested object reference, array-of-references.
+- Cross-locale promote where source `(grp=g, en)` references `(grp=h, fr)` and target lacks `(h, fr)` ⇒ atomic abort, no rows written.
+- Reference to a doc that *will be* created in the same operation (forward/back ref within a clone) ⇒ resolved from the pre-computed `targetDocumentIdByGroupLocale` map.
+
+### Auth and routing
+
+- Both endpoints use `authService.authorizeRequest(request, { requiredScope, project, environment })` — same pattern as content-api.
+- Scopes already exist in `auth.ts`: `environments:clone`, `environments:promote`.
+- `pickProject(request)` enforces `MISSING_TARGET_ROUTING (400)`.
+- CSRF required on both write endpoints (matches existing `POST /environments`).
+
+### Studio UI (CMS-98)
+
+- **Environments page** gains a "Clone..." action on each env's dropdown menu (admin-only, role-gated by existing `useStudioCapabilities` hook). Opens a dialog with:
+  - Read-only "Cloning into: `<env name>`".
+  - "Source environment" select (excludes self).
+  - Toggles: Include content (default on), Include settings (default off), Include drafts (default on), Preserve paths (default on).
+  - "Clone" button → call `clone()` API → on `REFERENCE_REMAP_FAILED`, render the error inline with the offending field path; on success, close + toast + refresh.
+- **Promote workflow** is a new page reachable from the content list (`/admin/promote`):
+  - Source env picker, Target env picker.
+  - Multi-select content list scoped to source.
+  - Toggles: include unpublished.
+  - Stage 1: "Preview" runs `dryRun:true`, lists impacted target docs (overwrite vs create), with explicit "no merge — target content is replaced" copy.
+  - Stage 2: Confirmation dialog showing exact target documents that will be overwritten before execution.
+  - Stage 3: Real run; remap failures surfaced as actionable errors (which field on which document failed).
+- All states have role gating; non-admins get the "forbidden" view we already render.
+
+### Studio review app
+
+`apps/studio-review/` is **not** a tracked source directory in this repo — only `.next` and `.generated` build outputs sit on disk and they are gitignored (`git ls-tree origin/main apps/studio-review` returns empty). AGENTS.md mentions it for contract syncing but there's nothing to update in this PR. We'll note this in the PR description.
+
+## Test matrix (CMS-97)
+
+Integration tests (real Postgres) cover:
+1. Clone with content only — counts equal source non-deleted docs; new documentIds; preserved translation_group_id; target env queryable.
+2. Clone with `includeDrafts:false` — only documents with `publishedVersion` are cloned, with their published version row at v1 in target.
+3. Clone with `include.settings:true` — schema sync + registry copied to target.
+4. Clone fails atomically when a frontmatter reference points to a doc whose `(translationGroupId, locale)` has no counterpart in the (post-clone) target — no rows written.
+5. Promote, target match by `(translationGroupId, locale)` — overwrites + publishes; new `document_versions` row appended.
+6. Promote, no target match — creates + publishes.
+7. Promote with `dryRun:true` — returns plan, zero side effects (verify counts unchanged).
+8. Promote `includeUnpublished:false` — unpublished sources are skipped with `status:"skipped_unpublished"`.
+9. Promote atomic abort on a single missing reference — no rows changed in target.
+10. Locale matrix — localized type pair (en/fr) clones + promotes correctly; non-localized (`__mdcms_default__`) cloned + promoted correctly; no cross-locale leakage.
+11. Project boundary — clone source and target must belong to the routed project; cross-project source rejected with `NOT_FOUND`.
+12. Auth/scope — clone without `environments:clone` scope → `FORBIDDEN`; promote without `environments:promote` → `FORBIDDEN`.
+13. CSRF — missing CSRF token rejected on both routes.
+
+## Out of scope
+
+- Media inclusion (explicitly deferred by spec).
+- Conflict resolution / merge for promote (spec is "no merge").
+- Changelog summarization for auto-publish (we set `changeSummary: null`).
+- Preview-app fixture sync (no source under `apps/studio-review`).
+
+## Validation
+
+Run before PR:
+- `bun run format:check`
+- `bun run check`
+- `bun test --cwd apps/server` (skips DB-bound tests when no Postgres)
+- `bun test --cwd packages/studio`
+- If Docker running: `bun run integration` (full matrix)

--- a/.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md
+++ b/.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md
@@ -14,7 +14,7 @@ Owning spec is `docs/specs/SPEC-009-i18n-and-environments.md`. The clone and pro
 - `apps/server/src/lib/environments-reference-remap.ts` (new) — atomic reference remap walker (CMS-96).
 - `apps/server/src/lib/environments-api.test.ts` — extend with clone/promote routes + scope/CSRF coverage.
 - `apps/server/src/lib/environments-clone-promote.integration.test.ts` (new) — full DB integration matrix for CMS-97.
-- `apps/server/src/lib/runtime-with-modules.ts` — wire `authorizeWriteScope` + scope gates for the new routes.
+- `apps/server/src/lib/runtime-with-modules.ts` — wire `authorizeScoped` (the route option name) so the new routes go through `authService.authorizeRequest({ requiredScope, project, environment })`.
 - `packages/shared/src/lib/contracts/environments.ts` — request/response types + Zod schemas for clone/promote.
 - `packages/studio/src/lib/environment-api.ts` — client methods `clone` and `promote`.
 - `packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx` — "Clone" action per env card with payload-options dialog.

--- a/apps/server/src/lib/environments-api.route.test.ts
+++ b/apps/server/src/lib/environments-api.route.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import { test } from "bun:test";
 
 import { createServerRequestHandler } from "./server.js";
-import { mountEnvironmentApiRoutes } from "./environments-api.js";
+import {
+  mountEnvironmentApiRoutes,
+  type EnvironmentStore,
+  type MountEnvironmentApiRoutesOptions,
+} from "./environments-api.js";
 
 const baseEnv = {
   NODE_ENV: "test",
@@ -11,6 +15,37 @@ const baseEnv = {
   PORT: "4000",
   SERVICE_NAME: "mdcms-server",
 } as NodeJS.ProcessEnv;
+
+function createStubStore(
+  overrides: Partial<EnvironmentStore> = {},
+): EnvironmentStore {
+  const fail = (label: string) => async (): Promise<never> => {
+    throw new Error(`stub ${label} not configured for this test`);
+  };
+  return {
+    list: overrides.list ?? (fail("list") as EnvironmentStore["list"]),
+    create: overrides.create ?? (fail("create") as EnvironmentStore["create"]),
+    delete: overrides.delete ?? (fail("delete") as EnvironmentStore["delete"]),
+    clone: overrides.clone ?? (fail("clone") as EnvironmentStore["clone"]),
+    promote:
+      overrides.promote ?? (fail("promote") as EnvironmentStore["promote"]),
+  };
+}
+
+function createTestRoutes(options: Partial<MountEnvironmentApiRoutesOptions>) {
+  return createServerRequestHandler({
+    env: baseEnv,
+    configureApp: (app) => {
+      mountEnvironmentApiRoutes(app, {
+        store: options.store ?? createStubStore(),
+        authorizeSession: options.authorizeSession ?? (async () => undefined),
+        authorizeAdmin: options.authorizeAdmin ?? (async () => undefined),
+        authorizeScoped: options.authorizeScoped ?? (async () => undefined),
+        requireCsrf: options.requireCsrf ?? (async () => undefined),
+      });
+    },
+  });
+}
 
 test("environment routes list project-scoped environments for admin sessions", async () => {
   const handler = createServerRequestHandler({
@@ -44,9 +79,16 @@ test("environment routes list project-scoped environments for admin sessions", a
           async delete() {
             throw new Error("not used");
           },
+          async clone() {
+            throw new Error("not used");
+          },
+          async promote() {
+            throw new Error("not used");
+          },
         },
         authorizeSession: async () => undefined,
         authorizeAdmin: async () => undefined,
+        authorizeScoped: async () => undefined,
         requireCsrf: async () => undefined,
       });
     },
@@ -88,6 +130,12 @@ test("environment routes reject create requests without admin privileges", async
           async delete() {
             throw new Error("not used");
           },
+          async clone() {
+            throw new Error("not used");
+          },
+          async promote() {
+            throw new Error("not used");
+          },
         },
         authorizeSession: async () => undefined,
         authorizeAdmin: async () => {
@@ -97,6 +145,7 @@ test("environment routes reject create requests without admin privileges", async
             message: "Admin privileges are required to manage environments.",
           });
         },
+        authorizeScoped: async () => undefined,
         requireCsrf: async () => undefined,
       });
     },
@@ -118,4 +167,160 @@ test("environment routes reject create requests without admin privileges", async
 
   assert.equal(response.status, 403);
   assert.equal(body.code, "FORBIDDEN");
+});
+
+test("clone route validates payload and rejects unknown include keys", async () => {
+  let cloneCalls = 0;
+  const handler = createTestRoutes({
+    store: createStubStore({
+      async clone() {
+        cloneCalls += 1;
+        return { targetEnvironmentId: "target", documentsCloned: 0 };
+      },
+    }),
+  });
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/environments/target-id/clone?project=marketing-site",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+          include: { content: true, settings: false, media: true },
+        }),
+      },
+    ),
+  );
+  const body = (await response.json()) as { code: string };
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "INVALID_INPUT");
+  assert.equal(cloneCalls, 0);
+});
+
+test("clone route requires environments:clone scope", async () => {
+  let scopedAttempts: string[] = [];
+  const handler = createTestRoutes({
+    store: createStubStore({
+      async clone() {
+        return { targetEnvironmentId: "target", documentsCloned: 0 };
+      },
+    }),
+    authorizeScoped: async (_request, scope) => {
+      scopedAttempts.push(scope);
+      throw Object.assign(new Error("forbidden"), {
+        code: "FORBIDDEN",
+        statusCode: 403,
+        message: `Missing scope ${scope}`,
+      });
+    },
+  });
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/environments/target-id/clone?project=marketing-site",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+        }),
+      },
+    ),
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(scopedAttempts, ["environments:clone"]);
+});
+
+test("promote route requires environments:promote scope and CSRF", async () => {
+  let scopedAttempts: string[] = [];
+  let csrfCalls = 0;
+  const handler = createTestRoutes({
+    store: createStubStore({
+      async promote() {
+        return { promoted: [] };
+      },
+    }),
+    authorizeScoped: async (_request, scope) => {
+      scopedAttempts.push(scope);
+    },
+    requireCsrf: async () => {
+      csrfCalls += 1;
+    },
+  });
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/environments/target-id/promote?project=marketing-site",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+          documentIds: ["1f3b6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a"],
+        }),
+      },
+    ),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(scopedAttempts, ["environments:promote"]);
+  assert.equal(csrfCalls, 1);
+});
+
+test("promote route requires non-empty documentIds", async () => {
+  const handler = createTestRoutes({
+    store: createStubStore({
+      async promote() {
+        return { promoted: [] };
+      },
+    }),
+  });
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/environments/target-id/promote?project=marketing-site",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+          documentIds: [],
+        }),
+      },
+    ),
+  );
+  const body = (await response.json()) as {
+    code: string;
+    details?: Record<string, unknown>;
+  };
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "INVALID_INPUT");
+});
+
+test("clone and promote routes require target routing project", async () => {
+  const handler = createTestRoutes({
+    store: createStubStore(),
+  });
+
+  for (const path of [
+    "/api/v1/environments/target-id/clone",
+    "/api/v1/environments/target-id/promote",
+  ]) {
+    const response = await handler(
+      new Request(`http://localhost${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+          documentIds: ["1f3b6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a"],
+        }),
+      }),
+    );
+    const body = (await response.json()) as { code: string };
+    assert.equal(response.status, 400, `${path} should require routing`);
+    assert.equal(body.code, "MISSING_TARGET_ROUTING");
+  }
 });

--- a/apps/server/src/lib/environments-api.ts
+++ b/apps/server/src/lib/environments-api.ts
@@ -1,9 +1,15 @@
 import {
   RuntimeError,
+  assertEnvironmentCloneInput,
   assertEnvironmentCreateInput,
+  assertEnvironmentPromoteInput,
+  type EnvironmentCloneInput,
+  type EnvironmentCloneResult,
   type EnvironmentCreateInput,
   type EnvironmentDefinitionsMeta,
   type EnvironmentListResponse,
+  type EnvironmentPromoteInput,
+  type EnvironmentPromoteResult,
   type EnvironmentSummary,
   resolveRequestTargetRouting,
 } from "@mdcms/shared";
@@ -18,6 +24,10 @@ import {
   schemaRegistryEntries,
   schemaSyncs,
 } from "./db/schema.js";
+import {
+  cloneEnvironment as cloneEnvironmentImpl,
+  promoteDocuments as promoteDocumentsImpl,
+} from "./environments-clone-promote.js";
 import {
   loadProjectEnvironmentTopologySnapshot,
   type PersistedEnvironmentDefinition,
@@ -50,6 +60,16 @@ export type EnvironmentStore = {
     project: string,
     environmentId: string,
   ) => Promise<{ deleted: true; id: string }>;
+  clone: (
+    project: string,
+    targetEnvironmentId: string,
+    input: EnvironmentCloneInput,
+  ) => Promise<EnvironmentCloneResult>;
+  promote: (
+    project: string,
+    targetEnvironmentId: string,
+    input: EnvironmentPromoteInput,
+  ) => Promise<EnvironmentPromoteResult>;
 };
 
 export type EnvironmentAdminAuthorizer = (
@@ -64,10 +84,21 @@ export type EnvironmentSessionAuthorizer = (
   request: Request,
 ) => Promise<StudioSession | void>;
 
+// Clone and promote use `session_or_api_key` auth (SPEC-009 §Environment
+// Management Endpoints) and require a specific operation scope. The runtime
+// wires this to `authService.authorizeRequest({ requiredScope, project })`
+// so the same gate applies to API-key callers (CLI, agents) and Studio
+// session users.
+export type EnvironmentScopedAuthorizer = (
+  request: Request,
+  scope: "environments:clone" | "environments:promote",
+) => Promise<void>;
+
 export type MountEnvironmentApiRoutesOptions = {
   store: EnvironmentStore;
   authorizeSession: EnvironmentSessionAuthorizer;
   authorizeAdmin: EnvironmentAdminAuthorizer;
+  authorizeScoped: EnvironmentScopedAuthorizer;
   requireCsrf: EnvironmentRequestCsrfProtector;
 };
 
@@ -503,6 +534,34 @@ export function createDatabaseEnvironmentStore(
         id: environmentRow.id,
       };
     },
+
+    async clone(project, targetEnvironmentId, input) {
+      const normalizedProject = assertRequiredString(project, "project");
+      const normalizedTargetId = assertRequiredString(
+        targetEnvironmentId,
+        "targetEnvironmentId",
+      );
+
+      return cloneEnvironmentImpl(db, {
+        ...input,
+        project: normalizedProject,
+        targetEnvironmentId: normalizedTargetId,
+      });
+    },
+
+    async promote(project, targetEnvironmentId, input) {
+      const normalizedProject = assertRequiredString(project, "project");
+      const normalizedTargetId = assertRequiredString(
+        targetEnvironmentId,
+        "targetEnvironmentId",
+      );
+
+      return promoteDocumentsImpl(db, {
+        ...input,
+        project: normalizedProject,
+        targetEnvironmentId: normalizedTargetId,
+      });
+    },
   };
 }
 
@@ -547,6 +606,55 @@ export function mountEnvironmentApiRoutes(
 
         return {
           data: await options.store.delete(project, environmentId),
+        };
+      });
+    },
+  );
+
+  environmentApp.post?.(
+    "/api/v1/environments/:id/clone",
+    ({ request, params, body }: any) => {
+      return executeWithRuntimeErrorsHandled(request, async () => {
+        const project = pickProject(request);
+        await options.requireCsrf(request);
+        await options.authorizeScoped(request, "environments:clone");
+        const targetEnvironmentId = assertRequiredString(params.id, "id");
+        const payload = (body ?? {}) as unknown;
+        assertEnvironmentCloneInput(payload);
+
+        return {
+          data: await options.store.clone(
+            project,
+            targetEnvironmentId,
+            payload,
+          ),
+        };
+      });
+    },
+  );
+
+  // SPEC-009 documents the path parameter as `:targetId` for clarity, but
+  // the underlying router cannot have two different parameter names at the
+  // same path slot (clone uses `:id` already). The path parameter still
+  // identifies the target environment id; the spec documentation name is
+  // for readability only.
+  environmentApp.post?.(
+    "/api/v1/environments/:id/promote",
+    ({ request, params, body }: any) => {
+      return executeWithRuntimeErrorsHandled(request, async () => {
+        const project = pickProject(request);
+        await options.requireCsrf(request);
+        await options.authorizeScoped(request, "environments:promote");
+        const targetEnvironmentId = assertRequiredString(params.id, "id");
+        const payload = (body ?? {}) as unknown;
+        assertEnvironmentPromoteInput(payload);
+
+        return {
+          data: await options.store.promote(
+            project,
+            targetEnvironmentId,
+            payload,
+          ),
         };
       });
     },

--- a/apps/server/src/lib/environments-clone-promote.integration.test.ts
+++ b/apps/server/src/lib/environments-clone-promote.integration.test.ts
@@ -852,5 +852,193 @@ integrationTest(
   },
 );
 
+integrationTest(
+  "clone with includeDrafts:false copies the published payload, not the draft state",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-published-payload");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // The fixture leaves source docs published at v1 with body "Hello body".
+      // Mutate the documents head row to simulate post-publish draft edits.
+      await dbConnection.db
+        .update(documents)
+        .set({
+          body: "DRAFT body — should not leak into published clone",
+          frontmatter: {
+            title: "DRAFT title",
+            author: fixture.authorDocumentId,
+          },
+          hasUnpublishedChanges: true,
+        })
+        .where(eq(documents.documentId, fixture.blogDocumentId));
+
+      const result = await cloneEnvironment(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        include: { content: true, settings: false },
+        includeDrafts: false,
+        preservePaths: true,
+      });
+      assert.equal(result.documentsCloned, 2);
+
+      const targetBlog = await dbConnection.db.query.documents.findFirst({
+        where: and(
+          eq(documents.projectId, fixture.projectId),
+          eq(documents.environmentId, fixture.productionEnvId),
+          eq(documents.schemaType, "BlogPost"),
+        ),
+      });
+      assert.ok(targetBlog);
+      // Head and version-1 must both reflect the *published* payload, not
+      // the draft body that was mutated above.
+      assert.equal(targetBlog.body, "Hello body");
+      assert.equal(
+        (targetBlog.frontmatter as { title: string }).title,
+        "Hello",
+      );
+      assert.equal(targetBlog.publishedVersion, 1);
+      assert.equal(targetBlog.hasUnpublishedChanges, false);
+
+      const targetVersionRow =
+        await dbConnection.db.query.documentVersions.findFirst({
+          where: and(
+            eq(documentVersions.documentId, targetBlog.documentId),
+            eq(documentVersions.version, 1),
+          ),
+        });
+      assert.ok(targetVersionRow);
+      assert.equal(targetVersionRow.body, "Hello body");
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "clone with preservePaths:false places target rows on suffix-derived paths",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-preserve-paths-false");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      const result = await cloneEnvironment(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        include: { content: true, settings: false },
+        includeDrafts: true,
+        preservePaths: false,
+      });
+      assert.equal(result.documentsCloned, 2);
+
+      const targetRows = await dbConnection.db
+        .select()
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      // Every target row's path should differ from its source path because
+      // preservePaths is false; a deterministic suffix is appended.
+      for (const row of targetRows) {
+        assert.ok(
+          row.path.includes(".cloned-"),
+          `target path should be suffixed when preservePaths:false (got ${row.path})`,
+        );
+      }
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "promote dryRun → real run replays preallocatedTargetIds deterministically",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("promote-replay");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      const dryRun = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.authorDocumentId, fixture.blogDocumentId],
+        includeUnpublished: false,
+        dryRun: true,
+      });
+
+      const preallocatedTargetIds: Record<string, string> = {};
+      for (const entry of dryRun.promoted) {
+        if (entry.status === "created" && entry.targetDocumentId) {
+          preallocatedTargetIds[entry.sourceDocumentId] =
+            entry.targetDocumentId;
+        }
+      }
+
+      const real = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.authorDocumentId, fixture.blogDocumentId],
+        includeUnpublished: false,
+        dryRun: false,
+        preallocatedTargetIds,
+      });
+
+      // The real run must use the exact target ids the dryRun returned, so
+      // the operator's confirmation dialog (built from dryRun) doesn't lie.
+      const dryRunIds = new Map(
+        dryRun.promoted.map((entry) => [
+          entry.sourceDocumentId,
+          entry.targetDocumentId,
+        ]),
+      );
+      for (const entry of real.promoted) {
+        assert.equal(
+          entry.targetDocumentId,
+          dryRunIds.get(entry.sourceDocumentId),
+        );
+      }
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
 // Suppress unused warning on rbacGrants (only imported for future tests).
 void rbacGrants;

--- a/apps/server/src/lib/environments-clone-promote.integration.test.ts
+++ b/apps/server/src/lib/environments-clone-promote.integration.test.ts
@@ -1,0 +1,856 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { test } from "bun:test";
+
+import {
+  createConsoleLogger,
+  parseMdcmsConfig,
+  type SchemaRegistryTypeSnapshot,
+} from "@mdcms/shared";
+import { and, eq } from "drizzle-orm";
+import postgres from "postgres";
+
+import {
+  documents,
+  documentVersions,
+  environments,
+  projects,
+  rbacGrants,
+  schemaRegistryEntries,
+  schemaSyncs,
+} from "./db/schema.js";
+import {
+  cloneEnvironment,
+  promoteDocuments,
+} from "./environments-clone-promote.js";
+import { createServerRequestHandlerWithModules } from "./runtime-with-modules.js";
+
+const env = {
+  NODE_ENV: "test",
+  LOG_LEVEL: "error",
+  APP_VERSION: "9.9.9",
+  PORT: "4000",
+  SERVICE_NAME: "mdcms-server",
+  DATABASE_URL: "postgres://mdcms:mdcms@localhost:5432/mdcms",
+} as NodeJS.ProcessEnv;
+
+const logger = createConsoleLogger({
+  level: "error",
+  sink: () => undefined,
+});
+
+const ACTOR = "00000000-0000-0000-0000-000000000001";
+const cloneTestConfig = parseMdcmsConfig({
+  project: "marketing-site",
+  serverUrl: "http://localhost:4000",
+  types: [],
+  environments: {
+    production: {},
+    staging: { extends: "production" },
+  },
+});
+
+async function canConnectToDatabase(): Promise<boolean> {
+  const client = postgres(env.DATABASE_URL ?? "", {
+    onnotice: () => undefined,
+    connect_timeout: 1,
+    max: 1,
+  });
+  try {
+    await client`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await client.end({ timeout: 1 });
+  }
+}
+
+const dbAvailable = await canConnectToDatabase();
+const integrationTest = dbAvailable ? test : test.skip;
+
+function uniqueProjectSlug(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const blogPostSchema: SchemaRegistryTypeSnapshot = {
+  type: "BlogPost",
+  directory: "blog",
+  localized: true,
+  fields: {
+    title: { kind: "string", required: true, nullable: false },
+    author: {
+      kind: "string",
+      required: false,
+      nullable: true,
+      reference: { targetType: "Author" },
+    },
+  },
+};
+
+const authorSchema: SchemaRegistryTypeSnapshot = {
+  type: "Author",
+  directory: "authors",
+  localized: false,
+  fields: {
+    name: { kind: "string", required: true, nullable: false },
+  },
+};
+
+type ProvisionedFixture = {
+  projectId: string;
+  productionEnvId: string;
+  stagingEnvId: string;
+  authorDocumentId: string;
+  blogDocumentId: string;
+};
+
+async function provisionTwoEnvironments(
+  db: ReturnType<
+    typeof createServerRequestHandlerWithModules
+  >["dbConnection"]["db"],
+  slug: string,
+): Promise<ProvisionedFixture> {
+  const [project] = await db
+    .insert(projects)
+    .values({ name: slug, slug, createdBy: ACTOR })
+    .returning();
+  if (!project) {
+    throw new Error("Failed to insert project");
+  }
+  const [production] = await db
+    .insert(environments)
+    .values({
+      projectId: project.id,
+      name: "production",
+      description: null,
+      createdBy: ACTOR,
+    })
+    .returning();
+  const [staging] = await db
+    .insert(environments)
+    .values({
+      projectId: project.id,
+      name: "staging",
+      description: null,
+      createdBy: ACTOR,
+    })
+    .returning();
+  if (!production || !staging) {
+    throw new Error("Failed to insert environments");
+  }
+
+  // Source env (staging) gets a synced schema sync + registry entries so the
+  // remap walker can see the BlogPost.author reference field.
+  await db.insert(schemaSyncs).values({
+    projectId: project.id,
+    environmentId: staging.id,
+    schemaHash: "sha256:test",
+    rawConfigSnapshot: { types: ["BlogPost", "Author"] },
+  });
+  await db.insert(schemaRegistryEntries).values({
+    projectId: project.id,
+    environmentId: staging.id,
+    schemaType: "BlogPost",
+    directory: "blog",
+    localized: true,
+    schemaHash: "sha256:test",
+    resolvedSchema: blogPostSchema,
+  });
+  await db.insert(schemaRegistryEntries).values({
+    projectId: project.id,
+    environmentId: staging.id,
+    schemaType: "Author",
+    directory: "authors",
+    localized: false,
+    schemaHash: "sha256:test",
+    resolvedSchema: authorSchema,
+  });
+
+  const authorDocumentId = randomUUID();
+  const authorTranslationGroup = randomUUID();
+  await db.insert(documents).values({
+    documentId: authorDocumentId,
+    translationGroupId: authorTranslationGroup,
+    projectId: project.id,
+    environmentId: staging.id,
+    path: "authors/jane",
+    schemaType: "Author",
+    locale: "__mdcms_default__",
+    contentFormat: "md",
+    body: "Author bio",
+    frontmatter: { name: "Jane" },
+    isDeleted: false,
+    hasUnpublishedChanges: true,
+    publishedVersion: null,
+    draftRevision: 1,
+    createdBy: ACTOR,
+    updatedBy: ACTOR,
+  });
+  await db.insert(documentVersions).values({
+    documentId: authorDocumentId,
+    translationGroupId: authorTranslationGroup,
+    projectId: project.id,
+    environmentId: staging.id,
+    schemaType: "Author",
+    locale: "__mdcms_default__",
+    contentFormat: "md",
+    path: "authors/jane",
+    body: "Author bio",
+    frontmatter: { name: "Jane" },
+    version: 1,
+    publishedBy: ACTOR,
+    changeSummary: null,
+  });
+  await db
+    .update(documents)
+    .set({ publishedVersion: 1, hasUnpublishedChanges: false })
+    .where(eq(documents.documentId, authorDocumentId));
+
+  const blogDocumentId = randomUUID();
+  const blogTranslationGroup = randomUUID();
+  await db.insert(documents).values({
+    documentId: blogDocumentId,
+    translationGroupId: blogTranslationGroup,
+    projectId: project.id,
+    environmentId: staging.id,
+    path: "blog/hello-world",
+    schemaType: "BlogPost",
+    locale: "en-US",
+    contentFormat: "md",
+    body: "Hello body",
+    frontmatter: { title: "Hello", author: authorDocumentId },
+    isDeleted: false,
+    hasUnpublishedChanges: true,
+    publishedVersion: null,
+    draftRevision: 1,
+    createdBy: ACTOR,
+    updatedBy: ACTOR,
+  });
+  await db.insert(documentVersions).values({
+    documentId: blogDocumentId,
+    translationGroupId: blogTranslationGroup,
+    projectId: project.id,
+    environmentId: staging.id,
+    schemaType: "BlogPost",
+    locale: "en-US",
+    contentFormat: "md",
+    path: "blog/hello-world",
+    body: "Hello body",
+    frontmatter: { title: "Hello", author: authorDocumentId },
+    version: 1,
+    publishedBy: ACTOR,
+    changeSummary: null,
+  });
+  await db
+    .update(documents)
+    .set({ publishedVersion: 1, hasUnpublishedChanges: false })
+    .where(eq(documents.documentId, blogDocumentId));
+
+  return {
+    projectId: project.id,
+    productionEnvId: production.id,
+    stagingEnvId: staging.id,
+    authorDocumentId,
+    blogDocumentId,
+  };
+}
+
+async function teardownProject(
+  db: ReturnType<
+    typeof createServerRequestHandlerWithModules
+  >["dbConnection"]["db"],
+  projectId: string,
+): Promise<void> {
+  // documents.publishedVersion is a `ON DELETE RESTRICT` FK into
+  // document_versions, so we have to clear it before deleting the version
+  // rows. Otherwise the version delete fails the referential integrity check.
+  await db
+    .update(documents)
+    .set({ publishedVersion: null })
+    .where(eq(documents.projectId, projectId));
+  await db
+    .delete(documentVersions)
+    .where(eq(documentVersions.projectId, projectId));
+  await db.delete(documents).where(eq(documents.projectId, projectId));
+  await db
+    .delete(schemaRegistryEntries)
+    .where(eq(schemaRegistryEntries.projectId, projectId));
+  await db.delete(schemaSyncs).where(eq(schemaSyncs.projectId, projectId));
+  await db.delete(environments).where(eq(environments.projectId, projectId));
+  await db.delete(projects).where(eq(projects.id, projectId));
+}
+
+integrationTest(
+  "clone copies content with new document_ids and remaps frontmatter references",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-content");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      const result = await cloneEnvironment(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        include: { content: true, settings: false },
+        includeDrafts: true,
+        preservePaths: true,
+      });
+
+      assert.equal(result.targetEnvironmentId, fixture.productionEnvId);
+      assert.equal(result.documentsCloned, 2);
+
+      const targetRows = await dbConnection.db
+        .select()
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      assert.equal(targetRows.length, 2);
+
+      const targetByType = new Map(
+        targetRows.map((row) => [row.schemaType, row]),
+      );
+      const targetAuthor = targetByType.get("Author");
+      const targetBlog = targetByType.get("BlogPost");
+      assert.ok(targetAuthor);
+      assert.ok(targetBlog);
+      // documentId must be new in the target env, but translation_group_id is
+      // preserved across environments per SPEC-009.
+      assert.notEqual(targetAuthor.documentId, fixture.authorDocumentId);
+      assert.notEqual(targetBlog.documentId, fixture.blogDocumentId);
+
+      const sourceAuthor = await dbConnection.db.query.documents.findFirst({
+        where: eq(documents.documentId, fixture.authorDocumentId),
+      });
+      const sourceBlog = await dbConnection.db.query.documents.findFirst({
+        where: eq(documents.documentId, fixture.blogDocumentId),
+      });
+      assert.ok(sourceAuthor);
+      assert.ok(sourceBlog);
+      assert.equal(
+        targetAuthor.translationGroupId,
+        sourceAuthor.translationGroupId,
+      );
+      assert.equal(
+        targetBlog.translationGroupId,
+        sourceBlog.translationGroupId,
+      );
+      // The reference in BlogPost.frontmatter.author should be remapped to
+      // the *new* target author documentId.
+      const remapped = targetBlog.frontmatter as { author: string };
+      assert.equal(remapped.author, targetAuthor.documentId);
+
+      // Published snapshot is copied as version 1 in the target.
+      const targetVersions = await dbConnection.db
+        .select()
+        .from(documentVersions)
+        .where(
+          and(
+            eq(documentVersions.projectId, fixture.projectId),
+            eq(documentVersions.environmentId, fixture.productionEnvId),
+          ),
+        );
+      assert.equal(targetVersions.length, 2);
+      assert.ok(targetVersions.every((row) => row.version === 1));
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "clone with include.settings copies schema sync and registry entries",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-settings");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      const result = await cloneEnvironment(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        include: { content: false, settings: true },
+        includeDrafts: true,
+        preservePaths: true,
+      });
+      assert.equal(result.documentsCloned, 0);
+
+      const targetSync = await dbConnection.db.query.schemaSyncs.findFirst({
+        where: and(
+          eq(schemaSyncs.projectId, fixture.projectId),
+          eq(schemaSyncs.environmentId, fixture.productionEnvId),
+        ),
+      });
+      assert.ok(targetSync);
+      assert.equal(targetSync.schemaHash, "sha256:test");
+
+      const targetRegistry = await dbConnection.db
+        .select()
+        .from(schemaRegistryEntries)
+        .where(
+          and(
+            eq(schemaRegistryEntries.projectId, fixture.projectId),
+            eq(schemaRegistryEntries.environmentId, fixture.productionEnvId),
+          ),
+        );
+      const types = targetRegistry.map((row) => row.schemaType).sort();
+      assert.deepEqual(types, ["Author", "BlogPost"]);
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "clone with includeDrafts:false skips unpublished docs",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-no-drafts");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // Demote BlogPost to draft (no published version) so it should be skipped
+      // when `includeDrafts: false`.
+      await dbConnection.db
+        .update(documents)
+        .set({ publishedVersion: null, hasUnpublishedChanges: true })
+        .where(eq(documents.documentId, fixture.blogDocumentId));
+      await dbConnection.db
+        .delete(documentVersions)
+        .where(eq(documentVersions.documentId, fixture.blogDocumentId));
+
+      const result = await cloneEnvironment(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        include: { content: true, settings: false },
+        includeDrafts: false,
+        preservePaths: true,
+      });
+      assert.equal(result.documentsCloned, 1);
+
+      const targetRows = await dbConnection.db
+        .select({ schemaType: documents.schemaType })
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      assert.deepEqual(
+        targetRows.map((row) => row.schemaType),
+        ["Author"],
+      );
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "clone fails atomically when reference target is missing",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-broken-ref");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // Point BlogPost.author at a non-existent source documentId. The clone
+      // walks the schema, fails to look up the source, and aborts.
+      const ghostId = randomUUID();
+      await dbConnection.db
+        .update(documents)
+        .set({ frontmatter: { title: "Hello", author: ghostId } })
+        .where(eq(documents.documentId, fixture.blogDocumentId));
+
+      let thrown: unknown;
+      try {
+        await cloneEnvironment(dbConnection.db, {
+          project: slug,
+          targetEnvironmentId: fixture.productionEnvId,
+          sourceEnvironmentId: fixture.stagingEnvId,
+          include: { content: true, settings: false },
+          includeDrafts: true,
+          preservePaths: true,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      assert.ok(thrown);
+      const error = thrown as { code: string; statusCode: number };
+      assert.equal(error.code, "REFERENCE_REMAP_FAILED");
+      assert.equal(error.statusCode, 409);
+
+      const targetCount = await dbConnection.db
+        .select({ count: documents.documentId })
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      // No partial clone — atomic abort means zero target rows.
+      assert.equal(targetCount.length, 0);
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest("promote dryRun returns plan without writing", async () => {
+  const { dbConnection } = createServerRequestHandlerWithModules({
+    env,
+    logger,
+    config: cloneTestConfig,
+  });
+  const slug = uniqueProjectSlug("promote-dryrun");
+  let projectId: string | undefined;
+  try {
+    const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+    projectId = fixture.projectId;
+
+    const result = await promoteDocuments(dbConnection.db, {
+      project: slug,
+      targetEnvironmentId: fixture.productionEnvId,
+      sourceEnvironmentId: fixture.stagingEnvId,
+      documentIds: [fixture.authorDocumentId, fixture.blogDocumentId],
+      includeUnpublished: false,
+      dryRun: true,
+    });
+
+    assert.equal(result.promoted.length, 2);
+    for (const entry of result.promoted) {
+      assert.equal(entry.status, "created");
+      // dryRun reports the would-be target id (pre-allocated UUID) so the
+      // operator preview can correlate planned creates to upcoming target
+      // documents — but no row exists yet.
+      assert.ok(
+        entry.targetDocumentId &&
+          /^[0-9a-f-]{36}$/i.test(entry.targetDocumentId),
+      );
+    }
+
+    const targetCount = await dbConnection.db
+      .select({ count: documents.documentId })
+      .from(documents)
+      .where(
+        and(
+          eq(documents.projectId, fixture.projectId),
+          eq(documents.environmentId, fixture.productionEnvId),
+        ),
+      );
+    assert.equal(targetCount.length, 0);
+  } finally {
+    if (projectId) {
+      await teardownProject(dbConnection.db, projectId);
+    }
+    await dbConnection.close();
+  }
+});
+
+integrationTest(
+  "promote creates and overwrites target docs and auto-publishes",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("promote-real");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // First promote creates target rows.
+      const first = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.authorDocumentId, fixture.blogDocumentId],
+        includeUnpublished: false,
+        dryRun: false,
+      });
+      assert.equal(first.promoted.length, 2);
+      for (const entry of first.promoted) {
+        assert.equal(entry.status, "created");
+        assert.equal(entry.publishedVersion, 1);
+      }
+
+      // Reference remap should rewrite BlogPost.author to the target author id.
+      const targetBlog = await dbConnection.db.query.documents.findFirst({
+        where: and(
+          eq(documents.projectId, fixture.projectId),
+          eq(documents.environmentId, fixture.productionEnvId),
+          eq(documents.schemaType, "BlogPost"),
+        ),
+      });
+      const targetAuthor = await dbConnection.db.query.documents.findFirst({
+        where: and(
+          eq(documents.projectId, fixture.projectId),
+          eq(documents.environmentId, fixture.productionEnvId),
+          eq(documents.schemaType, "Author"),
+        ),
+      });
+      assert.ok(targetBlog);
+      assert.ok(targetAuthor);
+      const remapped = targetBlog.frontmatter as { author: string };
+      assert.equal(remapped.author, targetAuthor.documentId);
+
+      // Mutate source BlogPost body and re-promote — should overwrite + publish v2.
+      await dbConnection.db
+        .update(documents)
+        .set({ body: "Updated body" })
+        .where(eq(documents.documentId, fixture.blogDocumentId));
+
+      const second = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.blogDocumentId],
+        includeUnpublished: false,
+        dryRun: false,
+      });
+      assert.equal(second.promoted.length, 1);
+      const overwroteEntry = second.promoted[0];
+      assert.ok(overwroteEntry);
+      assert.equal(overwroteEntry.status, "overwrote");
+      assert.equal(overwroteEntry.publishedVersion, 2);
+
+      const reread = await dbConnection.db.query.documents.findFirst({
+        where: eq(documents.documentId, targetBlog.documentId),
+      });
+      assert.ok(reread);
+      assert.equal(reread.body, "Updated body");
+      assert.equal(reread.publishedVersion, 2);
+
+      const versions = await dbConnection.db
+        .select()
+        .from(documentVersions)
+        .where(eq(documentVersions.documentId, targetBlog.documentId));
+      assert.equal(versions.length, 2);
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "promote skips unpublished docs unless includeUnpublished is true",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("promote-unpublished");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // Demote BlogPost to draft.
+      await dbConnection.db
+        .update(documents)
+        .set({ publishedVersion: null, hasUnpublishedChanges: true })
+        .where(eq(documents.documentId, fixture.blogDocumentId));
+      await dbConnection.db
+        .delete(documentVersions)
+        .where(eq(documentVersions.documentId, fixture.blogDocumentId));
+
+      const skippedRun = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.blogDocumentId],
+        includeUnpublished: false,
+        dryRun: false,
+      });
+      assert.equal(skippedRun.promoted.length, 1);
+      const skipped = skippedRun.promoted[0];
+      assert.ok(skipped);
+      assert.equal(skipped.status, "skipped_unpublished");
+
+      const targetRows = await dbConnection.db
+        .select()
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      // Skipping never writes, so the target stays empty.
+      assert.equal(targetRows.length, 0);
+
+      // Need an Author target for the reference to remap when we do include
+      // unpublished — promote the author first.
+      await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.authorDocumentId],
+        includeUnpublished: false,
+        dryRun: false,
+      });
+
+      const includedRun = await promoteDocuments(dbConnection.db, {
+        project: slug,
+        targetEnvironmentId: fixture.productionEnvId,
+        sourceEnvironmentId: fixture.stagingEnvId,
+        documentIds: [fixture.blogDocumentId],
+        includeUnpublished: true,
+        dryRun: false,
+      });
+      assert.equal(includedRun.promoted.length, 1);
+      assert.equal(includedRun.promoted[0]?.status, "created");
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "promote fails atomically when a reference cannot be remapped",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("promote-broken-ref");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      // Promote only the BlogPost (without its Author) — target has no
+      // author row to match `(authorTranslationGroupId, __mdcms_default__)`,
+      // so the remap must fail atomically.
+      let thrown: unknown;
+      try {
+        await promoteDocuments(dbConnection.db, {
+          project: slug,
+          targetEnvironmentId: fixture.productionEnvId,
+          sourceEnvironmentId: fixture.stagingEnvId,
+          documentIds: [fixture.blogDocumentId],
+          includeUnpublished: false,
+          dryRun: false,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      assert.ok(thrown);
+      assert.equal((thrown as { code: string }).code, "REFERENCE_REMAP_FAILED");
+
+      const targetRows = await dbConnection.db
+        .select()
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, fixture.projectId),
+            eq(documents.environmentId, fixture.productionEnvId),
+          ),
+        );
+      assert.equal(targetRows.length, 0);
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+integrationTest(
+  "clone rejects same source and target environment",
+  async () => {
+    const { dbConnection } = createServerRequestHandlerWithModules({
+      env,
+      logger,
+      config: cloneTestConfig,
+    });
+    const slug = uniqueProjectSlug("clone-same-env");
+    let projectId: string | undefined;
+    try {
+      const fixture = await provisionTwoEnvironments(dbConnection.db, slug);
+      projectId = fixture.projectId;
+
+      let thrown: unknown;
+      try {
+        await cloneEnvironment(dbConnection.db, {
+          project: slug,
+          targetEnvironmentId: fixture.stagingEnvId,
+          sourceEnvironmentId: fixture.stagingEnvId,
+          include: { content: true, settings: false },
+          includeDrafts: true,
+          preservePaths: true,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      assert.equal(
+        (thrown as { code: string } | undefined)?.code,
+        "INVALID_INPUT",
+      );
+    } finally {
+      if (projectId) {
+        await teardownProject(dbConnection.db, projectId);
+      }
+      await dbConnection.close();
+    }
+  },
+);
+
+// Suppress unused warning on rbacGrants (only imported for future tests).
+void rbacGrants;

--- a/apps/server/src/lib/environments-clone-promote.ts
+++ b/apps/server/src/lib/environments-clone-promote.ts
@@ -1,0 +1,806 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  RuntimeError,
+  type DocumentPromotionResult,
+  type EnvironmentCloneInput,
+  type EnvironmentCloneResult,
+  type EnvironmentPromoteInput,
+  type EnvironmentPromoteResult,
+  type SchemaRegistryTypeSnapshot,
+} from "@mdcms/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import type { DrizzleDatabase } from "./db.js";
+import {
+  documents,
+  documentVersions,
+  environments,
+  schemaRegistryEntries,
+  schemaSyncs,
+} from "./db/schema.js";
+import {
+  remapFrontmatterReferences,
+  type ReferenceLookupKey,
+  type ReferenceSourceLookup,
+  type ReferenceTargetResolver,
+} from "./environments-reference-remap.js";
+import { findProjectBySlug } from "./project-provisioning.js";
+
+// `clone` and `promote` are two related but distinct write paths:
+//
+//   - clone: copy *all* (or all-published) source docs into a target env that
+//     has no overlapping rows. New `documentId` per row, preserved
+//     `translationGroupId`. Optional published-version snapshot copy.
+//
+//   - promote: per-document overwrite (or create) into a target env, by
+//     `(translationGroupId, locale)`. Always auto-publishes the target.
+//
+// Both share the reference-remap helper and run inside a single transaction
+// so any failure rolls back atomically (SPEC-009 #Reference remapping).
+
+const DEFAULT_ACTOR = "00000000-0000-0000-0000-000000000001";
+
+type ScopeRow = {
+  projectId: string;
+  sourceEnvId: string;
+  targetEnvId: string;
+};
+
+type SourceDocumentRow = typeof documents.$inferSelect;
+
+type SourceContext = {
+  scope: ScopeRow;
+  rows: SourceDocumentRow[];
+  sourceLookup: ReferenceSourceLookup;
+  schemaByType: Map<string, SchemaRegistryTypeSnapshot>;
+};
+
+function buildScopeError(message: string, details: Record<string, unknown>) {
+  return new RuntimeError({
+    code: "NOT_FOUND",
+    message,
+    statusCode: 404,
+    details,
+  });
+}
+
+function buildInvalidInputError(field: string, message: string) {
+  return new RuntimeError({
+    code: "INVALID_INPUT",
+    message,
+    statusCode: 400,
+    details: { field },
+  });
+}
+
+function buildConflictError(message: string, details: Record<string, unknown>) {
+  return new RuntimeError({
+    code: "CONFLICT",
+    message,
+    statusCode: 409,
+    details,
+  });
+}
+
+async function loadProjectScope(
+  db: DrizzleDatabase,
+  input: { project: string; sourceEnvId: string; targetEnvId: string },
+): Promise<ScopeRow> {
+  if (input.sourceEnvId === input.targetEnvId) {
+    throw buildInvalidInputError(
+      "sourceEnvironmentId",
+      "Source and target environments must differ.",
+    );
+  }
+
+  const projectRow = await findProjectBySlug(db, input.project);
+  if (!projectRow) {
+    throw buildScopeError("Project not found.", { project: input.project });
+  }
+
+  const envRows = await db.query.environments.findMany({
+    where: and(
+      eq(environments.projectId, projectRow.id),
+      inArray(environments.id, [input.sourceEnvId, input.targetEnvId]),
+    ),
+  });
+
+  const envById = new Map(envRows.map((row) => [row.id, row]));
+  const sourceEnv = envById.get(input.sourceEnvId);
+  const targetEnv = envById.get(input.targetEnvId);
+
+  if (!sourceEnv) {
+    throw buildScopeError("Source environment not found in routed project.", {
+      project: input.project,
+      sourceEnvironmentId: input.sourceEnvId,
+    });
+  }
+  if (!targetEnv) {
+    throw buildScopeError("Target environment not found in routed project.", {
+      project: input.project,
+      targetEnvironmentId: input.targetEnvId,
+    });
+  }
+
+  return {
+    projectId: projectRow.id,
+    sourceEnvId: sourceEnv.id,
+    targetEnvId: targetEnv.id,
+  };
+}
+
+async function loadSourceContext(
+  db: DrizzleDatabase,
+  scope: ScopeRow,
+  options: { documentIds?: string[]; includeDrafts: boolean },
+): Promise<SourceContext> {
+  const baseConditions = [
+    eq(documents.projectId, scope.projectId),
+    eq(documents.environmentId, scope.sourceEnvId),
+    eq(documents.isDeleted, false),
+  ];
+
+  if (options.documentIds && options.documentIds.length > 0) {
+    baseConditions.push(inArray(documents.documentId, options.documentIds));
+  }
+
+  if (!options.includeDrafts) {
+    baseConditions.push(sql`${documents.publishedVersion} is not null`);
+  }
+
+  const rows = await db
+    .select()
+    .from(documents)
+    .where(and(...baseConditions));
+
+  // The reference lookup needs *every* source document, not just the ones
+  // we're about to copy/promote — promoted refs may point to source docs
+  // outside the requested set, but their (translation_group_id, locale)
+  // identity is enough to remap.
+  const allSourceRows = options.documentIds
+    ? await db
+        .select({
+          documentId: documents.documentId,
+          translationGroupId: documents.translationGroupId,
+          locale: documents.locale,
+        })
+        .from(documents)
+        .where(
+          and(
+            eq(documents.projectId, scope.projectId),
+            eq(documents.environmentId, scope.sourceEnvId),
+            eq(documents.isDeleted, false),
+          ),
+        )
+    : rows.map((row) => ({
+        documentId: row.documentId,
+        translationGroupId: row.translationGroupId,
+        locale: row.locale,
+      }));
+
+  const sourceMap = new Map<string, ReferenceLookupKey>();
+  for (const row of allSourceRows) {
+    sourceMap.set(row.documentId, {
+      translationGroupId: row.translationGroupId,
+      locale: row.locale,
+    });
+  }
+
+  const schemaRows = await db
+    .select({
+      schemaType: schemaRegistryEntries.schemaType,
+      resolvedSchema: schemaRegistryEntries.resolvedSchema,
+    })
+    .from(schemaRegistryEntries)
+    .where(
+      and(
+        eq(schemaRegistryEntries.projectId, scope.projectId),
+        eq(schemaRegistryEntries.environmentId, scope.sourceEnvId),
+      ),
+    );
+
+  const schemaByType = new Map<string, SchemaRegistryTypeSnapshot>();
+  for (const row of schemaRows) {
+    schemaByType.set(
+      row.schemaType,
+      row.resolvedSchema as SchemaRegistryTypeSnapshot,
+    );
+  }
+
+  return {
+    scope,
+    rows,
+    sourceLookup: (id) => sourceMap.get(id),
+    schemaByType,
+  };
+}
+
+function targetMapKey(key: ReferenceLookupKey): string {
+  return `${key.translationGroupId}::${key.locale}`;
+}
+
+async function loadTargetMap(
+  db: DrizzleDatabase,
+  scope: ScopeRow,
+): Promise<Map<string, string>> {
+  const rows = await db
+    .select({
+      documentId: documents.documentId,
+      translationGroupId: documents.translationGroupId,
+      locale: documents.locale,
+    })
+    .from(documents)
+    .where(
+      and(
+        eq(documents.projectId, scope.projectId),
+        eq(documents.environmentId, scope.targetEnvId),
+        eq(documents.isDeleted, false),
+      ),
+    );
+
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    map.set(
+      targetMapKey({
+        translationGroupId: row.translationGroupId,
+        locale: row.locale,
+      }),
+      row.documentId,
+    );
+  }
+  return map;
+}
+
+export type CloneEnvironmentInput = EnvironmentCloneInput & {
+  project: string;
+  targetEnvironmentId: string;
+};
+
+export async function cloneEnvironment(
+  db: DrizzleDatabase,
+  input: CloneEnvironmentInput,
+): Promise<EnvironmentCloneResult> {
+  return db.transaction(async (tx) => {
+    const txDb = tx as unknown as DrizzleDatabase;
+    const scope = await loadProjectScope(txDb, {
+      project: input.project,
+      sourceEnvId: input.sourceEnvironmentId,
+      targetEnvId: input.targetEnvironmentId,
+    });
+
+    if (input.include.settings) {
+      await copyEnvironmentSettings(txDb, scope);
+    }
+
+    if (!input.include.content) {
+      return {
+        targetEnvironmentId: scope.targetEnvId,
+        documentsCloned: 0,
+      };
+    }
+
+    const sourceContext = await loadSourceContext(txDb, scope, {
+      includeDrafts: input.includeDrafts,
+    });
+
+    if (sourceContext.rows.length === 0) {
+      return {
+        targetEnvironmentId: scope.targetEnvId,
+        documentsCloned: 0,
+      };
+    }
+
+    // Pre-allocate target document IDs so cross-document references inside
+    // the cloned set resolve via the (translationGroupId, locale) key map.
+    const targetIdByKey = new Map<string, string>();
+    for (const row of sourceContext.rows) {
+      const key = targetMapKey({
+        translationGroupId: row.translationGroupId,
+        locale: row.locale,
+      });
+      if (targetIdByKey.has(key)) {
+        // Source data integrity: should never happen given the active unique
+        // index `uniq_documents_active_translation_locale`. Surface clearly.
+        throw new RuntimeError({
+          code: "INTERNAL_ERROR",
+          message:
+            "Source environment has duplicate (translation_group_id, locale) tuples for active documents.",
+          statusCode: 500,
+          details: {
+            translationGroupId: row.translationGroupId,
+            locale: row.locale,
+          },
+        });
+      }
+      targetIdByKey.set(key, randomUUID());
+    }
+
+    // Existing target documents (if any) participate in remap so that
+    // cross-environment refs to docs already present in target still resolve.
+    const existingTargetMap = await loadTargetMap(txDb, scope);
+    const targetResolver: ReferenceTargetResolver = (key) => {
+      const composed = targetMapKey(key);
+      return targetIdByKey.get(composed) ?? existingTargetMap.get(composed);
+    };
+
+    const cloneActor = DEFAULT_ACTOR;
+    let documentsCloned = 0;
+
+    for (const row of sourceContext.rows) {
+      const schema = sourceContext.schemaByType.get(row.schemaType);
+      const remap = remapFrontmatterReferences({
+        schema,
+        frontmatter: row.frontmatter as Record<string, unknown>,
+        sourceLookup: sourceContext.sourceLookup,
+        targetResolver,
+        sourceDocumentId: row.documentId,
+      });
+
+      const targetDocumentId = targetIdByKey.get(
+        targetMapKey({
+          translationGroupId: row.translationGroupId,
+          locale: row.locale,
+        }),
+      )!;
+      const hasPublishedSnapshot = row.publishedVersion !== null;
+
+      try {
+        await txDb.insert(documents).values({
+          documentId: targetDocumentId,
+          translationGroupId: row.translationGroupId,
+          projectId: scope.projectId,
+          environmentId: scope.targetEnvId,
+          path: row.path,
+          schemaType: row.schemaType,
+          locale: row.locale,
+          contentFormat: row.contentFormat,
+          body: row.body,
+          frontmatter: remap.frontmatter,
+          isDeleted: false,
+          hasUnpublishedChanges: !hasPublishedSnapshot,
+          publishedVersion: null,
+          draftRevision: 1,
+          createdBy: cloneActor,
+          updatedBy: cloneActor,
+        });
+      } catch (error) {
+        if (isUniqueViolation(error)) {
+          throw buildConflictError(
+            "Target environment already contains content that conflicts with the clone payload.",
+            {
+              targetEnvironmentId: scope.targetEnvId,
+              path: row.path,
+              locale: row.locale,
+              translationGroupId: row.translationGroupId,
+              preservePaths: input.preservePaths,
+            },
+          );
+        }
+        throw error;
+      }
+
+      if (hasPublishedSnapshot) {
+        // Copy the latest published snapshot as version 1 in the target so
+        // the target row can be served as published immediately. Full version
+        // history is intentionally not copied (SPEC-009 #Cloning).
+        await txDb.insert(documentVersions).values({
+          documentId: targetDocumentId,
+          translationGroupId: row.translationGroupId,
+          projectId: scope.projectId,
+          environmentId: scope.targetEnvId,
+          schemaType: row.schemaType,
+          locale: row.locale,
+          contentFormat: row.contentFormat,
+          path: row.path,
+          body: row.body,
+          frontmatter: remap.frontmatter,
+          version: 1,
+          publishedBy: cloneActor,
+          changeSummary: "Cloned from source environment.",
+        });
+        await txDb
+          .update(documents)
+          .set({ publishedVersion: 1, hasUnpublishedChanges: false })
+          .where(eq(documents.documentId, targetDocumentId));
+      }
+
+      documentsCloned += 1;
+    }
+
+    return {
+      targetEnvironmentId: scope.targetEnvId,
+      documentsCloned,
+    };
+  });
+}
+
+async function copyEnvironmentSettings(
+  db: DrizzleDatabase,
+  scope: ScopeRow,
+): Promise<void> {
+  const sourceSync = await db.query.schemaSyncs.findFirst({
+    where: and(
+      eq(schemaSyncs.projectId, scope.projectId),
+      eq(schemaSyncs.environmentId, scope.sourceEnvId),
+    ),
+  });
+
+  if (!sourceSync) {
+    return;
+  }
+
+  await db
+    .insert(schemaSyncs)
+    .values({
+      projectId: scope.projectId,
+      environmentId: scope.targetEnvId,
+      schemaHash: sourceSync.schemaHash,
+      rawConfigSnapshot: sourceSync.rawConfigSnapshot,
+    })
+    .onConflictDoUpdate({
+      target: [schemaSyncs.projectId, schemaSyncs.environmentId],
+      set: {
+        schemaHash: sourceSync.schemaHash,
+        rawConfigSnapshot: sourceSync.rawConfigSnapshot,
+        syncedAt: new Date(),
+      },
+    });
+
+  const sourceRegistry = await db
+    .select()
+    .from(schemaRegistryEntries)
+    .where(
+      and(
+        eq(schemaRegistryEntries.projectId, scope.projectId),
+        eq(schemaRegistryEntries.environmentId, scope.sourceEnvId),
+      ),
+    );
+
+  for (const entry of sourceRegistry) {
+    await db
+      .insert(schemaRegistryEntries)
+      .values({
+        projectId: scope.projectId,
+        environmentId: scope.targetEnvId,
+        schemaType: entry.schemaType,
+        directory: entry.directory,
+        localized: entry.localized,
+        schemaHash: entry.schemaHash,
+        resolvedSchema: entry.resolvedSchema,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schemaRegistryEntries.projectId,
+          schemaRegistryEntries.environmentId,
+          schemaRegistryEntries.schemaType,
+        ],
+        set: {
+          directory: entry.directory,
+          localized: entry.localized,
+          schemaHash: entry.schemaHash,
+          resolvedSchema: entry.resolvedSchema,
+          syncedAt: new Date(),
+        },
+      });
+  }
+}
+
+export type PromoteEnvironmentInput = EnvironmentPromoteInput & {
+  project: string;
+  targetEnvironmentId: string;
+};
+
+export async function promoteDocuments(
+  db: DrizzleDatabase,
+  input: PromoteEnvironmentInput,
+): Promise<EnvironmentPromoteResult> {
+  return db.transaction(async (tx) => {
+    const txDb = tx as unknown as DrizzleDatabase;
+    const scope = await loadProjectScope(txDb, {
+      project: input.project,
+      sourceEnvId: input.sourceEnvironmentId,
+      targetEnvId: input.targetEnvironmentId,
+    });
+
+    const sourceContext = await loadSourceContext(txDb, scope, {
+      documentIds: input.documentIds,
+      // Promote loads all matching rows regardless of publish state; the
+      // include-unpublished gate is applied below per-row to drive the
+      // `skipped_unpublished` status in the result.
+      includeDrafts: true,
+    });
+
+    const requestedSet = new Set(input.documentIds);
+    const foundIds = new Set(sourceContext.rows.map((row) => row.documentId));
+    const missing = [...requestedSet].filter((id) => !foundIds.has(id));
+    if (missing.length > 0) {
+      throw buildScopeError(
+        "One or more document IDs were not found in the source environment.",
+        {
+          missingDocumentIds: missing,
+          sourceEnvironmentId: scope.sourceEnvId,
+        },
+      );
+    }
+
+    const targetMap = await loadTargetMap(txDb, scope);
+
+    // Pre-populate the target map with "would-be-created" ids for rows that
+    // don't yet have a target match. This lets the remap walker resolve
+    // references between docs in the same promoted batch — both during
+    // dry-run (no writes) and during the real run (in-progress creations).
+    // The pre-allocated id matches the id used by `createTargetDraft` when
+    // the row is actually written.
+    const preallocatedTargetIds = new Map<string, string>();
+    for (const row of sourceContext.rows) {
+      if (!input.includeUnpublished && row.publishedVersion === null) {
+        continue;
+      }
+      const key = targetMapKey({
+        translationGroupId: row.translationGroupId,
+        locale: row.locale,
+      });
+      if (!targetMap.has(key)) {
+        const allocated = randomUUID();
+        targetMap.set(key, allocated);
+        preallocatedTargetIds.set(key, allocated);
+      }
+    }
+
+    const targetResolver: ReferenceTargetResolver = (key) =>
+      targetMap.get(targetMapKey(key));
+
+    const promoted: DocumentPromotionResult[] = [];
+    const promoteActor = DEFAULT_ACTOR;
+
+    for (const row of sourceContext.rows) {
+      if (!input.includeUnpublished && row.publishedVersion === null) {
+        promoted.push({
+          sourceDocumentId: row.documentId,
+          targetDocumentId:
+            targetMap.get(
+              targetMapKey({
+                translationGroupId: row.translationGroupId,
+                locale: row.locale,
+              }),
+            ) ?? null,
+          status: "skipped_unpublished",
+          path: row.path,
+          locale: row.locale,
+          type: row.schemaType,
+          publishedVersion: null,
+          remappedReferences: 0,
+        });
+        continue;
+      }
+
+      const schema = sourceContext.schemaByType.get(row.schemaType);
+      const remap = remapFrontmatterReferences({
+        schema,
+        frontmatter: row.frontmatter as Record<string, unknown>,
+        sourceLookup: sourceContext.sourceLookup,
+        targetResolver,
+        sourceDocumentId: row.documentId,
+      });
+
+      const key = targetMapKey({
+        translationGroupId: row.translationGroupId,
+        locale: row.locale,
+      });
+      const preallocatedId = preallocatedTargetIds.get(key);
+      // `existingTargetId` is the *real* target id only if the row already
+      // existed before this batch; preallocated ids represent rows we plan
+      // to create within this same batch.
+      const existingTargetId = preallocatedId ? undefined : targetMap.get(key);
+
+      if (input.dryRun) {
+        promoted.push({
+          sourceDocumentId: row.documentId,
+          targetDocumentId: existingTargetId ?? preallocatedId ?? null,
+          status: existingTargetId ? "overwrote" : "created",
+          path: row.path,
+          locale: row.locale,
+          type: row.schemaType,
+          // We can't know the published version without doing the write; the
+          // contract reports `null` for created and the *current* published
+          // version for overwrote so consumers can show "v3 -> v4".
+          publishedVersion: null,
+          remappedReferences: remap.remappedReferences,
+        });
+        continue;
+      }
+
+      const targetDocumentId =
+        existingTargetId ??
+        (await createTargetDraft(txDb, {
+          scope,
+          source: row,
+          remappedFrontmatter: remap.frontmatter,
+          actor: promoteActor,
+          preallocatedId,
+        }));
+
+      if (existingTargetId) {
+        await overwriteTargetDraft(txDb, {
+          scope,
+          targetDocumentId: existingTargetId,
+          source: row,
+          remappedFrontmatter: remap.frontmatter,
+          actor: promoteActor,
+        });
+      }
+
+      const publishedVersion = await publishTargetDocument(txDb, {
+        scope,
+        targetDocumentId,
+        source: row,
+        remappedFrontmatter: remap.frontmatter,
+        actor: promoteActor,
+      });
+
+      // Record the new target id so subsequent promoted rows that reference
+      // this one can resolve via the in-progress map.
+      targetMap.set(key, targetDocumentId);
+
+      promoted.push({
+        sourceDocumentId: row.documentId,
+        targetDocumentId,
+        status: existingTargetId ? "overwrote" : "created",
+        path: row.path,
+        locale: row.locale,
+        type: row.schemaType,
+        publishedVersion,
+        remappedReferences: remap.remappedReferences,
+      });
+    }
+
+    return { promoted };
+  });
+}
+
+async function createTargetDraft(
+  db: DrizzleDatabase,
+  input: {
+    scope: ScopeRow;
+    source: SourceDocumentRow;
+    remappedFrontmatter: Record<string, unknown>;
+    actor: string;
+    // When provided, used instead of generating a new UUID. The caller
+    // pre-allocates these so cross-document references resolve via the
+    // remap target map (and so dryRun reports the same id that the real
+    // run would produce).
+    preallocatedId?: string;
+  },
+): Promise<string> {
+  const targetDocumentId = input.preallocatedId ?? randomUUID();
+  try {
+    await db.insert(documents).values({
+      documentId: targetDocumentId,
+      translationGroupId: input.source.translationGroupId,
+      projectId: input.scope.projectId,
+      environmentId: input.scope.targetEnvId,
+      path: input.source.path,
+      schemaType: input.source.schemaType,
+      locale: input.source.locale,
+      contentFormat: input.source.contentFormat,
+      body: input.source.body,
+      frontmatter: input.remappedFrontmatter,
+      isDeleted: false,
+      hasUnpublishedChanges: true,
+      publishedVersion: null,
+      draftRevision: 1,
+      createdBy: input.actor,
+      updatedBy: input.actor,
+    });
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw buildConflictError(
+        "Promote target conflicts with existing content (path or translation pair).",
+        {
+          targetEnvironmentId: input.scope.targetEnvId,
+          path: input.source.path,
+          locale: input.source.locale,
+          translationGroupId: input.source.translationGroupId,
+        },
+      );
+    }
+    throw error;
+  }
+  return targetDocumentId;
+}
+
+async function overwriteTargetDraft(
+  db: DrizzleDatabase,
+  input: {
+    scope: ScopeRow;
+    targetDocumentId: string;
+    source: SourceDocumentRow;
+    remappedFrontmatter: Record<string, unknown>;
+    actor: string;
+  },
+): Promise<void> {
+  await db
+    .update(documents)
+    .set({
+      schemaType: input.source.schemaType,
+      contentFormat: input.source.contentFormat,
+      body: input.source.body,
+      frontmatter: input.remappedFrontmatter,
+      path: input.source.path,
+      locale: input.source.locale,
+      isDeleted: false,
+      hasUnpublishedChanges: true,
+      draftRevision: sql`${documents.draftRevision} + 1`,
+      updatedBy: input.actor,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(documents.projectId, input.scope.projectId),
+        eq(documents.environmentId, input.scope.targetEnvId),
+        eq(documents.documentId, input.targetDocumentId),
+      ),
+    );
+}
+
+async function publishTargetDocument(
+  db: DrizzleDatabase,
+  input: {
+    scope: ScopeRow;
+    targetDocumentId: string;
+    source: SourceDocumentRow;
+    remappedFrontmatter: Record<string, unknown>;
+    actor: string;
+  },
+): Promise<number> {
+  const [latest] = await db
+    .select({
+      value: sql<number>`coalesce(max(${documentVersions.version}), 0)`,
+    })
+    .from(documentVersions)
+    .where(eq(documentVersions.documentId, input.targetDocumentId));
+
+  const nextVersion = (latest?.value ?? 0) + 1;
+  await db.insert(documentVersions).values({
+    documentId: input.targetDocumentId,
+    translationGroupId: input.source.translationGroupId,
+    projectId: input.scope.projectId,
+    environmentId: input.scope.targetEnvId,
+    schemaType: input.source.schemaType,
+    locale: input.source.locale,
+    contentFormat: input.source.contentFormat,
+    path: input.source.path,
+    body: input.source.body,
+    frontmatter: input.remappedFrontmatter,
+    version: nextVersion,
+    publishedBy: input.actor,
+    changeSummary: "Promoted from source environment.",
+  });
+
+  await db
+    .update(documents)
+    .set({
+      publishedVersion: nextVersion,
+      hasUnpublishedChanges: false,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(documents.projectId, input.scope.projectId),
+        eq(documents.environmentId, input.scope.targetEnvId),
+        eq(documents.documentId, input.targetDocumentId),
+      ),
+    );
+
+  return nextVersion;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: unknown }).code === "23505"
+  );
+}

--- a/apps/server/src/lib/environments-clone-promote.ts
+++ b/apps/server/src/lib/environments-clone-promote.ts
@@ -49,11 +49,27 @@ type ScopeRow = {
 
 type SourceDocumentRow = typeof documents.$inferSelect;
 
+// The published payload is what `documentVersions` holds for the row's
+// current `publishedVersion`. It is intentionally distinct from the
+// `documents` row, which always holds the most recent (possibly draft)
+// state. Clone uses the published payload when `includeDrafts: false` and
+// when copying the version-1 snapshot into the target.
+type PublishedPayload = {
+  body: string;
+  frontmatter: Record<string, unknown>;
+  path: string;
+  contentFormat: SourceDocumentRow["contentFormat"];
+  schemaType: string;
+  locale: string;
+  version: number;
+};
+
 type SourceContext = {
   scope: ScopeRow;
   rows: SourceDocumentRow[];
   sourceLookup: ReferenceSourceLookup;
   schemaByType: Map<string, SchemaRegistryTypeSnapshot>;
+  publishedByDocumentId: Map<string, PublishedPayload>;
 };
 
 function buildScopeError(message: string, details: Record<string, unknown>) {
@@ -208,11 +224,67 @@ async function loadSourceContext(
     );
   }
 
+  // Pull the published payload (body, frontmatter, path) for any source row
+  // that has a non-null publishedVersion. The `documents` row by itself can
+  // contain unsaved-draft content even when `publishedVersion` is set, so
+  // clone with `includeDrafts: false` and the version-1 snapshot copy must
+  // honor the version's payload to avoid leaking drafts into the target.
+  const publishedByDocumentId = new Map<string, PublishedPayload>();
+  const documentIdsWithPublished = rows
+    .filter((row) => row.publishedVersion !== null)
+    .map((row) => row.documentId);
+
+  if (documentIdsWithPublished.length > 0) {
+    const versionRows = await db
+      .select({
+        documentId: documentVersions.documentId,
+        version: documentVersions.version,
+        body: documentVersions.body,
+        frontmatter: documentVersions.frontmatter,
+        path: documentVersions.path,
+        contentFormat: documentVersions.contentFormat,
+        schemaType: documentVersions.schemaType,
+        locale: documentVersions.locale,
+      })
+      .from(documentVersions)
+      .where(
+        and(
+          eq(documentVersions.projectId, scope.projectId),
+          eq(documentVersions.environmentId, scope.sourceEnvId),
+          inArray(documentVersions.documentId, documentIdsWithPublished),
+        ),
+      );
+
+    // Each documentId may have many versions in the table — keep only the
+    // one matching the documents row's `publishedVersion`.
+    const expectedVersion = new Map(
+      rows
+        .filter((row) => row.publishedVersion !== null)
+        .map((row) => [row.documentId, row.publishedVersion as number]),
+    );
+    for (const versionRow of versionRows) {
+      if (expectedVersion.get(versionRow.documentId) !== versionRow.version) {
+        continue;
+      }
+      publishedByDocumentId.set(versionRow.documentId, {
+        body: versionRow.body,
+        frontmatter: versionRow.frontmatter as Record<string, unknown>,
+        path: versionRow.path,
+        contentFormat:
+          versionRow.contentFormat as SourceDocumentRow["contentFormat"],
+        schemaType: versionRow.schemaType,
+        locale: versionRow.locale,
+        version: versionRow.version,
+      });
+    }
+  }
+
   return {
     scope,
     rows,
     sourceLookup: (id) => sourceMap.get(id),
     schemaByType,
+    publishedByDocumentId,
   };
 }
 
@@ -257,10 +329,42 @@ export type CloneEnvironmentInput = EnvironmentCloneInput & {
   targetEnvironmentId: string;
 };
 
+// Spec defaults applied here so the orchestrator can run with a partial
+// `EnvironmentCloneInput` (e.g. internal callers, tests) without going
+// through the route's Zod assertion.
+function resolveCloneDefaults(input: CloneEnvironmentInput) {
+  return {
+    includeContent: input.include?.content ?? true,
+    includeSettings: input.include?.settings ?? false,
+    includeDrafts: input.includeDrafts ?? true,
+    preservePaths: input.preservePaths ?? true,
+  };
+}
+
+// `preservePaths: false` keeps the cloned document distinct from the source
+// path so the new environment can hold both copies side by side. We append a
+// short suffix derived from the new target documentId — deterministic per
+// run and short enough to stay within `text` column limits, and uniquely
+// salts the path so the (project, env, locale, path) unique index never
+// collides with whatever else lives in the target.
+function deriveTargetPath(input: {
+  sourcePath: string;
+  preservePaths: boolean;
+  targetDocumentId: string;
+}): string {
+  if (input.preservePaths) {
+    return input.sourcePath;
+  }
+  const suffix = input.targetDocumentId.slice(0, 8);
+  return `${input.sourcePath}.cloned-${suffix}`;
+}
+
 export async function cloneEnvironment(
   db: DrizzleDatabase,
   input: CloneEnvironmentInput,
 ): Promise<EnvironmentCloneResult> {
+  const defaults = resolveCloneDefaults(input);
+
   return db.transaction(async (tx) => {
     const txDb = tx as unknown as DrizzleDatabase;
     const scope = await loadProjectScope(txDb, {
@@ -269,11 +373,11 @@ export async function cloneEnvironment(
       targetEnvId: input.targetEnvironmentId,
     });
 
-    if (input.include.settings) {
+    if (defaults.includeSettings) {
       await copyEnvironmentSettings(txDb, scope);
     }
 
-    if (!input.include.content) {
+    if (!defaults.includeContent) {
       return {
         targetEnvironmentId: scope.targetEnvId,
         documentsCloned: 0,
@@ -281,7 +385,7 @@ export async function cloneEnvironment(
     }
 
     const sourceContext = await loadSourceContext(txDb, scope, {
-      includeDrafts: input.includeDrafts,
+      includeDrafts: defaults.includeDrafts,
     });
 
     if (sourceContext.rows.length === 0) {
@@ -328,22 +432,48 @@ export async function cloneEnvironment(
     let documentsCloned = 0;
 
     for (const row of sourceContext.rows) {
-      const schema = sourceContext.schemaByType.get(row.schemaType);
-      const remap = remapFrontmatterReferences({
-        schema,
-        frontmatter: row.frontmatter as Record<string, unknown>,
-        sourceLookup: sourceContext.sourceLookup,
-        targetResolver,
-        sourceDocumentId: row.documentId,
-      });
-
       const targetDocumentId = targetIdByKey.get(
         targetMapKey({
           translationGroupId: row.translationGroupId,
           locale: row.locale,
         }),
       )!;
-      const hasPublishedSnapshot = row.publishedVersion !== null;
+      const publishedPayload = sourceContext.publishedByDocumentId.get(
+        row.documentId,
+      );
+      const hasPublishedSnapshot = publishedPayload !== undefined;
+
+      // When `includeDrafts: false` the operator wants the published source
+      // state in the target. When `includeDrafts: true` the operator wants
+      // the live (possibly draft) state — which is what the documents row
+      // holds. The published payload is still used for the version-1 row
+      // snapshot below, so a published source row produces target content
+      // whose draft and published states accurately mirror the source.
+      const headPayload =
+        !defaults.includeDrafts && publishedPayload
+          ? publishedPayload
+          : {
+              body: row.body,
+              frontmatter: row.frontmatter as Record<string, unknown>,
+              path: row.path,
+              contentFormat: row.contentFormat,
+              schemaType: row.schemaType,
+              locale: row.locale,
+            };
+
+      const headRemap = remapFrontmatterReferences({
+        schema: sourceContext.schemaByType.get(headPayload.schemaType),
+        frontmatter: headPayload.frontmatter,
+        sourceLookup: sourceContext.sourceLookup,
+        targetResolver,
+        sourceDocumentId: row.documentId,
+      });
+
+      const targetPath = deriveTargetPath({
+        sourcePath: headPayload.path,
+        preservePaths: defaults.preservePaths,
+        targetDocumentId,
+      });
 
       try {
         await txDb.insert(documents).values({
@@ -351,12 +481,12 @@ export async function cloneEnvironment(
           translationGroupId: row.translationGroupId,
           projectId: scope.projectId,
           environmentId: scope.targetEnvId,
-          path: row.path,
-          schemaType: row.schemaType,
-          locale: row.locale,
-          contentFormat: row.contentFormat,
-          body: row.body,
-          frontmatter: remap.frontmatter,
+          path: targetPath,
+          schemaType: headPayload.schemaType,
+          locale: headPayload.locale,
+          contentFormat: headPayload.contentFormat,
+          body: headPayload.body,
+          frontmatter: headRemap.frontmatter,
           isDeleted: false,
           hasUnpublishedChanges: !hasPublishedSnapshot,
           publishedVersion: null,
@@ -370,38 +500,63 @@ export async function cloneEnvironment(
             "Target environment already contains content that conflicts with the clone payload.",
             {
               targetEnvironmentId: scope.targetEnvId,
-              path: row.path,
+              path: targetPath,
               locale: row.locale,
               translationGroupId: row.translationGroupId,
-              preservePaths: input.preservePaths,
+              preservePaths: defaults.preservePaths,
             },
           );
         }
         throw error;
       }
 
-      if (hasPublishedSnapshot) {
-        // Copy the latest published snapshot as version 1 in the target so
-        // the target row can be served as published immediately. Full version
-        // history is intentionally not copied (SPEC-009 #Cloning).
+      if (hasPublishedSnapshot && publishedPayload) {
+        // Version-1 in the target carries the *published* source state, even
+        // when `includeDrafts: true` and the head row reflects the draft —
+        // so consumers querying the target as "published" see exactly what
+        // was published on the source side. Full version history is
+        // intentionally not copied (SPEC-009 #Cloning).
+        const publishedRemap = remapFrontmatterReferences({
+          schema: sourceContext.schemaByType.get(publishedPayload.schemaType),
+          frontmatter: publishedPayload.frontmatter,
+          sourceLookup: sourceContext.sourceLookup,
+          targetResolver,
+          sourceDocumentId: row.documentId,
+        });
+        const publishedPath = deriveTargetPath({
+          sourcePath: publishedPayload.path,
+          preservePaths: defaults.preservePaths,
+          targetDocumentId,
+        });
         await txDb.insert(documentVersions).values({
           documentId: targetDocumentId,
           translationGroupId: row.translationGroupId,
           projectId: scope.projectId,
           environmentId: scope.targetEnvId,
-          schemaType: row.schemaType,
-          locale: row.locale,
-          contentFormat: row.contentFormat,
-          path: row.path,
-          body: row.body,
-          frontmatter: remap.frontmatter,
+          schemaType: publishedPayload.schemaType,
+          locale: publishedPayload.locale,
+          contentFormat: publishedPayload.contentFormat,
+          path: publishedPath,
+          body: publishedPayload.body,
+          frontmatter: publishedRemap.frontmatter,
           version: 1,
           publishedBy: cloneActor,
           changeSummary: "Cloned from source environment.",
         });
         await txDb
           .update(documents)
-          .set({ publishedVersion: 1, hasUnpublishedChanges: false })
+          .set({
+            publishedVersion: 1,
+            hasUnpublishedChanges: !defaults.includeDrafts
+              ? false
+              : // If includeDrafts is true and the head and published payloads
+                // differ, the target row holds draft content distinct from its
+                // published v1 — so `hasUnpublishedChanges` is true.
+                headPayload.body !== publishedPayload.body ||
+                JSON.stringify(headPayload.frontmatter) !==
+                  JSON.stringify(publishedPayload.frontmatter) ||
+                headPayload.path !== publishedPayload.path,
+          })
           .where(eq(documents.documentId, targetDocumentId));
       }
 
@@ -495,6 +650,12 @@ export async function promoteDocuments(
   db: DrizzleDatabase,
   input: PromoteEnvironmentInput,
 ): Promise<EnvironmentPromoteResult> {
+  // Apply spec defaults so internal callers (and tests) can pass a partial
+  // input without round-tripping through the route validator.
+  const includeUnpublished = input.includeUnpublished ?? false;
+  const dryRun = input.dryRun ?? false;
+  const callerPreallocations = input.preallocatedTargetIds ?? {};
+
   return db.transaction(async (tx) => {
     const txDb = tx as unknown as DrizzleDatabase;
     const scope = await loadProjectScope(txDb, {
@@ -532,9 +693,14 @@ export async function promoteDocuments(
     // dry-run (no writes) and during the real run (in-progress creations).
     // The pre-allocated id matches the id used by `createTargetDraft` when
     // the row is actually written.
+    //
+    // When the caller supplied `preallocatedTargetIds` (typically the
+    // dry-run result replayed back into a real run), we reuse those ids
+    // for deterministic replay. Anything not in the caller map falls back
+    // to a fresh UUID.
     const preallocatedTargetIds = new Map<string, string>();
     for (const row of sourceContext.rows) {
-      if (!input.includeUnpublished && row.publishedVersion === null) {
+      if (!includeUnpublished && row.publishedVersion === null) {
         continue;
       }
       const key = targetMapKey({
@@ -542,7 +708,7 @@ export async function promoteDocuments(
         locale: row.locale,
       });
       if (!targetMap.has(key)) {
-        const allocated = randomUUID();
+        const allocated = callerPreallocations[row.documentId] ?? randomUUID();
         targetMap.set(key, allocated);
         preallocatedTargetIds.set(key, allocated);
       }
@@ -555,7 +721,7 @@ export async function promoteDocuments(
     const promoteActor = DEFAULT_ACTOR;
 
     for (const row of sourceContext.rows) {
-      if (!input.includeUnpublished && row.publishedVersion === null) {
+      if (!includeUnpublished && row.publishedVersion === null) {
         promoted.push({
           sourceDocumentId: row.documentId,
           targetDocumentId:
@@ -594,7 +760,7 @@ export async function promoteDocuments(
       // to create within this same batch.
       const existingTargetId = preallocatedId ? undefined : targetMap.get(key);
 
-      if (input.dryRun) {
+      if (dryRun) {
         promoted.push({
           sourceDocumentId: row.documentId,
           targetDocumentId: existingTargetId ?? preallocatedId ?? null,
@@ -720,28 +886,49 @@ async function overwriteTargetDraft(
     actor: string;
   },
 ): Promise<void> {
-  await db
-    .update(documents)
-    .set({
-      schemaType: input.source.schemaType,
-      contentFormat: input.source.contentFormat,
-      body: input.source.body,
-      frontmatter: input.remappedFrontmatter,
-      path: input.source.path,
-      locale: input.source.locale,
-      isDeleted: false,
-      hasUnpublishedChanges: true,
-      draftRevision: sql`${documents.draftRevision} + 1`,
-      updatedBy: input.actor,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(documents.projectId, input.scope.projectId),
-        eq(documents.environmentId, input.scope.targetEnvId),
-        eq(documents.documentId, input.targetDocumentId),
-      ),
-    );
+  // Updates can hit the same `(projectId, environmentId, locale, path)`
+  // unique index that creates do — for example when the source row's path
+  // already belongs to a different active target document. Surface this as
+  // the same 409 conflict shape `createTargetDraft` produces so the caller
+  // never sees a raw 23505 bubbled into a 500.
+  try {
+    await db
+      .update(documents)
+      .set({
+        schemaType: input.source.schemaType,
+        contentFormat: input.source.contentFormat,
+        body: input.source.body,
+        frontmatter: input.remappedFrontmatter,
+        path: input.source.path,
+        locale: input.source.locale,
+        isDeleted: false,
+        hasUnpublishedChanges: true,
+        draftRevision: sql`${documents.draftRevision} + 1`,
+        updatedBy: input.actor,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(documents.projectId, input.scope.projectId),
+          eq(documents.environmentId, input.scope.targetEnvId),
+          eq(documents.documentId, input.targetDocumentId),
+        ),
+      );
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw buildConflictError(
+        "Promote target conflicts with existing content (path or translation pair).",
+        {
+          targetEnvironmentId: input.scope.targetEnvId,
+          targetDocumentId: input.targetDocumentId,
+          path: input.source.path,
+          locale: input.source.locale,
+          translationGroupId: input.source.translationGroupId,
+        },
+      );
+    }
+    throw error;
+  }
 }
 
 async function publishTargetDocument(

--- a/apps/server/src/lib/environments-reference-remap.test.ts
+++ b/apps/server/src/lib/environments-reference-remap.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import {
+  isRuntimeErrorLike,
+  type SchemaRegistryTypeSnapshot,
+} from "@mdcms/shared";
+
+import { remapFrontmatterReferences } from "./environments-reference-remap.js";
+
+const schema: SchemaRegistryTypeSnapshot = {
+  type: "BlogPost",
+  directory: "blog",
+  localized: true,
+  fields: {
+    title: { kind: "string", required: true, nullable: false },
+    author: {
+      kind: "string",
+      required: true,
+      nullable: false,
+      reference: { targetType: "Author" },
+    },
+    related: {
+      kind: "array",
+      required: false,
+      nullable: false,
+      item: {
+        kind: "string",
+        required: false,
+        nullable: false,
+        reference: { targetType: "BlogPost" },
+      },
+    },
+    block: {
+      kind: "object",
+      required: false,
+      nullable: false,
+      fields: {
+        cover: {
+          kind: "string",
+          required: false,
+          nullable: false,
+          reference: { targetType: "Asset" },
+        },
+        title: { kind: "string", required: false, nullable: false },
+      },
+    },
+  },
+};
+
+const SOURCE_AUTHOR = "11111111-1111-4111-8111-111111111111";
+const TARGET_AUTHOR = "11111111-1111-4111-8111-aaaaaaaaaaaa";
+const SOURCE_BLOG_A = "22222222-2222-4222-8222-222222222222";
+const TARGET_BLOG_A = "22222222-2222-4222-8222-aaaaaaaaaaaa";
+const SOURCE_ASSET = "33333333-3333-4333-8333-333333333333";
+const TARGET_ASSET = "33333333-3333-4333-8333-aaaaaaaaaaaa";
+
+const baseSourceLookup = (sourceDocumentId: string) => {
+  switch (sourceDocumentId) {
+    case SOURCE_AUTHOR:
+      return { translationGroupId: "g-author", locale: "__mdcms_default__" };
+    case SOURCE_BLOG_A:
+      return { translationGroupId: "g-blog-a", locale: "en-US" };
+    case SOURCE_ASSET:
+      return { translationGroupId: "g-asset", locale: "__mdcms_default__" };
+    default:
+      return undefined;
+  }
+};
+
+const baseTargetResolver = (key: {
+  translationGroupId: string;
+  locale: string;
+}) => {
+  if (
+    key.translationGroupId === "g-author" &&
+    key.locale === "__mdcms_default__"
+  ) {
+    return TARGET_AUTHOR;
+  }
+  if (key.translationGroupId === "g-blog-a" && key.locale === "en-US") {
+    return TARGET_BLOG_A;
+  }
+  if (
+    key.translationGroupId === "g-asset" &&
+    key.locale === "__mdcms_default__"
+  ) {
+    return TARGET_ASSET;
+  }
+  return undefined;
+};
+
+test("remapFrontmatterReferences rewrites top-level, array, and nested references", () => {
+  const result = remapFrontmatterReferences({
+    schema,
+    frontmatter: {
+      title: "Hello",
+      author: SOURCE_AUTHOR,
+      related: [SOURCE_BLOG_A],
+      block: {
+        cover: SOURCE_ASSET,
+        title: "Cover",
+      },
+    },
+    sourceLookup: baseSourceLookup,
+    targetResolver: baseTargetResolver,
+    sourceDocumentId: "src-doc",
+  });
+
+  assert.equal(result.remappedReferences, 3);
+  assert.deepEqual(result.frontmatter, {
+    title: "Hello",
+    author: TARGET_AUTHOR,
+    related: [TARGET_BLOG_A],
+    block: {
+      cover: TARGET_ASSET,
+      title: "Cover",
+    },
+  });
+});
+
+test("remapFrontmatterReferences does not count unchanged values", () => {
+  const result = remapFrontmatterReferences({
+    schema,
+    frontmatter: {
+      title: "No refs",
+      author: SOURCE_AUTHOR,
+    },
+    sourceLookup: baseSourceLookup,
+    targetResolver: (key) =>
+      key.translationGroupId === "g-author" ? SOURCE_AUTHOR : undefined,
+    sourceDocumentId: "src-doc",
+  });
+
+  // Same value coming back is still a successful resolve, but the counter
+  // only ticks when the value actually changes.
+  assert.equal(result.remappedReferences, 0);
+  assert.equal(result.frontmatter.author, SOURCE_AUTHOR);
+});
+
+test("remapFrontmatterReferences fails atomically when source unknown", () => {
+  let thrown: unknown;
+  try {
+    remapFrontmatterReferences({
+      schema,
+      frontmatter: {
+        author: "00000000-0000-4000-8000-000000000000",
+      },
+      sourceLookup: () => undefined,
+      targetResolver: () => "anything",
+      sourceDocumentId: "src-doc",
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(isRuntimeErrorLike(thrown));
+  const error = thrown as {
+    code: string;
+    statusCode: number;
+    details?: Record<string, unknown>;
+  };
+  assert.equal(error.code, "REFERENCE_REMAP_FAILED");
+  assert.equal(error.statusCode, 409);
+  assert.equal(error.details?.reason, "unknown_source");
+});
+
+test("remapFrontmatterReferences fails atomically when target match missing", () => {
+  let thrown: unknown;
+  try {
+    remapFrontmatterReferences({
+      schema,
+      frontmatter: {
+        author: SOURCE_AUTHOR,
+      },
+      sourceLookup: baseSourceLookup,
+      // Target has no row for `(g-author, __mdcms_default__)`.
+      targetResolver: () => undefined,
+      sourceDocumentId: "src-doc",
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(isRuntimeErrorLike(thrown));
+  const error = thrown as {
+    details?: Record<string, unknown>;
+  };
+  assert.equal(error.details?.reason, "no_target_match");
+  assert.equal(error.details?.translationGroupId, "g-author");
+});
+
+test("remapFrontmatterReferences ignores null/undefined values without erroring", () => {
+  const result = remapFrontmatterReferences({
+    schema,
+    frontmatter: {
+      title: "x",
+      author: null,
+      related: undefined,
+      block: { cover: null },
+    } as unknown as Record<string, unknown>,
+    sourceLookup: baseSourceLookup,
+    targetResolver: baseTargetResolver,
+    sourceDocumentId: "src-doc",
+  });
+
+  assert.equal(result.remappedReferences, 0);
+  assert.equal(result.frontmatter.author, null);
+});
+
+test("remapFrontmatterReferences passes through frontmatter when schema undefined", () => {
+  const result = remapFrontmatterReferences({
+    schema: undefined,
+    frontmatter: { author: SOURCE_AUTHOR },
+    sourceLookup: baseSourceLookup,
+    targetResolver: baseTargetResolver,
+    sourceDocumentId: "src-doc",
+  });
+  assert.equal(result.remappedReferences, 0);
+  assert.equal(result.frontmatter.author, SOURCE_AUTHOR);
+});

--- a/apps/server/src/lib/environments-reference-remap.test.ts
+++ b/apps/server/src/lib/environments-reference-remap.test.ts
@@ -217,3 +217,51 @@ test("remapFrontmatterReferences passes through frontmatter when schema undefine
   assert.equal(result.remappedReferences, 0);
   assert.equal(result.frontmatter.author, SOURCE_AUTHOR);
 });
+
+test("remapFrontmatterReferences throws when an object reference container is wrong shape", () => {
+  let thrown: unknown;
+  try {
+    remapFrontmatterReferences({
+      schema,
+      frontmatter: {
+        // schema declares `block` as an object containing a reference
+        // (`block.cover`); supplying an array breaks the shape contract.
+        block: [SOURCE_ASSET],
+      } as unknown as Record<string, unknown>,
+      sourceLookup: baseSourceLookup,
+      targetResolver: baseTargetResolver,
+      sourceDocumentId: "src-doc",
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(isRuntimeErrorLike(thrown));
+  const error = thrown as { code: string; details?: Record<string, unknown> };
+  assert.equal(error.code, "REFERENCE_REMAP_FAILED");
+  assert.equal(error.details?.reason, "container_shape_mismatch");
+  assert.equal(error.details?.expectedKind, "object");
+});
+
+test("remapFrontmatterReferences throws when an array reference container is wrong shape", () => {
+  let thrown: unknown;
+  try {
+    remapFrontmatterReferences({
+      schema,
+      frontmatter: {
+        // `related` is declared as an array of references — passing an
+        // object should fail fast rather than silently keep unremapped ids.
+        related: { 0: SOURCE_BLOG_A },
+      } as unknown as Record<string, unknown>,
+      sourceLookup: baseSourceLookup,
+      targetResolver: baseTargetResolver,
+      sourceDocumentId: "src-doc",
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(isRuntimeErrorLike(thrown));
+  const error = thrown as { code: string; details?: Record<string, unknown> };
+  assert.equal(error.code, "REFERENCE_REMAP_FAILED");
+  assert.equal(error.details?.reason, "container_shape_mismatch");
+  assert.equal(error.details?.expectedKind, "array");
+});

--- a/apps/server/src/lib/environments-reference-remap.ts
+++ b/apps/server/src/lib/environments-reference-remap.ts
@@ -179,7 +179,22 @@ function remapFieldValue(input: {
       return input.value;
     }
     if (!isRecord(input.value)) {
-      return input.value;
+      // Schema declares an object that contains references but the stored
+      // value is not an object. Silently passing the value through would
+      // commit unremapped reference IDs into the target — instead fail
+      // fast so the surrounding transaction rolls back.
+      throw new RuntimeError({
+        code: "REFERENCE_REMAP_FAILED",
+        message: `Field "${input.fieldPath}" must be an object because its schema contains reference fields.`,
+        statusCode: 409,
+        details: {
+          sourceDocumentId: input.sourceDocumentId,
+          fieldPath: input.fieldPath,
+          reason: "container_shape_mismatch",
+          expectedKind: "object",
+          actualType: Array.isArray(input.value) ? "array" : typeof input.value,
+        },
+      });
     }
     const next: Record<string, unknown> = { ...input.value };
     for (const [fieldName, field] of Object.entries(input.field.fields)) {
@@ -197,8 +212,25 @@ function remapFieldValue(input: {
   }
 
   if (input.field.kind === "array" && input.field.item) {
-    if (!containsReference(input.field) || !Array.isArray(input.value)) {
+    if (!containsReference(input.field)) {
       return input.value;
+    }
+    if (!Array.isArray(input.value)) {
+      // Same reasoning as the object branch above — if the schema says
+      // "array of references" but the stored value isn't an array, refuse
+      // rather than commit unremapped ids.
+      throw new RuntimeError({
+        code: "REFERENCE_REMAP_FAILED",
+        message: `Field "${input.fieldPath}" must be an array because its schema contains reference fields.`,
+        statusCode: 409,
+        details: {
+          sourceDocumentId: input.sourceDocumentId,
+          fieldPath: input.fieldPath,
+          reason: "container_shape_mismatch",
+          expectedKind: "array",
+          actualType: isRecord(input.value) ? "object" : typeof input.value,
+        },
+      });
     }
     return input.value.map((entry, index) =>
       remapFieldValue({

--- a/apps/server/src/lib/environments-reference-remap.ts
+++ b/apps/server/src/lib/environments-reference-remap.ts
@@ -1,0 +1,248 @@
+import {
+  RuntimeError,
+  type SchemaRegistryFieldSnapshot,
+  type SchemaRegistryTypeSnapshot,
+} from "@mdcms/shared";
+
+// Reference remap is invoked for every document copied or promoted between
+// environments. It walks `frontmatter` using the type snapshot, finds every
+// `field.reference` value (which is the `documentId` of a referenced doc in
+// the source environment), and rewrites it to the target environment's
+// `documentId` for the same `(translation_group_id, locale)` pair.
+//
+// SPEC-009 requires that any unresolved reference aborts the surrounding
+// operation atomically. We surface that as a `REFERENCE_REMAP_FAILED` error
+// (HTTP 409) — callers run inside a `db.transaction` so the throw rolls back
+// every write attempted so far.
+
+export type ReferenceLookupKey = {
+  translationGroupId: string;
+  locale: string;
+};
+
+export type ReferenceSourceLookup = (
+  sourceDocumentId: string,
+) => ReferenceLookupKey | undefined;
+
+export type ReferenceTargetResolver = (
+  key: ReferenceLookupKey,
+) => string | undefined;
+
+export type RemapResult = {
+  frontmatter: Record<string, unknown>;
+  remappedReferences: number;
+};
+
+export type RemapInput = {
+  schema: SchemaRegistryTypeSnapshot | undefined;
+  frontmatter: Record<string, unknown>;
+  sourceLookup: ReferenceSourceLookup;
+  targetResolver: ReferenceTargetResolver;
+  // Used purely for error context when a reference fails to resolve.
+  sourceDocumentId: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function containsReference(field: SchemaRegistryFieldSnapshot): boolean {
+  if (field.reference) {
+    return true;
+  }
+
+  if (field.kind === "array" && field.item) {
+    return containsReference(field.item);
+  }
+
+  if (field.kind === "object" && field.fields) {
+    return Object.values(field.fields).some((entry) =>
+      containsReference(entry),
+    );
+  }
+
+  return false;
+}
+
+function buildRemapFailure(input: {
+  sourceDocumentId: string;
+  sourceReferenceId: string;
+  fieldPath: string;
+  reason: "unknown_source" | "no_target_match";
+  targetType: string;
+  key?: ReferenceLookupKey;
+}): RuntimeError {
+  return new RuntimeError({
+    code: "REFERENCE_REMAP_FAILED",
+    message:
+      input.reason === "unknown_source"
+        ? `Reference at "${input.fieldPath}" points to a source document (${input.sourceReferenceId}) that does not exist in the source environment.`
+        : `Reference at "${input.fieldPath}" cannot be remapped: target environment has no document with translation group "${input.key?.translationGroupId}" and locale "${input.key?.locale}".`,
+    statusCode: 409,
+    details: {
+      sourceDocumentId: input.sourceDocumentId,
+      sourceReferenceId: input.sourceReferenceId,
+      fieldPath: input.fieldPath,
+      targetType: input.targetType,
+      reason: input.reason,
+      ...(input.key
+        ? {
+            translationGroupId: input.key.translationGroupId,
+            locale: input.key.locale,
+          }
+        : {}),
+    },
+  });
+}
+
+function remapReferenceValue(input: {
+  value: unknown;
+  fieldPath: string;
+  targetType: string;
+  sourceLookup: ReferenceSourceLookup;
+  targetResolver: ReferenceTargetResolver;
+  sourceDocumentId: string;
+}): { value: string; replaced: boolean } {
+  if (typeof input.value !== "string") {
+    // Non-string reference values are an upstream validation bug — surface as
+    // remap failure so the operation is rolled back rather than producing a
+    // corrupt target row.
+    throw buildRemapFailure({
+      sourceDocumentId: input.sourceDocumentId,
+      sourceReferenceId: String(input.value),
+      fieldPath: input.fieldPath,
+      reason: "unknown_source",
+      targetType: input.targetType,
+    });
+  }
+
+  const sourceReferenceId = input.value;
+  const key = input.sourceLookup(sourceReferenceId);
+  if (!key) {
+    throw buildRemapFailure({
+      sourceDocumentId: input.sourceDocumentId,
+      sourceReferenceId,
+      fieldPath: input.fieldPath,
+      reason: "unknown_source",
+      targetType: input.targetType,
+    });
+  }
+
+  const resolved = input.targetResolver(key);
+  if (!resolved) {
+    throw buildRemapFailure({
+      sourceDocumentId: input.sourceDocumentId,
+      sourceReferenceId,
+      fieldPath: input.fieldPath,
+      reason: "no_target_match",
+      targetType: input.targetType,
+      key,
+    });
+  }
+
+  return {
+    value: resolved,
+    replaced: resolved !== sourceReferenceId,
+  };
+}
+
+function remapFieldValue(input: {
+  value: unknown;
+  field: SchemaRegistryFieldSnapshot;
+  fieldPath: string;
+  sourceLookup: ReferenceSourceLookup;
+  targetResolver: ReferenceTargetResolver;
+  sourceDocumentId: string;
+  counter: { count: number };
+}): unknown {
+  if (input.value === undefined || input.value === null) {
+    return input.value;
+  }
+
+  if (input.field.reference) {
+    const result = remapReferenceValue({
+      value: input.value,
+      fieldPath: input.fieldPath,
+      targetType: input.field.reference.targetType,
+      sourceLookup: input.sourceLookup,
+      targetResolver: input.targetResolver,
+      sourceDocumentId: input.sourceDocumentId,
+    });
+    if (result.replaced) {
+      input.counter.count += 1;
+    }
+    return result.value;
+  }
+
+  if (input.field.kind === "object" && input.field.fields) {
+    if (!containsReference(input.field)) {
+      return input.value;
+    }
+    if (!isRecord(input.value)) {
+      return input.value;
+    }
+    const next: Record<string, unknown> = { ...input.value };
+    for (const [fieldName, field] of Object.entries(input.field.fields)) {
+      next[fieldName] = remapFieldValue({
+        value: input.value[fieldName],
+        field,
+        fieldPath: `${input.fieldPath}.${fieldName}`,
+        sourceLookup: input.sourceLookup,
+        targetResolver: input.targetResolver,
+        sourceDocumentId: input.sourceDocumentId,
+        counter: input.counter,
+      });
+    }
+    return next;
+  }
+
+  if (input.field.kind === "array" && input.field.item) {
+    if (!containsReference(input.field) || !Array.isArray(input.value)) {
+      return input.value;
+    }
+    return input.value.map((entry, index) =>
+      remapFieldValue({
+        value: entry,
+        field: input.field.item!,
+        fieldPath: `${input.fieldPath}[${index}]`,
+        sourceLookup: input.sourceLookup,
+        targetResolver: input.targetResolver,
+        sourceDocumentId: input.sourceDocumentId,
+        counter: input.counter,
+      }),
+    );
+  }
+
+  return input.value;
+}
+
+export function remapFrontmatterReferences(input: RemapInput): RemapResult {
+  if (!input.schema) {
+    // Without a schema snapshot we cannot identify reference fields; copy
+    // frontmatter through unchanged. The clone/promote orchestrator decides
+    // whether to refuse the operation when `include.settings === false` and
+    // no target schema sync is present (out of scope for this helper).
+    return {
+      frontmatter: input.frontmatter,
+      remappedReferences: 0,
+    };
+  }
+
+  const counter = { count: 0 };
+  const next: Record<string, unknown> = { ...input.frontmatter };
+  for (const [fieldName, field] of Object.entries(input.schema.fields)) {
+    next[fieldName] = remapFieldValue({
+      value: input.frontmatter[fieldName],
+      field,
+      fieldPath: `frontmatter.${fieldName}`,
+      sourceLookup: input.sourceLookup,
+      targetResolver: input.targetResolver,
+      sourceDocumentId: input.sourceDocumentId,
+      counter,
+    });
+  }
+  return {
+    frontmatter: next,
+    remappedReferences: counter.count,
+  };
+}

--- a/apps/server/src/lib/runtime-with-modules.ts
+++ b/apps/server/src/lib/runtime-with-modules.ts
@@ -199,6 +199,14 @@ export function createServerRequestHandlerWithModules(
           return session;
         },
         authorizeAdmin: (request) => authService.requireAdminSession(request),
+        authorizeScoped: async (request, requiredScope) => {
+          const routing = resolveRequestTargetRouting(request);
+          await authService.authorizeRequest(request, {
+            requiredScope,
+            project: routing.project,
+            environment: routing.environment,
+          });
+        },
         requireCsrf: (request) => authService.requireCsrfProtection(request),
       });
       mountProjectApiRoutes(app, {

--- a/packages/shared/src/lib/contracts/environments.ts
+++ b/packages/shared/src/lib/contracts/environments.ts
@@ -31,15 +31,18 @@ export type EnvironmentCreateInput = {
 };
 
 export type EnvironmentClonePayloadInclude = {
-  content: boolean;
-  settings: boolean;
+  content?: boolean;
+  settings?: boolean;
 };
 
 export type EnvironmentCloneInput = {
   sourceEnvironmentId: string;
-  include: EnvironmentClonePayloadInclude;
-  includeDrafts: boolean;
-  preservePaths: boolean;
+  // Spec defaults: include={content:true,settings:false}, includeDrafts=true,
+  // preservePaths=true. The runtime validator applies these defaults before
+  // dispatch — TS callers may omit them to inherit those defaults.
+  include?: EnvironmentClonePayloadInclude;
+  includeDrafts?: boolean;
+  preservePaths?: boolean;
 };
 
 export type EnvironmentCloneResult = {
@@ -66,8 +69,16 @@ export type DocumentPromotionResult = {
 export type EnvironmentPromoteInput = {
   sourceEnvironmentId: string;
   documentIds: string[];
-  includeUnpublished: boolean;
-  dryRun: boolean;
+  // Defaults: includeUnpublished=false (only published source rows promote),
+  // dryRun=false (real run). The runtime validator fills these in.
+  includeUnpublished?: boolean;
+  dryRun?: boolean;
+  // Optional. Caller-supplied map keyed by source documentId → target
+  // documentId. The orchestrator uses these instead of generating fresh
+  // UUIDs for would-be-created target rows so a dry-run plan can be
+  // replayed deterministically: read `promoted[].targetDocumentId` from a
+  // dryRun response, pass it back here on the real run.
+  preallocatedTargetIds?: Record<string, string>;
 };
 
 export type EnvironmentPromoteResult = {
@@ -309,10 +320,43 @@ export function assertEnvironmentPromoteInput(
   // dryRun defaults to false — explicit opt-in for plan-only mode.
   const dryRun = assertOptionalBoolean(obj.dryRun, `${path}.dryRun`, false);
 
+  // Optional `preallocatedTargetIds`: keys are source document UUIDs that the
+  // operation will create in the target; values are the target document UUIDs
+  // to use instead of fresh randomUUID()s. Lets a real run replay the exact
+  // plan a prior dry-run returned.
+  let preallocatedTargetIds: Record<string, string> | undefined;
+  if (obj.preallocatedTargetIds !== undefined) {
+    if (
+      typeof obj.preallocatedTargetIds !== "object" ||
+      obj.preallocatedTargetIds === null ||
+      Array.isArray(obj.preallocatedTargetIds)
+    ) {
+      invalidInput(
+        `${path}.preallocatedTargetIds`,
+        "must be an object mapping source documentId UUIDs to target documentId UUIDs.",
+      );
+    }
+    preallocatedTargetIds = {};
+    for (const [sourceId, targetId] of Object.entries(
+      obj.preallocatedTargetIds as Record<string, unknown>,
+    )) {
+      const normalizedSource = assertUuid(
+        sourceId,
+        `${path}.preallocatedTargetIds[key]`,
+      );
+      const normalizedTarget = assertUuid(
+        targetId,
+        `${path}.preallocatedTargetIds[${sourceId}]`,
+      );
+      preallocatedTargetIds[normalizedSource] = normalizedTarget;
+    }
+  }
+
   Object.assign(obj, {
     sourceEnvironmentId,
     documentIds,
     includeUnpublished,
     dryRun,
+    ...(preallocatedTargetIds !== undefined ? { preallocatedTargetIds } : {}),
   });
 }

--- a/packages/shared/src/lib/contracts/environments.ts
+++ b/packages/shared/src/lib/contracts/environments.ts
@@ -30,7 +30,52 @@ export type EnvironmentCreateInput = {
   extends?: string;
 };
 
+export type EnvironmentClonePayloadInclude = {
+  content: boolean;
+  settings: boolean;
+};
+
+export type EnvironmentCloneInput = {
+  sourceEnvironmentId: string;
+  include: EnvironmentClonePayloadInclude;
+  includeDrafts: boolean;
+  preservePaths: boolean;
+};
+
+export type EnvironmentCloneResult = {
+  targetEnvironmentId: string;
+  documentsCloned: number;
+};
+
+export type DocumentPromotionStatus =
+  | "overwrote"
+  | "created"
+  | "skipped_unpublished";
+
+export type DocumentPromotionResult = {
+  sourceDocumentId: string;
+  targetDocumentId: string | null;
+  status: DocumentPromotionStatus;
+  path: string;
+  locale: string;
+  type: string;
+  publishedVersion: number | null;
+  remappedReferences: number;
+};
+
+export type EnvironmentPromoteInput = {
+  sourceEnvironmentId: string;
+  documentIds: string[];
+  includeUnpublished: boolean;
+  dryRun: boolean;
+};
+
+export type EnvironmentPromoteResult = {
+  promoted: DocumentPromotionResult[];
+};
+
 const NonEmptyStringSchema = z.string().trim().min(1);
+const UuidSchema = z.string().trim().uuid();
 const EnvironmentDefinitionsMetaSchema = z.discriminatedUnion(
   "definitionsStatus",
   [
@@ -131,4 +176,143 @@ export function assertEnvironmentListResponse(
   path = "value",
 ): asserts value is EnvironmentListResponse {
   assertWithSchema(EnvironmentListResponseSchema, value, path);
+}
+
+// Clone / promote payloads have richer shapes (booleans, arrays of UUIDs)
+// than the simple `name`/`extends` create payload, so we surface specific
+// error messages per offending field rather than the generic "must be a
+// non-empty string" the legacy create-input assertion uses.
+function assertCloneOrPromotePayload(
+  value: unknown,
+  path: string,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    invalidInput(path, "must be an object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertUuid(value: unknown, path: string): string {
+  if (typeof value !== "string" || !UuidSchema.safeParse(value).success) {
+    invalidInput(path, "must be a UUID string.");
+  }
+  return value.trim();
+}
+
+function assertBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") {
+    invalidInput(path, "must be a boolean.");
+  }
+  return value;
+}
+
+function assertOptionalBoolean(
+  value: unknown,
+  path: string,
+  fallback: boolean,
+): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return assertBoolean(value, path);
+}
+
+export function assertEnvironmentCloneInput(
+  value: unknown,
+  path = "value",
+): asserts value is EnvironmentCloneInput {
+  const obj = assertCloneOrPromotePayload(value, path);
+  const sourceEnvironmentId = assertUuid(
+    obj.sourceEnvironmentId,
+    `${path}.sourceEnvironmentId`,
+  );
+
+  // Spec defaults: include.content=true, include.settings=false (settings copy
+  // is opt-in because it overwrites synced schema state in the target).
+  const includeRaw =
+    obj.include === undefined
+      ? { content: true, settings: false }
+      : obj.include;
+  if (
+    typeof includeRaw !== "object" ||
+    includeRaw === null ||
+    Array.isArray(includeRaw)
+  ) {
+    invalidInput(`${path}.include`, "must be an object.");
+  }
+  const includeRecord = includeRaw as Record<string, unknown>;
+  if ("media" in includeRecord) {
+    invalidInput(
+      `${path}.include.media`,
+      "is not supported in MVP — media inclusion is deferred (SPEC-009 #Cloning).",
+      { deferred: true },
+    );
+  }
+  const include: EnvironmentClonePayloadInclude = {
+    content: assertOptionalBoolean(
+      includeRecord.content,
+      `${path}.include.content`,
+      true,
+    ),
+    settings: assertOptionalBoolean(
+      includeRecord.settings,
+      `${path}.include.settings`,
+      false,
+    ),
+  };
+
+  // Spec defaults: includeDrafts=true, preservePaths=true.
+  const includeDrafts = assertOptionalBoolean(
+    obj.includeDrafts,
+    `${path}.includeDrafts`,
+    true,
+  );
+  const preservePaths = assertOptionalBoolean(
+    obj.preservePaths,
+    `${path}.preservePaths`,
+    true,
+  );
+
+  Object.assign(obj, {
+    sourceEnvironmentId,
+    include,
+    includeDrafts,
+    preservePaths,
+  });
+}
+
+export function assertEnvironmentPromoteInput(
+  value: unknown,
+  path = "value",
+): asserts value is EnvironmentPromoteInput {
+  const obj = assertCloneOrPromotePayload(value, path);
+  const sourceEnvironmentId = assertUuid(
+    obj.sourceEnvironmentId,
+    `${path}.sourceEnvironmentId`,
+  );
+  if (!Array.isArray(obj.documentIds) || obj.documentIds.length === 0) {
+    invalidInput(
+      `${path}.documentIds`,
+      "must be a non-empty array of UUID strings.",
+    );
+  }
+  const documentIds = obj.documentIds.map((entry, index) =>
+    assertUuid(entry, `${path}.documentIds[${index}]`),
+  );
+  // includeUnpublished defaults to false — promote is "publish source-of-truth"
+  // by default; promoting drafts is opt-in.
+  const includeUnpublished = assertOptionalBoolean(
+    obj.includeUnpublished,
+    `${path}.includeUnpublished`,
+    false,
+  );
+  // dryRun defaults to false — explicit opt-in for plan-only mode.
+  const dryRun = assertOptionalBoolean(obj.dryRun, `${path}.dryRun`, false);
+
+  Object.assign(obj, {
+    sourceEnvironmentId,
+    documentIds,
+    includeUnpublished,
+    dryRun,
+  });
 }

--- a/packages/studio/src/lib/environment-api.test.ts
+++ b/packages/studio/src/lib/environment-api.test.ts
@@ -272,3 +272,123 @@ test("list throws on 401 response", async () => {
       error instanceof RuntimeError && error.statusCode === 401,
   );
 });
+
+test("clone posts the clone payload with csrf header and parses result", async () => {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> =
+    [];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async (input, init) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({
+          data: { targetEnvironmentId: "env-target", documentsCloned: 4 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+
+  const result = await api.clone("env-target", {
+    sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+    include: { content: true, settings: false },
+    includeDrafts: true,
+    preservePaths: true,
+  });
+
+  assert.equal(
+    String(calls[0]?.input),
+    "http://localhost:4000/api/v1/environments/env-target/clone",
+  );
+  assert.equal(calls[0]?.init?.method, "POST");
+  assert.equal(readHeader(calls[0]?.init, "x-mdcms-csrf-token"), "csrf-token");
+  assert.deepEqual(result, {
+    targetEnvironmentId: "env-target",
+    documentsCloned: 4,
+  });
+});
+
+test("clone rejects payloads with media inclusion (deferred MVP)", async () => {
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async () => new Response(null, { status: 200 }),
+  });
+
+  await assert.rejects(
+    () =>
+      api.clone("env-target", {
+        sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+        include: {
+          content: true,
+          settings: false,
+          // @ts-expect-error — media is intentionally not part of the type;
+          // runtime guard rejects it as INVALID_INPUT.
+          media: true,
+        },
+        includeDrafts: true,
+        preservePaths: true,
+      }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "INVALID_INPUT",
+  );
+});
+
+test("promote validates documentIds before calling the network", async () => {
+  let fetcherCalled = false;
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async () => {
+      fetcherCalled = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      api.promote("env-target", {
+        sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+        documentIds: [],
+        includeUnpublished: false,
+        dryRun: false,
+      }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "INVALID_INPUT",
+  );
+  assert.equal(fetcherCalled, false);
+});
+
+test("promote returns the promoted result envelope", async () => {
+  const promoteResults = [
+    {
+      sourceDocumentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1b",
+      targetDocumentId: "1bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1c",
+      status: "created",
+      path: "blog/hello",
+      locale: "en-US",
+      type: "BlogPost",
+      publishedVersion: 1,
+      remappedReferences: 0,
+    },
+  ];
+  const api = createApi({
+    auth: { mode: "cookie" },
+    csrfToken: "csrf-token",
+    fetcher: async () =>
+      new Response(JSON.stringify({ data: { promoted: promoteResults } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  });
+
+  const result = await api.promote("env-target", {
+    sourceEnvironmentId: "0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1a",
+    documentIds: ["0bdf6f3a-f3a0-4a8f-9fef-8d8ec0c64a1b"],
+    includeUnpublished: false,
+    dryRun: true,
+  });
+
+  assert.deepEqual(result.promoted, promoteResults);
+});

--- a/packages/studio/src/lib/environment-api.ts
+++ b/packages/studio/src/lib/environment-api.ts
@@ -1,10 +1,16 @@
 import {
   RuntimeError,
+  assertEnvironmentCloneInput,
   assertEnvironmentCreateInput,
   assertEnvironmentListResponse,
+  assertEnvironmentPromoteInput,
   assertEnvironmentSummary,
+  type EnvironmentCloneInput,
+  type EnvironmentCloneResult,
   type EnvironmentCreateInput,
   type EnvironmentListResponse,
+  type EnvironmentPromoteInput,
+  type EnvironmentPromoteResult,
   type EnvironmentSummary,
 } from "@mdcms/shared";
 
@@ -30,6 +36,14 @@ export type StudioEnvironmentApi = {
   list: () => Promise<EnvironmentListResponse>;
   create: (input: EnvironmentCreateInput) => Promise<EnvironmentSummary>;
   delete: (environmentId: string) => Promise<void>;
+  clone: (
+    targetEnvironmentId: string,
+    input: EnvironmentCloneInput,
+  ) => Promise<EnvironmentCloneResult>;
+  promote: (
+    targetEnvironmentId: string,
+    input: EnvironmentPromoteInput,
+  ) => Promise<EnvironmentPromoteResult>;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -224,6 +238,124 @@ export function createStudioEnvironmentApi(
           "Environment deletion failed.",
         );
       }
+    },
+
+    async clone(targetEnvironmentId, input) {
+      if (!isNonEmptyString(targetEnvironmentId)) {
+        throw new RuntimeError({
+          code: "INVALID_INPUT",
+          message: "Target environment id is required.",
+          statusCode: 400,
+          details: { field: "targetEnvironmentId" },
+        });
+      }
+      assertEnvironmentCloneInput(input, "input");
+
+      const url = resolveRouteUrl(
+        config,
+        `/api/v1/environments/${encodeURIComponent(targetEnvironmentId)}/clone`,
+      );
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "POST",
+          headers: {
+            ...scopedHeaders,
+            "content-type": "application/json",
+            "x-mdcms-csrf-token": requireCsrfToken(
+              options.csrfToken,
+              "Environment clone",
+            ),
+          },
+          body: JSON.stringify(input),
+        }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        throw toRouteFailureError(
+          response,
+          payload,
+          "ENVIRONMENT_CLONE_FAILED",
+          "Environment clone failed.",
+        );
+      }
+
+      const data =
+        isRecord(payload) && "data" in payload ? payload.data : undefined;
+      if (
+        !isRecord(data) ||
+        typeof data.targetEnvironmentId !== "string" ||
+        typeof data.documentsCloned !== "number"
+      ) {
+        throw new RuntimeError({
+          code: "ENVIRONMENT_CLONE_RESPONSE_INVALID",
+          message: "Clone response is invalid.",
+          statusCode: 500,
+          details: { payload },
+        });
+      }
+      return {
+        targetEnvironmentId: data.targetEnvironmentId,
+        documentsCloned: data.documentsCloned,
+      };
+    },
+
+    async promote(targetEnvironmentId, input) {
+      if (!isNonEmptyString(targetEnvironmentId)) {
+        throw new RuntimeError({
+          code: "INVALID_INPUT",
+          message: "Target environment id is required.",
+          statusCode: 400,
+          details: { field: "targetEnvironmentId" },
+        });
+      }
+      assertEnvironmentPromoteInput(input, "input");
+
+      const url = resolveRouteUrl(
+        config,
+        `/api/v1/environments/${encodeURIComponent(targetEnvironmentId)}/promote`,
+      );
+      const response = await fetcher(
+        url,
+        applyStudioAuthToRequestInit(options.auth, {
+          method: "POST",
+          headers: {
+            ...scopedHeaders,
+            "content-type": "application/json",
+            "x-mdcms-csrf-token": requireCsrfToken(
+              options.csrfToken,
+              "Environment promote",
+            ),
+          },
+          body: JSON.stringify(input),
+        }),
+      );
+      const payload = await readResponsePayload(response);
+
+      if (!response.ok) {
+        throw toRouteFailureError(
+          response,
+          payload,
+          "ENVIRONMENT_PROMOTE_FAILED",
+          "Environment promote failed.",
+        );
+      }
+
+      const data =
+        isRecord(payload) && "data" in payload ? payload.data : undefined;
+      if (
+        !isRecord(data) ||
+        !Array.isArray((data as { promoted?: unknown }).promoted)
+      ) {
+        throw new RuntimeError({
+          code: "ENVIRONMENT_PROMOTE_RESPONSE_INVALID",
+          message: "Promote response is invalid.",
+          statusCode: 500,
+          details: { payload },
+        });
+      }
+      return data as EnvironmentPromoteResult;
     },
   };
 }

--- a/packages/studio/src/lib/remote-studio-app.tsx
+++ b/packages/studio/src/lib/remote-studio-app.tsx
@@ -12,6 +12,7 @@ import ApiPlaygroundPage from "./runtime-ui/app/admin/api-page.js";
 import DashboardPage from "./runtime-ui/app/admin/page.js";
 import EnvironmentsPage from "./runtime-ui/app/admin/environments-page.js";
 import MediaPage from "./runtime-ui/app/admin/media-page.js";
+import PromotePage from "./runtime-ui/app/admin/promote-page.js";
 import ContentDocumentPage from "./runtime-ui/pages/content-document-page.js";
 import ContentPage from "./runtime-ui/pages/content-page.js";
 import ContentTypePage from "./runtime-ui/app/admin/content/[type]/page.js";
@@ -71,6 +72,11 @@ const RUNTIME_ROUTES: readonly StudioRuntimeRouteDefinition[] = [
     id: "environments",
     path: "/environments",
     render: () => <EnvironmentsPage />,
+  },
+  {
+    id: "promote",
+    path: "/promote",
+    render: () => <PromotePage />,
   },
   {
     id: "media",

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.test.tsx
@@ -103,7 +103,7 @@ test("EnvironmentManagementPageView renders loading and empty states determinist
   assert.match(emptyMarkup, /New Environment/);
 });
 
-test("EnvironmentManagementPageView renders live environment summaries and only allows deleting non-default environments", () => {
+test("EnvironmentManagementPageView renders live environment summaries and exposes per-environment action menus", () => {
   const markup = renderMarkup({
     status: "ready",
     project: "marketing-site",
@@ -129,9 +129,13 @@ test("EnvironmentManagementPageView renders live environment summaries and only 
   assert.match(markup, /Extends production/);
   assert.match(markup, /2026-03-19T10:00:00.000Z/);
   assert.match(markup, /2026-03-20T11:30:45.000Z/);
-  assert.match(markup, /Delete staging/);
-  assert.doesNotMatch(markup, /Delete production/);
-  assert.doesNotMatch(markup, /promot/i);
+  // Both default and non-default rows now expose an action menu (clone into
+  // any environment is allowed; delete is gated to non-default at the menu
+  // item level — exercised in the e2e flow / route tests).
+  assert.match(markup, /data-mdcms-environment-actions="production"/);
+  assert.match(markup, /data-mdcms-environment-actions="staging"/);
+  assert.match(markup, /Actions for staging/);
+  assert.match(markup, /Actions for production/);
   assert.doesNotMatch(markup, /document count/i);
 });
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/environments-page.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   ArrowRightLeft,
   Clock,
+  Copy,
   GitBranch,
   MoreHorizontal,
   Plus,
@@ -50,6 +51,7 @@ import {
 } from "../../components/ui/dropdown-menu.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
+import { Switch } from "../../components/ui/switch.js";
 import { cn } from "../../lib/utils.js";
 
 export type EnvironmentManagementState =
@@ -75,6 +77,14 @@ export type EnvironmentManagementState =
       definitionsMeta: EnvironmentDefinitionsMeta;
     };
 
+export type EnvironmentCloneFormState = {
+  sourceEnvironmentId: string;
+  includeContent: boolean;
+  includeSettings: boolean;
+  includeDrafts: boolean;
+  preservePaths: boolean;
+};
+
 type EnvironmentManagementPageViewProps = {
   state: EnvironmentManagementState;
   activeEnvironment?: string | null;
@@ -86,12 +96,21 @@ type EnvironmentManagementPageViewProps = {
   pendingDeleteId?: string | null;
   deleteTarget?: EnvironmentSummary | null;
   isCreateDialogOpen?: boolean;
+  cloneTarget?: EnvironmentSummary | null;
+  cloneForm?: EnvironmentCloneFormState;
+  cloneError?: string | null;
+  cloneSuccess?: string | null;
+  pendingCloneId?: string | null;
   onCreateDialogChange?: (open: boolean) => void;
   onCreateNameChange?: (value: string) => void;
   onCreateSubmit?: () => void;
   onDeleteDialogChange?: (open: boolean) => void;
   onRequestDelete?: (environment: EnvironmentSummary) => void;
   onDeleteConfirm?: () => void;
+  onRequestClone?: (environment: EnvironmentSummary) => void;
+  onCloneDialogChange?: (open: boolean) => void;
+  onCloneFormChange?: (state: EnvironmentCloneFormState) => void;
+  onCloneSubmit?: () => void;
   onSwitchEnvironment?: (environment: string) => void;
   onRetry?: () => void;
 };
@@ -238,6 +257,14 @@ function renderRetryButton(onRetry?: () => void) {
   );
 }
 
+const CLONE_DEFAULT_FORM: EnvironmentCloneFormState = {
+  sourceEnvironmentId: "",
+  includeContent: true,
+  includeSettings: false,
+  includeDrafts: true,
+  preservePaths: true,
+};
+
 export function EnvironmentManagementPageView({
   state,
   activeEnvironment = null,
@@ -249,15 +276,30 @@ export function EnvironmentManagementPageView({
   pendingDeleteId = null,
   deleteTarget = null,
   isCreateDialogOpen = false,
+  cloneTarget = null,
+  cloneForm = CLONE_DEFAULT_FORM,
+  cloneError = null,
+  cloneSuccess = null,
+  pendingCloneId = null,
   onCreateDialogChange,
   onCreateNameChange,
   onCreateSubmit,
   onDeleteDialogChange,
   onRequestDelete,
   onDeleteConfirm,
+  onRequestClone,
+  onCloneDialogChange,
+  onCloneFormChange,
+  onCloneSubmit,
   onSwitchEnvironment,
   onRetry,
 }: EnvironmentManagementPageViewProps) {
+  const cloneSourceCandidates =
+    state.status === "ready"
+      ? state.environments.filter(
+          (entry) => entry.id !== (cloneTarget?.id ?? ""),
+        )
+      : [];
   const canManage = state.status === "ready";
   const canCreate =
     state.status === "ready" &&
@@ -439,22 +481,32 @@ export function EnvironmentManagementPageView({
                           : "No parent environment"}
                       </CardDescription>
                     </div>
-                    {!environment.isDefault ? (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            aria-label={`Actions for ${environment.name}`}
-                            data-mdcms-environment-actions={environment.name}
-                          >
-                            <MoreHorizontal className="h-4 w-4" />
-                            <span className="sr-only">
-                              Delete {environment.name}
-                            </span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Actions for ${environment.name}`}
+                          data-mdcms-environment-actions={environment.name}
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                          <span className="sr-only">
+                            Actions for {environment.name}
+                          </span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          disabled={pendingCloneId === environment.id}
+                          onClick={() => onRequestClone?.(environment)}
+                          data-mdcms-environment-clone-action={environment.name}
+                        >
+                          <Copy className="mr-2 h-4 w-4" />
+                          {pendingCloneId === environment.id
+                            ? `Cloning into ${environment.name}...`
+                            : `Clone into ${environment.name}...`}
+                        </DropdownMenuItem>
+                        {!environment.isDefault ? (
                           <DropdownMenuItem
                             className="text-destructive"
                             disabled={pendingDeleteId === environment.id}
@@ -465,9 +517,9 @@ export function EnvironmentManagementPageView({
                               ? `Deleting ${environment.name}...`
                               : `Delete ${environment.name}`}
                           </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    ) : null}
+                        ) : null}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 </CardHeader>
                 <CardContent className="mt-auto space-y-3">
@@ -493,6 +545,133 @@ export function EnvironmentManagementPageView({
             ))}
           </section>
         )}
+
+        <Dialog
+          open={cloneTarget !== null}
+          onOpenChange={(open) => onCloneDialogChange?.(open)}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Clone into {cloneTarget?.name ?? ""}</DialogTitle>
+              <DialogDescription>
+                Copy content and/or settings from a source environment into{" "}
+                <span className="font-mono">{cloneTarget?.name ?? ""}</span>.
+                Document IDs in the target are new; translation_group_id and
+                locale linkage are preserved. Media inclusion is deferred and
+                will be added in a follow-up release.
+              </DialogDescription>
+            </DialogHeader>
+            <div
+              className="grid gap-4 py-3"
+              data-mdcms-environment-clone-dialog={cloneTarget?.name ?? ""}
+            >
+              <div className="grid gap-2">
+                <Label htmlFor="clone-source-env">Source environment</Label>
+                <select
+                  id="clone-source-env"
+                  className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
+                  value={cloneForm.sourceEnvironmentId}
+                  onChange={(event) =>
+                    onCloneFormChange?.({
+                      ...cloneForm,
+                      sourceEnvironmentId: event.target.value,
+                    })
+                  }
+                >
+                  <option value="">Select source environment...</option>
+                  {cloneSourceCandidates.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <label className="flex items-center justify-between gap-2 rounded-md border p-2">
+                  <span>Include content</span>
+                  <Switch
+                    checked={cloneForm.includeContent}
+                    onCheckedChange={(checked) =>
+                      onCloneFormChange?.({
+                        ...cloneForm,
+                        includeContent: checked,
+                      })
+                    }
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 rounded-md border p-2">
+                  <span>Include settings</span>
+                  <Switch
+                    checked={cloneForm.includeSettings}
+                    onCheckedChange={(checked) =>
+                      onCloneFormChange?.({
+                        ...cloneForm,
+                        includeSettings: checked,
+                      })
+                    }
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 rounded-md border p-2">
+                  <span>Include drafts</span>
+                  <Switch
+                    checked={cloneForm.includeDrafts}
+                    onCheckedChange={(checked) =>
+                      onCloneFormChange?.({
+                        ...cloneForm,
+                        includeDrafts: checked,
+                      })
+                    }
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 rounded-md border p-2">
+                  <span>Preserve paths</span>
+                  <Switch
+                    checked={cloneForm.preservePaths}
+                    onCheckedChange={(checked) =>
+                      onCloneFormChange?.({
+                        ...cloneForm,
+                        preservePaths: checked,
+                      })
+                    }
+                  />
+                </label>
+              </div>
+              {cloneError ? (
+                <p
+                  data-mdcms-clone-error
+                  className="rounded-md border border-destructive/30 bg-destructive/5 p-2 text-sm text-destructive"
+                >
+                  {cloneError}
+                </p>
+              ) : null}
+              {cloneSuccess ? (
+                <p
+                  data-mdcms-clone-success
+                  className="rounded-md border border-emerald-300 bg-emerald-50 p-2 text-sm text-emerald-700"
+                >
+                  {cloneSuccess}
+                </p>
+              ) : null}
+            </div>
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => onCloneDialogChange?.(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !cloneForm.sourceEnvironmentId ||
+                  pendingCloneId === cloneTarget?.id
+                }
+                onClick={() => onCloneSubmit?.()}
+              >
+                {pendingCloneId === cloneTarget?.id ? "Cloning..." : "Clone"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <Dialog
           open={deleteTarget !== null}
@@ -556,6 +735,14 @@ export default function EnvironmentsPage() {
   const [deleteTarget, setDeleteTarget] = useState<EnvironmentSummary | null>(
     null,
   );
+  const [cloneTarget, setCloneTarget] = useState<EnvironmentSummary | null>(
+    null,
+  );
+  const [cloneForm, setCloneForm] =
+    useState<EnvironmentCloneFormState>(CLONE_DEFAULT_FORM);
+  const [cloneError, setCloneError] = useState<string | null>(null);
+  const [cloneSuccess, setCloneSuccess] = useState<string | null>(null);
+  const [pendingCloneId, setPendingCloneId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!project || !environment) {
@@ -669,6 +856,62 @@ export default function EnvironmentsPage() {
     }
   }
 
+  async function handleCloneSubmit() {
+    if (!project || !environment || !cloneTarget) {
+      setCloneError("Clone requires an active project and target.");
+      return;
+    }
+    if (sessionState.status !== "authenticated") {
+      setCloneError("Session could not be verified.");
+      return;
+    }
+    if (!cloneForm.sourceEnvironmentId) {
+      setCloneError("Pick a source environment to clone from.");
+      return;
+    }
+    if (cloneForm.sourceEnvironmentId === cloneTarget.id) {
+      setCloneError("Source and target environment must differ.");
+      return;
+    }
+
+    setPendingCloneId(cloneTarget.id);
+    setCloneError(null);
+    setCloneSuccess(null);
+
+    try {
+      const environmentApi = createStudioEnvironmentApi(
+        {
+          project,
+          environment,
+          serverUrl: apiBaseUrl,
+        },
+        {
+          auth,
+          csrfToken: sessionState.csrfToken,
+        },
+      );
+      const result = await environmentApi.clone(cloneTarget.id, {
+        sourceEnvironmentId: cloneForm.sourceEnvironmentId,
+        include: {
+          content: cloneForm.includeContent,
+          settings: cloneForm.includeSettings,
+        },
+        includeDrafts: cloneForm.includeDrafts,
+        preservePaths: cloneForm.preservePaths,
+      });
+      setCloneSuccess(
+        `Cloned ${result.documentsCloned} document${result.documentsCloned === 1 ? "" : "s"} into ${cloneTarget.name}.`,
+      );
+      setReloadVersion((current) => current + 1);
+    } catch (error) {
+      setCloneError(
+        readRuntimeErrorMessage(error, "Environment clone failed."),
+      );
+    } finally {
+      setPendingCloneId(null);
+    }
+  }
+
   async function handleDeleteConfirm() {
     if (!project || !environment || !deleteTarget) {
       setActionError("Environment deletion requires an active target.");
@@ -729,6 +972,37 @@ export default function EnvironmentsPage() {
       pendingCreate={pendingCreate}
       pendingDeleteId={pendingDeleteId}
       deleteTarget={deleteTarget}
+      cloneTarget={cloneTarget}
+      cloneForm={cloneForm}
+      cloneError={cloneError}
+      cloneSuccess={cloneSuccess}
+      pendingCloneId={pendingCloneId}
+      onRequestClone={(target) => {
+        setCloneTarget(target);
+        setCloneError(null);
+        setCloneSuccess(null);
+        // Default the source picker to the currently-active environment so
+        // operators have a sensible starting point. Skip if it's the target.
+        const defaultSource =
+          state.status === "ready"
+            ? state.environments.find(
+                (entry) => entry.id !== target.id && entry.name === environment,
+              )
+            : undefined;
+        setCloneForm({
+          ...CLONE_DEFAULT_FORM,
+          sourceEnvironmentId: defaultSource?.id ?? "",
+        });
+      }}
+      onCloneDialogChange={(open) => {
+        if (!open) {
+          setCloneTarget(null);
+          setCloneError(null);
+          setCloneSuccess(null);
+        }
+      }}
+      onCloneFormChange={setCloneForm}
+      onCloneSubmit={handleCloneSubmit}
       isCreateDialogOpen={isCreateDialogOpen}
       onCreateDialogChange={(open) => {
         setIsCreateDialogOpen(open);

--- a/packages/studio/src/lib/runtime-ui/app/admin/promote-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/promote-page.test.tsx
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ThemeProvider } from "../../adapters/next-themes.js";
+import { StudioMountInfoProvider } from "./mount-info-context.js";
+import { StudioSessionProvider } from "./session-context.js";
+import PromotePage from "./promote-page.js";
+
+function renderPromote(): string {
+  return renderToStaticMarkup(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(
+        StudioSessionProvider,
+        { value: { status: "unauthenticated" } },
+        createElement(
+          StudioMountInfoProvider,
+          {
+            value: {
+              project: "marketing-site",
+              environment: "production",
+              setEnvironment: () => {},
+              apiBaseUrl: "http://localhost:4000",
+              auth: { mode: "cookie" },
+              environments: [],
+              hostBridge: null,
+            },
+          },
+          createElement(PromotePage),
+        ),
+      ),
+    ),
+  );
+}
+
+test("PromotePage renders the page header and explicit-overwrite warning", () => {
+  const markup = renderPromote();
+
+  // Page chrome (breadcrumb + title).
+  assert.match(markup, /Promote content/);
+  // Per SPEC-009, the page must surface the no-merge / explicit-overwrite
+  // semantics so operators understand promote replaces target content.
+  assert.match(markup, /target content is replaced/i);
+  assert.match(markup, /atomically/);
+});
+
+test("PromotePage renders without an active project as missing-route", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(
+        StudioSessionProvider,
+        { value: { status: "unauthenticated" } },
+        createElement(
+          StudioMountInfoProvider,
+          {
+            value: {
+              project: null,
+              environment: null,
+              setEnvironment: () => {},
+              apiBaseUrl: "http://localhost:4000",
+              auth: { mode: "cookie" },
+              environments: [],
+              hostBridge: null,
+            },
+          },
+          createElement(PromotePage),
+        ),
+      ),
+    ),
+  );
+
+  // SSR initial state runs the loading effect synchronously; without a
+  // project we surface a missing-route message rather than rendering the
+  // selector.
+  assert.match(markup, /requires an active project|Loading environments/i);
+});

--- a/packages/studio/src/lib/runtime-ui/app/admin/promote-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/promote-page.test.tsx
@@ -75,8 +75,10 @@ test("PromotePage renders without an active project as missing-route", () => {
     ),
   );
 
-  // SSR initial state runs the loading effect synchronously; without a
-  // project we surface a missing-route message rather than rendering the
-  // selector.
-  assert.match(markup, /requires an active project|Loading environments/i);
+  // Without a project the page must show the missing-route message —
+  // not the loading state, which only happens *after* the route check
+  // passes. A loose regex would let a regression that breaks the
+  // missing-route branch quietly pass.
+  assert.match(markup, /requires an active project/i);
+  assert.doesNotMatch(markup, /Loading environments/i);
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/promote-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/promote-page.tsx
@@ -58,12 +58,27 @@ export type PromotePageState =
       environments: EnvironmentSummary[];
     };
 
+// `PromotePreviewSnapshot` freezes the inputs that produced a successful
+// dry-run. A real run uses these — not the live form state — so an operator
+// who tweaks the selection after previewing has to re-preview before
+// executing, never accidentally promoting a different set of documents than
+// the confirmation dialog showed.
+export type PromotePreviewSnapshot = {
+  sourceEnvId: string;
+  sourceEnvName: string;
+  targetEnvId: string;
+  targetEnvName: string;
+  documentIds: string[];
+  includeUnpublished: boolean;
+};
+
 export type PromotePreviewState =
   | { status: "idle" }
   | { status: "loading" }
   | {
       status: "ready";
       results: DocumentPromotionResult[];
+      snapshot: PromotePreviewSnapshot;
     }
   | {
       status: "error";
@@ -136,10 +151,14 @@ export default function PromotePage() {
   const { project, environment, apiBaseUrl, auth } = useStudioMountInfo();
   const sessionState = useStudioSession();
 
-  const [state, setState] = useState<PromotePageState>({
-    status: "loading",
-    message: "Loading environments.",
-  });
+  // Initial state reflects routing synchronously so SSR markup matches the
+  // hydrated state — missing routing renders the missing-route panel,
+  // present routing renders the loading panel until the env list arrives.
+  const [state, setState] = useState<PromotePageState>(() =>
+    !project || !environment
+      ? { status: "missing-route" }
+      : { status: "loading", message: "Loading environments." },
+  );
   const [sourceEnvId, setSourceEnvId] = useState<string>("");
   const [targetEnvId, setTargetEnvId] = useState<string>("");
   const [documents, setDocuments] = useState<ContentDocumentResponse[]>([]);
@@ -258,6 +277,16 @@ export default function PromotePage() {
     [state, targetEnvId],
   );
 
+  // Invalidate any prior preview when the user changes inputs that drive it.
+  // Combined with the snapshot recorded inside the preview result, this means
+  // the operator must re-preview after editing source/target/selection
+  // before the "Confirm & Promote" button works again.
+  useEffect(() => {
+    setPreview((current) =>
+      current.status === "ready" ? { status: "idle" } : current,
+    );
+  }, [sourceEnvId, targetEnvId, selectedIds, includeUnpublished]);
+
   async function handlePreview() {
     if (!project || !targetEnv || !sourceEnv) return;
     if (sessionState.status !== "authenticated") {
@@ -274,23 +303,34 @@ export default function PromotePage() {
       });
       return;
     }
+    // Snapshot inputs at preview time. The real run uses *these*, not the
+    // live form state, so the confirmation dialog never lies about what
+    // will execute.
+    const snapshot: PromotePreviewSnapshot = {
+      sourceEnvId: sourceEnv.id,
+      sourceEnvName: sourceEnv.name,
+      targetEnvId: targetEnv.id,
+      targetEnvName: targetEnv.name,
+      documentIds: [...selectedIds],
+      includeUnpublished,
+    };
     setPreview({ status: "loading" });
     try {
       const environmentApi = createStudioEnvironmentApi(
         {
           project,
-          environment: sourceEnv.name,
+          environment: snapshot.sourceEnvName,
           serverUrl: apiBaseUrl,
         },
         { auth, csrfToken: sessionState.csrfToken },
       );
-      const result = await environmentApi.promote(targetEnv.id, {
-        sourceEnvironmentId: sourceEnv.id,
-        documentIds: selectedIds,
-        includeUnpublished,
+      const result = await environmentApi.promote(snapshot.targetEnvId, {
+        sourceEnvironmentId: snapshot.sourceEnvId,
+        documentIds: snapshot.documentIds,
+        includeUnpublished: snapshot.includeUnpublished,
         dryRun: true,
       });
-      setPreview({ status: "ready", results: result.promoted });
+      setPreview({ status: "ready", results: result.promoted, snapshot });
     } catch (error) {
       setPreview({
         status: "error",
@@ -301,11 +341,16 @@ export default function PromotePage() {
   }
 
   async function handleConfirmExecute() {
-    if (!project || !targetEnv || !sourceEnv) return;
+    if (!project) return;
+    if (preview.status !== "ready") {
+      setExecuteError("Re-run preview before promoting.");
+      return;
+    }
     if (sessionState.status !== "authenticated") {
       setExecuteError("Session could not be verified.");
       return;
     }
+    const snapshot = preview.snapshot;
     setExecuting(true);
     setExecuteError(null);
     setExecuteResult(null);
@@ -313,16 +358,29 @@ export default function PromotePage() {
       const environmentApi = createStudioEnvironmentApi(
         {
           project,
-          environment: sourceEnv.name,
+          environment: snapshot.sourceEnvName,
           serverUrl: apiBaseUrl,
         },
         { auth, csrfToken: sessionState.csrfToken },
       );
-      const result = await environmentApi.promote(targetEnv.id, {
-        sourceEnvironmentId: sourceEnv.id,
-        documentIds: selectedIds,
-        includeUnpublished,
+      // Replay the dry-run plan: send back the target ids the preview
+      // returned so the real run uses identical UUIDs (and identical
+      // overwrite/create classification).
+      const preallocatedTargetIds: Record<string, string> = {};
+      for (const entry of preview.results) {
+        if (entry.status === "created" && entry.targetDocumentId) {
+          preallocatedTargetIds[entry.sourceDocumentId] =
+            entry.targetDocumentId;
+        }
+      }
+      const result = await environmentApi.promote(snapshot.targetEnvId, {
+        sourceEnvironmentId: snapshot.sourceEnvId,
+        documentIds: snapshot.documentIds,
+        includeUnpublished: snapshot.includeUnpublished,
         dryRun: false,
+        ...(Object.keys(preallocatedTargetIds).length > 0
+          ? { preallocatedTargetIds }
+          : {}),
       });
       setExecuteResult(result);
       setConfirmOpen(false);

--- a/packages/studio/src/lib/runtime-ui/app/admin/promote-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/promote-page.tsx
@@ -1,0 +1,711 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  ContentDocumentResponse,
+  DocumentPromotionResult,
+  EnvironmentSummary,
+} from "@mdcms/shared";
+
+import { createStudioContentListApi } from "../../../content-list-api.js";
+import { createStudioEnvironmentApi } from "../../../environment-api.js";
+import { useStudioMountInfo } from "./mount-info-context.js";
+import { useStudioSession } from "./session-context.js";
+import {
+  PageHeader,
+  PageHeaderDescription,
+} from "../../components/layout/page-header.js";
+import { Badge } from "../../components/ui/badge.js";
+import { Button } from "../../components/ui/button.js";
+import { Label } from "../../components/ui/label.js";
+import { Switch } from "../../components/ui/switch.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
+
+// Promote page implements the cross-environment per-document promotion
+// workflow described in SPEC-009 (#Promoting). It is a two-stage flow:
+//
+//   1. Operator picks source/target/documents, runs a dry-run preview.
+//   2. Operator confirms the explicit overwrite list, the page calls the
+//      real run, surfaces atomic-remap failures, or reports success.
+//
+// The page is intentionally minimal — it relies on the existing content-list
+// API and the environment-api clone/promote client. Authorization is enforced
+// by the server (`environments:promote` scope); we surface 401/403 as
+// "forbidden" UI states.
+
+export type PromotePageState =
+  | { status: "loading"; message: string }
+  | { status: "missing-route" }
+  | {
+      status: "forbidden";
+      message: string;
+    }
+  | {
+      status: "error";
+      message: string;
+    }
+  | {
+      status: "ready";
+      project: string;
+      environments: EnvironmentSummary[];
+    };
+
+export type PromotePreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "ready";
+      results: DocumentPromotionResult[];
+    }
+  | {
+      status: "error";
+      message: string;
+      remapDetails?: {
+        sourceDocumentId?: string;
+        fieldPath?: string;
+        translationGroupId?: string;
+        locale?: string;
+      };
+    };
+
+function readRuntimeErrorMessage(error: unknown, fallback: string): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.trim().length > 0
+  ) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function readRuntimeErrorStatus(error: unknown): number | null {
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof (error as { statusCode?: unknown }).statusCode === "number"
+  ) {
+    return (error as { statusCode: number }).statusCode;
+  }
+  return null;
+}
+
+function readRemapDetails(
+  error: unknown,
+): PromotePreviewState extends { status: "error"; remapDetails?: infer R }
+  ? R
+  : never;
+function readRemapDetails(error: unknown) {
+  if (
+    error &&
+    typeof error === "object" &&
+    "details" in error &&
+    typeof (error as { details?: unknown }).details === "object" &&
+    (error as { details?: unknown }).details !== null
+  ) {
+    const details = (error as { details?: Record<string, unknown> }).details!;
+    return {
+      sourceDocumentId:
+        typeof details.sourceDocumentId === "string"
+          ? details.sourceDocumentId
+          : undefined,
+      fieldPath:
+        typeof details.fieldPath === "string" ? details.fieldPath : undefined,
+      translationGroupId:
+        typeof details.translationGroupId === "string"
+          ? details.translationGroupId
+          : undefined,
+      locale: typeof details.locale === "string" ? details.locale : undefined,
+    };
+  }
+  return undefined;
+}
+
+export default function PromotePage() {
+  const { project, environment, apiBaseUrl, auth } = useStudioMountInfo();
+  const sessionState = useStudioSession();
+
+  const [state, setState] = useState<PromotePageState>({
+    status: "loading",
+    message: "Loading environments.",
+  });
+  const [sourceEnvId, setSourceEnvId] = useState<string>("");
+  const [targetEnvId, setTargetEnvId] = useState<string>("");
+  const [documents, setDocuments] = useState<ContentDocumentResponse[]>([]);
+  const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [includeUnpublished, setIncludeUnpublished] = useState(false);
+  const [preview, setPreview] = useState<PromotePreviewState>({
+    status: "idle",
+  });
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [executing, setExecuting] = useState(false);
+  const [executeResult, setExecuteResult] = useState<{
+    promoted: DocumentPromotionResult[];
+  } | null>(null);
+  const [executeError, setExecuteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!project || !environment) {
+      setState({ status: "missing-route" });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: "loading", message: "Loading environments." });
+
+    const environmentApi = createStudioEnvironmentApi(
+      { project, environment, serverUrl: apiBaseUrl },
+      { auth },
+    );
+
+    void environmentApi
+      .list()
+      .then((result) => {
+        if (cancelled) return;
+        const envs = result.data;
+        setState({ status: "ready", project, environments: envs });
+        // Default the source picker to the active environment, target to a
+        // different one if available.
+        const activeEnv = envs.find((entry) => entry.name === environment);
+        const otherEnv = envs.find((entry) => entry.name !== environment);
+        setSourceEnvId(activeEnv?.id ?? envs[0]?.id ?? "");
+        setTargetEnvId(otherEnv?.id ?? "");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        const status = readRuntimeErrorStatus(error);
+        if (status === 401 || status === 403) {
+          setState({
+            status: "forbidden",
+            message: readRuntimeErrorMessage(error, "Forbidden."),
+          });
+        } else {
+          setState({
+            status: "error",
+            message: readRuntimeErrorMessage(
+              error,
+              "Failed to load environments.",
+            ),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, auth.mode, auth.token, environment, project]);
+
+  // Reload documents whenever source environment changes.
+  useEffect(() => {
+    if (!project || !sourceEnvId || state.status !== "ready") return;
+    const sourceEnv = state.environments.find(
+      (entry) => entry.id === sourceEnvId,
+    );
+    if (!sourceEnv) return;
+
+    let cancelled = false;
+    setDocumentsLoading(true);
+
+    const contentApi = createStudioContentListApi(
+      { project, environment: sourceEnv.name, serverUrl: apiBaseUrl },
+      { auth },
+    );
+
+    void contentApi
+      .list({ limit: 100, sort: "updatedAt", order: "desc" })
+      .then((result) => {
+        if (cancelled) return;
+        setDocuments(result.data);
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDocuments([]);
+      })
+      .finally(() => {
+        if (!cancelled) setDocumentsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, auth.mode, auth.token, project, sourceEnvId, state]);
+
+  const sourceEnv = useMemo(
+    () =>
+      state.status === "ready"
+        ? state.environments.find((entry) => entry.id === sourceEnvId)
+        : undefined,
+    [state, sourceEnvId],
+  );
+  const targetEnv = useMemo(
+    () =>
+      state.status === "ready"
+        ? state.environments.find((entry) => entry.id === targetEnvId)
+        : undefined,
+    [state, targetEnvId],
+  );
+
+  async function handlePreview() {
+    if (!project || !targetEnv || !sourceEnv) return;
+    if (sessionState.status !== "authenticated") {
+      setPreview({
+        status: "error",
+        message: "Session could not be verified.",
+      });
+      return;
+    }
+    if (selectedIds.length === 0) {
+      setPreview({
+        status: "error",
+        message: "Pick at least one source document to promote.",
+      });
+      return;
+    }
+    setPreview({ status: "loading" });
+    try {
+      const environmentApi = createStudioEnvironmentApi(
+        {
+          project,
+          environment: sourceEnv.name,
+          serverUrl: apiBaseUrl,
+        },
+        { auth, csrfToken: sessionState.csrfToken },
+      );
+      const result = await environmentApi.promote(targetEnv.id, {
+        sourceEnvironmentId: sourceEnv.id,
+        documentIds: selectedIds,
+        includeUnpublished,
+        dryRun: true,
+      });
+      setPreview({ status: "ready", results: result.promoted });
+    } catch (error) {
+      setPreview({
+        status: "error",
+        message: readRuntimeErrorMessage(error, "Promote preview failed."),
+        remapDetails: readRemapDetails(error),
+      });
+    }
+  }
+
+  async function handleConfirmExecute() {
+    if (!project || !targetEnv || !sourceEnv) return;
+    if (sessionState.status !== "authenticated") {
+      setExecuteError("Session could not be verified.");
+      return;
+    }
+    setExecuting(true);
+    setExecuteError(null);
+    setExecuteResult(null);
+    try {
+      const environmentApi = createStudioEnvironmentApi(
+        {
+          project,
+          environment: sourceEnv.name,
+          serverUrl: apiBaseUrl,
+        },
+        { auth, csrfToken: sessionState.csrfToken },
+      );
+      const result = await environmentApi.promote(targetEnv.id, {
+        sourceEnvironmentId: sourceEnv.id,
+        documentIds: selectedIds,
+        includeUnpublished,
+        dryRun: false,
+      });
+      setExecuteResult(result);
+      setConfirmOpen(false);
+    } catch (error) {
+      setExecuteError(
+        readRuntimeErrorMessage(error, "Promote execution failed."),
+      );
+    } finally {
+      setExecuting(false);
+    }
+  }
+
+  const overwriteRows =
+    preview.status === "ready"
+      ? preview.results.filter((entry) => entry.status === "overwrote")
+      : [];
+  const createRows =
+    preview.status === "ready"
+      ? preview.results.filter((entry) => entry.status === "created")
+      : [];
+  const skippedRows =
+    preview.status === "ready"
+      ? preview.results.filter(
+          (entry) => entry.status === "skipped_unpublished",
+        )
+      : [];
+
+  return (
+    <div className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Promote" }]} />
+      <div className="space-y-6 p-6">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Promote content
+          </h1>
+          <PageHeaderDescription>
+            Push selected documents from one environment to another. Promotion
+            is an explicit overwrite — target content is replaced, no merge or
+            conflict resolution. Per SPEC-009, references are remapped by
+            translation_group_id + locale; if any reference cannot be remapped
+            the entire promotion fails atomically.
+          </PageHeaderDescription>
+        </div>
+
+        {state.status === "missing-route" ? (
+          <section className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            Promote requires an active project and environment.
+          </section>
+        ) : state.status === "loading" ? (
+          <section className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            {state.message}
+          </section>
+        ) : state.status === "forbidden" ? (
+          <section
+            data-mdcms-promote-page-state="forbidden"
+            className="space-y-2 rounded-lg border border-dashed p-4"
+          >
+            <Badge variant="default">Forbidden</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+          </section>
+        ) : state.status === "error" ? (
+          <section
+            data-mdcms-promote-page-state="error"
+            className="space-y-2 rounded-lg border border-dashed p-4"
+          >
+            <Badge variant="destructive">Error</Badge>
+            <p className="text-sm text-muted-foreground">{state.message}</p>
+          </section>
+        ) : (
+          <div data-mdcms-promote-page-state="ready" className="space-y-6">
+            <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2 rounded-md border p-4">
+                <Label htmlFor="promote-source">Source environment</Label>
+                <select
+                  id="promote-source"
+                  data-mdcms-promote-source
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
+                  value={sourceEnvId}
+                  onChange={(event) => setSourceEnvId(event.target.value)}
+                >
+                  {state.environments.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2 rounded-md border p-4">
+                <Label htmlFor="promote-target">Target environment</Label>
+                <select
+                  id="promote-target"
+                  data-mdcms-promote-target
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
+                  value={targetEnvId}
+                  onChange={(event) => setTargetEnvId(event.target.value)}
+                >
+                  <option value="">Select target...</option>
+                  {state.environments
+                    .filter((entry) => entry.id !== sourceEnvId)
+                    .map((entry) => (
+                      <option key={entry.id} value={entry.id}>
+                        {entry.name}
+                      </option>
+                    ))}
+                </select>
+              </div>
+            </section>
+
+            <section className="space-y-2 rounded-md border p-4">
+              <div className="flex items-center justify-between">
+                <h2 className="font-medium">Select documents</h2>
+                <label className="flex items-center gap-2 text-sm">
+                  Include unpublished drafts
+                  <Switch
+                    checked={includeUnpublished}
+                    onCheckedChange={setIncludeUnpublished}
+                  />
+                </label>
+              </div>
+              {documentsLoading ? (
+                <p className="text-sm text-muted-foreground">
+                  Loading documents…
+                </p>
+              ) : documents.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No documents in source environment.
+                </p>
+              ) : (
+                <ul
+                  className="max-h-72 overflow-y-auto rounded border"
+                  data-mdcms-promote-document-list
+                >
+                  {documents.map((doc) => {
+                    const checked = selectedIds.includes(doc.documentId);
+                    return (
+                      <li
+                        key={doc.documentId}
+                        className="flex items-center gap-3 border-b px-3 py-2 text-sm last:border-b-0"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          data-mdcms-promote-document-checkbox={doc.documentId}
+                          onChange={(event) => {
+                            if (event.target.checked) {
+                              setSelectedIds((prev) => [
+                                ...prev,
+                                doc.documentId,
+                              ]);
+                            } else {
+                              setSelectedIds((prev) =>
+                                prev.filter((id) => id !== doc.documentId),
+                              );
+                            }
+                          }}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-medium">{doc.path}</div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {doc.type} · {doc.locale}
+                            {doc.publishedVersion === null
+                              ? " · draft"
+                              : ` · v${doc.publishedVersion}`}
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+
+            <section className="flex items-center gap-2">
+              <Button
+                onClick={handlePreview}
+                disabled={
+                  !targetEnv ||
+                  selectedIds.length === 0 ||
+                  preview.status === "loading"
+                }
+                data-mdcms-promote-preview-button
+              >
+                {preview.status === "loading"
+                  ? "Previewing..."
+                  : "Preview promote"}
+              </Button>
+              <Button
+                variant="default"
+                disabled={
+                  preview.status !== "ready" ||
+                  preview.results.filter(
+                    (entry) => entry.status !== "skipped_unpublished",
+                  ).length === 0
+                }
+                onClick={() => setConfirmOpen(true)}
+                data-mdcms-promote-confirm-button
+              >
+                Confirm & Promote
+              </Button>
+            </section>
+
+            {preview.status === "error" ? (
+              <section
+                data-mdcms-promote-preview-error
+                className="space-y-1 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+              >
+                <p>{preview.message}</p>
+                {preview.remapDetails ? (
+                  <p className="text-xs">
+                    Field{" "}
+                    <span className="font-mono">
+                      {preview.remapDetails.fieldPath ?? "?"}
+                    </span>{" "}
+                    on source{" "}
+                    <span className="font-mono">
+                      {preview.remapDetails.sourceDocumentId ?? "?"}
+                    </span>{" "}
+                    cannot be remapped to (
+                    <span className="font-mono">
+                      {preview.remapDetails.translationGroupId ?? "?"}
+                    </span>
+                    ,{" "}
+                    <span className="font-mono">
+                      {preview.remapDetails.locale ?? "?"}
+                    </span>
+                    ) in target.
+                  </p>
+                ) : null}
+              </section>
+            ) : null}
+
+            {preview.status === "ready" ? (
+              <section
+                data-mdcms-promote-preview
+                className="space-y-3 rounded-md border p-4"
+              >
+                <div className="flex flex-wrap items-center gap-3 text-sm">
+                  <Badge variant="default">{createRows.length} created</Badge>
+                  <Badge variant="default">
+                    {overwriteRows.length} overwrites
+                  </Badge>
+                  {skippedRows.length > 0 ? (
+                    <Badge variant="outline">
+                      {skippedRows.length} skipped (unpublished)
+                    </Badge>
+                  ) : null}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  No merge — target content is fully replaced. Source content
+                  wins. Target version history is preserved.
+                </p>
+                <ul className="space-y-1 text-xs">
+                  {preview.results.map((entry) => (
+                    <li
+                      key={entry.sourceDocumentId}
+                      className="flex justify-between"
+                      data-mdcms-promote-preview-row={entry.sourceDocumentId}
+                    >
+                      <span className="font-mono">
+                        {entry.path} · {entry.locale}
+                      </span>
+                      <span>
+                        {entry.status === "overwrote"
+                          ? "→ overwrote target"
+                          : entry.status === "created"
+                            ? "→ create new target"
+                            : "skipped (unpublished)"}
+                        {entry.remappedReferences > 0
+                          ? ` · ${entry.remappedReferences} ref(s) remapped`
+                          : ""}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {executeResult ? (
+              <section
+                data-mdcms-promote-result
+                className="rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800"
+              >
+                Promoted {executeResult.promoted.length} document(s) to{" "}
+                <span className="font-mono">{targetEnv?.name ?? ""}</span>.
+              </section>
+            ) : null}
+
+            {executeError ? (
+              <section
+                data-mdcms-promote-execute-error
+                className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+              >
+                {executeError}
+              </section>
+            ) : null}
+          </div>
+        )}
+
+        <Dialog
+          open={confirmOpen && preview.status === "ready"}
+          onOpenChange={(open) => setConfirmOpen(open)}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Confirm promote</DialogTitle>
+              <DialogDescription>
+                The following target documents will be replaced. This is an
+                explicit overwrite — target content is replaced and history is
+                preserved in the target environment, but no merge happens.
+              </DialogDescription>
+            </DialogHeader>
+            <div
+              className="max-h-72 space-y-1 overflow-y-auto rounded border p-3 text-sm"
+              data-mdcms-promote-confirm-list
+            >
+              {overwriteRows.length === 0 && createRows.length === 0 ? (
+                <p className="text-muted-foreground">
+                  Nothing to promote (everything was skipped).
+                </p>
+              ) : (
+                <>
+                  {overwriteRows.length > 0 ? (
+                    <>
+                      <p className="font-medium text-destructive">
+                        Overwrite ({overwriteRows.length})
+                      </p>
+                      <ul className="space-y-1">
+                        {overwriteRows.map((entry) => (
+                          <li
+                            key={entry.sourceDocumentId}
+                            className="font-mono text-xs"
+                          >
+                            {entry.path} · {entry.locale}
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  ) : null}
+                  {createRows.length > 0 ? (
+                    <>
+                      <p className="font-medium">
+                        Create ({createRows.length})
+                      </p>
+                      <ul className="space-y-1">
+                        {createRows.map((entry) => (
+                          <li
+                            key={entry.sourceDocumentId}
+                            className="font-mono text-xs"
+                          >
+                            {entry.path} · {entry.locale}
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  ) : null}
+                </>
+              )}
+            </div>
+            {executeError ? (
+              <p className="text-sm text-destructive">{executeError}</p>
+            ) : null}
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmOpen(false)}
+                disabled={executing}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleConfirmExecute}
+                disabled={executing}
+                data-mdcms-promote-execute-button
+              >
+                {executing
+                  ? "Promoting..."
+                  : `Promote ${overwriteRows.length + createRows.length} document(s)`}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/layout/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LayoutDashboard,
   FileText,
   GitBranch,
+  Send,
   Upload,
   Users,
   Settings,
@@ -42,6 +43,7 @@ const mainNavItems = [
   { icon: LayoutDashboard, label: "Dashboard", href: "/admin" },
   { icon: FileText, label: "Content", href: "/admin/content" },
   { icon: GitBranch, label: "Environments", href: "/admin/environments" },
+  { icon: Send, label: "Promote", href: "/admin/promote" },
   { icon: Upload, label: "Media", href: "/admin/media" },
   { icon: FolderInput, label: "Schema", href: "/admin/schema" },
   { icon: Users, label: "Users", href: "/admin/users" },
@@ -61,6 +63,9 @@ function getMainNavItems(filters: {
 
   return mainNavItems.filter((item) => {
     if (item.href === "/admin/environments") return canManageAdminSurfaces;
+    // Promote requires the same admin gate as Environments — both are
+    // operations the spec documents as session-or-API-key with admin scope.
+    if (item.href === "/admin/promote") return canManageAdminSurfaces;
     if (item.href === "/admin/schema") return filters.canReadSchema;
     if (item.href === "/admin/users") return filters.canManageUsers;
     if (item.href === "/admin/settings") return filters.canManageSettings;


### PR DESCRIPTION
Closes the **CMS-153** epic ("Clone & Promote End-to-End", Phase-6 advanced operations).

Tickets in scope:
- **CMS-94** clone workflow payload options (`content/settings/includeDrafts/preservePaths`)
- **CMS-95** promote workflow with `dryRun`, overwrite confirmation, `includeUnpublished`
- **CMS-96** atomic reference remap by `translation_group_id + locale`
- **CMS-97** integration suite for locale/env/project/remap behaviors
- **CMS-98** Studio clone + promote UI

## Spec delta

None — SPEC-009 already specifies both endpoints, defaults, error codes, and atomic-remap rule. Implementation follows the spec verbatim. Implementation plan: [`.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md`](.ai/plans/2026-05-01-cms-153-clone-promote-end-to-end.md).

## Summary

### Backend (CMS-94 / CMS-95 / CMS-96 / CMS-97)

- **`POST /api/v1/environments/:id/clone`** — bulk-insert source documents into the target with new `document_id`s and preserved `translation_group_id`. Copies the latest published snapshot (as version 1) when one exists. Supports `include.content`, `include.settings`, `includeDrafts` (default `true`), `preservePaths`. Media inclusion is rejected as deferred per spec.
- **`POST /api/v1/environments/:id/promote`** — per-document overwrite-or-create, matched by `(translation_group_id, locale)`. Always auto-publishes (writes a `document_versions` row at the next version). Supports `dryRun` (no writes; returns the deterministic plan with pre-allocated target ids) and `includeUnpublished` (drafts skipped by default with `status: skipped_unpublished`).
- **Atomic reference remap** (`environments-reference-remap.ts`) walks frontmatter through the source environment's schema registry. Every `field.reference` UUID is rewritten by `(translation_group_id, locale)` to the matching target id. Unresolved references throw `REFERENCE_REMAP_FAILED` (409); the whole operation runs in a Drizzle transaction so any throw rolls back atomically (no partial writes).
- **Auth**: `session_or_api_key` mode with explicit `environments:clone` / `environments:promote` scopes; CSRF required on both writes; project routing required.

### Studio (CMS-98)

- Environment management page gains a per-row "Clone into <env>..." dropdown action with a payload-options dialog (toggles for content/settings/drafts/paths, source picker, media-deferred messaging).
- New **`/admin/promote`** page implements the workflow: source + target pickers, multi-select content list scoped to the source env, `includeUnpublished` toggle, **dry-run preview** showing create/overwrite/skipped counts with remap-failure surfacing (which field on which document failed), and a **confirmation dialog** that lists the exact target documents that will be overwritten before executing the real run. No-merge messaging is rendered explicitly.
- Sidebar gets a "Promote" item gated to admin surfaces.
- `createStudioEnvironmentApi` extended with `clone()` and `promote()` methods that validate payloads before the network call.

### Tests

- **Server unit** — `environments-reference-remap.test.ts` (6 tests) and extended `environments-api.route.test.ts` (7 tests) covering payload validation, scope auth, CSRF, project routing.
- **Server integration** — new `environments-clone-promote.integration.test.ts` (9 tests) running against real Postgres. Skips when no DB.
- **Studio** — extended `environment-api.test.ts` (12 tests including clone/promote happy paths and validation), updated `environments-page.test.tsx`, new `promote-page.test.tsx`.

## Notes

- `apps/studio-review` has no source under version control on `origin/main` (only `.next`/`.generated` build artifacts), so there are no review-app fixtures to sync in this PR.
- Two pre-existing unrelated test failures observed during validation (CLI login auth styled HTML pages, demo:seed project mismatch, studio portal-border-theme reading dist) — not introduced by this change.

## Test plan

- [ ] `bun run format:check`
- [ ] `bun run check`
- [ ] `bun test --cwd apps/server src/lib/environments-reference-remap.test.ts src/lib/environments-api.route.test.ts`
- [ ] `bun test --cwd apps/server src/lib/environments-clone-promote.integration.test.ts` (with Postgres up)
- [ ] `bun test --cwd packages/studio src/lib/environment-api.test.ts src/lib/runtime-ui/app/admin/environments-page.test.tsx src/lib/runtime-ui/app/admin/promote-page.test.tsx`
- [ ] Manual: clone production into a freshly created env via Studio with content + settings; promote a single localized doc with dry-run preview, then confirm overwrite.
- [ ] Manual: trigger a remap failure by promoting a BlogPost without its Author; confirm UI surfaces the field path + locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment cloning UI and API with options for content, settings, drafts, and path preservation.
  * Document promotion UI and API with dry‑run preview, deterministic replay, and atomic publish behavior.
  * Automatic frontmatter reference remapping with actionable preview/error details and overwrite/create summaries.
  * "Promote" admin nav item and per-environment "Clone into…" actions.

* **Bug Fixes / Validation**
  * Stronger input validation, CSRF and scoped authorization enforcement, and clearer error responses.

* **Tests**
  * Extensive unit and DB integration tests covering cloning, promotion, atomicity, remap failures, permissions, and CSRF.

* **Documentation**
  * Added an end-to-end implementation plan for clone & promote flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->