### PR TITLE
docs(ai): specify Studio AI direction

### DIFF
--- a/.ai/research/2026-05-01-ai-integration-mcp-scope.md
+++ b/.ai/research/2026-05-01-ai-integration-mcp-scope.md
@@ -1,0 +1,99 @@
+# AI Integration and MCP Scope Decision Memo
+
+Date: 2026-05-01
+Status: Updated decision memo. MCP is deferred; in-product Studio AI is the next focus.
+
+## Decision
+
+Defer MCP for now. MDCMS already has a public skills pack plus CLI workflows
+that cover the highest-value external coding-agent use cases: setup, schema
+refinement, document edits, validation, pull, push, and CI automation. MCP may
+still become useful later, but it adds protocol, auth, approval, audit, routing,
+and tool-filtering complexity before the in-product AI foundation exists.
+
+Focus the next AI work on Studio:
+
+- Inline selection transforms modeled after Apple Intelligence and Notion AI.
+- Inline accept/reject/try-again controls at the edited content.
+- Document-scoped chat that can propose edits to the current draft and propose
+  new draft documents.
+- Structured proposals rather than direct model writes.
+- MDX component grounding so AI cannot hallucinate unavailable components or
+  invalid props.
+- SEO and copy-improvement workflows that produce inspectable draft edits.
+
+The canonical product contract is now
+`docs/specs/SPEC-014-ai-assisted-studio-editing.md`.
+
+## Current Setup Review
+
+The public skills pack remains the right external-agent baseline:
+
+- `mdcms-content-editing` directs agents to edit local files, validate, and push
+  rather than calling the API directly, because `push` preserves manifests,
+  hashes, and rename detection.
+- `mdcms-content-sync-workflow` covers login, credential precedence,
+  pull/push/status, CI automation, `--force`, `--validate`, and `--sync-schema`.
+- The skills pack explicitly does not bundle an MCP server, hooks, or subagents.
+
+Local repo state still confirms there is no MDCMS MCP implementation. That is
+intentional for the current product direction.
+
+## Deferred Areas to Track
+
+Track these explicitly so they are not forgotten:
+
+1. External-agent MCP integration after the Studio AI baseline.
+2. AI-assisted CMS migration workflows after the proposal/audit/eval foundation.
+3. AI autocomplete or ghost-text authoring after inline transforms prove useful.
+4. AI-assisted schema, environment, or project administration after document
+   editing is stable.
+
+## Follow-Up Ticket Shape
+
+Immediate Studio AI work:
+
+1. Studio AI provider and orchestration foundation.
+2. Inline Studio AI selection transforms.
+3. AI proposal lifecycle and draft apply contracts.
+4. Document-scoped Studio AI chat for draft create/edit proposals.
+5. MDX component grounding and validation for AI proposals.
+6. Studio AI SEO and copy-improvement workflows.
+7. Studio AI safety, audit, and evaluation coverage.
+
+Deferred research:
+
+1. Revisit external-agent MCP after Studio AI baseline.
+2. Research AI-assisted CMS migration workflows.
+3. Research AI autocomplete and ghost-text authoring.
+
+## Sources
+
+Local:
+
+- `docs/specs/SPEC-014-ai-assisted-studio-editing.md`
+- `docs/specs/SPEC-001-platform-overview-and-scope.md`
+- `docs/specs/SPEC-002-system-architecture-and-extensibility.md`
+- `docs/specs/SPEC-003-content-storage-versioning-and-migrations.md`
+- `docs/specs/SPEC-005-auth-authorization-and-request-routing.md`
+- `docs/specs/SPEC-008-cli-and-sdk.md`
+- `skills/README.md`
+- `skills/mdcms-content-editing/SKILL.md`
+- `skills/mdcms-content-sync-workflow/SKILL.md`
+- `.ai/memory/product.md`
+- `.ai/memory/stack.md`
+
+External context used during the original research pass:
+
+- Model Context Protocol docs: https://modelcontextprotocol.io/docs/getting-started/intro
+- MCP Tools spec: https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+- Anthropic MCP announcement: https://www.anthropic.com/news/model-context-protocol
+- Anthropic, Building effective agents: https://www.anthropic.com/engineering/building-effective-agents
+- Anthropic, Writing effective tools for agents: https://www.anthropic.com/engineering/writing-tools-for-agents
+- Claude Code MCP docs: https://docs.anthropic.com/en/docs/claude-code/mcp
+- OpenAI MCP/connectors docs: https://platform.openai.com/docs/guides/tools-remote-mcp
+- OpenAI Codex announcement: https://openai.com/index/introducing-codex/
+- ReAct paper: https://arxiv.org/abs/2210.03629
+- Toolformer paper: https://arxiv.org/abs/2302.04761
+- ToolLLM paper: https://arxiv.org/abs/2307.16789
+- SWE-agent paper: https://arxiv.org/abs/2405.15793

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,3 +27,4 @@ This catalog owns the live product and subsystem specifications for MDCMS. Contr
 | SPEC-010 | [Media, Webhooks, Search, and Integrations](./SPEC-010-media-webhooks-search-and-integrations.md)      | Post-MVP media, webhooks, and search                                                                 |
 | SPEC-011 | [Local Development and Operations](./SPEC-011-local-development-and-operations.md)                     | Docker Compose stack and local developer workflow                                                    |
 | SPEC-013 | [Mintlify Documentation Site](./SPEC-013-mintlify-docs-site.md)                                        | `apps/docs` documentation site: design system mapping, information architecture, and page inventory  |
+| SPEC-014 | [AI-Assisted Studio Editing](./SPEC-014-ai-assisted-studio-editing.md)                                 | In-product Studio AI assistance, inline AI transforms, document chat, proposal lifecycle, and safety |

--- a/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
+++ b/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
@@ -415,7 +415,8 @@ Machine-to-machine access (SDK, CI/CD) uses API keys:
   - `webhooks:write`
   - `environments:clone`
   - `environments:promote`
-- `migrations:run`
+  - `ai:use`
+  - `migrations:run`
 - Scopes are deny-by-default: a key without an operation scope cannot perform that action.
 - Public routes and session-only routes may specify required scope `none`; operation scopes apply only to API-key-capable routes.
 - Keys are hashed at rest and never retrievable after creation.

--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -1,0 +1,330 @@
+---
+status: live
+canonical: true
+created: 2026-05-01
+last_updated: 2026-05-01
+---
+
+# SPEC-014 AI-Assisted Studio Editing
+
+This spec owns in-product AI assistance for Studio document authoring and
+editing. It does not define external-agent MCP integration, AI-assisted
+migrations, or schema authoring automation.
+
+## Product Scope
+
+AI assistance in Studio is a bounded editing aid. It helps users create and
+revise draft documents while preserving MDCMS's existing content invariants:
+schema validation, MDX component validation, explicit draft writes, optimistic
+concurrency, authorization, and normal publish separation.
+
+The first product scope includes:
+
+- Inline AI transforms for selected editor content.
+- Document-scoped AI chat that can propose draft document edits or new draft
+  documents.
+- Copy-improvement workflows such as rewrite, shorten, expand, change tone, fix
+  grammar, and improve clarity.
+- SEO-improvement workflows that produce actionable edits for document body and
+  metadata.
+- MDX-aware generation that can use only registered components and valid props.
+
+The first product scope excludes:
+
+- Autocomplete or ghost-text generation while typing.
+- External-agent MCP integration.
+- AI-assisted migrations and import transforms.
+- Schema, environment, project, role, or provider configuration changes through
+  chat.
+- Publish, unpublish, restore, delete, or environment promotion actions through
+  AI.
+
+## User Experience
+
+### Inline Selection Transforms
+
+Users can select text or an editor block and invoke an AI action from an inline
+editor affordance. Supported actions include rewrite, shorten, expand, change
+tone, fix grammar, improve clarity, and improve SEO.
+
+The result renders inline at the selection location as a proposed replacement,
+not as a committed draft write. The proposed replacement has visible controls:
+
+- `Accept` applies the proposal to the local editor state and then persists the
+  accepted proposal through the proposal apply endpoint; Studio updates local
+  editor state from the successful draft response.
+- `Reject` discards the proposal and keeps the original selection.
+- `Try again` requests a replacement using the same action and current context.
+
+Inline proposals must stay anchored near the source selection. Studio must not
+move selection-based proposals into a separate suggestion queue.
+
+### Document Chat
+
+Studio provides a document-scoped chat surface for authoring assistance. Chat is
+allowed to answer questions about the current document, propose edits to the
+current draft, and propose new draft documents of existing content types.
+
+Chat is not a general administration console. It cannot change schemas,
+environments, projects, roles, API keys, modules, provider settings, or publish
+state.
+
+When chat proposes a content change, Studio renders the change as a draft
+proposal with explicit accept/reject controls. For current-document edits,
+proposed changes render inline in the editor where practical. For new-document
+creation, Studio renders a proposed draft document summary that includes type,
+path, locale, frontmatter, body preview, and validation status before creation.
+
+### Proposal Handling
+
+AI output is always mediated through proposals:
+
+1. User invokes an inline action or sends a document chat message.
+2. Server creates one or more proposals.
+3. Studio renders the proposal with validation status and accept/reject
+   controls.
+4. User explicitly accepts a proposal.
+5. Server applies the accepted proposal as a draft write if the target still
+   matches the proposal's base revision and validation passes.
+6. Studio reconciles local editor state from the accepted draft response.
+
+Rejecting a proposal has no content side effects. Proposals expire after a short
+server-defined lifetime and may also become stale when a draft revision changes.
+
+## Context Model
+
+The server, not the browser, owns AI context assembly. Browser requests provide
+the user intent, selected text or target document, and optional action
+parameters. The server resolves target-scoped context using the caller's
+authorization.
+
+Allowed context:
+
+- Current draft document body and frontmatter when the caller can read drafts.
+- Current content type schema and field metadata.
+- Current locale and path.
+- Selected text or block range.
+- Nearby editor context needed to produce a coherent replacement.
+- Registered MDX component catalog metadata supplied through the Studio host
+  bridge and normalized into serializable component names, prop schemas, prop
+  hints, and child-content rules.
+- Action-specific instructions for copy, SEO, MDX component insertion, or
+  document creation workflows.
+
+Disallowed context:
+
+- Documents outside the caller's project/environment routing context.
+- Drafts the caller cannot read.
+- Provider secrets, API keys, session cookies, or credential-store values.
+- Unbounded repository source code.
+- Schema or environment mutation authority.
+
+## Structured Proposals
+
+AI providers must not return unstructured final content directly into the draft.
+The orchestration layer converts model output into structured proposal objects.
+
+```typescript
+export type AiProposalKind =
+  | "replace_selection"
+  | "insert_block"
+  | "update_frontmatter"
+  | "create_document";
+
+export type AiProposal = {
+  proposalId: string;
+  kind: AiProposalKind;
+  project: string;
+  environment: string;
+  documentId?: string;
+  baseDraftRevision?: number;
+  type: string;
+  locale: string;
+  summary: string;
+  operations: AiProposalOperation[];
+  validation: AiProposalValidation;
+  expiresAt: string;
+};
+
+export type AiProposalOperation =
+  | {
+      op: "replace_selection";
+      selectionId: string;
+      originalText: string;
+      replacementText: string;
+    }
+  | {
+      op: "insert_block";
+      afterSelectionId?: string;
+      bodyMdx: string;
+    }
+  | {
+      op: "update_frontmatter";
+      patch: Record<string, unknown>;
+    }
+  | {
+      op: "create_document";
+      path: string;
+      format: "md" | "mdx";
+      frontmatter: Record<string, unknown>;
+      body: string;
+    };
+
+export type AiProposalValidation =
+  | { status: "valid" }
+  | {
+      status: "invalid";
+      errors: {
+        code: string;
+        message: string;
+        path?: string;
+      }[];
+    };
+```
+
+The implementation may store proposals server-side or encode them in signed
+proposal tokens, but clients must treat proposal identifiers as opaque.
+
+## MDX Component Grounding
+
+AI-generated MDX must be grounded in the active MDX component catalog.
+
+Rules:
+
+- Generated component names must exist in the active catalog.
+- Generated props must validate against the component's extracted prop metadata
+  and any author-provided prop hints.
+- Required props must be present.
+- Unknown props are rejected unless the component metadata explicitly permits
+  passthrough props.
+- Wrapper components must follow their declared child-content rules.
+- Studio must show validation failures before the user can accept a proposal.
+
+Invalid MDX proposals are never silently repaired on apply. The user may request
+another proposal or edit manually.
+
+## SEO Assistance
+
+SEO assistance is a document-editing workflow, not a separate search or
+analytics product in this spec.
+
+The first SEO workflow may inspect and propose edits for:
+
+- title and description-style fields when present in the content type schema
+- headings
+- intro clarity
+- excerpt quality
+- keyword/topic coverage provided by the user
+- internal link opportunities when linkable context is explicitly available
+
+SEO suggestions that change content follow the same proposal lifecycle as other
+AI edits. SEO scoring may be shown as supporting context, but score changes
+must not be the only success signal; proposed edits must remain inspectable.
+
+## Authorization and Safety
+
+AI endpoints require explicit project/environment routing and obey the shared
+HTTP boundary in `SPEC-005`.
+
+Minimum scopes:
+
+- Generating proposals for an existing draft requires `ai:use` and
+  `content:read:draft`.
+- Generating a new-document proposal requires `ai:use` and schema visibility for
+  the requested content type.
+- Applying an edit proposal requires `content:write`.
+- Applying a create-document proposal requires `content:write`.
+
+AI endpoints must not grant publish authority. Accepted AI edits update drafts
+only. Publishing remains owned by the content publish endpoints.
+
+All AI write application paths must:
+
+- verify the caller is still authorized at apply time
+- verify the proposal has not expired
+- verify the proposal target still matches the expected draft revision
+- validate content against the current synced schema
+- validate generated MDX before writing
+- write through the same draft mutation semantics as normal content updates
+- produce an audit event that identifies the human actor, target document,
+  proposal kind, accepted/rejected outcome, model/provider metadata, and
+  validation result
+
+## Endpoint Contracts
+
+This table is normative and follows the shared contract template in `SPEC-005`.
+
+| Method | Endpoint                                 | Auth mode          | Required scope                                                 | Target routing                  | Request schema                                                                                                                                   | Success response schema                                               | Errors                                                                                                                                                                                                                                                                                                                     |
+| ------ | ---------------------------------------- | ------------------ | -------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| POST   | `/api/v1/ai/inline-transform`            | session_or_api_key | `ai:use`, `content:read:draft`                                 | required: `project_environment` | JSON: `{ documentId, draftRevision, selectionId, selectedText, action, instruction?, tone?, keyword?, componentIntent? }`                        | `200` `{ data: { proposals: AiProposal[] } }`                         | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_INPUT` (`400`), `AI_DISABLED` (`403`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `AI_CONTEXT_TOO_LARGE` (`413`), `AI_RATE_LIMITED` (`429`), `AI_PROVIDER_UNAVAILABLE` (`503`)                                        |
+| POST   | `/api/v1/ai/chat/messages`               | session_or_api_key | `ai:use`, `content:read:draft` for current-document operations | required: `project_environment` | JSON: `{ documentId?, draftRevision?, message, conversationId?, allowedActions?: ("answer" \| "edit_current_document" \| "create_document")[] }` | `200` `{ data: { conversationId, message, proposals? } }`             | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_INPUT` (`400`), `AI_DISABLED` (`403`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `AI_UNSUPPORTED_ACTION` (`400`), `AI_CONTEXT_TOO_LARGE` (`413`), `AI_RATE_LIMITED` (`429`), `AI_PROVIDER_UNAVAILABLE` (`503`)       |
+| POST   | `/api/v1/ai/proposals/:proposalId/apply` | session_or_api_key | `content:write`                                                | required: `project_environment` | path `proposalId`, JSON: `{ draftRevision?, schemaHash, clientSelectionState? }`                                                                 | `200` `{ data: { proposal: AiProposal, document: ContentDocument } }` | `MISSING_TARGET_ROUTING` (`400`), `TARGET_ROUTING_MISMATCH` (`400`), `INVALID_INPUT` (`400`), `UNAUTHORIZED` (`401`), `FORBIDDEN` (`403`), `NOT_FOUND` (`404`), `AI_PROPOSAL_EXPIRED` (`410`), `AI_PROPOSAL_CONFLICT` (`409`), `AI_OUTPUT_INVALID` (`422`), `SCHEMA_HASH_REQUIRED` (`400`), `SCHEMA_HASH_MISMATCH` (`409`) |
+
+`action` for inline transforms is an enum:
+
+- `rewrite`
+- `shorten`
+- `expand`
+- `change_tone`
+- `fix_grammar`
+- `improve_clarity`
+- `improve_seo`
+- `insert_mdx_component`
+
+## Provider and Orchestration Requirements
+
+AI provider credentials are server-side only. Studio never receives provider API
+keys or raw provider request payloads.
+
+The orchestration layer must support task-specific prompt templates or
+equivalent workflow definitions for at least:
+
+- copy improvement
+- SEO improvement
+- MDX component insertion
+- current-document editing through chat
+- new-document draft creation through chat
+
+The implementation may use specialized subagents, but subagents are not a
+product contract. The product contract is the validated proposal output and the
+human accept/reject workflow.
+
+## Observability and Evaluation
+
+AI operations must be auditable without storing unnecessary secrets.
+
+Audit records include:
+
+- actor id
+- project and environment
+- document id when applicable
+- proposal id
+- proposal kind
+- action name or chat allowed action
+- accepted, rejected, expired, or failed outcome
+- provider and model identifier
+- prompt template or workflow identifier
+- validation status
+- token/cost metadata when available
+
+Regression coverage must include:
+
+- hallucinated MDX component names are rejected
+- invalid component props are rejected
+- stale draft revisions cannot be applied
+- prompt-injection attempts cannot trigger publish, schema, environment, or
+  project changes
+- generated frontmatter is schema-validated before writing
+- rejected proposals do not mutate content
+- accepted proposals write drafts only
+
+## Deferred Follow-Up Areas
+
+The following areas are intentionally deferred but should remain tracked:
+
+- External-agent MCP integration for Codex, Claude Code, Cursor, ChatGPT, and
+  other agent clients.
+- AI-assisted migration workflows for imports, schema mapping, transforms, and
+  dry-run reports.
+- Autocomplete or ghost-text authoring while the user types.
+- AI-assisted schema design and environment/project administration.


### PR DESCRIPTION
## Summary
- add SPEC-014 for AI-assisted Studio editing
- document inline AI transforms, document chat, proposal lifecycle, MDX grounding, and safety/eval requirements
- update auth scopes with ai:use and add the spec to the catalog
- add research memo capturing the decision to defer MCP and focus Studio AI next

## Verification
- bun x prettier --check docs/specs/README.md docs/specs/SPEC-005-auth-authorization-and-request-routing.md docs/specs/SPEC-014-ai-assisted-studio-editing.md .ai/research/2026-05-01-ai-integration-mcp-scope.md
- rg -n "TBD|TODO|FIXME|issue tracker|this task" docs/specs/SPEC-014-ai-assisted-studio-editing.md docs/specs/README.md docs/specs/SPEC-005-auth-authorization-and-request-routing.md

Refs CMS-184