### PR TITLE
ci: require changesets for published package changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,24 @@ env:
   NX_CACHE_DIRECTORY: ".nx/cache"
 
 jobs:
+  changeset-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun test ./scripts/check-published-package-changeset.test.ts
+      - run: bun run changeset:check
+        env:
+          CHANGESET_CHECK_BASE: ${{ github.event.pull_request.base.sha }}
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-install-${{ hashFiles('bun.lock', 'package.json', 'apps/*/package.json', 'packages/*/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-install-
+
+      - run: bun install --frozen-lockfile
       - run: bun test ./scripts/check-published-package-changeset.test.ts
       - run: bun run changeset:check
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ The `.ai/` directory at the repo root holds the team's shared AI-agent-facing ar
 5. **Research goes in `.ai/research/`.** Date-prefixed filename (`YYYY-MM-DD-topic.md`).
 6. **Major efforts get an initiative file** in `.ai/memory/initiatives/` (see that folder's README for the format). Update it on milestones; mark `Status: completed` when wrapping.
 7. **Skills are auto-discovered** by Claude Code, Codex, and Cursor via symlinks (`.claude/skills`, `.agents/skills`, `.cursor/skills` all point to `../.ai/skills`). These are POSIX-style symlinks; on Windows they may not check out correctly without developer mode or `core.symlinks=true`. If skill discovery fails on a Windows clone, replace each symlink with a directory junction or a recursive copy of `.ai/skills/` as a fallback.
+8. **Published package changes require a changeset.** If your change touches `src/**` or `package.json` in a published package, create the changeset with `bun run changeset` before opening or updating the PR. Never create or edit `.changeset/*.md` files manually; always go through the Changesets CLI.
 
 The vendored superpowers in `.ai/skills/` is the canonical copy used by every supported agent in this repo. The globally installed `superpowers` plugin is disabled at the project level via `.claude/settings.json` to prevent duplicate skill registration.
 
@@ -230,6 +231,7 @@ Any new public API surface must include minimal usage docs and, where applicable
 - Make focused, task-scoped commits.
 - Don't include unrelated local folders or tooling artifacts. `.gitignore` enforces what stays local.
 - Follow conventional commit message format: `type(scope): message`.
+- If the change touches published package source or manifests, run `bun run changeset` and commit the generated changeset. Do not hand-write changeset files.
 
 Before commit, ensure:
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "prettier": "~3.6.2",
         "tslib": "^2.3.0",
         "typescript": "~5.9.2",
+        "zod": "^4.3.6",
       },
     },
     "apps/cli": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "integration:content": "bash scripts/content-api-integration-check.sh",
     "ci:required": "bun run quality && bun run unit && bun run integration",
     "check": "bun nx run-many -t build typecheck",
+    "changeset:check": "bun scripts/check-published-package-changeset.ts",
     "dev": "bun nx run-many -t dev --projects studio,server,studio-example",
     "compose:dev": "docker compose -f docker-compose.dev.yml up",
     "compose:dev:down": "docker compose -f docker-compose.dev.yml down",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "nx": "22.5.1",
     "prettier": "~3.6.2",
     "tslib": "^2.3.0",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "zod": "^4.3.6"
   },
   "workspaces": [
     "apps/*",

--- a/scripts/check-published-package-changeset.test.ts
+++ b/scripts/check-published-package-changeset.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 import {
   discoverPublishedPackages,
   evaluateChangesetGate,
+  readChangedFiles,
 } from "./check-published-package-changeset.js";
 
 function withWorkspace(callback: (rootDir: string) => void) {
@@ -55,12 +57,76 @@ function writeJson(path: string, value: unknown) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
+function runGit(rootDir: string, args: string[]) {
+  const result = spawnSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${result.stderr || result.stdout}`,
+    );
+  }
+
+  return result.stdout.trim();
+}
+
 describe("discoverPublishedPackages", () => {
   test("loads publishable workspaces and excludes private or ignored packages", () => {
     withWorkspace((rootDir) => {
       expect(discoverPublishedPackages(rootDir)).toEqual([
         { name: "@mdcms/cli", root: "apps/cli" },
         { name: "@mdcms/sdk", root: "packages/sdk" },
+      ]);
+    });
+  });
+
+  test("fails explicitly when root package.json workspaces are malformed", () => {
+    withWorkspace((rootDir) => {
+      writeJson(join(rootDir, "package.json"), {
+        private: true,
+        workspaces: [42],
+      });
+
+      expect(() => discoverPublishedPackages(rootDir)).toThrow(
+        /Invalid JSON shape in package\.json/,
+      );
+    });
+  });
+
+  test("fails explicitly when changeset ignore config is malformed", () => {
+    withWorkspace((rootDir) => {
+      writeJson(join(rootDir, ".changeset/config.json"), {
+        ignore: "@mdcms/server",
+      });
+
+      expect(() => discoverPublishedPackages(rootDir)).toThrow(
+        /Invalid JSON shape in \.changeset\/config\.json/,
+      );
+    });
+  });
+});
+
+describe("readChangedFiles", () => {
+  test("includes deleted files in the diff result", () => {
+    withWorkspace((rootDir) => {
+      runGit(rootDir, ["init"]);
+      runGit(rootDir, ["config", "user.email", "test@example.com"]);
+      runGit(rootDir, ["config", "user.name", "Test User"]);
+
+      const sourcePath = join(rootDir, "packages/sdk/src/index.ts");
+      writeFileSync(sourcePath, "export const value = 1;\n", "utf8");
+      runGit(rootDir, ["add", "."]);
+      runGit(rootDir, ["commit", "-m", "initial"]);
+      const base = runGit(rootDir, ["rev-parse", "HEAD"]);
+
+      rmSync(sourcePath);
+      runGit(rootDir, ["add", "-A"]);
+      runGit(rootDir, ["commit", "-m", "delete source"]);
+
+      expect(readChangedFiles(rootDir, base, "HEAD")).toEqual([
+        "packages/sdk/src/index.ts",
       ]);
     });
   });

--- a/scripts/check-published-package-changeset.test.ts
+++ b/scripts/check-published-package-changeset.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  discoverPublishedPackages,
+  evaluateChangesetGate,
+} from "./check-published-package-changeset.js";
+
+function withWorkspace(callback: (rootDir: string) => void) {
+  const rootDir = mkdtempSync(join(tmpdir(), "mdcms-changeset-check-"));
+
+  try {
+    writeJson(join(rootDir, "package.json"), {
+      private: true,
+      workspaces: ["apps/*", "packages/*"],
+    });
+    mkdirSync(join(rootDir, ".changeset"), { recursive: true });
+    writeJson(join(rootDir, ".changeset/config.json"), {
+      ignore: ["@mdcms/server"],
+    });
+
+    writePackage(rootDir, "apps/cli", {
+      name: "@mdcms/cli",
+      version: "0.1.0",
+    });
+    writePackage(rootDir, "apps/server", {
+      name: "@mdcms/server",
+      version: "0.1.0",
+      private: true,
+    });
+    writePackage(rootDir, "packages/sdk", {
+      name: "@mdcms/sdk",
+      version: "0.1.0",
+    });
+
+    callback(rootDir);
+  } finally {
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+}
+
+function writePackage(
+  rootDir: string,
+  packageRoot: string,
+  packageJson: Record<string, unknown>,
+) {
+  const fullRoot = join(rootDir, packageRoot);
+  mkdirSync(join(fullRoot, "src"), { recursive: true });
+  writeJson(join(fullRoot, "package.json"), packageJson);
+}
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+describe("discoverPublishedPackages", () => {
+  test("loads publishable workspaces and excludes private or ignored packages", () => {
+    withWorkspace((rootDir) => {
+      expect(discoverPublishedPackages(rootDir)).toEqual([
+        { name: "@mdcms/cli", root: "apps/cli" },
+        { name: "@mdcms/sdk", root: "packages/sdk" },
+      ]);
+    });
+  });
+});
+
+describe("evaluateChangesetGate", () => {
+  test("requires a changeset for published package source changes", () => {
+    withWorkspace((rootDir) => {
+      const result = evaluateChangesetGate({
+        changedFiles: ["packages/sdk/src/index.ts"],
+        packages: discoverPublishedPackages(rootDir),
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.changedPackages).toEqual([
+        {
+          name: "@mdcms/sdk",
+          root: "packages/sdk",
+          files: ["packages/sdk/src/index.ts"],
+        },
+      ]);
+    });
+  });
+
+  test("accepts published package source changes when a changeset is present", () => {
+    withWorkspace((rootDir) => {
+      const result = evaluateChangesetGate({
+        changedFiles: [
+          "packages/sdk/src/index.ts",
+          ".changeset/fresh-planets.md",
+        ],
+        packages: discoverPublishedPackages(rootDir),
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  test("ignores private package source changes", () => {
+    withWorkspace((rootDir) => {
+      const result = evaluateChangesetGate({
+        changedFiles: ["apps/server/src/index.ts"],
+        packages: discoverPublishedPackages(rootDir),
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  test("ignores non-source files in published packages", () => {
+    withWorkspace((rootDir) => {
+      const result = evaluateChangesetGate({
+        changedFiles: ["packages/sdk/README.md"],
+        packages: discoverPublishedPackages(rootDir),
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  test("requires a changeset for published package manifest changes", () => {
+    withWorkspace((rootDir) => {
+      const result = evaluateChangesetGate({
+        changedFiles: ["apps/cli/package.json"],
+        packages: discoverPublishedPackages(rootDir),
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.changedPackages).toEqual([
+        {
+          name: "@mdcms/cli",
+          root: "apps/cli",
+          files: ["apps/cli/package.json"],
+        },
+      ]);
+    });
+  });
+});

--- a/scripts/check-published-package-changeset.ts
+++ b/scripts/check-published-package-changeset.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
+import { z } from "zod";
 
 export interface PublishedPackage {
   name: string;
@@ -23,15 +24,27 @@ export interface GateResult {
   hasChangeset: boolean;
 }
 
-interface PackageJson {
-  name?: unknown;
-  private?: unknown;
-  workspaces?: unknown;
-}
+const packageJsonSchema = z
+  .object({
+    name: z.string().optional(),
+    private: z.boolean().optional(),
+    workspaces: z
+      .union([
+        z.array(z.string()),
+        z.object({ packages: z.array(z.string()) }).passthrough(),
+      ])
+      .optional(),
+  })
+  .passthrough();
 
-interface ChangesetConfig {
-  ignore?: unknown;
-}
+const changesetConfigSchema = z
+  .object({
+    ignore: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+type PackageJson = z.infer<typeof packageJsonSchema>;
+type ChangesetConfig = z.infer<typeof changesetConfigSchema>;
 
 interface CliOptions {
   base: string;
@@ -39,7 +52,10 @@ interface CliOptions {
 }
 
 export function discoverPublishedPackages(rootDir: string): PublishedPackage[] {
-  const rootPackage = readJson<PackageJson>(join(rootDir, "package.json"));
+  const rootPackage = readPackageJson(
+    join(rootDir, "package.json"),
+    "package.json",
+  );
   const ignoredPackages = readIgnoredPackages(rootDir);
 
   return readWorkspacePatterns(rootPackage)
@@ -51,7 +67,10 @@ export function discoverPublishedPackages(rootDir: string): PublishedPackage[] {
         return [];
       }
 
-      const packageJson = readJson<PackageJson>(packageJsonPath);
+      const packageJson = readPackageJson(
+        packageJsonPath,
+        `${packageRoot}/package.json`,
+      );
 
       if (
         typeof packageJson.name !== "string" ||
@@ -87,23 +106,11 @@ export function evaluateChangesetGate(input: GateInput): GateResult {
 
 function readWorkspacePatterns(packageJson: PackageJson): string[] {
   if (Array.isArray(packageJson.workspaces)) {
-    return packageJson.workspaces.filter(
-      (workspace): workspace is string => typeof workspace === "string",
-    );
+    return packageJson.workspaces;
   }
 
-  if (
-    packageJson.workspaces &&
-    typeof packageJson.workspaces === "object" &&
-    "packages" in packageJson.workspaces
-  ) {
-    const packages = packageJson.workspaces.packages;
-
-    if (Array.isArray(packages)) {
-      return packages.filter(
-        (workspace): workspace is string => typeof workspace === "string",
-      );
-    }
+  if (packageJson.workspaces) {
+    return packageJson.workspaces.packages;
   }
 
   return [];
@@ -116,17 +123,9 @@ function readIgnoredPackages(rootDir: string): Set<string> {
     return new Set();
   }
 
-  const config = readJson<ChangesetConfig>(configPath);
+  const config = readChangesetConfig(configPath, ".changeset/config.json");
 
-  if (!Array.isArray(config.ignore)) {
-    return new Set();
-  }
-
-  return new Set(
-    config.ignore.filter(
-      (packageName): packageName is string => typeof packageName === "string",
-    ),
-  );
+  return new Set(config.ignore ?? []);
 }
 
 function expandWorkspacePattern(rootDir: string, pattern: string): string[] {
@@ -172,22 +171,48 @@ function isChangesetFile(file: string): boolean {
   );
 }
 
-function readJson<T>(path: string): T {
-  return JSON.parse(readFileSync(path, "utf8")) as T;
+function readPackageJson(path: string, label: string): PackageJson {
+  return readValidatedJson(path, label, packageJsonSchema);
+}
+
+function readChangesetConfig(path: string, label: string): ChangesetConfig {
+  return readValidatedJson(path, label, changesetConfigSchema);
+}
+
+function readValidatedJson<T>(
+  path: string,
+  label: string,
+  schema: z.ZodType<T>,
+): T {
+  const parsed = schema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => {
+        const issuePath = issue.path.join(".") || "(root)";
+
+        return `${issuePath}: ${issue.message}`;
+      })
+      .join("; ");
+
+    throw new Error(`Invalid JSON shape in ${label}: ${issues}`);
+  }
+
+  return parsed.data;
 }
 
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.?\//, "");
 }
 
-function readChangedFiles(
+export function readChangedFiles(
   rootDir: string,
   base: string,
   head: string,
 ): string[] {
   const result = spawnSync(
     "git",
-    ["diff", "--name-only", "--diff-filter=ACMR", `${base}...${head}`, "--"],
+    ["diff", "--name-only", "--diff-filter=ACMRD", `${base}...${head}`, "--"],
     {
       cwd: rootDir,
       encoding: "utf8",

--- a/scripts/check-published-package-changeset.ts
+++ b/scripts/check-published-package-changeset.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface PublishedPackage {
+  name: string;
+  root: string;
+}
+
+export interface ChangedPackage extends PublishedPackage {
+  files: string[];
+}
+
+export interface GateInput {
+  changedFiles: string[];
+  packages: PublishedPackage[];
+}
+
+export interface GateResult {
+  ok: boolean;
+  changedPackages: ChangedPackage[];
+  hasChangeset: boolean;
+}
+
+interface PackageJson {
+  name?: unknown;
+  private?: unknown;
+  workspaces?: unknown;
+}
+
+interface ChangesetConfig {
+  ignore?: unknown;
+}
+
+interface CliOptions {
+  base: string;
+  head: string;
+}
+
+export function discoverPublishedPackages(rootDir: string): PublishedPackage[] {
+  const rootPackage = readJson<PackageJson>(join(rootDir, "package.json"));
+  const ignoredPackages = readIgnoredPackages(rootDir);
+
+  return readWorkspacePatterns(rootPackage)
+    .flatMap((pattern) => expandWorkspacePattern(rootDir, pattern))
+    .flatMap((packageRoot) => {
+      const packageJsonPath = join(rootDir, packageRoot, "package.json");
+
+      if (!existsSync(packageJsonPath)) {
+        return [];
+      }
+
+      const packageJson = readJson<PackageJson>(packageJsonPath);
+
+      if (
+        typeof packageJson.name !== "string" ||
+        packageJson.private === true ||
+        ignoredPackages.has(packageJson.name)
+      ) {
+        return [];
+      }
+
+      return [{ name: packageJson.name, root: packageRoot }];
+    })
+    .sort((left, right) => left.root.localeCompare(right.root));
+}
+
+export function evaluateChangesetGate(input: GateInput): GateResult {
+  const changedFiles = input.changedFiles.map(normalizePath).filter(Boolean);
+  const changedPackages = input.packages
+    .map((publishedPackage) => ({
+      ...publishedPackage,
+      files: changedFiles.filter((file) =>
+        isPublishedSourceChange(file, publishedPackage.root),
+      ),
+    }))
+    .filter((publishedPackage) => publishedPackage.files.length > 0);
+  const hasChangeset = changedFiles.some(isChangesetFile);
+
+  return {
+    ok: changedPackages.length === 0 || hasChangeset,
+    changedPackages,
+    hasChangeset,
+  };
+}
+
+function readWorkspacePatterns(packageJson: PackageJson): string[] {
+  if (Array.isArray(packageJson.workspaces)) {
+    return packageJson.workspaces.filter(
+      (workspace): workspace is string => typeof workspace === "string",
+    );
+  }
+
+  if (
+    packageJson.workspaces &&
+    typeof packageJson.workspaces === "object" &&
+    "packages" in packageJson.workspaces
+  ) {
+    const packages = packageJson.workspaces.packages;
+
+    if (Array.isArray(packages)) {
+      return packages.filter(
+        (workspace): workspace is string => typeof workspace === "string",
+      );
+    }
+  }
+
+  return [];
+}
+
+function readIgnoredPackages(rootDir: string): Set<string> {
+  const configPath = join(rootDir, ".changeset/config.json");
+
+  if (!existsSync(configPath)) {
+    return new Set();
+  }
+
+  const config = readJson<ChangesetConfig>(configPath);
+
+  if (!Array.isArray(config.ignore)) {
+    return new Set();
+  }
+
+  return new Set(
+    config.ignore.filter(
+      (packageName): packageName is string => typeof packageName === "string",
+    ),
+  );
+}
+
+function expandWorkspacePattern(rootDir: string, pattern: string): string[] {
+  const normalizedPattern = normalizePath(pattern);
+  const starIndex = normalizedPattern.indexOf("*");
+
+  if (starIndex === -1) {
+    return packageRootExists(rootDir, normalizedPattern)
+      ? [normalizedPattern]
+      : [];
+  }
+
+  const prefix = normalizedPattern.slice(0, starIndex);
+  const suffix = normalizedPattern.slice(starIndex + 1);
+  const directory = join(rootDir, prefix);
+
+  if (!existsSync(directory) || !statSync(directory).isDirectory()) {
+    return [];
+  }
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => normalizePath(`${prefix}${entry.name}${suffix}`))
+    .filter((packageRoot) => packageRootExists(rootDir, packageRoot));
+}
+
+function packageRootExists(rootDir: string, packageRoot: string): boolean {
+  return existsSync(join(rootDir, packageRoot, "package.json"));
+}
+
+function isPublishedSourceChange(file: string, packageRoot: string): boolean {
+  return (
+    file === `${packageRoot}/package.json` ||
+    file.startsWith(`${packageRoot}/src/`)
+  );
+}
+
+function isChangesetFile(file: string): boolean {
+  return (
+    file.startsWith(".changeset/") &&
+    file.endsWith(".md") &&
+    basename(file) !== "README.md"
+  );
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.?\//, "");
+}
+
+function readChangedFiles(
+  rootDir: string,
+  base: string,
+  head: string,
+): string[] {
+  const result = spawnSync(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACMR", `${base}...${head}`, "--"],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Unable to read changed files from git diff: ${result.stderr.trim()}`,
+    );
+  }
+
+  return result.stdout.split("\n").filter(Boolean);
+}
+
+function parseOptions(args: string[]): CliOptions {
+  const options: CliOptions = {
+    base: process.env.CHANGESET_CHECK_BASE ?? "origin/main",
+    head: process.env.CHANGESET_CHECK_HEAD ?? "HEAD",
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = args[index + 1];
+
+    if (arg === "--base" && value) {
+      options.base = value;
+      index += 1;
+    } else if (arg === "--head" && value) {
+      options.head = value;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function formatFailure(changedPackages: ChangedPackage[]): string {
+  const details = changedPackages
+    .map((publishedPackage) => {
+      const files = publishedPackage.files
+        .map((file) => `    - ${file}`)
+        .join("\n");
+
+      return `  - ${publishedPackage.name}\n${files}`;
+    })
+    .join("\n");
+
+  return [
+    "Published package source changed without a changeset.",
+    "",
+    "Changed published packages:",
+    details,
+    "",
+    "Add a changeset with `bun run changeset` before merging this PR.",
+  ].join("\n");
+}
+
+function run() {
+  const rootDir = process.cwd();
+  const options = parseOptions(process.argv.slice(2));
+  const packages = discoverPublishedPackages(rootDir);
+  const changedFiles = readChangedFiles(rootDir, options.base, options.head);
+  const result = evaluateChangesetGate({ changedFiles, packages });
+
+  if (!result.ok) {
+    console.error(formatFailure(result.changedPackages));
+    process.exit(1);
+  }
+
+  if (result.changedPackages.length === 0) {
+    console.log("No published package source changes found.");
+  } else {
+    console.log("Published package source changes include a changeset.");
+  }
+}
+
+if (import.meta.main) {
+  run();
+}


### PR DESCRIPTION
## Summary
- Add a PR-only CI job that checks publishable workspace source changes for a changeset.
- Discover publishable packages from workspace package metadata and `.changeset/config.json`.
- Add focused tests for package discovery and changeset gate behavior.

## Test Plan
- [x] bun test ./scripts/check-published-package-changeset.test.ts
- [x] CHANGESET_CHECK_BASE=main bun run changeset:check
- [x] bun run quality

Full Docker-backed integration was not run for this CI-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Changeset validation for published packages ensures all source changes are properly documented
  * New command-line script enables verification of changesets before publishing

* **Chores**
  * Automated changeset checks now run in CI pipeline for all pull requests
  * Early detection of missing changesets prevents incomplete releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->