### PR TITLE
feat(cli): auto-load env files

### DIFF
--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -6,14 +6,8 @@ Entries are reverse-chronological (newest first).
 
 ---
 
-<!-- Example shape (delete when first real entry is added):
+## 2026-05-01 — rerun loopback CLI tests outside the sandbox
 
-## YYYY-MM-DD — short rule
-
-**Rule:** State the takeaway in one sentence.
-
-**Why:** The incident or constraint that produced this rule.
-
-**How to apply:** When does this kick in. Where to look. What to do differently.
-
--->
+**Rule:** Treat loopback listener failures on port `0` in CLI tests as a likely sandbox artifact before debugging login code.
+**Why:** `bun test --cwd apps/cli ./src` can fail `loopback callback returns styled HTML success page` with `Failed to start server. Is port 0 in use?` under Codex sandboxing, while the same targeted test passes outside the sandbox.
+**How to apply:** When a CLI test that binds `127.0.0.1` fails with a port-bind error, rerun the targeted test with sandbox escalation before attributing the failure to product code.

--- a/.changeset/cli-dotenv-loading.md
+++ b/.changeset/cli-dotenv-loading.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/cli": patch
+---
+
+Auto-load dotenv files before CLI config import, with config-root lookup, shell env precedence, and opt-out controls.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -53,6 +53,28 @@ export default defineConfig({
 });
 ```
 
+### Environment files
+
+The CLI loads `.env*` files from the directory containing the nearest `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs` before it imports the config. Put local developer values in `.env.local` next to `mdcms.config.ts`:
+
+```bash
+MDCMS_SERVER_URL=http://localhost:4000
+MDCMS_PROJECT=marketing-site
+MDCMS_ENVIRONMENT=staging
+MDCMS_API_KEY=mdcms_key_local
+```
+
+Loading order, highest precedence first:
+
+| Order | File                    | When loaded                 |
+| ----- | ----------------------- | --------------------------- |
+| 1     | `.env.{NODE_ENV}.local` | Always                      |
+| 2     | `.env.local`            | Except when `NODE_ENV=test` |
+| 3     | `.env.{NODE_ENV}`       | Always                      |
+| 4     | `.env`                  | Always                      |
+
+`NODE_ENV` defaults to `development` for CLI runs. Shell-exported variables override all file values. Use `--no-env-file` or `MDCMS_DOTENV=0` to disable auto-loading for a run.
+
 ## Commands
 
 | Command             | Description                                              |
@@ -89,6 +111,7 @@ mdcms push --dry-run    # Preview changes without uploading
 | `--server-url`  | `MDCMS_SERVER_URL`  | Server URL                                       |
 | `--api-key`     | `MDCMS_API_KEY`     | API key (for headless/CI use)                    |
 | `--config`      |                     | Path to config file (default: `mdcms.config.ts`) |
+| `--no-env-file` | `MDCMS_DOTENV=0`    | Disable automatic `.env*` loading                |
 
 ## Documentation
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -55,7 +55,9 @@ export default defineConfig({
 
 ### Environment files
 
-The CLI loads `.env*` files from the directory containing the nearest `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs` before it imports the config. Put local developer values in `.env.local` next to `mdcms.config.ts`:
+The CLI loads `.env*` files from the directory containing the nearest `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs` before it imports the config. This lets `mdcms.config.ts` read values from `process.env`.
+
+Put local developer values in `.env.local` next to `mdcms.config.ts`:
 
 ```bash
 MDCMS_SERVER_URL=http://localhost:4000
@@ -73,7 +75,9 @@ Loading order, highest precedence first:
 | 3     | `.env.{NODE_ENV}`       | Always                      |
 | 4     | `.env`                  | Always                      |
 
-`NODE_ENV` defaults to `development` for CLI runs. Shell-exported variables override all file values. Use `--no-env-file` or `MDCMS_DOTENV=0` to disable auto-loading for a run.
+`NODE_ENV` defaults to `development` for CLI runs. In this table, `NODE_ENV` is only the dotenv file selector; it is not the same thing as the MDCMS `environment` field or `MDCMS_ENVIRONMENT`. For example, `NODE_ENV=production` makes the CLI look for `.env.production` and `.env.production.local`, while `MDCMS_ENVIRONMENT=staging` tells MDCMS which content environment to target.
+
+Shell-exported variables override all file values. Use `--no-env-file` or `MDCMS_DOTENV=0` to disable auto-loading for a run.
 
 ## Commands
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,6 +50,7 @@
     "@elysiajs/eden": "^1.4.8",
     "@inquirer/prompts": "^7.0.0",
     "@mdcms/shared": "^0.1.4",
+    "dotenv": "^16.4.7",
     "elysia": "^1.4.25",
     "ora": "^8.0.0",
     "tslib": "^2.3.0",

--- a/apps/cli/src/lib/config-path.ts
+++ b/apps/cli/src/lib/config-path.ts
@@ -1,0 +1,54 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+export const CLI_CONFIG_FILE_NAMES = [
+  "mdcms.config.ts",
+  "mdcms.config.js",
+  "mdcms.config.mjs",
+] as const;
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveCliConfigPath(options: {
+  cwd: string;
+  configPath?: string;
+}): Promise<string> {
+  if (options.configPath) {
+    return resolve(options.cwd, options.configPath);
+  }
+
+  let current = resolve(options.cwd);
+
+  while (true) {
+    for (const fileName of CLI_CONFIG_FILE_NAMES) {
+      const candidate = join(current, fileName);
+      if (await isFile(candidate)) {
+        return candidate;
+      }
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return resolve(options.cwd, "mdcms.config.ts");
+    }
+    current = parent;
+  }
+}
+
+export async function resolveCliConfigRoot(options: {
+  cwd: string;
+  configPath?: string;
+}): Promise<string> {
+  if (options.configPath) {
+    return dirname(resolve(options.cwd, options.configPath));
+  }
+
+  const configPath = await resolveCliConfigPath(options);
+  return dirname(configPath);
+}

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -8,6 +7,8 @@ import {
   type ParsedMdcmsConfig,
   type ParsedMdcmsTypeDefinition,
 } from "@mdcms/shared";
+
+import { resolveCliConfigPath } from "./config-path.js";
 
 export type CliContentTypeConfig = Pick<
   ParsedMdcmsTypeDefinition,
@@ -43,10 +44,7 @@ export async function loadCliConfig(options: {
   cwd: string;
   configPath?: string;
 }): Promise<{ config: LoadedCliConfig; configPath: string }> {
-  const configPath = resolve(
-    options.cwd,
-    options.configPath ?? "mdcms.config.ts",
-  );
+  const configPath = await resolveCliConfigPath(options);
 
   if (!existsSync(configPath)) {
     throw new RuntimeError({

--- a/apps/cli/src/lib/env-files.test.ts
+++ b/apps/cli/src/lib/env-files.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 
 import { createConsoleLogger, type CliPreflightHook } from "@mdcms/shared";
 
+import { loadCliEnvFiles } from "./env-files.js";
 import { runMdcmsCli, type CliCommand } from "./framework.js";
 import type { CliRuntimeContextWithModules } from "./runtime-with-modules.js";
 
@@ -355,5 +356,34 @@ test("runMdcmsCli warns and continues when an env file cannot be loaded", async 
   } finally {
     await cleanup();
     restoreEnv(snapshot);
+  }
+});
+
+test("loadCliEnvFiles accepts dotenv-compatible multiline quoted values", async () => {
+  const { projectRoot, cleanup } = await createProject();
+  try {
+    await writeFile(
+      join(projectRoot, ".env"),
+      [
+        'TEST_MDCMS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----',
+        "line-2",
+        '-----END PRIVATE KEY-----"',
+        "TEST_MDCMS_PROJECT=multiline-project",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const env: NodeJS.ProcessEnv = {};
+    const result = await loadCliEnvFiles({ cwd: projectRoot, env });
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(
+      env.TEST_MDCMS_PRIVATE_KEY,
+      "-----BEGIN PRIVATE KEY-----\nline-2\n-----END PRIVATE KEY-----",
+    );
+    assert.equal(env.TEST_MDCMS_PROJECT, "multiline-project");
+  } finally {
+    await cleanup();
   }
 });

--- a/apps/cli/src/lib/env-files.test.ts
+++ b/apps/cli/src/lib/env-files.test.ts
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { createConsoleLogger, type CliPreflightHook } from "@mdcms/shared";
+
+import { runMdcmsCli, type CliCommand } from "./framework.js";
+import type { CliRuntimeContextWithModules } from "./runtime-with-modules.js";
+
+const ENV_KEYS = [
+  "MDCMS_DOTENV",
+  "NODE_ENV",
+  "TEST_MDCMS_SERVER_URL",
+  "TEST_MDCMS_PROJECT",
+  "TEST_MDCMS_ENVIRONMENT",
+] as const;
+
+type CapturedContext = {
+  serverUrl: string;
+  project: string;
+  environment: string;
+};
+
+function createRuntimeWithPreflightHooks(
+  preflightHooks: readonly CliPreflightHook[] = [],
+): CliRuntimeContextWithModules {
+  return {
+    env: {
+      NODE_ENV: "test",
+      LOG_LEVEL: "debug",
+      APP_VERSION: "1.0.0",
+      CLI_NAME: "mdcms",
+    },
+    logger: createConsoleLogger({
+      level: "trace",
+      sink: () => undefined,
+    }),
+    moduleLoadReport: {
+      evaluatedModuleIds: [],
+      loadedModuleIds: [],
+      skippedModuleIds: [],
+      loaded: [],
+      skipped: [],
+    },
+    actionAliases: [],
+    outputFormatters: [],
+    preflightHooks,
+  };
+}
+
+function snapshotEnv(): Record<(typeof ENV_KEYS)[number], string | undefined> {
+  return Object.fromEntries(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+}
+
+function restoreEnv(
+  snapshot: Record<(typeof ENV_KEYS)[number], string | undefined>,
+): void {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+async function createProject(): Promise<{
+  projectRoot: string;
+  nestedCwd: string;
+  cleanup: () => Promise<void>;
+}> {
+  const projectRoot = await mkdtemp(join(tmpdir(), "mdcms-env-files-"));
+  const nestedCwd = join(projectRoot, "content", "pages");
+  await mkdir(nestedCwd, { recursive: true });
+  return {
+    projectRoot,
+    nestedCwd,
+    cleanup: () => rm(projectRoot, { recursive: true, force: true }),
+  };
+}
+
+async function writeConfig(
+  projectRoot: string,
+  fallback:
+    | {
+        serverUrl: string;
+        project: string;
+        environment: string;
+      }
+    | undefined = undefined,
+): Promise<void> {
+  const readEnv = (key: string, fallbackValue?: string) =>
+    fallbackValue === undefined
+      ? `process.env.${key}`
+      : `process.env.${key} ?? ${JSON.stringify(fallbackValue)}`;
+
+  await writeFile(
+    join(projectRoot, "mdcms.config.ts"),
+    `
+      export default {
+        serverUrl: ${readEnv("TEST_MDCMS_SERVER_URL", fallback?.serverUrl)},
+        project: ${readEnv("TEST_MDCMS_PROJECT", fallback?.project)},
+        environment: ${readEnv("TEST_MDCMS_ENVIRONMENT", fallback?.environment)},
+        types: [],
+      };
+    `,
+    "utf8",
+  );
+}
+
+async function writeEnvFile(
+  projectRoot: string,
+  fileName: string,
+  values: CapturedContext,
+): Promise<void> {
+  await writeFile(
+    join(projectRoot, fileName),
+    [
+      `TEST_MDCMS_SERVER_URL=${values.serverUrl}`,
+      `TEST_MDCMS_PROJECT=${values.project}`,
+      `TEST_MDCMS_ENVIRONMENT=${values.environment}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function runInspectCommand(
+  argv: string[],
+  cwd: string,
+): Promise<{
+  exitCode: number;
+  captured: CapturedContext | undefined;
+  stderr: string;
+}> {
+  let captured: CapturedContext | undefined;
+  let stderr = "";
+  const command: CliCommand = {
+    name: "inspect",
+    description: "Inspect resolved CLI context",
+    run: (context) => {
+      captured = {
+        serverUrl: context.serverUrl,
+        project: context.project,
+        environment: context.environment,
+      };
+      return 0;
+    },
+  };
+
+  const exitCode = await runMdcmsCli(argv, {
+    cwd,
+    env: process.env,
+    commands: [command],
+    runtimeWithModules: createRuntimeWithPreflightHooks(),
+    stdout: {
+      write: () => undefined,
+    },
+    stderr: {
+      write: (chunk) => {
+        stderr += chunk;
+      },
+    },
+  });
+
+  return { exitCode, captured, stderr };
+}
+
+test("runMdcmsCli loads env files from the nearest config root before importing config", async () => {
+  const snapshot = snapshotEnv();
+  clearEnv();
+  const { projectRoot, nestedCwd, cleanup } = await createProject();
+  try {
+    await writeConfig(projectRoot);
+    await writeEnvFile(projectRoot, ".env", {
+      serverUrl: "http://base.example",
+      project: "base-project",
+      environment: "base",
+    });
+    await writeEnvFile(projectRoot, ".env.development", {
+      serverUrl: "http://mode.example",
+      project: "mode-project",
+      environment: "mode",
+    });
+    await writeEnvFile(projectRoot, ".env.local", {
+      serverUrl: "http://local.example",
+      project: "local-project",
+      environment: "local",
+    });
+    await writeEnvFile(projectRoot, ".env.development.local", {
+      serverUrl: "http://mode-local.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+
+    const { exitCode, captured, stderr } = await runInspectCommand(
+      ["inspect"],
+      nestedCwd,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(stderr, "");
+    assert.deepEqual(captured, {
+      serverUrl: "http://mode-local.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+  } finally {
+    await cleanup();
+    restoreEnv(snapshot);
+  }
+});
+
+test("runMdcmsCli keeps shell-exported values ahead of env-file values", async () => {
+  const snapshot = snapshotEnv();
+  clearEnv();
+  process.env.TEST_MDCMS_SERVER_URL = "http://shell.example";
+  const { projectRoot, nestedCwd, cleanup } = await createProject();
+  try {
+    await writeConfig(projectRoot);
+    await writeEnvFile(projectRoot, ".env", {
+      serverUrl: "http://base.example",
+      project: "base-project",
+      environment: "base",
+    });
+    await writeEnvFile(projectRoot, ".env.development.local", {
+      serverUrl: "http://mode-local.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+
+    const { exitCode, captured } = await runInspectCommand(
+      ["inspect"],
+      nestedCwd,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(captured, {
+      serverUrl: "http://shell.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+    assert.equal(process.env.TEST_MDCMS_SERVER_URL, "http://shell.example");
+  } finally {
+    await cleanup();
+    restoreEnv(snapshot);
+  }
+});
+
+test("runMdcmsCli skips env-file loading when --no-env-file is present", async () => {
+  const snapshot = snapshotEnv();
+  clearEnv();
+  const { projectRoot, nestedCwd, cleanup } = await createProject();
+  try {
+    await writeConfig(projectRoot, {
+      serverUrl: "http://config.example",
+      project: "config-project",
+      environment: "config",
+    });
+    await writeEnvFile(projectRoot, ".env.development.local", {
+      serverUrl: "http://mode-local.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+
+    const { exitCode, captured } = await runInspectCommand(
+      ["inspect", "--no-env-file"],
+      nestedCwd,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(captured, {
+      serverUrl: "http://config.example",
+      project: "config-project",
+      environment: "config",
+    });
+    assert.equal(process.env.TEST_MDCMS_SERVER_URL, undefined);
+  } finally {
+    await cleanup();
+    restoreEnv(snapshot);
+  }
+});
+
+test("runMdcmsCli skips env-file loading when MDCMS_DOTENV is 0", async () => {
+  const snapshot = snapshotEnv();
+  clearEnv();
+  process.env.MDCMS_DOTENV = "0";
+  const { projectRoot, nestedCwd, cleanup } = await createProject();
+  try {
+    await writeConfig(projectRoot, {
+      serverUrl: "http://config.example",
+      project: "config-project",
+      environment: "config",
+    });
+    await writeEnvFile(projectRoot, ".env.development.local", {
+      serverUrl: "http://mode-local.example",
+      project: "mode-local-project",
+      environment: "mode-local",
+    });
+
+    const { exitCode, captured } = await runInspectCommand(
+      ["inspect"],
+      nestedCwd,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(captured, {
+      serverUrl: "http://config.example",
+      project: "config-project",
+      environment: "config",
+    });
+  } finally {
+    await cleanup();
+    restoreEnv(snapshot);
+  }
+});
+
+test("runMdcmsCli warns and continues when an env file cannot be loaded", async () => {
+  const snapshot = snapshotEnv();
+  clearEnv();
+  const { projectRoot, nestedCwd, cleanup } = await createProject();
+  try {
+    await writeConfig(projectRoot);
+    await writeEnvFile(projectRoot, ".env", {
+      serverUrl: "http://base.example",
+      project: "base-project",
+      environment: "base",
+    });
+    await mkdir(join(projectRoot, ".env.development.local"));
+
+    const { exitCode, captured, stderr } = await runInspectCommand(
+      ["inspect"],
+      nestedCwd,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(captured, {
+      serverUrl: "http://base.example",
+      project: "base-project",
+      environment: "base",
+    });
+    assert.match(stderr, /Warning: Failed to load env file/);
+    assert.match(stderr, /\.env\.development\.local/);
+  } finally {
+    await cleanup();
+    restoreEnv(snapshot);
+  }
+});

--- a/apps/cli/src/lib/env-files.ts
+++ b/apps/cli/src/lib/env-files.ts
@@ -45,25 +45,6 @@ function formatUnknownError(error: unknown): string {
   return "Unknown error";
 }
 
-function validateEnvFileSyntax(filePath: string, content: string): void {
-  const lines = content.split(/\r?\n/);
-
-  lines.forEach((line, index) => {
-    const trimmed = line.trim();
-    if (trimmed.length === 0 || trimmed.startsWith("#")) {
-      return;
-    }
-
-    const candidate = trimmed.startsWith("export ")
-      ? trimmed.slice("export ".length).trimStart()
-      : trimmed;
-
-    if (!/^[A-Za-z_][A-Za-z0-9_.-]*\s*=/.test(candidate)) {
-      throw new Error(`Invalid env assignment at ${filePath}:${index + 1}.`);
-    }
-  });
-}
-
 export async function loadCliEnvFiles(
   options: LoadCliEnvFilesOptions,
 ): Promise<LoadCliEnvFilesResult> {
@@ -109,7 +90,6 @@ export async function loadCliEnvFiles(
     }
 
     try {
-      validateEnvFileSyntax(filePath, content);
       const parsed = parseDotenv(content);
       for (const [key, value] of Object.entries(parsed)) {
         if (!protectedKeys.has(key)) {

--- a/apps/cli/src/lib/env-files.ts
+++ b/apps/cli/src/lib/env-files.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse as parseDotenv } from "dotenv";
+
+import { resolveCliConfigRoot } from "./config-path.js";
+
+export type CliEnvFileWarning = {
+  filePath: string;
+  message: string;
+};
+
+export type LoadCliEnvFilesOptions = {
+  cwd: string;
+  configPath?: string;
+  env: NodeJS.ProcessEnv;
+  disabled?: boolean;
+};
+
+export type LoadCliEnvFilesResult = {
+  envRoot: string;
+  loadedFiles: string[];
+  warnings: CliEnvFileWarning[];
+};
+
+function normalizeMode(value: string | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : "development";
+}
+
+function getEnvFileNames(mode: string): string[] {
+  return [
+    ".env",
+    `.env.${mode}`,
+    ...(mode === "test" ? [] : [".env.local"]),
+    `.env.${mode}.local`,
+  ];
+}
+
+function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown error";
+}
+
+function validateEnvFileSyntax(filePath: string, content: string): void {
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      return;
+    }
+
+    const candidate = trimmed.startsWith("export ")
+      ? trimmed.slice("export ".length).trimStart()
+      : trimmed;
+
+    if (!/^[A-Za-z_][A-Za-z0-9_.-]*\s*=/.test(candidate)) {
+      throw new Error(`Invalid env assignment at ${filePath}:${index + 1}.`);
+    }
+  });
+}
+
+export async function loadCliEnvFiles(
+  options: LoadCliEnvFilesOptions,
+): Promise<LoadCliEnvFilesResult> {
+  const envRoot = await resolveCliConfigRoot({
+    cwd: options.cwd,
+    configPath: options.configPath,
+  });
+  const loadedFiles: string[] = [];
+  const warnings: CliEnvFileWarning[] = [];
+
+  if (options.disabled) {
+    return { envRoot, loadedFiles, warnings };
+  }
+
+  if (!options.env.NODE_ENV || options.env.NODE_ENV.trim().length === 0) {
+    options.env.NODE_ENV = "development";
+  }
+
+  const protectedKeys = new Set(
+    Object.keys(options.env).filter((key) => options.env[key] !== undefined),
+  );
+  const mode = normalizeMode(options.env.NODE_ENV);
+
+  for (const fileName of getEnvFileNames(mode)) {
+    const filePath = join(envRoot, fileName);
+    let content: string;
+
+    try {
+      content = await readFile(filePath, "utf8");
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String((error as { code: unknown }).code)
+          : undefined;
+
+      if (code !== "ENOENT") {
+        warnings.push({
+          filePath,
+          message: formatUnknownError(error),
+        });
+      }
+      continue;
+    }
+
+    try {
+      validateEnvFileSyntax(filePath, content);
+      const parsed = parseDotenv(content);
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!protectedKeys.has(key)) {
+          options.env[key] = value;
+        }
+      }
+      loadedFiles.push(filePath);
+    } catch (error) {
+      warnings.push({
+        filePath,
+        message: formatUnknownError(error),
+      });
+    }
+  }
+
+  return { envRoot, loadedFiles, warnings };
+}

--- a/apps/cli/src/lib/framework.ts
+++ b/apps/cli/src/lib/framework.ts
@@ -7,6 +7,7 @@ import { RuntimeError, type CliPreflightHook } from "@mdcms/shared";
 import { formatCliErrorEnvelope } from "./cli.js";
 import { loadCliConfig, type CliConfig } from "./config.js";
 import { createCredentialStore, type CredentialStore } from "./credentials.js";
+import { loadCliEnvFiles } from "./env-files.js";
 import { createInitCommand } from "./init.js";
 import { createLoginCommand } from "./login.js";
 import { createLogoutCommand } from "./logout.js";
@@ -39,6 +40,7 @@ export type CliGlobalOptions = {
   apiKey?: string;
   configPath?: string;
   serverUrl?: string;
+  noEnvFile?: boolean;
 };
 
 export type ParsedCliInvocation = {
@@ -152,6 +154,7 @@ export function parseCliInvocation(argv: string[]): ParsedCliInvocation {
     help: false,
     verbose: false,
     version: false,
+    noEnvFile: false,
   };
   const commandTokens: string[] = [];
 
@@ -170,6 +173,11 @@ export function parseCliInvocation(argv: string[]): ParsedCliInvocation {
 
     if (token === "-V" || token === "--version") {
       global.version = true;
+      continue;
+    }
+
+    if (token === "--no-env-file") {
+      global.noEnvFile = true;
       continue;
     }
 
@@ -373,6 +381,7 @@ function renderHelp(commands: readonly CliCommand[]): string {
     "  --api-key <token>      API key for headless/CI auth",
     "  --config <path>        Config file path (default: mdcms.config.ts)",
     "  --server-url <url>     Override server URL",
+    "  --no-env-file          Disable automatic .env* file loading",
     "  -v, --verbose          Show internal runtime diagnostics",
     "  -V, --version          Show version",
     "  -h, --help             Show help",
@@ -460,22 +469,6 @@ export async function runMdcmsCli(
   const multiSelect = options.multiSelect ?? defaultMultiSelectPrompt;
   const registry = createCommandRegistry(commands);
   const invocation = parseCliInvocation(argv);
-  const runtimeWithModules =
-    options.runtimeWithModules ??
-    createCliRuntimeContextWithModules(env, {
-      verbose: invocation.global.verbose,
-    });
-  const credentialStore =
-    options.credentialStore ??
-    createCredentialStore({
-      env,
-    });
-  const resolveStoredApiKey =
-    options.resolveStoredApiKey ??
-    (async (input) => {
-      const profile = await credentialStore.getProfile(input);
-      return profile?.apiKey;
-    });
 
   if (invocation.global.version) {
     stdout.write(`mdcms/${options.version ?? "0.0.0"}\n`);
@@ -518,6 +511,37 @@ export async function runMdcmsCli(
   }
 
   try {
+    const envFiles = await loadCliEnvFiles({
+      cwd,
+      configPath: invocation.global.configPath,
+      env,
+      disabled:
+        invocation.global.noEnvFile ||
+        env.MDCMS_DOTENV?.trim().toLowerCase() === "0",
+    });
+
+    for (const warning of envFiles.warnings) {
+      stderr.write(
+        `Warning: Failed to load env file "${warning.filePath}": ${warning.message}\n`,
+      );
+    }
+
+    const runtimeWithModules =
+      options.runtimeWithModules ??
+      createCliRuntimeContextWithModules(env, {
+        verbose: invocation.global.verbose,
+      });
+    const credentialStore =
+      options.credentialStore ??
+      createCredentialStore({
+        env,
+      });
+    const resolveStoredApiKey =
+      options.resolveStoredApiKey ??
+      (async (input) => {
+        const profile = await credentialStore.getProfile(input);
+        return profile?.apiKey;
+      });
     const loadConfig = options.loadConfig ?? loadCliConfig;
     let config: CliConfig = {
       serverUrl: "",

--- a/apps/docs/guide/cli/ci-cd.mdx
+++ b/apps/docs/guide/cli/ci-cd.mdx
@@ -16,6 +16,14 @@ Set these in your CI provider's secret management:
 | `MDCMS_ENVIRONMENT` | Target environment name                             |
 | `MDCMS_SERVER_URL`  | MDCMS server URL (overrides `mdcms.config.ts`)      |
 
+The CLI also auto-loads `.env*` files before reading `mdcms.config.ts`. In CI, shell-exported variables from the `env:` block override values from files. Add `--no-env-file` to CLI commands, or set `MDCMS_DOTENV=0`, when the pipeline should rely only on CI-provided variables.
+
+<Note>
+  `NODE_ENV` only selects dotenv filenames such as `.env.production`. It is
+  separate from `MDCMS_ENVIRONMENT`, which selects the MDCMS content environment
+  targeted by schema sync, push, pull, and status commands.
+</Note>
+
 <Tip>
   Create a dedicated API key with minimal scopes for CI use. Schema sync
   requires `schema:read` and `schema:write`. Content push requires

--- a/apps/docs/guide/cli/configuration.mdx
+++ b/apps/docs/guide/cli/configuration.mdx
@@ -99,6 +99,50 @@ Each `defineType(name, options)` accepts:
 
 ---
 
+## Environment files
+
+The CLI loads `.env*` files before importing `mdcms.config.ts`, so config files can read values from `process.env`:
+
+```typescript mdcms.config.ts
+export default defineConfig({
+  serverUrl: process.env.MDCMS_SERVER_URL,
+  project: process.env.MDCMS_PROJECT,
+  environment: process.env.MDCMS_ENVIRONMENT ?? "development",
+  types: [BlogPost],
+});
+```
+
+Env files are read from the directory that contains the resolved `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs`. If you pass `--config ./config/mdcms.config.ts`, the CLI looks for env files in `./config`. Without `--config`, the CLI searches upward from the current directory for the nearest config file.
+
+Put local developer values in `.env.local` next to `mdcms.config.ts`:
+
+```bash .env.local
+MDCMS_SERVER_URL=http://localhost:4000
+MDCMS_PROJECT=marketing-site
+MDCMS_ENVIRONMENT=staging
+MDCMS_API_KEY=mdcms_key_local
+```
+
+Loading order, highest precedence first:
+
+| Order | File                    | When loaded                 |
+| ----- | ----------------------- | --------------------------- |
+| 1     | `.env.{NODE_ENV}.local` | Always                      |
+| 2     | `.env.local`            | Except when `NODE_ENV=test` |
+| 3     | `.env.{NODE_ENV}`       | Always                      |
+| 4     | `.env`                  | Always                      |
+
+<Note>
+  `NODE_ENV` is only the dotenv file selector. It controls names such as
+  `.env.production`; it does not select the MDCMS content environment. Use
+  `MDCMS_ENVIRONMENT` or the config `environment` field to choose an MDCMS
+  environment such as `staging` or `production`.
+</Note>
+
+`NODE_ENV` defaults to `development` when unset. Shell-exported variables override all file values, so CI secrets and one-off command exports always win. Use `--no-env-file` or `MDCMS_DOTENV=0` to disable automatic env file loading for a run.
+
+---
+
 ## Manifest file
 
 The manifest tracks the mapping between server documents and local files. It is stored at `.mdcms.manifest.json` in the project root, scoped to the current project and environment.

--- a/apps/studio-example/README.md
+++ b/apps/studio-example/README.md
@@ -58,6 +58,8 @@ CLI env-file order, highest precedence first:
 3. `.env.{NODE_ENV}`
 4. `.env`
 
+`NODE_ENV` is only the dotenv file selector here. It controls names such as `.env.production`; it does not select the MDCMS content environment. Use `MDCMS_ENVIRONMENT` or the config `environment` field for that.
+
 Use `--no-env-file` or `MDCMS_DOTENV=0` when CI should rely only on explicitly exported environment variables.
 
 ## Documentation

--- a/apps/studio-example/README.md
+++ b/apps/studio-example/README.md
@@ -49,6 +49,17 @@ Default demo credentials (seeded automatically in `compose:dev`):
 | `DATABASE_URL`              | `postgresql://mdcms:mdcms@localhost:5432/mdcms` | For `server:dev`               |
 | `MDCMS_DEMO_API_KEY`        | Seeded in compose                               | API key for demo content pages |
 
+For local CLI workflows in this demo, put developer-specific values in `apps/studio-example/.env.local` next to `mdcms.config.ts`. The `mdcms` CLI loads `.env*` files from that config directory before importing the config, with shell exports taking precedence over file values.
+
+CLI env-file order, highest precedence first:
+
+1. `.env.{NODE_ENV}.local`
+2. `.env.local` (skipped when `NODE_ENV=test`)
+3. `.env.{NODE_ENV}`
+4. `.env`
+
+Use `--no-env-file` or `MDCMS_DOTENV=0` when CI should rely only on explicitly exported environment variables.
+
 ## Documentation
 
 See [docs.mdcms.ai](https://docs.mdcms.ai/) for the full Studio embedding guide.

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@elysiajs/eden": "^1.4.8",
         "@inquirer/prompts": "^7.0.0",
         "@mdcms/shared": "^0.1.4",
+        "dotenv": "^16.4.7",
         "elysia": "^1.4.25",
         "ora": "^8.0.0",
         "tslib": "^2.3.0",

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -117,7 +117,7 @@ At process startup, the CLI auto-loads `.env*` files before importing `mdcms.con
 
 The env root is the directory containing the resolved `mdcms.config.{ts,js,mjs}` file. With `--config <path>`, the explicit config file path defines the env root. Without `--config`, the CLI searches upward from the current working directory for the nearest `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs`; if none exists, it falls back to the current working directory so config-optional commands still get local env defaults.
 
-The CLI uses `NODE_ENV` as the mode and defaults it to `development` when unset. Higher-precedence files override lower-precedence files, but variables that already exist in the shell environment always win over file values:
+The CLI uses `NODE_ENV` only as the dotenv file selector, sometimes called the dotenv mode, and defaults it to `development` when unset. This is separate from the MDCMS `environment` target such as `staging` or `production`; `MDCMS_ENVIRONMENT` selects CMS content, while `NODE_ENV` selects files like `.env.production`. Higher-precedence files override lower-precedence files, but variables that already exist in the shell environment always win over file values:
 
 | Precedence | File                    | Loaded when            |
 | ---------- | ----------------------- | ---------------------- |

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -105,10 +105,28 @@ All commands that interact with server content resolve a target `(project, envir
 | `--api-key <token>`    | API key for headless/CI auth                             | No                   |
 | `--config <path>`      | Config file path (default: `mdcms.config.ts`)            | No                   |
 | `--server-url <url>`   | Override server URL                                      | No                   |
+| `--no-env-file`        | Disable automatic `.env*` file loading for this run      | No                   |
 | `-V`, `--version`      | Print installed CLI version (`mdcms/<version>`) and exit | No                   |
 | `-h`, `--help`         | Show help and exit                                       | No                   |
 
 `--version` exits immediately with code 0 and does not require a config file, authentication, or server connectivity. Output format is `mdcms/<semver>` (e.g. `mdcms/0.1.4`), suitable for scripting and troubleshooting.
+
+### Environment File Loading
+
+At process startup, the CLI auto-loads `.env*` files before importing `mdcms.config.ts` so config files may read `process.env` directly. Auto-loading is enabled by default for every command, including `cms login`, and may be disabled with `--no-env-file` or `MDCMS_DOTENV=0`.
+
+The env root is the directory containing the resolved `mdcms.config.{ts,js,mjs}` file. With `--config <path>`, the explicit config file path defines the env root. Without `--config`, the CLI searches upward from the current working directory for the nearest `mdcms.config.ts`, `mdcms.config.js`, or `mdcms.config.mjs`; if none exists, it falls back to the current working directory so config-optional commands still get local env defaults.
+
+The CLI uses `NODE_ENV` as the mode and defaults it to `development` when unset. Higher-precedence files override lower-precedence files, but variables that already exist in the shell environment always win over file values:
+
+| Precedence | File                    | Loaded when            |
+| ---------- | ----------------------- | ---------------------- |
+| 1          | `.env.{NODE_ENV}.local` | Always, if present     |
+| 2          | `.env.local`            | Unless `NODE_ENV=test` |
+| 3          | `.env.{NODE_ENV}`       | Always, if present     |
+| 4          | `.env`                  | Always, if present     |
+
+Malformed or unreadable env files are non-fatal. The CLI writes a warning to stderr and continues using shell-only environment values.
 
 CLI extensibility in v1 is intentionally action-based: aliases, formatters, and preflight hooks are allowed; arbitrary command-tree injection is out of scope.
 


### PR DESCRIPTION
## Summary
- load .env, .env.local, .env.<mode>, and .env.<mode>.local before CLI config import
- add --no-env-file and MDCMS_DOTENV=0 opt-outs
- document the SPEC-008 contract, CLI README usage, and studio-example local workflow

## Validation
- bun run format:check
- bun run check
- bun test --cwd apps/cli ./src/lib/env-files.test.ts ./src/lib/framework.test.ts ./src/lib/config.test.ts

## Notes
- Full bun run unit was attempted outside the sandbox. CLI loopback tests passed, but unrelated server tests failed in apps/server/src/lib/auth.test.ts and apps/server/src/lib/demo-seed.test.ts; these failures are outside the CMS-221 CLI change surface.

Closes CMS-221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI automatically loads environment configuration files (`.env*`) from the nearest config directory before importing config code, with support for environment-specific overrides.
  * Added `--no-env-file` flag and `MDCMS_DOTENV=0` environment variable to disable env-file loading when needed.

* **Documentation**
  * Updated documentation with environment-file loading behavior, configuration precedence, load order, and usage examples.

* **Tests**
  * Added comprehensive test coverage for environment-file loading and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->