### PR TITLE
feat(ai): add Studio AI provider and orchestration foundation (CMS-223)

### DIFF
--- a/.ai/plans/2026-05-01-cms-223-studio-ai-foundation.md
+++ b/.ai/plans/2026-05-01-cms-223-studio-ai-foundation.md
@@ -24,12 +24,20 @@ Affected acceptance criteria from the issue:
 
 ## Architecture
 
-A new first-party module: `packages/modules/core.ai/`. Module surface
-exposes the orchestrator factory through future server actions; for this
-ticket the surface mounts no routes — only the foundation is in place.
-Cross-module contract types live in `@mdcms/shared` so callers (Studio
-clients via SDK, future endpoints in apps/server) can import the same
-shape without depending on the module's runtime.
+A new first-party module: `packages/modules/core.ai/`. The provider
+seam wraps an AI SDK `LanguageModelV3` so any Vercel AI SDK provider
+package (`@ai-sdk/anthropic`, `@ai-sdk/openai`, …) plugs in via the
+factory without changes to the orchestrator. The orchestrator drives
+generation through `generateObject({ model, schema })` so structured
+output validation, JSON parsing, and provider error normalization
+come from the SDK rather than hand-rolled code.
+
+Module surface exposes the orchestrator factory through future server
+actions; for this ticket the surface mounts no routes — only the
+foundation is in place. Cross-module contract types live in
+`@mdcms/shared` so callers (Studio clients via SDK, future endpoints
+in apps/server) can import the same shape without depending on the
+module's runtime.
 
 Why a module and not `apps/server/src/lib/ai/`:
 
@@ -39,6 +47,18 @@ Why a module and not `apps/server/src/lib/ai/`:
   module's `server.actions[]` list once endpoints land.
 - Provider credentials/state are server-only; modules' `server.mount()`
   receives the same `AppDeps` (logger, env) the rest of the server uses.
+
+Why Vercel AI SDK as the underlying mechanism:
+
+- Single seam for OpenAI / Anthropic / Google / Gateway provider
+  packages — adding a real adapter is a one-liner once the API key
+  env handling is wired in a follow-up ticket.
+- `generateObject` does JSON parsing and Zod-schema validation against
+  task output contracts in one call; we map its error classes
+  (`NoObjectGeneratedError`, `JSONParseError`, `TypeValidationError`,
+  `APICallError`) onto our `AI_*` codes.
+- `MockLanguageModelV3` from `ai/test` gives us a deterministic test
+  provider without our own bespoke fake.
 
 ## Files
 

--- a/.ai/plans/2026-05-01-cms-223-studio-ai-foundation.md
+++ b/.ai/plans/2026-05-01-cms-223-studio-ai-foundation.md
@@ -1,0 +1,266 @@
+# CMS-223 — Studio AI provider and orchestration foundation
+
+Status: in_progress
+Owner spec: docs/specs/SPEC-014-ai-assisted-studio-editing.md
+Created: 2026-05-01
+
+## Spec delta
+
+Implements the server-side foundation in SPEC-014 §"Provider and
+Orchestration Requirements" and §"Structured Proposals". No HTTP endpoints,
+no DB tables, no Studio UI in this ticket — those land in follow-up
+tickets that consume the foundation through the endpoint-contract table
+already in SPEC-014.
+
+Affected acceptance criteria from the issue:
+
+- Studio AI workflows can call a unified provider interface without
+  coupling UI code to a provider SDK.
+- Provider failures return deterministic errors.
+- Orchestration emits structured proposals compatible with the
+  AI-assisted Studio editing spec.
+- Unit tests cover provider success, provider failure, disabled AI, and
+  invalid model output.
+
+## Architecture
+
+A new first-party module: `packages/modules/core.ai/`. Module surface
+exposes the orchestrator factory through future server actions; for this
+ticket the surface mounts no routes — only the foundation is in place.
+Cross-module contract types live in `@mdcms/shared` so callers (Studio
+clients via SDK, future endpoints in apps/server) can import the same
+shape without depending on the module's runtime.
+
+Why a module and not `apps/server/src/lib/ai/`:
+
+- Module pattern is the canonical extension point per
+  `.ai/memory/architecture.md`.
+- The endpoint contracts in SPEC-014 will be added as actions on this
+  module's `server.actions[]` list once endpoints land.
+- Provider credentials/state are server-only; modules' `server.mount()`
+  receives the same `AppDeps` (logger, env) the rest of the server uses.
+
+## Files
+
+### packages/shared/src/lib/contracts/ai.ts (new)
+
+Exports types + Zod schemas:
+
+- `AiProposalKind` (`"replace_selection"` | `"insert_block"` |
+  `"update_frontmatter"` | `"create_document"`).
+- `AiProposalOperation` discriminated union (per SPEC-014).
+- `AiProposalValidation` (`{ status: "valid" }` |
+  `{ status: "invalid", errors: ... }`).
+- `AiProposal` carrying spec fields plus `provider`/`model` metadata.
+- `AiTaskKind` (`"copy_improvement"` | `"seo_improvement"` |
+  `"mdx_component_insertion"` | `"current_document_edit"` |
+  `"new_document_draft"`).
+- `AI_ERROR_CODES` constant + `AiErrorCode` type (`"AI_DISABLED"`,
+  `"AI_PROVIDER_UNAVAILABLE"`, `"AI_RATE_LIMITED"`,
+  `"AI_CONTEXT_TOO_LARGE"`, `"AI_OUTPUT_INVALID"`,
+  `"AI_UNSUPPORTED_TASK"`).
+- Zod schemas: `aiProposalSchema`, `aiProposalOperationSchema`,
+  `aiProposalValidationSchema`, plus `assertAiProposal()` helper that
+  follows the `assertWithSchema` pattern from `extensibility.ts`.
+
+### packages/shared/src/index.ts (modify)
+
+Re-export the new ai contracts.
+
+### packages/modules/core.ai/src/manifest.ts (new)
+
+`{ id: "core.ai", version: "1.0.0", apiVersion: "1", kind: "core",
+minCoreVersion: "0.0.0" }`.
+
+### packages/modules/core.ai/src/server/provider.ts (new)
+
+- `AiProviderRequest` — `{ taskKind, system, user, schema?,
+  maxOutputTokens? }`.
+- `AiProviderResponse` — `{ output: string, model: string,
+  usage?: { promptTokens?, completionTokens?, costUsd? } }`.
+- `AiProvider` — `{ readonly id: string; complete(request):
+  Promise<AiProviderResponse> }`.
+- `AiProviderFactoryDeps` — `{ env: Record<string,string|undefined>,
+  fetch?: typeof fetch }` (fetch is injected so unit tests can supply a
+  stub without real network).
+
+### packages/modules/core.ai/src/server/providers/null.ts (new)
+
+Provider that always throws `RuntimeError({ code: "AI_DISABLED",
+statusCode: 403 })`. Used when no provider is configured.
+
+### packages/modules/core.ai/src/server/providers/echo.ts (new)
+
+Deterministic, in-memory provider for tests. Emits the user prompt back
+as `output`. Optional constructor overrides for failure injection
+(`{ throwOnComplete?: Error, output?: string, usage?: ... }`).
+
+### packages/modules/core.ai/src/server/providers/factory.ts (new)
+
+`resolveAiProvider(deps): AiProvider`:
+
+- If `env.AI_PROVIDER` is missing or `"disabled"`, return null provider.
+- If `env.AI_PROVIDER === "echo"`, return echo provider (used by tests
+  + smoke).
+- For real provider ids (e.g. `"anthropic"`, `"openai"`), this ticket
+  throws `AI_PROVIDER_UNAVAILABLE` with a clear "not yet implemented"
+  message — wiring the SDKs is a follow-up ticket. The factory shape is
+  what unblocks downstream work.
+
+### packages/modules/core.ai/src/server/errors.ts (new)
+
+- `aiError(code, message, details?, statusCode?)` factory returning
+  `RuntimeError`.
+- `mapProviderError(error)`:
+  - `RuntimeError` with `AI_*` code → passthrough.
+  - Caught network/timeout error → `AI_PROVIDER_UNAVAILABLE` (503).
+  - Anything else → `AI_PROVIDER_UNAVAILABLE` with a sanitized message
+    (no provider response bodies, no env values).
+
+### packages/modules/core.ai/src/server/tasks.ts (new)
+
+`AiTaskDefinition` registry — one per `AiTaskKind`. Each entry holds:
+
+- `kind: AiTaskKind`.
+- `system: string` (template).
+- `buildUserPrompt(input): string` (deterministic; no IO).
+- `outputContract`: a Zod schema describing the expected JSON shape
+  the model must return.
+
+The registry is built once and frozen. Tests can iterate it.
+
+### packages/modules/core.ai/src/server/proposal-builder.ts (new)
+
+`buildProposalFromOutput({ taskKind, model, providerId,
+parsedOutput, base }) → AiProposal`:
+
+- Maps task-specific parsed output → `AiProposalOperation[]`.
+- Embeds metadata: `proposalId` (random + deterministic for tests via
+  injectable `idFactory`), `expiresAt` from injectable `clock`.
+- Runs spec-required validation (`AiProposalValidation` is `valid` if
+  the operations parse against `aiProposalOperationSchema`; otherwise
+  `invalid` with the Zod issues).
+- Output is parsed by `aiProposalSchema` before return; failure throws
+  `AI_OUTPUT_INVALID`.
+
+### packages/modules/core.ai/src/server/orchestrator.ts (new)
+
+`createAiOrchestrator(deps): AiOrchestrator`:
+
+- `deps`: `{ provider, clock, idFactory, logger }`.
+- `runTask(input): Promise<AiOrchestrationResult>`:
+  1. Resolve `AiTaskDefinition` by `kind`. Unknown → `AI_UNSUPPORTED_TASK`.
+  2. Build provider request (system + user prompt + schema).
+  3. `provider.complete(request)`. Errors → `mapProviderError`.
+  4. Parse `response.output` against task's `outputContract`. Failure →
+     `AI_OUTPUT_INVALID`.
+  5. `buildProposalFromOutput` → `AiProposal[]`.
+  6. Return `{ proposals, audit: buildAuditRecord(...) }` with model +
+     usage metadata.
+
+`AiOrchestrationResult`:
+
+```ts
+{
+  proposals: AiProposal[];
+  audit: AiAuditRecord;
+}
+```
+
+### packages/modules/core.ai/src/server/audit.ts (new)
+
+`AiAuditRecord` shape (no persistence in this ticket — caller is
+responsible for sinking the record):
+
+```ts
+{
+  taskKind: AiTaskKind;
+  providerId: string;
+  model: string;
+  promptTemplateId: string;       // taskKind for v1
+  validation: AiProposalValidation;
+  usage?: { promptTokens?, completionTokens?, costUsd? };
+  outcome: "succeeded" | "invalid_output" | "provider_error";
+  errorCode?: AiErrorCode;
+}
+```
+
+`buildAuditRecord(input, result)` produces the record for the caller.
+Future tickets wire this into the audit pipeline.
+
+### packages/modules/core.ai/src/server/index.ts (new)
+
+`coreAiServerSurface: ServerSurface<unknown, Record<string, unknown>>`:
+
+- `mount` is a no-op for this ticket. Future ticket adds AI routes here.
+- `actions: []` for now.
+
+Exports a `createAiOrchestratorFromEnv(deps)` helper for downstream
+callers to use without re-implementing factory wiring.
+
+### packages/modules/core.ai/src/index.ts (new)
+
+Wires `manifest`, `server`, no `cli`. Exports `coreAiModule`.
+
+### packages/modules/src/index.ts (modify)
+
+Add `coreAiModule` to `localModules`. Sorted registry takes care of
+ordering.
+
+### packages/modules/src/index.test.ts (modify)
+
+Add: `installedModules includes core.ai`.
+
+## Tests
+
+`packages/shared/src/lib/contracts/ai.test.ts`:
+- Schema accepts each `AiProposalKind` shape.
+- Schema rejects unknown kind, missing required fields, mistyped operations.
+
+`packages/modules/core.ai/src/server/errors.test.ts`:
+- `mapProviderError` passthroughs RuntimeError with `AI_*` code.
+- Unknown error → `AI_PROVIDER_UNAVAILABLE`, sanitized message.
+
+`packages/modules/core.ai/src/server/proposal-builder.test.ts`:
+- Builds valid proposal for each task kind given a parsed output fixture.
+- Throws `AI_OUTPUT_INVALID` for shapes that fail `aiProposalSchema`.
+
+`packages/modules/core.ai/src/server/orchestrator.test.ts`:
+- **provider success**: echo provider returns valid JSON for
+  `copy_improvement` → orchestrator returns proposals + audit record
+  with `outcome: "succeeded"`.
+- **provider failure**: provider throws → orchestrator surfaces
+  `AI_PROVIDER_UNAVAILABLE`, audit record `outcome: "provider_error"`.
+- **disabled AI**: null provider → orchestrator surfaces `AI_DISABLED`,
+  audit record `outcome: "provider_error"` with `errorCode:
+  "AI_DISABLED"`.
+- **invalid model output**: echo provider returns text that fails the
+  task's output contract → `AI_OUTPUT_INVALID`, audit record
+  `outcome: "invalid_output"`.
+- Unknown `taskKind` → `AI_UNSUPPORTED_TASK`.
+- Audit record always includes `providerId`, `model` (when known),
+  `promptTemplateId`.
+
+`packages/modules/core.ai/src/server/audit.test.ts`:
+- `buildAuditRecord` echoes provider/model/usage/validation status.
+- Drops undefined optionals.
+
+## Verification
+
+```bash
+bun run --cwd packages/shared test
+bun test --cwd packages/modules ./src
+bun run format:check
+bun run check
+```
+
+Smoke: `bun run --cwd packages/modules test ./core.ai/src`.
+
+## Out of scope (deferred)
+
+- HTTP routes for `/api/v1/ai/*` (separate ticket).
+- Real provider SDK adapters (Anthropic, OpenAI) — separate ticket.
+- DB tables for proposals + audit log — separate ticket.
+- Studio UI changes — separate ticket.
+- studio-review fixtures — `apps/studio-review` does not exist on this
+  branch; nothing to mirror.

--- a/.changeset/keen-tigers-spark.md
+++ b/.changeset/keen-tigers-spark.md
@@ -2,4 +2,4 @@
 "@mdcms/shared": minor
 ---
 
-Add AI contract types and Zod schemas (AiProposal, AiProposalKind, AiProposalOperation, AiProposalValidation, AiTaskKind, AI_ERROR_CODES) consumed by the Studio AI provider and orchestration foundation.
+Add AI contract types and Zod schemas (AiProposal, AiProposalKind, AiProposalOperation, AiProposalValidation, AiTaskKind, AI_ERROR_CODES) consumed by the Studio AI provider and orchestration foundation. The orchestrator is built on the Vercel AI SDK, so future provider adapters (Anthropic, OpenAI) plug in through `@ai-sdk/*` packages without changing the public contract.

--- a/.changeset/keen-tigers-spark.md
+++ b/.changeset/keen-tigers-spark.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/shared": minor
+---
+
+Add AI contract types and Zod schemas (AiProposal, AiProposalKind, AiProposalOperation, AiProposalValidation, AiTaskKind, AI_ERROR_CODES) consumed by the Studio AI provider and orchestration foundation.

--- a/apps/server/src/lib/runtime-with-modules.test.ts
+++ b/apps/server/src/lib/runtime-with-modules.test.ts
@@ -147,6 +147,7 @@ test("createServerRequestHandlerWithModules loads bundled modules when APP_VERSI
 
   try {
     assert.deepEqual(moduleLoadReport.loadedModuleIds, [
+      "core.ai",
       "core.system",
       "domain.content",
     ]);

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/cli": {
       "name": "@mdcms/cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "mdcms": "./dist/bin/mdcms.js",
       },
@@ -79,7 +79,9 @@
       "name": "@mdcms/modules",
       "version": "0.0.1",
       "dependencies": {
+        "@ai-sdk/provider": "^3.0.10",
         "@mdcms/shared": "workspace:*",
+        "ai": "^6.0.173",
         "tslib": "^2.3.0",
       },
     },
@@ -162,6 +164,12 @@
     },
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.108", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hOtwiM6E/m1PgqHnx0/grvh0P/kjENHsN222OL5iYPQwfWmcX+26oFXM7HGL/UzonB+RORMkYAbskgAiANVwCQ=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@authenio/xml-encryption": ["@authenio/xml-encryption@2.0.2", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "escape-html": "^1.0.3", "xpath": "0.0.32" } }, "sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg=="],
@@ -692,6 +700,8 @@
 
     "@nx/workspace": ["@nx/workspace@22.5.1", "", { "dependencies": { "@nx/devkit": "22.5.1", "@zkochan/js-yaml": "0.0.7", "chalk": "^4.1.0", "enquirer": "~2.3.6", "nx": "22.5.1", "picomatch": "4.0.2", "semver": "^7.6.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-IZJ440ITiNpswacrTGGpo46adOszLAAZM9RYYvQg5ak8kZDmmrskTm0SWWVgZCuiJazw8s23vqDLQ07TN/t1NQ=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.17.1", "", { "os": "android", "cpu": "arm" }, "sha512-+VuZyMYYaap5uDAU1xDU3Kul0FekLqpBS8kI5JozlWfYQKnc/HsZg2gHPkQrj0SC9lt74WMNCfOzZZJlYXSdEQ=="],
 
     "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.17.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YlDDTjvOEKhom/cRSVsXsMVeXVIAM9PJ/x2mfe08rfuS0iIEfJd8PngKbEIhG72WPxleUa+vkEZj9ncmC14z3Q=="],
@@ -1010,6 +1020,8 @@
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "@xmldom/is-dom-node": ["@xmldom/is-dom-node@1.0.1", "", {}, "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
@@ -1021,6 +1033,8 @@
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
     "address": ["address@1.2.2", "", {}, "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA=="],
+
+    "ai": ["ai@6.0.173", "", { "dependencies": { "@ai-sdk/gateway": "3.0.108", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-X2noFb82kouYQ4nlKGm1cR1Wvlp4Xit7fjJzwXv/msKQmtqkQn9NiXH6kCX4Gl4G+9DRWsJHIKANtWk8Ix1nTw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -1232,6 +1246,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
@@ -1383,6 +1399,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 

--- a/packages/modules/core.ai/src/index.ts
+++ b/packages/modules/core.ai/src/index.ts
@@ -65,7 +65,5 @@ export type {
   AiProvider,
   AiProviderEnv,
   AiProviderFactoryDeps,
-  AiProviderRequest,
-  AiProviderResponse,
   AiProviderUsage,
 } from "./server/provider.js";

--- a/packages/modules/core.ai/src/index.ts
+++ b/packages/modules/core.ai/src/index.ts
@@ -29,8 +29,11 @@ export {
 export { aiError, isAiErrorCode, mapProviderError } from "./server/errors.js";
 export {
   buildProposalsFromOutput,
+  type AiProposalAnchors,
   type AiProposalBuilderDeps,
+  type AiProposalCandidate,
   type AiProposalEnvelope,
+  type AiProposalValidator,
   type BuildProposalsInput,
 } from "./server/proposal-builder.js";
 export {

--- a/packages/modules/core.ai/src/index.ts
+++ b/packages/modules/core.ai/src/index.ts
@@ -1,0 +1,71 @@
+import type { MdcmsModulePackage } from "@mdcms/shared";
+
+import { coreAiManifest } from "./manifest.js";
+import { coreAiServerSurface } from "./server/index.js";
+
+export const coreAiModule: MdcmsModulePackage<
+  unknown,
+  Record<string, unknown>
+> = {
+  manifest: coreAiManifest,
+  server: coreAiServerSurface,
+};
+
+export {
+  createAiOrchestrator,
+  DEFAULT_PROPOSAL_TTL_MS,
+  getOrchestratorFailureAudit,
+  getOrchestratorFailureRuntimeError,
+  OrchestratorFailure,
+  type AiOrchestrationInput,
+  type AiOrchestrationResult,
+  type AiOrchestrator,
+  type AiOrchestratorDeps,
+} from "./server/orchestrator.js";
+export {
+  createAiOrchestratorFromEnv,
+  type CreateAiOrchestratorFromEnvDeps,
+} from "./server/index.js";
+export { aiError, isAiErrorCode, mapProviderError } from "./server/errors.js";
+export {
+  buildProposalsFromOutput,
+  type AiProposalBuilderDeps,
+  type AiProposalEnvelope,
+  type BuildProposalsInput,
+} from "./server/proposal-builder.js";
+export {
+  buildAuditRecord,
+  type AiAuditOutcome,
+  type AiAuditRecord,
+  type BuildAuditRecordInput,
+} from "./server/audit.js";
+export {
+  AI_TASK_DEFINITIONS,
+  getAiTaskDefinition,
+  SUPPORTED_AI_TASK_KINDS,
+  type AiTaskDefinition,
+  type AiTaskInput,
+  type AiTaskOutput,
+} from "./server/tasks.js";
+export {
+  AI_PROVIDER_ENV_KEY,
+  resolveAiProvider,
+} from "./server/providers/factory.js";
+export {
+  createNullAiProvider,
+  NULL_PROVIDER_ID,
+} from "./server/providers/null.js";
+export {
+  createEchoAiProvider,
+  ECHO_PROVIDER_DEFAULT_MODEL,
+  ECHO_PROVIDER_ID,
+  type EchoAiProviderOptions,
+} from "./server/providers/echo.js";
+export type {
+  AiProvider,
+  AiProviderEnv,
+  AiProviderFactoryDeps,
+  AiProviderRequest,
+  AiProviderResponse,
+  AiProviderUsage,
+} from "./server/provider.js";

--- a/packages/modules/core.ai/src/manifest.ts
+++ b/packages/modules/core.ai/src/manifest.ts
@@ -1,0 +1,9 @@
+import type { ModuleManifest } from "@mdcms/shared";
+
+export const coreAiManifest: ModuleManifest = {
+  id: "core.ai",
+  version: "1.0.0",
+  apiVersion: "1",
+  kind: "core",
+  minCoreVersion: "0.0.0",
+};

--- a/packages/modules/core.ai/src/server/audit.test.ts
+++ b/packages/modules/core.ai/src/server/audit.test.ts
@@ -43,7 +43,12 @@ describe("buildAuditRecord", () => {
       outcome: "succeeded",
       validation: { status: "valid" },
       proposals: [proposal],
-      usage: { promptTokens: 12, completionTokens: 7, costUsd: 0.0001 },
+      usage: {
+        inputTokens: 12,
+        outputTokens: 7,
+        totalTokens: 19,
+        costUsd: 0.0001,
+      },
     });
 
     assert.equal(record.outcome, "succeeded");
@@ -52,8 +57,9 @@ describe("buildAuditRecord", () => {
     assert.equal(record.promptTemplateId, "copy_improvement.v1");
     assert.deepEqual(record.proposalIds, ["p_1"]);
     assert.deepEqual(record.usage, {
-      promptTokens: 12,
-      completionTokens: 7,
+      inputTokens: 12,
+      outputTokens: 7,
+      totalTokens: 19,
       costUsd: 0.0001,
     });
     assert.equal(record.occurredAt, "2026-05-01T00:00:00.000Z");

--- a/packages/modules/core.ai/src/server/audit.test.ts
+++ b/packages/modules/core.ai/src/server/audit.test.ts
@@ -98,6 +98,26 @@ describe("buildAuditRecord", () => {
     assert.equal(record.usage, undefined);
   });
 
+  test("drops NaN, Infinity, and negative usage values", () => {
+    const record = buildAuditRecord({
+      taskKind: "copy_improvement",
+      providerId: "echo",
+      model: "echo-1",
+      promptTemplateId: "copy_improvement.v1",
+      occurredAt,
+      outcome: "succeeded",
+      proposals: [proposal],
+      usage: {
+        inputTokens: Number.NaN,
+        outputTokens: Number.POSITIVE_INFINITY,
+        totalTokens: -1,
+        costUsd: 0,
+      },
+    });
+
+    assert.deepEqual(record.usage, { costUsd: 0 });
+  });
+
   test("captures invalid_output case with validation errors", () => {
     const record = buildAuditRecord({
       taskKind: "seo_improvement",

--- a/packages/modules/core.ai/src/server/audit.test.ts
+++ b/packages/modules/core.ai/src/server/audit.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import type { AiProposal } from "@mdcms/shared";
+
+import { buildAuditRecord } from "./audit.js";
+
+const occurredAt = new Date("2026-05-01T00:00:00.000Z");
+
+const proposal: AiProposal = {
+  proposalId: "p_1",
+  kind: "replace_selection",
+  project: "demo",
+  environment: "draft",
+  type: "page",
+  locale: "en",
+  summary: "ok",
+  operations: [
+    {
+      op: "replace_selection",
+      selectionId: "sel_1",
+      originalText: "old",
+      replacementText: "new",
+    },
+  ],
+  validation: { status: "valid" },
+  expiresAt: "2026-05-01T00:05:00.000Z",
+  provider: {
+    providerId: "echo",
+    model: "echo-1",
+    promptTemplateId: "copy_improvement.v1",
+  },
+};
+
+describe("buildAuditRecord", () => {
+  test("captures success case with proposal ids and usage", () => {
+    const record = buildAuditRecord({
+      taskKind: "copy_improvement",
+      providerId: "echo",
+      model: "echo-1",
+      promptTemplateId: "copy_improvement.v1",
+      occurredAt,
+      outcome: "succeeded",
+      validation: { status: "valid" },
+      proposals: [proposal],
+      usage: { promptTokens: 12, completionTokens: 7, costUsd: 0.0001 },
+    });
+
+    assert.equal(record.outcome, "succeeded");
+    assert.equal(record.providerId, "echo");
+    assert.equal(record.model, "echo-1");
+    assert.equal(record.promptTemplateId, "copy_improvement.v1");
+    assert.deepEqual(record.proposalIds, ["p_1"]);
+    assert.deepEqual(record.usage, {
+      promptTokens: 12,
+      completionTokens: 7,
+      costUsd: 0.0001,
+    });
+    assert.equal(record.occurredAt, "2026-05-01T00:00:00.000Z");
+  });
+
+  test("captures provider_error case with error code and message", () => {
+    const record = buildAuditRecord({
+      taskKind: "copy_improvement",
+      providerId: "null",
+      promptTemplateId: "copy_improvement.v1",
+      occurredAt,
+      outcome: "provider_error",
+      errorCode: "AI_DISABLED",
+      errorMessage: "AI provider is not configured for this deployment.",
+    });
+
+    assert.equal(record.outcome, "provider_error");
+    assert.equal(record.errorCode, "AI_DISABLED");
+    assert.equal(record.providerId, "null");
+    assert.equal(record.model, "");
+    assert.equal(record.proposalIds, undefined);
+  });
+
+  test("drops empty usage objects", () => {
+    const record = buildAuditRecord({
+      taskKind: "copy_improvement",
+      providerId: "echo",
+      model: "echo-1",
+      promptTemplateId: "copy_improvement.v1",
+      occurredAt,
+      outcome: "succeeded",
+      proposals: [proposal],
+      usage: {},
+    });
+
+    assert.equal(record.usage, undefined);
+  });
+
+  test("captures invalid_output case with validation errors", () => {
+    const record = buildAuditRecord({
+      taskKind: "seo_improvement",
+      providerId: "echo",
+      model: "echo-1",
+      promptTemplateId: "seo_improvement.v1",
+      occurredAt,
+      outcome: "invalid_output",
+      validation: {
+        status: "invalid",
+        errors: [{ code: "AI_OUTPUT_INVALID", message: "bad shape" }],
+      },
+      errorCode: "AI_OUTPUT_INVALID",
+      errorMessage: "bad shape",
+    });
+
+    assert.equal(record.outcome, "invalid_output");
+    assert.equal(record.validation.status, "invalid");
+  });
+});

--- a/packages/modules/core.ai/src/server/audit.ts
+++ b/packages/modules/core.ai/src/server/audit.ts
@@ -39,7 +39,9 @@ export type BuildAuditRecordInput = {
   usage?: AiProviderUsage;
 };
 
-const DEFAULT_VALIDATION: AiProposalValidation = { status: "valid" };
+const DEFAULT_VALIDATION: AiProposalValidation = Object.freeze({
+  status: "valid",
+}) as AiProposalValidation;
 
 /**
  * Build a structured audit record describing a single orchestration
@@ -82,22 +84,26 @@ export function buildAuditRecord(input: BuildAuditRecordInput): AiAuditRecord {
   return record;
 }
 
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function sanitizeUsage(usage: AiProviderUsage): AiProviderUsage | undefined {
   const result: AiProviderUsage = {};
 
-  if (typeof usage.inputTokens === "number") {
+  if (isFiniteNonNegative(usage.inputTokens)) {
     result.inputTokens = usage.inputTokens;
   }
 
-  if (typeof usage.outputTokens === "number") {
+  if (isFiniteNonNegative(usage.outputTokens)) {
     result.outputTokens = usage.outputTokens;
   }
 
-  if (typeof usage.totalTokens === "number") {
+  if (isFiniteNonNegative(usage.totalTokens)) {
     result.totalTokens = usage.totalTokens;
   }
 
-  if (typeof usage.costUsd === "number") {
+  if (isFiniteNonNegative(usage.costUsd)) {
     result.costUsd = usage.costUsd;
   }
 

--- a/packages/modules/core.ai/src/server/audit.ts
+++ b/packages/modules/core.ai/src/server/audit.ts
@@ -85,12 +85,16 @@ export function buildAuditRecord(input: BuildAuditRecordInput): AiAuditRecord {
 function sanitizeUsage(usage: AiProviderUsage): AiProviderUsage | undefined {
   const result: AiProviderUsage = {};
 
-  if (typeof usage.promptTokens === "number") {
-    result.promptTokens = usage.promptTokens;
+  if (typeof usage.inputTokens === "number") {
+    result.inputTokens = usage.inputTokens;
   }
 
-  if (typeof usage.completionTokens === "number") {
-    result.completionTokens = usage.completionTokens;
+  if (typeof usage.outputTokens === "number") {
+    result.outputTokens = usage.outputTokens;
+  }
+
+  if (typeof usage.totalTokens === "number") {
+    result.totalTokens = usage.totalTokens;
   }
 
   if (typeof usage.costUsd === "number") {

--- a/packages/modules/core.ai/src/server/audit.ts
+++ b/packages/modules/core.ai/src/server/audit.ts
@@ -1,0 +1,101 @@
+import type {
+  AiErrorCode,
+  AiProposal,
+  AiProposalValidation,
+  AiTaskKind,
+} from "@mdcms/shared";
+
+import type { AiProviderUsage } from "./provider.js";
+
+export type AiAuditOutcome = "succeeded" | "invalid_output" | "provider_error";
+
+export type AiAuditRecord = {
+  taskKind: AiTaskKind;
+  providerId: string;
+  /** Empty string when the call failed before the model identified itself. */
+  model: string;
+  promptTemplateId: string;
+  outcome: AiAuditOutcome;
+  validation: AiProposalValidation;
+  proposalIds?: string[];
+  errorCode?: AiErrorCode;
+  errorMessage?: string;
+  usage?: AiProviderUsage;
+  /** ISO-8601 timestamp captured by the orchestrator. */
+  occurredAt: string;
+};
+
+export type BuildAuditRecordInput = {
+  taskKind: AiTaskKind;
+  providerId: string;
+  model?: string;
+  promptTemplateId: string;
+  occurredAt: Date;
+  outcome: AiAuditOutcome;
+  validation?: AiProposalValidation;
+  proposals?: AiProposal[];
+  errorCode?: AiErrorCode;
+  errorMessage?: string;
+  usage?: AiProviderUsage;
+};
+
+const DEFAULT_VALIDATION: AiProposalValidation = { status: "valid" };
+
+/**
+ * Build a structured audit record describing a single orchestration
+ * outcome. This module does not persist the record; downstream
+ * consumers (audit log writer, observability sinks) are responsible
+ * for forwarding it. Producing the record server-side keeps fields
+ * stable across consumers.
+ */
+export function buildAuditRecord(input: BuildAuditRecordInput): AiAuditRecord {
+  const record: AiAuditRecord = {
+    taskKind: input.taskKind,
+    providerId: input.providerId,
+    model: input.model ?? "",
+    promptTemplateId: input.promptTemplateId,
+    outcome: input.outcome,
+    validation: input.validation ?? DEFAULT_VALIDATION,
+    occurredAt: input.occurredAt.toISOString(),
+  };
+
+  if (input.proposals && input.proposals.length > 0) {
+    record.proposalIds = input.proposals.map((proposal) => proposal.proposalId);
+  }
+
+  if (input.errorCode) {
+    record.errorCode = input.errorCode;
+  }
+
+  if (input.errorMessage) {
+    record.errorMessage = input.errorMessage;
+  }
+
+  if (input.usage) {
+    const usage = sanitizeUsage(input.usage);
+
+    if (usage) {
+      record.usage = usage;
+    }
+  }
+
+  return record;
+}
+
+function sanitizeUsage(usage: AiProviderUsage): AiProviderUsage | undefined {
+  const result: AiProviderUsage = {};
+
+  if (typeof usage.promptTokens === "number") {
+    result.promptTokens = usage.promptTokens;
+  }
+
+  if (typeof usage.completionTokens === "number") {
+    result.completionTokens = usage.completionTokens;
+  }
+
+  if (typeof usage.costUsd === "number") {
+    result.costUsd = usage.costUsd;
+  }
+
+  return Object.keys(result).length === 0 ? undefined : result;
+}

--- a/packages/modules/core.ai/src/server/errors.test.ts
+++ b/packages/modules/core.ai/src/server/errors.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "bun:test";
 
+import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
 import { RuntimeError } from "@mdcms/shared";
 
 import { aiError, isAiErrorCode, mapProviderError } from "./errors.js";
@@ -81,6 +82,77 @@ describe("mapProviderError", () => {
 
   test("handles non-Error throws", () => {
     const mapped = mapProviderError("string failure");
+    assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
+  });
+
+  test("maps NoObjectGeneratedError to AI_OUTPUT_INVALID", () => {
+    const noObject = new NoObjectGeneratedError({
+      message: "no object",
+      cause: undefined,
+      text: "garbage",
+      response: { id: "r", timestamp: new Date(), modelId: "m" },
+      usage: {
+        inputTokens: undefined,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: undefined,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: undefined,
+      },
+      finishReason: "stop",
+    });
+    const mapped = mapProviderError(noObject);
+    assert.equal(mapped.code, "AI_OUTPUT_INVALID");
+    assert.equal(mapped.statusCode, 422);
+  });
+
+  test("maps TypeValidationError to AI_OUTPUT_INVALID", () => {
+    const typeError = new TypeValidationError({
+      value: { foo: "bar" },
+      cause: new Error("schema check failed"),
+    });
+    const mapped = mapProviderError(typeError);
+    assert.equal(mapped.code, "AI_OUTPUT_INVALID");
+  });
+
+  test("maps APICallError 429 to AI_RATE_LIMITED", () => {
+    const rate = new APICallError({
+      message: "rate limited",
+      url: "https://example",
+      requestBodyValues: {},
+      statusCode: 429,
+    });
+    const mapped = mapProviderError(rate);
+    assert.equal(mapped.code, "AI_RATE_LIMITED");
+    assert.equal(mapped.statusCode, 429);
+  });
+
+  test("maps APICallError 413 to AI_CONTEXT_TOO_LARGE", () => {
+    const tooLarge = new APICallError({
+      message: "context too large",
+      url: "https://example",
+      requestBodyValues: {},
+      statusCode: 413,
+    });
+    const mapped = mapProviderError(tooLarge);
+    assert.equal(mapped.code, "AI_CONTEXT_TOO_LARGE");
+    assert.equal(mapped.statusCode, 413);
+  });
+
+  test("maps generic APICallError to AI_PROVIDER_UNAVAILABLE", () => {
+    const apiError = new APICallError({
+      message: "boom",
+      url: "https://example",
+      requestBodyValues: {},
+      statusCode: 500,
+    });
+    const mapped = mapProviderError(apiError);
     assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
   });
 });

--- a/packages/modules/core.ai/src/server/errors.test.ts
+++ b/packages/modules/core.ai/src/server/errors.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import { RuntimeError } from "@mdcms/shared";
+
+import { aiError, isAiErrorCode, mapProviderError } from "./errors.js";
+
+describe("aiError", () => {
+  test("uses default status code per AI error code", () => {
+    assert.equal(aiError("AI_DISABLED", "off").statusCode, 403);
+    assert.equal(aiError("AI_PROVIDER_UNAVAILABLE", "x").statusCode, 503);
+    assert.equal(aiError("AI_RATE_LIMITED", "x").statusCode, 429);
+    assert.equal(aiError("AI_CONTEXT_TOO_LARGE", "x").statusCode, 413);
+    assert.equal(aiError("AI_OUTPUT_INVALID", "x").statusCode, 422);
+    assert.equal(aiError("AI_UNSUPPORTED_TASK", "x").statusCode, 400);
+  });
+
+  test("respects explicit statusCode override", () => {
+    assert.equal(
+      aiError("AI_PROVIDER_UNAVAILABLE", "x", undefined, 502).statusCode,
+      502,
+    );
+  });
+
+  test("forwards details", () => {
+    const error = aiError("AI_OUTPUT_INVALID", "boom", { path: "operations" });
+    assert.deepEqual(error.details, { path: "operations" });
+  });
+});
+
+describe("isAiErrorCode", () => {
+  test("matches all known codes", () => {
+    [
+      "AI_DISABLED",
+      "AI_PROVIDER_UNAVAILABLE",
+      "AI_RATE_LIMITED",
+      "AI_CONTEXT_TOO_LARGE",
+      "AI_OUTPUT_INVALID",
+      "AI_UNSUPPORTED_TASK",
+    ].forEach((code) => assert.equal(isAiErrorCode(code), true));
+  });
+
+  test("rejects unrelated codes", () => {
+    assert.equal(isAiErrorCode("INTERNAL_ERROR"), false);
+    assert.equal(isAiErrorCode("ai_disabled"), false);
+  });
+});
+
+describe("mapProviderError", () => {
+  test("passes through existing AI_* RuntimeErrors", () => {
+    const original = aiError("AI_DISABLED", "off");
+    const mapped = mapProviderError(original);
+    assert.equal(mapped, original);
+  });
+
+  test("does not pass through unrelated RuntimeError codes", () => {
+    const unrelated = new RuntimeError({
+      code: "INTERNAL_ERROR",
+      message: "boom",
+      statusCode: 500,
+    });
+    const mapped = mapProviderError(unrelated);
+    assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
+    assert.equal(mapped.statusCode, 503);
+  });
+
+  test("collapses generic Errors to AI_PROVIDER_UNAVAILABLE", () => {
+    const mapped = mapProviderError(new Error("network down"));
+    assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
+    assert.equal(mapped.statusCode, 503);
+  });
+
+  test("does not leak provider error message", () => {
+    const mapped = mapProviderError(new Error("API_KEY=sk-secret invalid"));
+    assert.equal(
+      mapped.message.includes("sk-secret"),
+      false,
+      "mapped message must not echo provider error text",
+    );
+  });
+
+  test("handles non-Error throws", () => {
+    const mapped = mapProviderError("string failure");
+    assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
+  });
+});

--- a/packages/modules/core.ai/src/server/errors.test.ts
+++ b/packages/modules/core.ai/src/server/errors.test.ts
@@ -65,6 +65,27 @@ describe("mapProviderError", () => {
     assert.equal(mapped.statusCode, 503);
   });
 
+  test("does not pass through orchestrator-only AI codes", () => {
+    const orchestratorOnly = aiError("AI_UNSUPPORTED_TASK", "boom");
+    const mapped = mapProviderError(orchestratorOnly);
+    assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");
+    assert.notEqual(mapped, orchestratorOnly);
+  });
+
+  test("passes through provider-facing AI codes", () => {
+    for (const code of [
+      "AI_DISABLED",
+      "AI_PROVIDER_UNAVAILABLE",
+      "AI_RATE_LIMITED",
+      "AI_CONTEXT_TOO_LARGE",
+      "AI_OUTPUT_INVALID",
+    ] as const) {
+      const original = aiError(code, "x");
+      const mapped = mapProviderError(original);
+      assert.equal(mapped, original);
+    }
+  });
+
   test("collapses generic Errors to AI_PROVIDER_UNAVAILABLE", () => {
     const mapped = mapProviderError(new Error("network down"));
     assert.equal(mapped.code, "AI_PROVIDER_UNAVAILABLE");

--- a/packages/modules/core.ai/src/server/errors.ts
+++ b/packages/modules/core.ai/src/server/errors.ts
@@ -17,6 +17,19 @@ const DEFAULT_STATUS_BY_CODE: Record<AiErrorCode, number> = {
 
 const AI_ERROR_CODE_SET: ReadonlySet<AiErrorCode> = new Set(AI_ERROR_CODES);
 
+/**
+ * Codes a provider adapter is allowed to surface up to the orchestrator.
+ * `AI_UNSUPPORTED_TASK` is excluded because that is an orchestrator-level
+ * concern, not something a provider call can produce.
+ */
+const PROVIDER_FACING_CODES: ReadonlySet<AiErrorCode> = new Set<AiErrorCode>([
+  "AI_DISABLED",
+  "AI_PROVIDER_UNAVAILABLE",
+  "AI_RATE_LIMITED",
+  "AI_CONTEXT_TOO_LARGE",
+  "AI_OUTPUT_INVALID",
+]);
+
 export function aiError(
   code: AiErrorCode,
   message: string,
@@ -40,13 +53,20 @@ const OUTPUT_INVALID_MESSAGE = "AI provider returned invalid output.";
 
 /**
  * Map any thrown value from a provider call to a deterministic
- * RuntimeError. Existing AI_* RuntimeErrors pass through; AI SDK
- * error classes map to specific AI_* codes; everything else
- * collapses to AI_PROVIDER_UNAVAILABLE so callers never see raw
- * provider response bodies or env values in error output.
+ * RuntimeError. Provider-facing AI_* RuntimeErrors pass through (so
+ * adapters can surface AI_RATE_LIMITED, AI_CONTEXT_TOO_LARGE, etc.
+ * directly); AI SDK error classes map to specific AI_* codes;
+ * everything else — including non-provider-facing AI codes such as
+ * AI_UNSUPPORTED_TASK — collapses to AI_PROVIDER_UNAVAILABLE so
+ * callers never see raw provider response bodies or unrelated
+ * orchestrator codes leaking out of the provider seam.
  */
 export function mapProviderError(error: unknown): RuntimeError {
-  if (error instanceof RuntimeError && isAiErrorCode(error.code)) {
+  if (
+    error instanceof RuntimeError &&
+    isAiErrorCode(error.code) &&
+    PROVIDER_FACING_CODES.has(error.code as AiErrorCode)
+  ) {
     return error;
   }
 

--- a/packages/modules/core.ai/src/server/errors.ts
+++ b/packages/modules/core.ai/src/server/errors.ts
@@ -1,3 +1,9 @@
+import {
+  APICallError,
+  JSONParseError,
+  NoObjectGeneratedError,
+  TypeValidationError,
+} from "ai";
 import { AI_ERROR_CODES, RuntimeError, type AiErrorCode } from "@mdcms/shared";
 
 const DEFAULT_STATUS_BY_CODE: Record<AiErrorCode, number> = {
@@ -30,16 +36,53 @@ export function isAiErrorCode(value: string): value is AiErrorCode {
 }
 
 const PROVIDER_FAILURE_MESSAGE = "AI provider request failed.";
+const OUTPUT_INVALID_MESSAGE = "AI provider returned invalid output.";
 
 /**
  * Map any thrown value from a provider call to a deterministic
- * RuntimeError. Existing AI_* RuntimeErrors pass through; everything
- * else collapses to AI_PROVIDER_UNAVAILABLE so callers never see raw
+ * RuntimeError. Existing AI_* RuntimeErrors pass through; AI SDK
+ * error classes map to specific AI_* codes; everything else
+ * collapses to AI_PROVIDER_UNAVAILABLE so callers never see raw
  * provider response bodies or env values in error output.
  */
 export function mapProviderError(error: unknown): RuntimeError {
   if (error instanceof RuntimeError && isAiErrorCode(error.code)) {
     return error;
+  }
+
+  if (NoObjectGeneratedError.isInstance(error)) {
+    return aiError("AI_OUTPUT_INVALID", OUTPUT_INVALID_MESSAGE, {
+      cause: "NoObjectGeneratedError",
+    });
+  }
+
+  if (
+    JSONParseError.isInstance(error) ||
+    TypeValidationError.isInstance(error)
+  ) {
+    return aiError("AI_OUTPUT_INVALID", OUTPUT_INVALID_MESSAGE, {
+      cause: error.name,
+    });
+  }
+
+  if (APICallError.isInstance(error)) {
+    if (error.statusCode === 429) {
+      return aiError("AI_RATE_LIMITED", "AI provider rate limit exceeded.", {
+        cause: error.name,
+      });
+    }
+
+    if (error.statusCode === 413) {
+      return aiError(
+        "AI_CONTEXT_TOO_LARGE",
+        "AI provider rejected the request as too large.",
+        { cause: error.name },
+      );
+    }
+
+    return aiError("AI_PROVIDER_UNAVAILABLE", PROVIDER_FAILURE_MESSAGE, {
+      cause: error.name,
+    });
   }
 
   if (error instanceof Error) {

--- a/packages/modules/core.ai/src/server/errors.ts
+++ b/packages/modules/core.ai/src/server/errors.ts
@@ -1,0 +1,52 @@
+import { AI_ERROR_CODES, RuntimeError, type AiErrorCode } from "@mdcms/shared";
+
+const DEFAULT_STATUS_BY_CODE: Record<AiErrorCode, number> = {
+  AI_DISABLED: 403,
+  AI_PROVIDER_UNAVAILABLE: 503,
+  AI_RATE_LIMITED: 429,
+  AI_CONTEXT_TOO_LARGE: 413,
+  AI_OUTPUT_INVALID: 422,
+  AI_UNSUPPORTED_TASK: 400,
+};
+
+const AI_ERROR_CODE_SET: ReadonlySet<AiErrorCode> = new Set(AI_ERROR_CODES);
+
+export function aiError(
+  code: AiErrorCode,
+  message: string,
+  details?: Record<string, unknown>,
+  statusCode?: number,
+): RuntimeError {
+  return new RuntimeError({
+    code,
+    message,
+    statusCode: statusCode ?? DEFAULT_STATUS_BY_CODE[code],
+    details,
+  });
+}
+
+export function isAiErrorCode(value: string): value is AiErrorCode {
+  return AI_ERROR_CODE_SET.has(value as AiErrorCode);
+}
+
+const PROVIDER_FAILURE_MESSAGE = "AI provider request failed.";
+
+/**
+ * Map any thrown value from a provider call to a deterministic
+ * RuntimeError. Existing AI_* RuntimeErrors pass through; everything
+ * else collapses to AI_PROVIDER_UNAVAILABLE so callers never see raw
+ * provider response bodies or env values in error output.
+ */
+export function mapProviderError(error: unknown): RuntimeError {
+  if (error instanceof RuntimeError && isAiErrorCode(error.code)) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return aiError("AI_PROVIDER_UNAVAILABLE", PROVIDER_FAILURE_MESSAGE, {
+      cause: error.name,
+    });
+  }
+
+  return aiError("AI_PROVIDER_UNAVAILABLE", PROVIDER_FAILURE_MESSAGE);
+}

--- a/packages/modules/core.ai/src/server/index.ts
+++ b/packages/modules/core.ai/src/server/index.ts
@@ -1,0 +1,47 @@
+import type { ServerSurface } from "@mdcms/shared";
+
+import {
+  createAiOrchestrator,
+  type AiOrchestrator,
+  type AiOrchestratorDeps,
+} from "./orchestrator.js";
+import type { AiProviderFactoryDeps } from "./provider.js";
+import { resolveAiProvider } from "./providers/factory.js";
+
+export type CreateAiOrchestratorFromEnvDeps = AiProviderFactoryDeps &
+  Omit<AiOrchestratorDeps, "provider">;
+
+/**
+ * Convenience factory used by hosts (apps/server) to build an
+ * orchestrator without re-implementing provider resolution.
+ */
+export function createAiOrchestratorFromEnv(
+  deps: CreateAiOrchestratorFromEnvDeps,
+): AiOrchestrator {
+  const provider = resolveAiProvider({ env: deps.env, fetch: deps.fetch });
+
+  return createAiOrchestrator({
+    provider,
+    clock: deps.clock,
+    idFactory: deps.idFactory,
+    proposalTtlMs: deps.proposalTtlMs,
+  });
+}
+
+/**
+ * Server surface for the AI module.
+ *
+ * The mount step is currently a no-op. The endpoint contracts in
+ * SPEC-014 are added by follow-up tickets that consume the
+ * orchestrator built above. Keeping the surface here lets future
+ * tickets register `actions[]` without restructuring the module.
+ */
+export const coreAiServerSurface: ServerSurface<
+  unknown,
+  Record<string, unknown>
+> = {
+  mount: () => {
+    /* foundation only — no routes registered in this ticket */
+  },
+  actions: [],
+};

--- a/packages/modules/core.ai/src/server/index.ts
+++ b/packages/modules/core.ai/src/server/index.ts
@@ -18,7 +18,7 @@ export type CreateAiOrchestratorFromEnvDeps = AiProviderFactoryDeps &
 export function createAiOrchestratorFromEnv(
   deps: CreateAiOrchestratorFromEnvDeps,
 ): AiOrchestrator {
-  const provider = resolveAiProvider({ env: deps.env, fetch: deps.fetch });
+  const provider = resolveAiProvider({ env: deps.env });
 
   return createAiOrchestrator({
     provider,

--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -211,13 +211,16 @@ describe("createAiOrchestrator", () => {
           input: { locale: "en" /* missing selectionText */ },
         }),
       (error) => {
+        assert.ok(error instanceof OrchestratorFailure);
         const runtime = getOrchestratorFailureRuntimeError(error);
-        return runtime?.code === "AI_OUTPUT_INVALID" || runtime === undefined;
+        assert.ok(runtime !== undefined);
+        assert.equal(runtime.code, "AI_OUTPUT_INVALID");
+        return true;
       },
     );
   });
 
-  test("unknown task kind → AI_UNSUPPORTED_TASK", async () => {
+  test("unknown task kind → AI_UNSUPPORTED_TASK wrapped in OrchestratorFailure", async () => {
     const provider = createEchoAiProvider({
       respond: () => buildEchoOutput(),
     });
@@ -233,8 +236,16 @@ describe("createAiOrchestrator", () => {
           ...baseInput,
           taskKind: "unknown_task" as never,
         }),
-      (error) =>
-        error instanceof RuntimeError && error.code === "AI_UNSUPPORTED_TASK",
+      (error) => {
+        assert.ok(error instanceof OrchestratorFailure);
+        const runtime = getOrchestratorFailureRuntimeError(error);
+        const audit = getOrchestratorFailureAudit(error);
+        assert.ok(runtime !== undefined);
+        assert.equal(runtime.code, "AI_UNSUPPORTED_TASK");
+        assert.equal(audit?.errorCode, "AI_UNSUPPORTED_TASK");
+        assert.equal(audit?.taskKind, "unknown_task");
+        return true;
+      },
     );
   });
 });

--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -30,6 +30,7 @@ const baseInput: AiOrchestrationInput = {
   input: {
     locale: "en",
     selectionText: "Hello world",
+    selectionId: "sel_anchor",
     instruction: "make it punchier",
   },
 };

--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -249,4 +249,89 @@ describe("createAiOrchestrator", () => {
       },
     );
   });
+
+  test("current_document_edit rejects input that omits selectionId", async () => {
+    const provider = createEchoAiProvider({
+      respond: () =>
+        JSON.stringify({
+          summary: "edit",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_invented",
+              originalText: "a",
+              replacementText: "b",
+            },
+          ],
+        }),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    await assert.rejects(
+      () =>
+        orchestrator.runTask({
+          taskKind: "current_document_edit",
+          envelope: baseInput.envelope,
+          input: {
+            locale: "en",
+            documentBody: "Some body",
+            instruction: "rewrite the intro",
+            // selectionId intentionally absent
+          },
+        }),
+      (error) => {
+        assert.ok(error instanceof OrchestratorFailure);
+        const runtime = getOrchestratorFailureRuntimeError(error);
+        assert.ok(runtime !== undefined);
+        assert.equal(runtime.code, "AI_OUTPUT_INVALID");
+        return true;
+      },
+    );
+  });
+
+  test("seo_improvement task only allows update_frontmatter operations", async () => {
+    const provider = createEchoAiProvider({
+      respond: () =>
+        JSON.stringify({
+          summary: "Tighten title",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_invented",
+              originalText: "Old title",
+              replacementText: "New title",
+            },
+          ],
+        }),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    await assert.rejects(
+      () =>
+        orchestrator.runTask({
+          taskKind: "seo_improvement",
+          envelope: baseInput.envelope,
+          input: {
+            locale: "en",
+            instruction: "improve SEO",
+            frontmatter: { title: "Old title" },
+          },
+        }),
+      (error) => {
+        assert.ok(error instanceof OrchestratorFailure);
+        const runtime = getOrchestratorFailureRuntimeError(error);
+        assert.ok(runtime !== undefined);
+        assert.equal(runtime.code, "AI_OUTPUT_INVALID");
+        return true;
+      },
+    );
+  });
 });

--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import { RuntimeError } from "@mdcms/shared";
+
+import {
+  createAiOrchestrator,
+  getOrchestratorFailureAudit,
+  getOrchestratorFailureRuntimeError,
+  OrchestratorFailure,
+  type AiOrchestrationInput,
+} from "./orchestrator.js";
+import {
+  createEchoAiProvider,
+  ECHO_PROVIDER_DEFAULT_MODEL,
+  ECHO_PROVIDER_ID,
+} from "./providers/echo.js";
+import { createNullAiProvider } from "./providers/null.js";
+
+const baseInput: AiOrchestrationInput = {
+  taskKind: "copy_improvement",
+  envelope: {
+    project: "demo",
+    environment: "draft",
+    type: "page",
+    locale: "en",
+    documentId: "doc_1",
+    baseDraftRevision: 4,
+  },
+  input: {
+    locale: "en",
+    selectionText: "Hello world",
+    instruction: "make it punchier",
+  },
+};
+
+const fixedClock = () => new Date("2026-05-01T00:00:00.000Z");
+
+let nextProposalId = 0;
+const idFactory = () => {
+  nextProposalId += 1;
+  return `prop_${nextProposalId}`;
+};
+
+function resetIds(): void {
+  nextProposalId = 0;
+}
+
+function buildEchoOutput(): string {
+  return JSON.stringify({
+    summary: "Tightened intro",
+    operations: [
+      {
+        op: "replace_selection",
+        selectionId: "sel_1",
+        originalText: "Hello world",
+        replacementText: "Hi.",
+      },
+    ],
+  });
+}
+
+describe("createAiOrchestrator", () => {
+  test("provider success → proposals and succeeded audit", async () => {
+    resetIds();
+    const provider = createEchoAiProvider({
+      respond: () => buildEchoOutput(),
+      usage: { promptTokens: 12, completionTokens: 6 },
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    const result = await orchestrator.runTask(baseInput);
+
+    assert.equal(result.proposals.length, 1);
+    assert.equal(result.proposals[0]?.kind, "replace_selection");
+    assert.equal(result.proposals[0]?.proposalId, "prop_1");
+    assert.equal(result.proposals[0]?.provider.providerId, ECHO_PROVIDER_ID);
+    assert.equal(
+      result.proposals[0]?.provider.model,
+      ECHO_PROVIDER_DEFAULT_MODEL,
+    );
+
+    assert.equal(result.audit.outcome, "succeeded");
+    assert.equal(result.audit.providerId, ECHO_PROVIDER_ID);
+    assert.equal(result.audit.model, ECHO_PROVIDER_DEFAULT_MODEL);
+    assert.deepEqual(result.audit.proposalIds, ["prop_1"]);
+    assert.deepEqual(result.audit.usage, {
+      promptTokens: 12,
+      completionTokens: 6,
+    });
+  });
+
+  test("provider failure → AI_PROVIDER_UNAVAILABLE with provider_error audit", async () => {
+    const provider = createEchoAiProvider({
+      throwOnComplete: new Error("network down"),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    try {
+      await orchestrator.runTask(baseInput);
+      assert.fail("expected throw");
+    } catch (error) {
+      const runtime = getOrchestratorFailureRuntimeError(error);
+      const audit = getOrchestratorFailureAudit(error);
+      assert.ok(error instanceof OrchestratorFailure);
+      assert.ok(runtime instanceof RuntimeError);
+      assert.equal(runtime?.code, "AI_PROVIDER_UNAVAILABLE");
+      assert.equal(audit?.outcome, "provider_error");
+      assert.equal(audit?.errorCode, "AI_PROVIDER_UNAVAILABLE");
+      assert.equal(audit?.providerId, ECHO_PROVIDER_ID);
+    }
+  });
+
+  test("disabled AI → AI_DISABLED with provider_error audit", async () => {
+    const provider = createNullAiProvider();
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    try {
+      await orchestrator.runTask(baseInput);
+      assert.fail("expected throw");
+    } catch (error) {
+      const runtime = getOrchestratorFailureRuntimeError(error);
+      const audit = getOrchestratorFailureAudit(error);
+      assert.equal(runtime?.code, "AI_DISABLED");
+      assert.equal(audit?.outcome, "provider_error");
+      assert.equal(audit?.errorCode, "AI_DISABLED");
+    }
+  });
+
+  test("invalid model output → AI_OUTPUT_INVALID with invalid_output audit", async () => {
+    const provider = createEchoAiProvider({
+      respond: () => "not json at all",
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    try {
+      await orchestrator.runTask(baseInput);
+      assert.fail("expected throw");
+    } catch (error) {
+      const runtime = getOrchestratorFailureRuntimeError(error);
+      const audit = getOrchestratorFailureAudit(error);
+      assert.equal(runtime?.code, "AI_OUTPUT_INVALID");
+      assert.equal(audit?.outcome, "invalid_output");
+      assert.equal(audit?.validation.status, "invalid");
+    }
+  });
+
+  test("model output failing schema → AI_OUTPUT_INVALID", async () => {
+    const provider = createEchoAiProvider({
+      respond: () =>
+        JSON.stringify({
+          summary: "ok",
+          operations: [
+            {
+              op: "create_document",
+              path: "x.md",
+              format: "md",
+              frontmatter: {},
+              body: "x",
+            },
+          ],
+        }),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    // copy_improvement only allows replace_selection ops
+    await assert.rejects(
+      () => orchestrator.runTask(baseInput),
+      (error) => {
+        const runtime = getOrchestratorFailureRuntimeError(error);
+        return runtime?.code === "AI_OUTPUT_INVALID";
+      },
+    );
+  });
+
+  test("rejects task input that fails task schema", async () => {
+    const provider = createEchoAiProvider({
+      respond: () => buildEchoOutput(),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    await assert.rejects(
+      () =>
+        orchestrator.runTask({
+          ...baseInput,
+          input: { locale: "en" /* missing selectionText */ },
+        }),
+      (error) => {
+        const runtime = getOrchestratorFailureRuntimeError(error);
+        return runtime?.code === "AI_OUTPUT_INVALID" || runtime === undefined;
+      },
+    );
+  });
+
+  test("unknown task kind → AI_UNSUPPORTED_TASK", async () => {
+    const provider = createEchoAiProvider({
+      respond: () => buildEchoOutput(),
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    await assert.rejects(
+      () =>
+        orchestrator.runTask({
+          ...baseInput,
+          taskKind: "unknown_task" as never,
+        }),
+      (error) =>
+        error instanceof RuntimeError && error.code === "AI_UNSUPPORTED_TASK",
+    );
+  });
+});

--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -65,7 +65,7 @@ describe("createAiOrchestrator", () => {
     resetIds();
     const provider = createEchoAiProvider({
       respond: () => buildEchoOutput(),
-      usage: { promptTokens: 12, completionTokens: 6 },
+      usage: { inputTokens: 12, outputTokens: 6 },
     });
     const orchestrator = createAiOrchestrator({
       provider,
@@ -89,14 +89,15 @@ describe("createAiOrchestrator", () => {
     assert.equal(result.audit.model, ECHO_PROVIDER_DEFAULT_MODEL);
     assert.deepEqual(result.audit.proposalIds, ["prop_1"]);
     assert.deepEqual(result.audit.usage, {
-      promptTokens: 12,
-      completionTokens: 6,
+      inputTokens: 12,
+      outputTokens: 6,
+      totalTokens: 18,
     });
   });
 
   test("provider failure → AI_PROVIDER_UNAVAILABLE with provider_error audit", async () => {
     const provider = createEchoAiProvider({
-      throwOnComplete: new Error("network down"),
+      throwOnGenerate: new Error("network down"),
     });
     const orchestrator = createAiOrchestrator({
       provider,

--- a/packages/modules/core.ai/src/server/orchestrator.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.ts
@@ -1,3 +1,4 @@
+import { generateObject } from "ai";
 import {
   RuntimeError,
   type AiErrorCode,
@@ -11,7 +12,7 @@ import {
   buildProposalsFromOutput,
   type AiProposalEnvelope,
 } from "./proposal-builder.js";
-import type { AiProvider, AiProviderResponse } from "./provider.js";
+import type { AiProvider, AiProviderUsage } from "./provider.js";
 import {
   AI_TASK_DEFINITIONS,
   type AiTaskDefinition,
@@ -59,62 +60,51 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
     async runTask(call) {
       const definition = resolveTaskDefinition(call.taskKind);
       const occurredAt = clock();
+      const baseContext: ErrorAuditContext = {
+        taskKind: definition.kind,
+        providerId: deps.provider.id,
+        promptTemplateId: definition.promptTemplateId,
+        occurredAt,
+      };
 
-      const parsedInput = parseTaskInput(definition, call.input);
-      const providerResponse = await callProvider(
+      const parsedInput = parseTaskInput(definition, call.input, baseContext);
+
+      const generation = await generateForTask(
         deps.provider,
         definition,
         parsedInput,
         call.maxOutputTokens,
-        {
-          taskKind: definition.kind,
-          providerId: deps.provider.id,
-          promptTemplateId: definition.promptTemplateId,
-          occurredAt,
-        },
+        baseContext,
       );
 
-      const parsedOutput = parseTaskOutput(
-        definition,
-        providerResponse.output,
-        {
-          taskKind: definition.kind,
-          providerId: deps.provider.id,
-          model: providerResponse.model,
-          promptTemplateId: definition.promptTemplateId,
-          occurredAt,
-          usage: providerResponse.usage,
-        },
-      );
+      const enrichedContext: ErrorAuditContext = {
+        ...baseContext,
+        model: generation.model,
+        usage: generation.usage,
+      };
 
       const proposals = buildProposals(
         definition,
-        parsedOutput,
-        providerResponse,
+        generation.output,
+        deps.provider.id,
+        generation.model,
         call.envelope,
         idFactory,
         clock,
         ttlMs,
-        {
-          taskKind: definition.kind,
-          providerId: deps.provider.id,
-          model: providerResponse.model,
-          promptTemplateId: definition.promptTemplateId,
-          occurredAt,
-          usage: providerResponse.usage,
-        },
+        enrichedContext,
       );
 
       const audit = buildAuditRecord({
         taskKind: definition.kind,
         providerId: deps.provider.id,
-        model: providerResponse.model,
+        model: generation.model,
         promptTemplateId: definition.promptTemplateId,
         occurredAt,
         outcome: "succeeded",
         validation: { status: "valid" },
         proposals,
-        usage: providerResponse.usage,
+        usage: generation.usage,
       });
 
       return { proposals, audit };
@@ -139,13 +129,17 @@ function resolveTaskDefinition(taskKind: AiTaskKind): AiTaskDefinition {
 function parseTaskInput(
   definition: AiTaskDefinition,
   raw: AiTaskInput,
+  context: ErrorAuditContext,
 ): AiTaskInput {
   const parsed = definition.inputSchema.safeParse(raw);
 
-  if (!parsed.success) {
-    const [first] = parsed.error.issues;
+  if (parsed.success) {
+    return parsed.data;
+  }
 
-    throw aiError(
+  const [first] = parsed.error.issues;
+  throw new OrchestratorFailure(
+    aiError(
       "AI_OUTPUT_INVALID",
       first?.message ?? "Invalid task input.",
       {
@@ -153,10 +147,23 @@ function parseTaskInput(
         issues: parsed.error.issues,
       },
       400,
-    );
-  }
-
-  return parsed.data;
+    ),
+    buildAuditRecord({
+      ...context,
+      outcome: "invalid_output",
+      validation: {
+        status: "invalid",
+        errors: [
+          {
+            code: "AI_OUTPUT_INVALID",
+            message: first?.message ?? "Invalid task input.",
+          },
+        ],
+      },
+      errorCode: "AI_OUTPUT_INVALID",
+      errorMessage: first?.message ?? "Invalid task input.",
+    }),
+  );
 }
 
 type ErrorAuditContext = {
@@ -165,32 +172,71 @@ type ErrorAuditContext = {
   promptTemplateId: string;
   occurredAt: Date;
   model?: string;
-  usage?: AiProviderResponse["usage"];
+  usage?: AiProviderUsage;
 };
 
-async function callProvider(
+type GenerationResult = {
+  output: AiTaskOutput;
+  model: string;
+  usage?: AiProviderUsage;
+};
+
+async function generateForTask(
   provider: AiProvider,
   definition: AiTaskDefinition,
   input: AiTaskInput,
   maxOutputTokens: number | undefined,
   context: ErrorAuditContext,
-): Promise<AiProviderResponse> {
-  try {
-    return await provider.complete({
-      taskKind: definition.kind,
-      promptTemplateId: definition.promptTemplateId,
-      system: definition.system,
-      user: definition.buildUserPrompt(input),
-      maxOutputTokens,
-    });
-  } catch (error) {
-    const mapped = mapProviderError(error);
+): Promise<GenerationResult> {
+  if (provider.languageModel === null) {
     throw new OrchestratorFailure(
-      mapped,
+      aiError(
+        "AI_DISABLED",
+        "AI provider is not configured for this deployment.",
+      ),
       buildAuditRecord({
         ...context,
         outcome: "provider_error",
         validation: { status: "valid" },
+        errorCode: "AI_DISABLED",
+        errorMessage: "AI provider is not configured for this deployment.",
+      }),
+    );
+  }
+
+  try {
+    const result = await generateObject({
+      model: provider.languageModel,
+      schema: definition.outputSchema,
+      schemaName: `Ai${pascalCase(definition.kind)}Output`,
+      system: definition.system,
+      prompt: definition.buildUserPrompt(input),
+      maxOutputTokens,
+    });
+
+    return {
+      output: result.object as AiTaskOutput,
+      model: provider.languageModel.modelId,
+      usage: normalizeUsage(result.usage),
+    };
+  } catch (error) {
+    const mapped = mapProviderError(error);
+    const outcome: "invalid_output" | "provider_error" =
+      mapped.code === "AI_OUTPUT_INVALID" ? "invalid_output" : "provider_error";
+
+    throw new OrchestratorFailure(
+      mapped,
+      buildAuditRecord({
+        ...context,
+        model: provider.languageModel.modelId,
+        outcome,
+        validation:
+          outcome === "invalid_output"
+            ? {
+                status: "invalid",
+                errors: [{ code: mapped.code, message: mapped.message }],
+              }
+            : { status: "valid" },
         errorCode: isAiErrorCode(mapped.code)
           ? (mapped.code as AiErrorCode)
           : "AI_PROVIDER_UNAVAILABLE",
@@ -200,43 +246,11 @@ async function callProvider(
   }
 }
 
-function parseTaskOutput(
-  definition: AiTaskDefinition,
-  rawOutput: string,
-  context: ErrorAuditContext,
-): AiTaskOutput {
-  const json = tryParseJson(rawOutput);
-
-  if (json.kind === "error") {
-    throw invalidOutputFailure(
-      "Task output was not valid JSON.",
-      { reason: json.message },
-      context,
-    );
-  }
-
-  const parsed = definition.outputSchema.safeParse(json.value);
-
-  if (!parsed.success) {
-    const [first] = parsed.error.issues;
-
-    throw invalidOutputFailure(
-      first?.message ?? "Task output failed schema validation.",
-      {
-        path: first?.path?.join(".") || undefined,
-        issues: parsed.error.issues,
-      },
-      context,
-    );
-  }
-
-  return parsed.data;
-}
-
 function buildProposals(
   definition: AiTaskDefinition,
   output: AiTaskOutput,
-  providerResponse: AiProviderResponse,
+  providerId: string,
+  model: string,
   envelope: AiProposalEnvelope,
   idFactory: AiOrchestratorIdFactory,
   clock: AiOrchestratorClock,
@@ -248,10 +262,8 @@ function buildProposals(
       {
         taskKind: definition.kind,
         promptTemplateId: definition.promptTemplateId,
-        providerId: providerResponse.model
-          ? context.providerId
-          : context.providerId,
-        model: providerResponse.model,
+        providerId,
+        model,
         envelope,
         output,
       },
@@ -263,56 +275,66 @@ function buildProposals(
       isAiErrorCode(error.code) &&
       error.code === "AI_OUTPUT_INVALID"
     ) {
-      throw invalidOutputFailure(error.message, error.details, {
-        ...context,
-        model: providerResponse.model,
-        usage: providerResponse.usage,
-      });
+      throw new OrchestratorFailure(
+        error,
+        buildAuditRecord({
+          ...context,
+          outcome: "invalid_output",
+          validation: {
+            status: "invalid",
+            errors: [{ code: "AI_OUTPUT_INVALID", message: error.message }],
+          },
+          errorCode: "AI_OUTPUT_INVALID",
+          errorMessage: error.message,
+        }),
+      );
     }
 
     throw error;
   }
 }
 
-function invalidOutputFailure(
-  message: string,
-  details: Record<string, unknown> | undefined,
-  context: ErrorAuditContext,
-): OrchestratorFailure {
-  const error = aiError("AI_OUTPUT_INVALID", message, details);
+/**
+ * Map AI SDK's LanguageModelUsage shape onto our internal AiProviderUsage,
+ * dropping undefined fields so audit records stay tidy.
+ */
+function normalizeUsage(
+  usage:
+    | {
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+      }
+    | undefined,
+): AiProviderUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
 
-  return new OrchestratorFailure(
-    error,
-    buildAuditRecord({
-      ...context,
-      outcome: "invalid_output",
-      validation: {
-        status: "invalid",
-        errors: [
-          {
-            code: "AI_OUTPUT_INVALID",
-            message,
-          },
-        ],
-      },
-      errorCode: "AI_OUTPUT_INVALID",
-      errorMessage: message,
-    }),
-  );
+  const result: AiProviderUsage = {};
+
+  if (typeof usage.inputTokens === "number") {
+    result.inputTokens = usage.inputTokens;
+  }
+
+  if (typeof usage.outputTokens === "number") {
+    result.outputTokens = usage.outputTokens;
+  }
+
+  if (typeof usage.totalTokens === "number") {
+    result.totalTokens = usage.totalTokens;
+  }
+
+  return Object.keys(result).length === 0 ? undefined : result;
 }
 
-type ParseJsonResult =
-  | { kind: "ok"; value: unknown }
-  | { kind: "error"; message: string };
-
-function tryParseJson(raw: string): ParseJsonResult {
-  try {
-    return { kind: "ok", value: JSON.parse(raw) };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "JSON parse error";
-
-    return { kind: "error", message };
-  }
+function pascalCase(value: string): string {
+  return value
+    .split(/[_\-\s]+/)
+    .map((segment) =>
+      segment.length === 0 ? "" : segment[0].toUpperCase() + segment.slice(1),
+    )
+    .join("");
 }
 
 /**

--- a/packages/modules/core.ai/src/server/orchestrator.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.ts
@@ -11,6 +11,7 @@ import { aiError, isAiErrorCode, mapProviderError } from "./errors.js";
 import {
   buildProposalsFromOutput,
   type AiProposalEnvelope,
+  type AiProposalValidator,
 } from "./proposal-builder.js";
 import type { AiProvider, AiProviderUsage } from "./provider.js";
 import {
@@ -30,6 +31,14 @@ export type AiOrchestratorDeps = {
   clock?: AiOrchestratorClock;
   idFactory?: AiOrchestratorIdFactory;
   proposalTtlMs?: number;
+  /**
+   * Domain validator forwarded to the proposal builder. When omitted,
+   * proposals receive a shape-only `{ status: "valid" }` validation
+   * — callers shipping endpoints that mutate drafts MUST provide a
+   * validator that checks MDX components, frontmatter, and any other
+   * domain constraints required by SPEC-014.
+   */
+  proposalValidator?: AiProposalValidator;
 };
 
 export type AiOrchestrationInput = {
@@ -54,6 +63,7 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
   const clock = deps.clock ?? (() => new Date());
   const idFactory = deps.idFactory ?? defaultIdFactory;
   const ttlMs = deps.proposalTtlMs ?? DEFAULT_PROPOSAL_TTL_MS;
+  const validator = deps.proposalValidator;
 
   return {
     providerId: deps.provider.id,
@@ -93,9 +103,11 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
         deps.provider.id,
         generation.model,
         call.envelope,
+        parsedInput,
         idFactory,
         clock,
         ttlMs,
+        validator,
         enrichedContext,
       );
 
@@ -106,7 +118,7 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
         promptTemplateId: definition.promptTemplateId,
         occurredAt,
         outcome: "succeeded",
-        validation: { status: "valid" },
+        validation: aggregateValidation(proposals),
         proposals,
         usage: generation.usage,
       });
@@ -270,9 +282,11 @@ function buildProposals(
   providerId: string,
   model: string,
   envelope: AiProposalEnvelope,
+  taskInput: AiTaskInput,
   idFactory: AiOrchestratorIdFactory,
   clock: AiOrchestratorClock,
   ttlMs: number,
+  validator: AiProposalValidator | undefined,
   context: ErrorAuditContext,
 ): AiProposal[] {
   try {
@@ -284,8 +298,11 @@ function buildProposals(
         model,
         envelope,
         output,
+        anchors: taskInput.selectionId
+          ? { selectionId: taskInput.selectionId }
+          : undefined,
       },
-      { clock, idFactory, ttlMs },
+      { clock, idFactory, ttlMs, validator },
     );
   } catch (error) {
     if (
@@ -344,6 +361,32 @@ function normalizeUsage(
   }
 
   return Object.keys(result).length === 0 ? undefined : result;
+}
+
+/**
+ * When multiple proposals come back from a single orchestration call,
+ * the audit record's `validation` field collapses them into one
+ * representative state. Any invalid proposal poisons the audit record
+ * so downstream sinks can flag the call without scanning per-proposal
+ * fields.
+ */
+function aggregateValidation(
+  proposals: readonly AiProposal[],
+): AiAuditRecord["validation"] {
+  const aggregatedErrors: { code: string; message: string; path?: string }[] =
+    [];
+
+  for (const proposal of proposals) {
+    if (proposal.validation.status === "invalid") {
+      aggregatedErrors.push(...proposal.validation.errors);
+    }
+  }
+
+  if (aggregatedErrors.length === 0) {
+    return { status: "valid" };
+  }
+
+  return { status: "invalid", errors: aggregatedErrors };
 }
 
 function pascalCase(value: string): string {

--- a/packages/modules/core.ai/src/server/orchestrator.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.ts
@@ -1,0 +1,355 @@
+import {
+  RuntimeError,
+  type AiErrorCode,
+  type AiProposal,
+  type AiTaskKind,
+} from "@mdcms/shared";
+
+import { buildAuditRecord, type AiAuditRecord } from "./audit.js";
+import { aiError, isAiErrorCode, mapProviderError } from "./errors.js";
+import {
+  buildProposalsFromOutput,
+  type AiProposalEnvelope,
+} from "./proposal-builder.js";
+import type { AiProvider, AiProviderResponse } from "./provider.js";
+import {
+  AI_TASK_DEFINITIONS,
+  type AiTaskDefinition,
+  type AiTaskInput,
+  type AiTaskOutput,
+} from "./tasks.js";
+
+export const DEFAULT_PROPOSAL_TTL_MS = 5 * 60 * 1000;
+
+export type AiOrchestratorClock = () => Date;
+export type AiOrchestratorIdFactory = () => string;
+
+export type AiOrchestratorDeps = {
+  provider: AiProvider;
+  clock?: AiOrchestratorClock;
+  idFactory?: AiOrchestratorIdFactory;
+  proposalTtlMs?: number;
+};
+
+export type AiOrchestrationInput = {
+  taskKind: AiTaskKind;
+  envelope: AiProposalEnvelope;
+  input: AiTaskInput;
+  /** Hard ceiling forwarded to the provider when supported. */
+  maxOutputTokens?: number;
+};
+
+export type AiOrchestrationResult = {
+  proposals: AiProposal[];
+  audit: AiAuditRecord;
+};
+
+export type AiOrchestrator = {
+  readonly providerId: string;
+  runTask(input: AiOrchestrationInput): Promise<AiOrchestrationResult>;
+};
+
+export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
+  const clock = deps.clock ?? (() => new Date());
+  const idFactory = deps.idFactory ?? defaultIdFactory;
+  const ttlMs = deps.proposalTtlMs ?? DEFAULT_PROPOSAL_TTL_MS;
+
+  return {
+    providerId: deps.provider.id,
+    async runTask(call) {
+      const definition = resolveTaskDefinition(call.taskKind);
+      const occurredAt = clock();
+
+      const parsedInput = parseTaskInput(definition, call.input);
+      const providerResponse = await callProvider(
+        deps.provider,
+        definition,
+        parsedInput,
+        call.maxOutputTokens,
+        {
+          taskKind: definition.kind,
+          providerId: deps.provider.id,
+          promptTemplateId: definition.promptTemplateId,
+          occurredAt,
+        },
+      );
+
+      const parsedOutput = parseTaskOutput(
+        definition,
+        providerResponse.output,
+        {
+          taskKind: definition.kind,
+          providerId: deps.provider.id,
+          model: providerResponse.model,
+          promptTemplateId: definition.promptTemplateId,
+          occurredAt,
+          usage: providerResponse.usage,
+        },
+      );
+
+      const proposals = buildProposals(
+        definition,
+        parsedOutput,
+        providerResponse,
+        call.envelope,
+        idFactory,
+        clock,
+        ttlMs,
+        {
+          taskKind: definition.kind,
+          providerId: deps.provider.id,
+          model: providerResponse.model,
+          promptTemplateId: definition.promptTemplateId,
+          occurredAt,
+          usage: providerResponse.usage,
+        },
+      );
+
+      const audit = buildAuditRecord({
+        taskKind: definition.kind,
+        providerId: deps.provider.id,
+        model: providerResponse.model,
+        promptTemplateId: definition.promptTemplateId,
+        occurredAt,
+        outcome: "succeeded",
+        validation: { status: "valid" },
+        proposals,
+        usage: providerResponse.usage,
+      });
+
+      return { proposals, audit };
+    },
+  };
+}
+
+function resolveTaskDefinition(taskKind: AiTaskKind): AiTaskDefinition {
+  const definition = AI_TASK_DEFINITIONS[taskKind];
+
+  if (!definition) {
+    throw aiError(
+      "AI_UNSUPPORTED_TASK",
+      `AI task "${taskKind}" is not supported.`,
+      { taskKind },
+    );
+  }
+
+  return definition;
+}
+
+function parseTaskInput(
+  definition: AiTaskDefinition,
+  raw: AiTaskInput,
+): AiTaskInput {
+  const parsed = definition.inputSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    const [first] = parsed.error.issues;
+
+    throw aiError(
+      "AI_OUTPUT_INVALID",
+      first?.message ?? "Invalid task input.",
+      {
+        path: first?.path?.join(".") || undefined,
+        issues: parsed.error.issues,
+      },
+      400,
+    );
+  }
+
+  return parsed.data;
+}
+
+type ErrorAuditContext = {
+  taskKind: AiTaskKind;
+  providerId: string;
+  promptTemplateId: string;
+  occurredAt: Date;
+  model?: string;
+  usage?: AiProviderResponse["usage"];
+};
+
+async function callProvider(
+  provider: AiProvider,
+  definition: AiTaskDefinition,
+  input: AiTaskInput,
+  maxOutputTokens: number | undefined,
+  context: ErrorAuditContext,
+): Promise<AiProviderResponse> {
+  try {
+    return await provider.complete({
+      taskKind: definition.kind,
+      promptTemplateId: definition.promptTemplateId,
+      system: definition.system,
+      user: definition.buildUserPrompt(input),
+      maxOutputTokens,
+    });
+  } catch (error) {
+    const mapped = mapProviderError(error);
+    throw new OrchestratorFailure(
+      mapped,
+      buildAuditRecord({
+        ...context,
+        outcome: "provider_error",
+        validation: { status: "valid" },
+        errorCode: isAiErrorCode(mapped.code)
+          ? (mapped.code as AiErrorCode)
+          : "AI_PROVIDER_UNAVAILABLE",
+        errorMessage: mapped.message,
+      }),
+    );
+  }
+}
+
+function parseTaskOutput(
+  definition: AiTaskDefinition,
+  rawOutput: string,
+  context: ErrorAuditContext,
+): AiTaskOutput {
+  const json = tryParseJson(rawOutput);
+
+  if (json.kind === "error") {
+    throw invalidOutputFailure(
+      "Task output was not valid JSON.",
+      { reason: json.message },
+      context,
+    );
+  }
+
+  const parsed = definition.outputSchema.safeParse(json.value);
+
+  if (!parsed.success) {
+    const [first] = parsed.error.issues;
+
+    throw invalidOutputFailure(
+      first?.message ?? "Task output failed schema validation.",
+      {
+        path: first?.path?.join(".") || undefined,
+        issues: parsed.error.issues,
+      },
+      context,
+    );
+  }
+
+  return parsed.data;
+}
+
+function buildProposals(
+  definition: AiTaskDefinition,
+  output: AiTaskOutput,
+  providerResponse: AiProviderResponse,
+  envelope: AiProposalEnvelope,
+  idFactory: AiOrchestratorIdFactory,
+  clock: AiOrchestratorClock,
+  ttlMs: number,
+  context: ErrorAuditContext,
+): AiProposal[] {
+  try {
+    return buildProposalsFromOutput(
+      {
+        taskKind: definition.kind,
+        promptTemplateId: definition.promptTemplateId,
+        providerId: providerResponse.model
+          ? context.providerId
+          : context.providerId,
+        model: providerResponse.model,
+        envelope,
+        output,
+      },
+      { clock, idFactory, ttlMs },
+    );
+  } catch (error) {
+    if (
+      error instanceof RuntimeError &&
+      isAiErrorCode(error.code) &&
+      error.code === "AI_OUTPUT_INVALID"
+    ) {
+      throw invalidOutputFailure(error.message, error.details, {
+        ...context,
+        model: providerResponse.model,
+        usage: providerResponse.usage,
+      });
+    }
+
+    throw error;
+  }
+}
+
+function invalidOutputFailure(
+  message: string,
+  details: Record<string, unknown> | undefined,
+  context: ErrorAuditContext,
+): OrchestratorFailure {
+  const error = aiError("AI_OUTPUT_INVALID", message, details);
+
+  return new OrchestratorFailure(
+    error,
+    buildAuditRecord({
+      ...context,
+      outcome: "invalid_output",
+      validation: {
+        status: "invalid",
+        errors: [
+          {
+            code: "AI_OUTPUT_INVALID",
+            message,
+          },
+        ],
+      },
+      errorCode: "AI_OUTPUT_INVALID",
+      errorMessage: message,
+    }),
+  );
+}
+
+type ParseJsonResult =
+  | { kind: "ok"; value: unknown }
+  | { kind: "error"; message: string };
+
+function tryParseJson(raw: string): ParseJsonResult {
+  try {
+    return { kind: "ok", value: JSON.parse(raw) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "JSON parse error";
+
+    return { kind: "error", message };
+  }
+}
+
+/**
+ * OrchestratorFailure pairs the public RuntimeError with the audit
+ * record describing the failure. The orchestrator throws it; callers
+ * that catch the error can read the audit record via
+ * `getOrchestratorFailureAudit()` to record the outcome.
+ */
+export class OrchestratorFailure extends Error {
+  override readonly cause: RuntimeError;
+  readonly audit: AiAuditRecord;
+
+  constructor(cause: RuntimeError, audit: AiAuditRecord) {
+    super(cause.message);
+    this.name = "OrchestratorFailure";
+    this.cause = cause;
+    this.audit = audit;
+  }
+}
+
+export function getOrchestratorFailureAudit(
+  error: unknown,
+): AiAuditRecord | undefined {
+  return error instanceof OrchestratorFailure ? error.audit : undefined;
+}
+
+export function getOrchestratorFailureRuntimeError(
+  error: unknown,
+): RuntimeError | undefined {
+  return error instanceof OrchestratorFailure ? error.cause : undefined;
+}
+
+let nextProposalCounter = 0;
+
+function defaultIdFactory(): string {
+  nextProposalCounter += 1;
+  const random = Math.random().toString(36).slice(2, 10);
+
+  return `prop_${Date.now().toString(36)}_${nextProposalCounter}_${random}`;
+}

--- a/packages/modules/core.ai/src/server/orchestrator.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.ts
@@ -58,8 +58,12 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
   return {
     providerId: deps.provider.id,
     async runTask(call) {
-      const definition = resolveTaskDefinition(call.taskKind);
       const occurredAt = clock();
+      const definition = resolveTaskDefinitionOrFail(
+        call.taskKind,
+        deps.provider.id,
+        occurredAt,
+      );
       const baseContext: ErrorAuditContext = {
         taskKind: definition.kind,
         providerId: deps.provider.id,
@@ -112,18 +116,32 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
   };
 }
 
-function resolveTaskDefinition(taskKind: AiTaskKind): AiTaskDefinition {
+function resolveTaskDefinitionOrFail(
+  taskKind: AiTaskKind,
+  providerId: string,
+  occurredAt: Date,
+): AiTaskDefinition {
   const definition = AI_TASK_DEFINITIONS[taskKind];
 
-  if (!definition) {
-    throw aiError(
-      "AI_UNSUPPORTED_TASK",
-      `AI task "${taskKind}" is not supported.`,
-      { taskKind },
-    );
+  if (definition) {
+    return definition;
   }
 
-  return definition;
+  const message = `AI task "${taskKind}" is not supported.`;
+
+  throw new OrchestratorFailure(
+    aiError("AI_UNSUPPORTED_TASK", message, { taskKind }),
+    buildAuditRecord({
+      taskKind,
+      providerId,
+      promptTemplateId: `unknown:${taskKind}`,
+      occurredAt,
+      outcome: "provider_error",
+      validation: { status: "valid" },
+      errorCode: "AI_UNSUPPORTED_TASK",
+      errorMessage: message,
+    }),
+  );
 }
 
 function parseTaskInput(

--- a/packages/modules/core.ai/src/server/proposal-builder.test.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import { RuntimeError } from "@mdcms/shared";
+
+import {
+  buildProposalsFromOutput,
+  type AiProposalEnvelope,
+} from "./proposal-builder.js";
+
+const envelope: AiProposalEnvelope = {
+  project: "demo",
+  environment: "draft",
+  type: "page",
+  locale: "en",
+  documentId: "doc_1",
+  baseDraftRevision: 4,
+};
+
+const baseClock = () => new Date("2026-05-01T00:00:00.000Z");
+
+let counter = 0;
+const idFactory = () => {
+  counter += 1;
+  return `prop_${counter}`;
+};
+
+const deps = { clock: baseClock, idFactory, ttlMs: 5 * 60 * 1000 };
+
+describe("buildProposalsFromOutput", () => {
+  test("builds a replace_selection proposal", () => {
+    counter = 0;
+    const [proposal, ...rest] = buildProposalsFromOutput(
+      {
+        taskKind: "copy_improvement",
+        promptTemplateId: "copy_improvement.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope,
+        output: {
+          summary: "Tightened intro",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_1",
+              originalText: "old",
+              replacementText: "new",
+            },
+          ],
+        },
+      },
+      deps,
+    );
+
+    assert.equal(rest.length, 0);
+    assert.equal(proposal.kind, "replace_selection");
+    assert.equal(proposal.proposalId, "prop_1");
+    assert.equal(proposal.expiresAt, "2026-05-01T00:05:00.000Z");
+    assert.equal(proposal.documentId, "doc_1");
+    assert.equal(proposal.baseDraftRevision, 4);
+    assert.equal(proposal.provider.providerId, "echo");
+    assert.equal(proposal.provider.model, "echo-1");
+    assert.equal(proposal.provider.promptTemplateId, "copy_improvement.v1");
+    assert.deepEqual(proposal.validation, { status: "valid" });
+  });
+
+  test("builds a create_document proposal", () => {
+    counter = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "new_document_draft",
+        promptTemplateId: "new_document_draft.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope: { ...envelope, documentId: undefined },
+        output: {
+          summary: "New welcome post",
+          operations: [
+            {
+              op: "create_document",
+              path: "blog/welcome.mdx",
+              format: "mdx",
+              frontmatter: { title: "Welcome" },
+              body: "# Hi",
+            },
+          ],
+        },
+      },
+      deps,
+    );
+
+    assert.equal(proposal.kind, "create_document");
+    assert.equal(proposal.documentId, undefined);
+  });
+
+  test("splits mixed operation kinds into one proposal each", () => {
+    counter = 0;
+    const proposals = buildProposalsFromOutput(
+      {
+        taskKind: "current_document_edit",
+        promptTemplateId: "current_document_edit.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope,
+        output: {
+          summary: "Body and frontmatter changes",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_1",
+              originalText: "old",
+              replacementText: "new",
+            },
+            {
+              op: "update_frontmatter",
+              patch: { description: "updated" },
+            },
+          ],
+        },
+      },
+      deps,
+    );
+
+    assert.equal(proposals.length, 2);
+    assert.equal(proposals[0]?.kind, "replace_selection");
+    assert.equal(proposals[1]?.kind, "update_frontmatter");
+    assert.notEqual(proposals[0]?.proposalId, proposals[1]?.proposalId);
+  });
+
+  test("throws AI_OUTPUT_INVALID for empty operations", () => {
+    assert.throws(
+      () =>
+        buildProposalsFromOutput(
+          {
+            taskKind: "copy_improvement",
+            promptTemplateId: "copy_improvement.v1",
+            providerId: "echo",
+            model: "echo-1",
+            envelope,
+            output: { summary: "x", operations: [] },
+          },
+          deps,
+        ),
+      (error) =>
+        error instanceof RuntimeError && error.code === "AI_OUTPUT_INVALID",
+    );
+  });
+});

--- a/packages/modules/core.ai/src/server/proposal-builder.test.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.test.ts
@@ -145,4 +145,144 @@ describe("buildProposalsFromOutput", () => {
         error instanceof RuntimeError && error.code === "AI_OUTPUT_INVALID",
     );
   });
+
+  test("anchors override the model's selectionId on replace_selection ops", () => {
+    counter = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "copy_improvement",
+        promptTemplateId: "copy_improvement.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope,
+        output: {
+          summary: "Tightened intro",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_invented_by_model",
+              originalText: "old",
+              replacementText: "new",
+            },
+          ],
+        },
+        anchors: { selectionId: "sel_trusted" },
+      },
+      deps,
+    );
+
+    assert.equal(
+      (proposal.operations[0] as { selectionId: string }).selectionId,
+      "sel_trusted",
+    );
+  });
+
+  test("anchors leave non-replace_selection ops untouched", () => {
+    counter = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "new_document_draft",
+        promptTemplateId: "new_document_draft.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope: { ...envelope, documentId: undefined },
+        output: {
+          summary: "draft",
+          operations: [
+            {
+              op: "create_document",
+              path: "blog/post.mdx",
+              format: "mdx",
+              frontmatter: {},
+              body: "# x",
+            },
+          ],
+        },
+        anchors: { selectionId: "ignored" },
+      },
+      deps,
+    );
+
+    assert.equal(proposal.kind, "create_document");
+  });
+
+  test("validator hook replaces validation status", () => {
+    counter = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "mdx_component_insertion",
+        promptTemplateId: "mdx_component_insertion.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope,
+        output: {
+          summary: "Add callout",
+          operations: [
+            {
+              op: "insert_block",
+              bodyMdx: "<UnknownComponent>hi</UnknownComponent>",
+            },
+          ],
+        },
+      },
+      {
+        ...deps,
+        validator: (candidate) => {
+          assert.equal(candidate.kind, "insert_block");
+          return {
+            status: "invalid",
+            errors: [
+              {
+                code: "MDX_COMPONENT_UNKNOWN",
+                message: "UnknownComponent is not registered.",
+              },
+            ],
+          };
+        },
+      },
+    );
+
+    assert.equal(proposal.validation.status, "invalid");
+    if (proposal.validation.status === "invalid") {
+      assert.equal(
+        proposal.validation.errors[0]?.code,
+        "MDX_COMPONENT_UNKNOWN",
+      );
+    }
+  });
+
+  test("validator hook can return valid for trusted operations", () => {
+    counter = 0;
+    let calls = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "copy_improvement",
+        promptTemplateId: "copy_improvement.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope,
+        output: {
+          summary: "ok",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_1",
+              originalText: "a",
+              replacementText: "b",
+            },
+          ],
+        },
+      },
+      {
+        ...deps,
+        validator: () => {
+          calls += 1;
+          return { status: "valid" };
+        },
+      },
+    );
+
+    assert.equal(calls, 1);
+    assert.deepEqual(proposal.validation, { status: "valid" });
+  });
 });

--- a/packages/modules/core.ai/src/server/proposal-builder.test.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.test.ts
@@ -177,6 +177,87 @@ describe("buildProposalsFromOutput", () => {
     );
   });
 
+  test("create_document proposals drop source-document anchors from envelope", () => {
+    counter = 0;
+    const [proposal] = buildProposalsFromOutput(
+      {
+        taskKind: "new_document_draft",
+        promptTemplateId: "new_document_draft.v1",
+        providerId: "echo",
+        model: "echo-1",
+        // envelope still carries source document refs
+        envelope: {
+          ...envelope,
+          documentId: "doc_source",
+          baseDraftRevision: 4,
+        },
+        output: {
+          summary: "New post",
+          operations: [
+            {
+              op: "create_document",
+              path: "blog/new.mdx",
+              format: "mdx",
+              frontmatter: {},
+              body: "# x",
+            },
+          ],
+        },
+      },
+      deps,
+    );
+
+    assert.equal(proposal.kind, "create_document");
+    assert.equal(proposal.documentId, undefined);
+    assert.equal(proposal.baseDraftRevision, undefined);
+  });
+
+  test("mixed-kind output keeps source anchors only on the non-create_document proposal", () => {
+    counter = 0;
+    const proposals = buildProposalsFromOutput(
+      {
+        taskKind: "current_document_edit",
+        promptTemplateId: "current_document_edit.v1",
+        providerId: "echo",
+        model: "echo-1",
+        envelope: {
+          ...envelope,
+          documentId: "doc_source",
+          baseDraftRevision: 7,
+        },
+        output: {
+          summary: "Mixed",
+          operations: [
+            {
+              op: "replace_selection",
+              selectionId: "sel_1",
+              originalText: "a",
+              replacementText: "b",
+            },
+            {
+              op: "create_document",
+              path: "blog/new.mdx",
+              format: "mdx",
+              frontmatter: {},
+              body: "# x",
+            },
+          ],
+        },
+      },
+      deps,
+    );
+
+    const replaceProposal = proposals.find(
+      (p) => p.kind === "replace_selection",
+    );
+    const createProposal = proposals.find((p) => p.kind === "create_document");
+
+    assert.equal(replaceProposal?.documentId, "doc_source");
+    assert.equal(replaceProposal?.baseDraftRevision, 7);
+    assert.equal(createProposal?.documentId, undefined);
+    assert.equal(createProposal?.baseDraftRevision, undefined);
+  });
+
   test("anchors leave non-replace_selection ops untouched", () => {
     counter = 0;
     const [proposal] = buildProposalsFromOutput(

--- a/packages/modules/core.ai/src/server/proposal-builder.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.ts
@@ -19,6 +19,32 @@ export type AiProposalEnvelope = {
   baseDraftRevision?: number;
 };
 
+/**
+ * Server-trusted anchors that callers stamp onto the generated
+ * operations so the model never has to invent them. The orchestrator
+ * forwards values from `AiTaskInput` here.
+ */
+export type AiProposalAnchors = {
+  /** Forced selectionId on every `replace_selection` operation. */
+  selectionId?: string;
+};
+
+export type AiProposalCandidate = Omit<AiProposal, "validation">;
+
+/**
+ * Domain validator hook. Receives a candidate proposal (envelope +
+ * operations) and returns the validation status that should land on
+ * the final proposal. The foundation defaults to `{ status: "valid" }`
+ * when no validator is provided, which means callers without a
+ * validator are explicitly opting into shape-only validation —
+ * future endpoints that wire MDX/schema/frontmatter checks must pass
+ * a real validator so Studio's accept/reject controls reflect actual
+ * apply-time correctness.
+ */
+export type AiProposalValidator = (
+  candidate: AiProposalCandidate,
+) => AiProposalValidation;
+
 export type ProposalBuilderClock = () => Date;
 export type ProposalIdFactory = () => string;
 
@@ -27,6 +53,7 @@ export type AiProposalBuilderDeps = {
   idFactory: ProposalIdFactory;
   /** Proposal lifetime in milliseconds. */
   ttlMs: number;
+  validator?: AiProposalValidator;
 };
 
 export type BuildProposalsInput = {
@@ -36,6 +63,7 @@ export type BuildProposalsInput = {
   model: string;
   envelope: AiProposalEnvelope;
   output: AiTaskOutput;
+  anchors?: AiProposalAnchors;
 };
 
 const PROPOSAL_KIND_BY_OPERATION: Record<
@@ -47,6 +75,10 @@ const PROPOSAL_KIND_BY_OPERATION: Record<
   update_frontmatter: "update_frontmatter",
   create_document: "create_document",
 };
+
+const SHAPE_VALID: AiProposalValidation = Object.freeze({
+  status: "valid",
+}) as AiProposalValidation;
 
 function deriveProposalKind(
   operations: readonly AiProposalOperation[],
@@ -73,6 +105,27 @@ function mixedOperationKinds(
 }
 
 /**
+ * Apply server-trusted anchors to the model's operations. The model's
+ * value for any anchored field is discarded; the input value wins.
+ */
+function applyAnchors(
+  operations: readonly AiProposalOperation[],
+  anchors: AiProposalAnchors | undefined,
+): AiProposalOperation[] {
+  if (!anchors) {
+    return operations.slice();
+  }
+
+  return operations.map((op) => {
+    if (op.op === "replace_selection" && anchors.selectionId) {
+      return { ...op, selectionId: anchors.selectionId };
+    }
+
+    return op;
+  });
+}
+
+/**
  * Build one or more validated AiProposal objects from a parsed
  * task output. Multi-op outputs that mix operation kinds are split
  * into one proposal per kind so Studio can render homogenous
@@ -88,10 +141,11 @@ export function buildProposalsFromOutput(
   }
 
   const expiresAt = new Date(deps.clock().getTime() + deps.ttlMs).toISOString();
-  const groups = groupOperationsByKind(input.output.operations);
+  const stamped = applyAnchors(input.output.operations, input.anchors);
+  const groups = groupOperationsByKind(stamped);
 
   const proposals: AiProposal[] = groups.map((group) => {
-    const proposal: AiProposal = {
+    const candidate: AiProposalCandidate = {
       proposalId: deps.idFactory(),
       kind: deriveProposalKind(group),
       project: input.envelope.project,
@@ -100,7 +154,6 @@ export function buildProposalsFromOutput(
       locale: input.envelope.locale,
       summary: input.output.summary,
       operations: group,
-      validation: { status: "valid" },
       expiresAt,
       provider: {
         providerId: input.providerId,
@@ -115,29 +168,28 @@ export function buildProposalsFromOutput(
         : {}),
     };
 
+    const validation = deps.validator ? deps.validator(candidate) : SHAPE_VALID;
+    const proposal: AiProposal = { ...candidate, validation };
+
     const parsed = aiProposalSchema.safeParse(proposal);
 
     if (!parsed.success) {
-      const validation: AiProposalValidation = {
-        status: "invalid",
-        errors: parsed.error.issues.map((issue) => ({
-          code: issue.code ?? "invalid",
-          message: issue.message,
-          path: issue.path?.join(".") || undefined,
-        })),
-      };
-
       throw aiError(
         "AI_OUTPUT_INVALID",
         "Generated proposal failed schema validation.",
-        { validation },
+        {
+          issues: parsed.error.issues.map((issue) => ({
+            code: issue.code ?? "invalid",
+            message: issue.message,
+            path: issue.path?.join(".") || undefined,
+          })),
+        },
       );
     }
 
     return parsed.data;
   });
 
-  // When mixed, only the actually-grouped result reflects the split.
   if (proposals.length === 0) {
     throw aiError(
       "AI_OUTPUT_INVALID",

--- a/packages/modules/core.ai/src/server/proposal-builder.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.ts
@@ -145,9 +145,15 @@ export function buildProposalsFromOutput(
   const groups = groupOperationsByKind(stamped);
 
   const proposals: AiProposal[] = groups.map((group) => {
+    const kind = deriveProposalKind(group);
+    // create_document targets a NEW document, so source-document
+    // anchors from the envelope must not leak in. The other kinds
+    // mutate an existing draft, so they keep documentId and
+    // baseDraftRevision when supplied.
+    const carriesSourceDocument = kind !== "create_document";
     const candidate: AiProposalCandidate = {
       proposalId: deps.idFactory(),
-      kind: deriveProposalKind(group),
+      kind,
       project: input.envelope.project,
       environment: input.envelope.environment,
       type: input.envelope.type,
@@ -160,10 +166,11 @@ export function buildProposalsFromOutput(
         model: input.model,
         promptTemplateId: input.promptTemplateId,
       },
-      ...(input.envelope.documentId !== undefined
+      ...(carriesSourceDocument && input.envelope.documentId !== undefined
         ? { documentId: input.envelope.documentId }
         : {}),
-      ...(input.envelope.baseDraftRevision !== undefined
+      ...(carriesSourceDocument &&
+      input.envelope.baseDraftRevision !== undefined
         ? { baseDraftRevision: input.envelope.baseDraftRevision }
         : {}),
     };

--- a/packages/modules/core.ai/src/server/proposal-builder.ts
+++ b/packages/modules/core.ai/src/server/proposal-builder.ts
@@ -1,0 +1,171 @@
+import {
+  aiProposalSchema,
+  type AiProposal,
+  type AiProposalKind,
+  type AiProposalOperation,
+  type AiProposalValidation,
+  type AiTaskKind,
+} from "@mdcms/shared";
+
+import { aiError } from "./errors.js";
+import type { AiTaskOutput } from "./tasks.js";
+
+export type AiProposalEnvelope = {
+  project: string;
+  environment: string;
+  type: string;
+  locale: string;
+  documentId?: string;
+  baseDraftRevision?: number;
+};
+
+export type ProposalBuilderClock = () => Date;
+export type ProposalIdFactory = () => string;
+
+export type AiProposalBuilderDeps = {
+  clock: ProposalBuilderClock;
+  idFactory: ProposalIdFactory;
+  /** Proposal lifetime in milliseconds. */
+  ttlMs: number;
+};
+
+export type BuildProposalsInput = {
+  taskKind: AiTaskKind;
+  promptTemplateId: string;
+  providerId: string;
+  model: string;
+  envelope: AiProposalEnvelope;
+  output: AiTaskOutput;
+};
+
+const PROPOSAL_KIND_BY_OPERATION: Record<
+  AiProposalOperation["op"],
+  AiProposalKind
+> = {
+  replace_selection: "replace_selection",
+  insert_block: "insert_block",
+  update_frontmatter: "update_frontmatter",
+  create_document: "create_document",
+};
+
+function deriveProposalKind(
+  operations: readonly AiProposalOperation[],
+): AiProposalKind {
+  const [first] = operations;
+
+  if (!first) {
+    throw aiError("AI_OUTPUT_INVALID", "Task output produced no operations.");
+  }
+
+  return PROPOSAL_KIND_BY_OPERATION[first.op];
+}
+
+function mixedOperationKinds(
+  operations: readonly AiProposalOperation[],
+): boolean {
+  if (operations.length <= 1) {
+    return false;
+  }
+
+  const [head, ...tail] = operations;
+
+  return tail.some((operation) => operation.op !== head.op);
+}
+
+/**
+ * Build one or more validated AiProposal objects from a parsed
+ * task output. Multi-op outputs that mix operation kinds are split
+ * into one proposal per kind so Studio can render homogenous
+ * accept/reject controls per surface (inline edit vs. frontmatter
+ * edit vs. block insertion vs. new document).
+ */
+export function buildProposalsFromOutput(
+  input: BuildProposalsInput,
+  deps: AiProposalBuilderDeps,
+): AiProposal[] {
+  if (input.output.operations.length === 0) {
+    throw aiError("AI_OUTPUT_INVALID", "Task output produced no operations.");
+  }
+
+  const expiresAt = new Date(deps.clock().getTime() + deps.ttlMs).toISOString();
+  const groups = groupOperationsByKind(input.output.operations);
+
+  const proposals: AiProposal[] = groups.map((group) => {
+    const proposal: AiProposal = {
+      proposalId: deps.idFactory(),
+      kind: deriveProposalKind(group),
+      project: input.envelope.project,
+      environment: input.envelope.environment,
+      type: input.envelope.type,
+      locale: input.envelope.locale,
+      summary: input.output.summary,
+      operations: group,
+      validation: { status: "valid" },
+      expiresAt,
+      provider: {
+        providerId: input.providerId,
+        model: input.model,
+        promptTemplateId: input.promptTemplateId,
+      },
+      ...(input.envelope.documentId !== undefined
+        ? { documentId: input.envelope.documentId }
+        : {}),
+      ...(input.envelope.baseDraftRevision !== undefined
+        ? { baseDraftRevision: input.envelope.baseDraftRevision }
+        : {}),
+    };
+
+    const parsed = aiProposalSchema.safeParse(proposal);
+
+    if (!parsed.success) {
+      const validation: AiProposalValidation = {
+        status: "invalid",
+        errors: parsed.error.issues.map((issue) => ({
+          code: issue.code ?? "invalid",
+          message: issue.message,
+          path: issue.path?.join(".") || undefined,
+        })),
+      };
+
+      throw aiError(
+        "AI_OUTPUT_INVALID",
+        "Generated proposal failed schema validation.",
+        { validation },
+      );
+    }
+
+    return parsed.data;
+  });
+
+  // When mixed, only the actually-grouped result reflects the split.
+  if (proposals.length === 0) {
+    throw aiError(
+      "AI_OUTPUT_INVALID",
+      "Task output produced no usable proposals.",
+    );
+  }
+
+  return proposals;
+}
+
+function groupOperationsByKind(
+  operations: readonly AiProposalOperation[],
+): AiProposalOperation[][] {
+  if (!mixedOperationKinds(operations)) {
+    return [operations.slice()];
+  }
+
+  const buckets = new Map<AiProposalOperation["op"], AiProposalOperation[]>();
+  const order: AiProposalOperation["op"][] = [];
+
+  for (const operation of operations) {
+    if (!buckets.has(operation.op)) {
+      buckets.set(operation.op, []);
+      order.push(operation.op);
+    }
+
+    buckets.get(operation.op)!.push(operation);
+  }
+
+  return order.map((op) => buckets.get(op)!);
+}

--- a/packages/modules/core.ai/src/server/provider.ts
+++ b/packages/modules/core.ai/src/server/provider.ts
@@ -1,0 +1,45 @@
+import type { AiTaskKind } from "@mdcms/shared";
+
+export type AiProviderUsage = {
+  promptTokens?: number;
+  completionTokens?: number;
+  costUsd?: number;
+};
+
+export type AiProviderRequest = {
+  taskKind: AiTaskKind;
+  promptTemplateId: string;
+  system: string;
+  user: string;
+  /**
+   * JSON schema describing the expected output shape. Providers that
+   * support structured outputs use this to constrain decoding; providers
+   * that do not are expected to coerce to JSON and rely on the
+   * orchestrator's output validation.
+   */
+  outputJsonSchema?: Record<string, unknown>;
+  maxOutputTokens?: number;
+};
+
+export type AiProviderResponse = {
+  /** Raw model output. Always a string; orchestration parses to JSON. */
+  output: string;
+  model: string;
+  usage?: AiProviderUsage;
+};
+
+export type AiProvider = {
+  readonly id: string;
+  complete(request: AiProviderRequest): Promise<AiProviderResponse>;
+};
+
+export type AiProviderEnv = Record<string, string | undefined>;
+
+export type AiProviderFactoryDeps = {
+  env: AiProviderEnv;
+  /**
+   * Injectable fetch so unit tests can stub network calls without
+   * patching globals. Real provider adapters use this for HTTP I/O.
+   */
+  fetch?: typeof fetch;
+};

--- a/packages/modules/core.ai/src/server/provider.ts
+++ b/packages/modules/core.ai/src/server/provider.ts
@@ -1,45 +1,28 @@
-import type { AiTaskKind } from "@mdcms/shared";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 
 export type AiProviderUsage = {
-  promptTokens?: number;
-  completionTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
   costUsd?: number;
 };
 
-export type AiProviderRequest = {
-  taskKind: AiTaskKind;
-  promptTemplateId: string;
-  system: string;
-  user: string;
-  /**
-   * JSON schema describing the expected output shape. Providers that
-   * support structured outputs use this to constrain decoding; providers
-   * that do not are expected to coerce to JSON and rely on the
-   * orchestrator's output validation.
-   */
-  outputJsonSchema?: Record<string, unknown>;
-  maxOutputTokens?: number;
-};
-
-export type AiProviderResponse = {
-  /** Raw model output. Always a string; orchestration parses to JSON. */
-  output: string;
-  model: string;
-  usage?: AiProviderUsage;
-};
-
+/**
+ * AiProvider wraps an AI SDK language model so the orchestrator can
+ * run any provider supported by the Vercel AI SDK behind a single
+ * seam.
+ *
+ * `languageModel === null` represents the disabled state — the
+ * orchestrator translates that into AI_DISABLED before constructing a
+ * provider request.
+ */
 export type AiProvider = {
   readonly id: string;
-  complete(request: AiProviderRequest): Promise<AiProviderResponse>;
+  readonly languageModel: LanguageModelV3 | null;
 };
 
 export type AiProviderEnv = Record<string, string | undefined>;
 
 export type AiProviderFactoryDeps = {
   env: AiProviderEnv;
-  /**
-   * Injectable fetch so unit tests can stub network calls without
-   * patching globals. Real provider adapters use this for HTTP I/O.
-   */
-  fetch?: typeof fetch;
 };

--- a/packages/modules/core.ai/src/server/providers/echo.ts
+++ b/packages/modules/core.ai/src/server/providers/echo.ts
@@ -1,0 +1,53 @@
+import type {
+  AiProvider,
+  AiProviderRequest,
+  AiProviderResponse,
+  AiProviderUsage,
+} from "../provider.js";
+
+export const ECHO_PROVIDER_ID = "echo" as const;
+export const ECHO_PROVIDER_DEFAULT_MODEL = "echo-1" as const;
+
+export type EchoAiProviderOptions = {
+  model?: string;
+  /**
+   * Synchronous override for the response output. Receives the prompt
+   * payload so tests can return shape-specific JSON per task kind.
+   */
+  respond?: (request: AiProviderRequest) => string;
+  usage?: AiProviderUsage;
+  /**
+   * If set, every call rejects with this error. Used in tests to
+   * exercise the provider-failure path.
+   */
+  throwOnComplete?: Error;
+};
+
+/**
+ * Deterministic in-memory provider for unit tests and local
+ * development. By default it echoes the user prompt back as the
+ * model output so downstream parsing can be exercised without a
+ * real provider.
+ */
+export function createEchoAiProvider(
+  options: EchoAiProviderOptions = {},
+): AiProvider {
+  const model = options.model ?? ECHO_PROVIDER_DEFAULT_MODEL;
+
+  return {
+    id: ECHO_PROVIDER_ID,
+    async complete(request): Promise<AiProviderResponse> {
+      if (options.throwOnComplete) {
+        throw options.throwOnComplete;
+      }
+
+      const output = options.respond ? options.respond(request) : request.user;
+
+      return {
+        output,
+        model,
+        usage: options.usage,
+      };
+    },
+  };
+}

--- a/packages/modules/core.ai/src/server/providers/echo.ts
+++ b/packages/modules/core.ai/src/server/providers/echo.ts
@@ -1,9 +1,7 @@
-import type {
-  AiProvider,
-  AiProviderRequest,
-  AiProviderResponse,
-  AiProviderUsage,
-} from "../provider.js";
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { MockLanguageModelV3 } from "ai/test";
+
+import type { AiProvider, AiProviderUsage } from "../provider.js";
 
 export const ECHO_PROVIDER_ID = "echo" as const;
 export const ECHO_PROVIDER_DEFAULT_MODEL = "echo-1" as const;
@@ -11,43 +9,81 @@ export const ECHO_PROVIDER_DEFAULT_MODEL = "echo-1" as const;
 export type EchoAiProviderOptions = {
   model?: string;
   /**
-   * Synchronous override for the response output. Receives the prompt
-   * payload so tests can return shape-specific JSON per task kind.
+   * Returns the model output text for a given call. The returned
+   * string must be valid JSON matching the task's output schema for
+   * `generateObject` to succeed; tests can intentionally return
+   * malformed text to exercise the AI_OUTPUT_INVALID path.
    */
-  respond?: (request: AiProviderRequest) => string;
+  respond?: (options: LanguageModelV3CallOptions) => string;
   usage?: AiProviderUsage;
   /**
-   * If set, every call rejects with this error. Used in tests to
-   * exercise the provider-failure path.
+   * If set, every doGenerate call rejects with this error. Used in
+   * tests to exercise AI_PROVIDER_UNAVAILABLE handling.
    */
-  throwOnComplete?: Error;
+  throwOnGenerate?: Error;
 };
 
 /**
  * Deterministic in-memory provider for unit tests and local
- * development. By default it echoes the user prompt back as the
- * model output so downstream parsing can be exercised without a
- * real provider.
+ * development. Wraps `MockLanguageModelV3` from the AI SDK and
+ * lets callers control output text, usage, or failure injection.
  */
 export function createEchoAiProvider(
   options: EchoAiProviderOptions = {},
 ): AiProvider {
-  const model = options.model ?? ECHO_PROVIDER_DEFAULT_MODEL;
+  const modelId = options.model ?? ECHO_PROVIDER_DEFAULT_MODEL;
+
+  const languageModel = new MockLanguageModelV3({
+    provider: ECHO_PROVIDER_ID,
+    modelId,
+    doGenerate: async (callOptions) => {
+      if (options.throwOnGenerate) {
+        throw options.throwOnGenerate;
+      }
+
+      const text = options.respond
+        ? options.respond(callOptions)
+        : extractUserPrompt(callOptions);
+
+      return {
+        content: [{ type: "text", text }],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: {
+            total: options.usage?.inputTokens,
+            noCache: options.usage?.inputTokens,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: options.usage?.outputTokens,
+            text: options.usage?.outputTokens,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      };
+    },
+  });
 
   return {
     id: ECHO_PROVIDER_ID,
-    async complete(request): Promise<AiProviderResponse> {
-      if (options.throwOnComplete) {
-        throw options.throwOnComplete;
-      }
-
-      const output = options.respond ? options.respond(request) : request.user;
-
-      return {
-        output,
-        model,
-        usage: options.usage,
-      };
-    },
+    languageModel,
   };
+}
+
+function extractUserPrompt(options: LanguageModelV3CallOptions): string {
+  for (const message of options.prompt) {
+    if (message.role !== "user") {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === "text") {
+        return part.text;
+      }
+    }
+  }
+
+  return "";
 }

--- a/packages/modules/core.ai/src/server/providers/factory.test.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import { RuntimeError } from "@mdcms/shared";
+
+import { ECHO_PROVIDER_ID } from "./echo.js";
+import { AI_PROVIDER_ENV_KEY, resolveAiProvider } from "./factory.js";
+import { NULL_PROVIDER_ID } from "./null.js";
+
+describe("resolveAiProvider", () => {
+  test("returns null provider when env var is missing", () => {
+    const provider = resolveAiProvider({ env: {} });
+    assert.equal(provider.id, NULL_PROVIDER_ID);
+  });
+
+  test("returns null provider when env var is 'disabled'", () => {
+    const provider = resolveAiProvider({
+      env: { [AI_PROVIDER_ENV_KEY]: "disabled" },
+    });
+    assert.equal(provider.id, NULL_PROVIDER_ID);
+  });
+
+  test("returns echo provider when env var is 'echo'", () => {
+    const provider = resolveAiProvider({
+      env: { [AI_PROVIDER_ENV_KEY]: "echo" },
+    });
+    assert.equal(provider.id, ECHO_PROVIDER_ID);
+  });
+
+  test("normalizes case and whitespace", () => {
+    const provider = resolveAiProvider({
+      env: { [AI_PROVIDER_ENV_KEY]: "  ECHO  " },
+    });
+    assert.equal(provider.id, ECHO_PROVIDER_ID);
+  });
+
+  test("throws AI_PROVIDER_UNAVAILABLE for unknown ids", () => {
+    assert.throws(
+      () =>
+        resolveAiProvider({
+          env: { [AI_PROVIDER_ENV_KEY]: "anthropic" },
+        }),
+      (error) =>
+        error instanceof RuntimeError &&
+        error.code === "AI_PROVIDER_UNAVAILABLE",
+    );
+  });
+
+  test("null provider throws AI_DISABLED on use", async () => {
+    const provider = resolveAiProvider({ env: {} });
+
+    await assert.rejects(
+      () =>
+        provider.complete({
+          taskKind: "copy_improvement",
+          promptTemplateId: "copy_improvement.v1",
+          system: "x",
+          user: "y",
+        }),
+      (error) => error instanceof RuntimeError && error.code === "AI_DISABLED",
+    );
+  });
+});

--- a/packages/modules/core.ai/src/server/providers/factory.test.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.test.ts
@@ -46,18 +46,16 @@ describe("resolveAiProvider", () => {
     );
   });
 
-  test("null provider throws AI_DISABLED on use", async () => {
+  test("null provider exposes a null language model", () => {
     const provider = resolveAiProvider({ env: {} });
+    assert.equal(provider.languageModel, null);
+  });
 
-    await assert.rejects(
-      () =>
-        provider.complete({
-          taskKind: "copy_improvement",
-          promptTemplateId: "copy_improvement.v1",
-          system: "x",
-          user: "y",
-        }),
-      (error) => error instanceof RuntimeError && error.code === "AI_DISABLED",
-    );
+  test("echo provider exposes a non-null language model", () => {
+    const provider = resolveAiProvider({
+      env: { [AI_PROVIDER_ENV_KEY]: "echo" },
+    });
+    assert.notEqual(provider.languageModel, null);
+    assert.equal(provider.languageModel?.modelId, "echo-1");
   });
 });

--- a/packages/modules/core.ai/src/server/providers/factory.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.ts
@@ -1,0 +1,39 @@
+import { aiError } from "../errors.js";
+import type { AiProvider, AiProviderFactoryDeps } from "../provider.js";
+import { createEchoAiProvider, ECHO_PROVIDER_ID } from "./echo.js";
+import { createNullAiProvider, NULL_PROVIDER_ID } from "./null.js";
+
+export const AI_PROVIDER_ENV_KEY = "AI_PROVIDER" as const;
+
+/**
+ * Resolve an AiProvider from environment configuration.
+ *
+ * Behavior:
+ * - Missing or "disabled" → null provider (returns AI_DISABLED on use).
+ * - "echo" → in-memory echo provider for tests/local dev.
+ * - Any other id (e.g. "anthropic", "openai") is reserved for future
+ *   adapters. This ticket throws AI_PROVIDER_UNAVAILABLE so callers
+ *   surface a stable error instead of silently degrading.
+ */
+export function resolveAiProvider(deps: AiProviderFactoryDeps): AiProvider {
+  const raw = deps.env[AI_PROVIDER_ENV_KEY];
+  const id = raw?.trim().toLowerCase();
+
+  if (!id || id === "disabled") {
+    return createNullAiProvider();
+  }
+
+  if (id === ECHO_PROVIDER_ID) {
+    return createEchoAiProvider();
+  }
+
+  if (id === NULL_PROVIDER_ID) {
+    return createNullAiProvider();
+  }
+
+  throw aiError(
+    "AI_PROVIDER_UNAVAILABLE",
+    `AI provider "${id}" is not implemented in this build.`,
+    { providerId: id },
+  );
+}

--- a/packages/modules/core.ai/src/server/providers/factory.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.ts
@@ -9,11 +9,14 @@ export const AI_PROVIDER_ENV_KEY = "AI_PROVIDER" as const;
  * Resolve an AiProvider from environment configuration.
  *
  * Behavior:
- * - Missing or "disabled" → null provider (returns AI_DISABLED on use).
- * - "echo" → in-memory echo provider for tests/local dev.
+ * - Missing or "disabled" → null provider (orchestrator surfaces
+ *   AI_DISABLED).
+ * - "echo" → in-memory Vercel AI SDK mock model for tests and local
+ *   dev.
  * - Any other id (e.g. "anthropic", "openai") is reserved for future
- *   adapters. This ticket throws AI_PROVIDER_UNAVAILABLE so callers
- *   surface a stable error instead of silently degrading.
+ *   AI SDK provider package adapters. This ticket throws
+ *   AI_PROVIDER_UNAVAILABLE so callers surface a stable error
+ *   instead of silently degrading.
  */
 export function resolveAiProvider(deps: AiProviderFactoryDeps): AiProvider {
   const raw = deps.env[AI_PROVIDER_ENV_KEY];

--- a/packages/modules/core.ai/src/server/providers/null.ts
+++ b/packages/modules/core.ai/src/server/providers/null.ts
@@ -1,0 +1,20 @@
+import { aiError } from "../errors.js";
+import type { AiProvider } from "../provider.js";
+
+export const NULL_PROVIDER_ID = "null" as const;
+
+/**
+ * Disabled provider. Every call surfaces AI_DISABLED with a stable
+ * error code, used when no provider is configured for the deployment.
+ */
+export function createNullAiProvider(): AiProvider {
+  return {
+    id: NULL_PROVIDER_ID,
+    async complete() {
+      throw aiError(
+        "AI_DISABLED",
+        "AI provider is not configured for this deployment.",
+      );
+    },
+  };
+}

--- a/packages/modules/core.ai/src/server/providers/null.ts
+++ b/packages/modules/core.ai/src/server/providers/null.ts
@@ -1,20 +1,14 @@
-import { aiError } from "../errors.js";
 import type { AiProvider } from "../provider.js";
 
 export const NULL_PROVIDER_ID = "null" as const;
 
 /**
- * Disabled provider. Every call surfaces AI_DISABLED with a stable
- * error code, used when no provider is configured for the deployment.
+ * Disabled provider. Carries a null language model so the orchestrator
+ * surfaces AI_DISABLED before attempting any generation.
  */
 export function createNullAiProvider(): AiProvider {
   return {
     id: NULL_PROVIDER_ID,
-    async complete() {
-      throw aiError(
-        "AI_DISABLED",
-        "AI provider is not configured for this deployment.",
-      );
-    },
+    languageModel: null,
   };
 }

--- a/packages/modules/core.ai/src/server/tasks.ts
+++ b/packages/modules/core.ai/src/server/tasks.ts
@@ -1,0 +1,234 @@
+import { z } from "zod";
+
+import {
+  AI_TASK_KINDS,
+  aiProposalOperationSchema,
+  type AiProposalOperation,
+  type AiTaskKind,
+} from "@mdcms/shared";
+
+export type AiTaskInput = {
+  /**
+   * Free-form caller-supplied instruction or topic. Required for chat
+   * and SEO tasks; ignored otherwise.
+   */
+  instruction?: string;
+  /** Selected text in the editor, when relevant to the task. */
+  selectionText?: string;
+  /** Document body content for context-bearing tasks. */
+  documentBody?: string;
+  /** Frontmatter snapshot for SEO and current-document edits. */
+  frontmatter?: Record<string, unknown>;
+  /** Locale of the target document, used to anchor the response. */
+  locale: string;
+  /** Tone hint for tone-changing copy edits. */
+  tone?: string;
+};
+
+export type AiTaskOutput = {
+  summary: string;
+  operations: AiProposalOperation[];
+};
+
+export type AiTaskDefinition = {
+  kind: AiTaskKind;
+  promptTemplateId: string;
+  system: string;
+  buildUserPrompt: (input: AiTaskInput) => string;
+  /** Operation kinds this task is allowed to emit. */
+  allowedOperationOps: AiProposalOperation["op"][];
+  inputSchema: z.ZodType<AiTaskInput>;
+  outputSchema: z.ZodType<AiTaskOutput>;
+};
+
+const baseInputSchema = z
+  .object({
+    instruction: z.string().trim().min(1).optional(),
+    selectionText: z.string().optional(),
+    documentBody: z.string().optional(),
+    frontmatter: z.record(z.string(), z.unknown()).optional(),
+    locale: z.string().trim().min(1),
+    tone: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+function makeOutputSchema(
+  allowedOps: readonly AiProposalOperation["op"][],
+): z.ZodType<AiTaskOutput> {
+  const allowed = new Set<string>(allowedOps);
+
+  const operationSchema = aiProposalOperationSchema.refine(
+    (op) => allowed.has(op.op),
+    {
+      message: `operation kind not allowed for this task.`,
+    },
+  );
+
+  return z
+    .object({
+      summary: z.string().trim().min(1),
+      operations: z.array(operationSchema).min(1),
+    })
+    .strict();
+}
+
+const copyImprovementInputSchema = baseInputSchema.refine(
+  (input) =>
+    typeof input.selectionText === "string" && input.selectionText.length > 0,
+  {
+    path: ["selectionText"],
+    message: "must include selected text for copy improvement.",
+  },
+);
+
+const seoImprovementInputSchema = baseInputSchema.refine(
+  (input) => Boolean(input.documentBody) || Boolean(input.frontmatter),
+  {
+    path: ["documentBody"],
+    message: "must include document body or frontmatter for SEO improvement.",
+  },
+);
+
+const mdxInsertionInputSchema = baseInputSchema.refine(
+  (input) =>
+    typeof input.instruction === "string" && input.instruction.length > 0,
+  {
+    path: ["instruction"],
+    message: "must include an instruction for MDX component insertion.",
+  },
+);
+
+const currentDocumentEditInputSchema = baseInputSchema.refine(
+  (input) => Boolean(input.documentBody) || Boolean(input.selectionText),
+  {
+    path: ["documentBody"],
+    message:
+      "must include document body or a selection for current-document edit.",
+  },
+);
+
+const newDocumentDraftInputSchema = baseInputSchema.refine(
+  (input) =>
+    typeof input.instruction === "string" && input.instruction.length > 0,
+  {
+    path: ["instruction"],
+    message: "must include an instruction for new-document creation.",
+  },
+);
+
+const formatLocaleHint = (input: AiTaskInput): string =>
+  `Target locale: ${input.locale}.`;
+
+const definitions: Record<AiTaskKind, AiTaskDefinition> = {
+  copy_improvement: {
+    kind: "copy_improvement",
+    promptTemplateId: "copy_improvement.v1",
+    system:
+      "You revise selected document copy. Return only valid JSON matching the requested schema. Do not invent facts or alter unrelated content.",
+    buildUserPrompt: (input) =>
+      [
+        formatLocaleHint(input),
+        input.tone ? `Tone: ${input.tone}.` : null,
+        input.instruction ? `Instruction: ${input.instruction}.` : null,
+        `Original selection:\n${input.selectionText ?? ""}`,
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n"),
+    allowedOperationOps: ["replace_selection"],
+    inputSchema: copyImprovementInputSchema,
+    outputSchema: makeOutputSchema(["replace_selection"]),
+  },
+  seo_improvement: {
+    kind: "seo_improvement",
+    promptTemplateId: "seo_improvement.v1",
+    system:
+      "You suggest SEO edits to an MDCMS document without altering meaning. Output JSON describing replace_selection or update_frontmatter operations only.",
+    buildUserPrompt: (input) =>
+      [
+        formatLocaleHint(input),
+        input.instruction ? `Goal: ${input.instruction}.` : null,
+        input.frontmatter
+          ? `Frontmatter:\n${JSON.stringify(input.frontmatter, null, 2)}`
+          : null,
+        input.documentBody ? `Body:\n${input.documentBody}` : null,
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n"),
+    allowedOperationOps: ["replace_selection", "update_frontmatter"],
+    inputSchema: seoImprovementInputSchema,
+    outputSchema: makeOutputSchema(["replace_selection", "update_frontmatter"]),
+  },
+  mdx_component_insertion: {
+    kind: "mdx_component_insertion",
+    promptTemplateId: "mdx_component_insertion.v1",
+    system:
+      "You compose MDX content using only registered MDX components and valid props. Output a single insert_block operation as JSON.",
+    buildUserPrompt: (input) =>
+      [
+        formatLocaleHint(input),
+        `Instruction: ${input.instruction ?? ""}`,
+        input.documentBody ? `Surrounding body:\n${input.documentBody}` : null,
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n"),
+    allowedOperationOps: ["insert_block"],
+    inputSchema: mdxInsertionInputSchema,
+    outputSchema: makeOutputSchema(["insert_block"]),
+  },
+  current_document_edit: {
+    kind: "current_document_edit",
+    promptTemplateId: "current_document_edit.v1",
+    system:
+      "You propose edits to the current draft document. Return JSON with replace_selection, insert_block, or update_frontmatter operations.",
+    buildUserPrompt: (input) =>
+      [
+        formatLocaleHint(input),
+        input.instruction ? `Instruction: ${input.instruction}.` : null,
+        input.selectionText ? `Selection:\n${input.selectionText}` : null,
+        input.documentBody ? `Body:\n${input.documentBody}` : null,
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n"),
+    allowedOperationOps: [
+      "replace_selection",
+      "insert_block",
+      "update_frontmatter",
+    ],
+    inputSchema: currentDocumentEditInputSchema,
+    outputSchema: makeOutputSchema([
+      "replace_selection",
+      "insert_block",
+      "update_frontmatter",
+    ]),
+  },
+  new_document_draft: {
+    kind: "new_document_draft",
+    promptTemplateId: "new_document_draft.v1",
+    system:
+      "You draft a new MDCMS document from a brief. Output a single create_document operation as JSON. Do not include unsupported frontmatter fields.",
+    buildUserPrompt: (input) =>
+      [formatLocaleHint(input), `Instruction: ${input.instruction ?? ""}`].join(
+        "\n",
+      ),
+    allowedOperationOps: ["create_document"],
+    inputSchema: newDocumentDraftInputSchema,
+    outputSchema: makeOutputSchema(["create_document"]),
+  },
+};
+
+export const AI_TASK_DEFINITIONS: Readonly<
+  Record<AiTaskKind, AiTaskDefinition>
+> = Object.freeze(definitions);
+
+export function getAiTaskDefinition(
+  kind: AiTaskKind,
+): AiTaskDefinition | undefined {
+  return AI_TASK_DEFINITIONS[kind];
+}
+
+/**
+ * Public list of supported task kinds. Source of truth is the shared
+ * AI_TASK_KINDS constant; this re-export keeps callers from touching
+ * the registry directly when they only need the discrete set.
+ */
+export const SUPPORTED_AI_TASK_KINDS: readonly AiTaskKind[] = AI_TASK_KINDS;

--- a/packages/modules/core.ai/src/server/tasks.ts
+++ b/packages/modules/core.ai/src/server/tasks.ts
@@ -15,6 +15,13 @@ export type AiTaskInput = {
   instruction?: string;
   /** Selected text in the editor, when relevant to the task. */
   selectionText?: string;
+  /**
+   * Server-trusted selection identifier. The orchestrator stamps this
+   * onto every generated `replace_selection` operation, so the model
+   * never has to invent a selection id (and any value the model
+   * supplies for that field is ignored).
+   */
+  selectionId?: string;
   /** Document body content for context-bearing tasks. */
   documentBody?: string;
   /** Frontmatter snapshot for SEO and current-document edits. */
@@ -45,6 +52,7 @@ const baseInputSchema = z
   .object({
     instruction: z.string().trim().min(1).optional(),
     selectionText: z.string().optional(),
+    selectionId: z.string().trim().min(1).optional(),
     documentBody: z.string().optional(),
     frontmatter: z.record(z.string(), z.unknown()).optional(),
     locale: z.string().trim().min(1),
@@ -72,14 +80,23 @@ function makeOutputSchema(
     .strict();
 }
 
-const copyImprovementInputSchema = baseInputSchema.refine(
-  (input) =>
-    typeof input.selectionText === "string" && input.selectionText.length > 0,
-  {
-    path: ["selectionText"],
-    message: "must include selected text for copy improvement.",
-  },
-);
+const copyImprovementInputSchema = baseInputSchema
+  .refine(
+    (input) =>
+      typeof input.selectionText === "string" && input.selectionText.length > 0,
+    {
+      path: ["selectionText"],
+      message: "must include selected text for copy improvement.",
+    },
+  )
+  .refine(
+    (input) =>
+      typeof input.selectionId === "string" && input.selectionId.length > 0,
+    {
+      path: ["selectionId"],
+      message: "must include a selectionId for copy improvement.",
+    },
+  );
 
 const seoImprovementInputSchema = baseInputSchema.refine(
   (input) => Boolean(input.documentBody) || Boolean(input.frontmatter),

--- a/packages/modules/core.ai/src/server/tasks.ts
+++ b/packages/modules/core.ai/src/server/tasks.ts
@@ -115,14 +115,24 @@ const mdxInsertionInputSchema = baseInputSchema.refine(
   },
 );
 
-const currentDocumentEditInputSchema = baseInputSchema.refine(
-  (input) => Boolean(input.documentBody) || Boolean(input.selectionText),
-  {
-    path: ["documentBody"],
-    message:
-      "must include document body or a selection for current-document edit.",
-  },
-);
+const currentDocumentEditInputSchema = baseInputSchema
+  .refine(
+    (input) => Boolean(input.documentBody) || Boolean(input.selectionText),
+    {
+      path: ["documentBody"],
+      message:
+        "must include document body or a selection for current-document edit.",
+    },
+  )
+  .refine(
+    (input) =>
+      typeof input.selectionId === "string" && input.selectionId.length > 0,
+    {
+      path: ["selectionId"],
+      message:
+        "must include a selectionId for current-document edit so replace_selection proposals can be anchored server-side.",
+    },
+  );
 
 const newDocumentDraftInputSchema = baseInputSchema.refine(
   (input) =>
@@ -159,7 +169,7 @@ const definitions: Record<AiTaskKind, AiTaskDefinition> = {
     kind: "seo_improvement",
     promptTemplateId: "seo_improvement.v1",
     system:
-      "You suggest SEO edits to an MDCMS document without altering meaning. Output JSON describing replace_selection or update_frontmatter operations only.",
+      "You suggest SEO edits to an MDCMS document by updating frontmatter only. Return JSON describing update_frontmatter operations.",
     buildUserPrompt: (input) =>
       [
         formatLocaleHint(input),
@@ -171,9 +181,14 @@ const definitions: Record<AiTaskKind, AiTaskDefinition> = {
       ]
         .filter((line): line is string => line !== null)
         .join("\n"),
-    allowedOperationOps: ["replace_selection", "update_frontmatter"],
+    // replace_selection is intentionally excluded: SEO is invoked
+    // doc-level (no trusted selection anchor), so we cannot stamp a
+    // server-trusted selectionId. Body rewrites for SEO go through
+    // copy_improvement (inline) or current_document_edit (chat), both
+    // of which require a selectionId in input.
+    allowedOperationOps: ["update_frontmatter"],
     inputSchema: seoImprovementInputSchema,
-    outputSchema: makeOutputSchema(["replace_selection", "update_frontmatter"]),
+    outputSchema: makeOutputSchema(["update_frontmatter"]),
   },
   mdx_component_insertion: {
     kind: "mdx_component_insertion",
@@ -196,7 +211,10 @@ const definitions: Record<AiTaskKind, AiTaskDefinition> = {
     kind: "current_document_edit",
     promptTemplateId: "current_document_edit.v1",
     system:
-      "You propose edits to the current draft document. Return JSON with replace_selection, insert_block, or update_frontmatter operations.",
+      "You propose edits to the current draft document. Return JSON with replace_selection, insert_block, or update_frontmatter operations. The replace_selection target is the caller's selectionId; do not address other locations.",
+    // selectionId is required by currentDocumentEditInputSchema, so
+    // every replace_selection operation gets a server-trusted
+    // anchor stamped by the proposal builder.
     buildUserPrompt: (input) =>
       [
         formatLocaleHint(input),

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -23,7 +23,9 @@
     "test": "bun test ./src"
   },
   "dependencies": {
+    "@ai-sdk/provider": "^3.0.10",
     "@mdcms/shared": "workspace:*",
+    "ai": "^6.0.173",
     "tslib": "^2.3.0"
   },
   "license": "MIT"

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -20,7 +20,7 @@
     "name": "modules"
   },
   "scripts": {
-    "test": "bun test ./src"
+    "test": "bun test ./src ./core.ai ./core.system ./domain.content"
   },
   "dependencies": {
     "@ai-sdk/provider": "^3.0.10",

--- a/packages/modules/src/bun-test.d.ts
+++ b/packages/modules/src/bun-test.d.ts
@@ -1,0 +1,10 @@
+declare module "bun:test" {
+  export const test: {
+    (name: string, fn?: (...args: unknown[]) => unknown): unknown;
+    skip: (name: string, fn?: (...args: unknown[]) => unknown) => unknown;
+    only: (name: string, fn?: (...args: unknown[]) => unknown) => unknown;
+    todo: (name: string, fn?: (...args: unknown[]) => unknown) => unknown;
+  };
+
+  export const describe: (name: string, fn: () => void | Promise<void>) => void;
+}

--- a/packages/modules/src/index.test.ts
+++ b/packages/modules/src/index.test.ts
@@ -19,4 +19,5 @@ test("installedModules includes seed modules", () => {
 
   assert.equal(ids.has("core.system"), true);
   assert.equal(ids.has("domain.content"), true);
+  assert.equal(ids.has("core.ai"), true);
 });

--- a/packages/modules/src/index.ts
+++ b/packages/modules/src/index.ts
@@ -1,5 +1,6 @@
 import type { MdcmsModulePackage } from "@mdcms/shared";
 
+import { coreAiModule } from "../core.ai/src/index.js";
 import { coreSystemModule } from "../core.system/src/index.js";
 import { domainContentModule } from "../domain.content/src/index.js";
 
@@ -8,6 +9,7 @@ type LocalModulePackage = MdcmsModulePackage<unknown, Record<string, unknown>>;
 const localModules: LocalModulePackage[] = [
   domainContentModule,
   coreSystemModule,
+  coreAiModule,
 ];
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/runtime/index.js";
 export * from "./lib/contracts/action-catalog.js";
+export * from "./lib/contracts/ai.js";
 export * from "./lib/contracts/config.js";
 export * from "./lib/contracts/content-api.js";
 export * from "./lib/contracts/current-principal-capabilities.js";

--- a/packages/shared/src/lib/contracts/ai.test.ts
+++ b/packages/shared/src/lib/contracts/ai.test.ts
@@ -96,6 +96,22 @@ test("aiProposalSchema rejects proposals with non-ISO expiresAt", () => {
   assert.equal(parsed.success, false);
 });
 
+test("aiProposalSchema rejects date-only expiresAt strings", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    expiresAt: "2026-05-01",
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects locale-formatted dates that Date.parse accepts", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    expiresAt: "May 1 2026 12:00:00",
+  });
+  assert.equal(parsed.success, false);
+});
+
 test("aiProposalSchema rejects proposals missing provider metadata", () => {
   const { provider: _provider, ...rest } = validProposal;
   const parsed = aiProposalSchema.safeParse(rest);

--- a/packages/shared/src/lib/contracts/ai.test.ts
+++ b/packages/shared/src/lib/contracts/ai.test.ts
@@ -123,6 +123,40 @@ test("aiProposalSchema rejects unknown top-level keys", () => {
   assert.equal(parsed.success, false);
 });
 
+test("aiProposalSchema rejects mismatched kind/operation", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "replace_selection",
+    operations: [
+      {
+        op: "create_document",
+        path: "foo.md",
+        format: "md",
+        frontmatter: {},
+        body: "x",
+      },
+    ],
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects heterogeneous operations", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "replace_selection",
+    operations: [
+      {
+        op: "replace_selection",
+        selectionId: "sel_1",
+        originalText: "a",
+        replacementText: "b",
+      },
+      { op: "update_frontmatter", patch: {} },
+    ],
+  });
+  assert.equal(parsed.success, false);
+});
+
 test("AI_PROPOSAL_KINDS exposes all four spec proposal kinds", () => {
   assert.deepEqual([...AI_PROPOSAL_KINDS].sort(), [
     "create_document",

--- a/packages/shared/src/lib/contracts/ai.test.ts
+++ b/packages/shared/src/lib/contracts/ai.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import { RuntimeError } from "../runtime/error.js";
+import {
+  AI_PROPOSAL_KINDS,
+  aiProposalOperationSchema,
+  aiProposalSchema,
+  aiProposalValidationSchema,
+  assertAiProposal,
+  isAiProposal,
+  type AiProposal,
+} from "./ai.js";
+
+const baseProvider = {
+  providerId: "echo",
+  model: "echo-1",
+  promptTemplateId: "copy_improvement",
+};
+
+const validProposal: AiProposal = {
+  proposalId: "p_1",
+  kind: "replace_selection",
+  project: "demo",
+  environment: "draft",
+  documentId: "doc_1",
+  baseDraftRevision: 4,
+  type: "page",
+  locale: "en",
+  summary: "Tighten the intro",
+  operations: [
+    {
+      op: "replace_selection",
+      selectionId: "sel_1",
+      originalText: "old",
+      replacementText: "new",
+    },
+  ],
+  validation: { status: "valid" },
+  expiresAt: "2026-05-01T00:05:00.000Z",
+  provider: baseProvider,
+};
+
+test("aiProposalSchema accepts a fully populated proposal", () => {
+  const parsed = aiProposalSchema.safeParse(validProposal);
+  assert.equal(parsed.success, true);
+});
+
+test("aiProposalSchema accepts an insert_block proposal without afterSelectionId", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "insert_block",
+    operations: [{ op: "insert_block", bodyMdx: "<Callout>Hi</Callout>" }],
+  });
+  assert.equal(parsed.success, true);
+});
+
+test("aiProposalSchema accepts a create_document proposal", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "create_document",
+    operations: [
+      {
+        op: "create_document",
+        path: "blog/new-post.mdx",
+        format: "mdx",
+        frontmatter: { title: "New" },
+        body: "# Hello",
+      },
+    ],
+  });
+  assert.equal(parsed.success, true);
+});
+
+test("aiProposalSchema rejects proposals with unknown kind", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "rewrite_everything",
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects proposals with empty operations", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    operations: [],
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects proposals with non-ISO expiresAt", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    expiresAt: "yesterday",
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects proposals missing provider metadata", () => {
+  const { provider: _provider, ...rest } = validProposal;
+  const parsed = aiProposalSchema.safeParse(rest);
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects unknown top-level keys", () => {
+  const parsed = aiProposalSchema.safeParse({ ...validProposal, extra: true });
+  assert.equal(parsed.success, false);
+});
+
+test("AI_PROPOSAL_KINDS exposes all four spec proposal kinds", () => {
+  assert.deepEqual([...AI_PROPOSAL_KINDS].sort(), [
+    "create_document",
+    "insert_block",
+    "replace_selection",
+    "update_frontmatter",
+  ]);
+});
+
+test("aiProposalOperationSchema accepts a replace_selection operation", () => {
+  const parsed = aiProposalOperationSchema.safeParse({
+    op: "replace_selection",
+    selectionId: "sel_1",
+    originalText: "",
+    replacementText: "Hi",
+  });
+  assert.equal(parsed.success, true);
+});
+
+test("aiProposalOperationSchema rejects insert_block operations with empty body", () => {
+  const parsed = aiProposalOperationSchema.safeParse({
+    op: "insert_block",
+    bodyMdx: "",
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalValidationSchema accepts a valid status", () => {
+  assert.equal(
+    aiProposalValidationSchema.safeParse({ status: "valid" }).success,
+    true,
+  );
+});
+
+test("aiProposalValidationSchema rejects invalid status with empty error list", () => {
+  assert.equal(
+    aiProposalValidationSchema.safeParse({ status: "invalid", errors: [] })
+      .success,
+    false,
+  );
+});
+
+test("aiProposalValidationSchema accepts invalid status with error entries", () => {
+  assert.equal(
+    aiProposalValidationSchema.safeParse({
+      status: "invalid",
+      errors: [{ code: "X", message: "boom" }],
+    }).success,
+    true,
+  );
+});
+
+test("assertAiProposal returns when value matches", () => {
+  assertAiProposal(validProposal);
+});
+
+test("assertAiProposal throws AI_OUTPUT_INVALID for malformed value", () => {
+  assert.throws(
+    () =>
+      assertAiProposal({
+        ...validProposal,
+        operations: [{ op: "replace_selection", selectionId: "" }],
+      }),
+    (error) =>
+      error instanceof RuntimeError &&
+      error.code === "AI_OUTPUT_INVALID" &&
+      error.statusCode === 422,
+  );
+});
+
+test("assertAiProposal carries issue path in details", () => {
+  try {
+    assertAiProposal({ ...validProposal, expiresAt: "soon" });
+    assert.fail("expected throw");
+  } catch (error) {
+    assert.ok(error instanceof RuntimeError);
+    assert.equal((error as RuntimeError).code, "AI_OUTPUT_INVALID");
+    assert.equal(typeof (error as RuntimeError).details?.path, "string");
+  }
+});
+
+test("isAiProposal returns true for valid proposal", () => {
+  assert.equal(isAiProposal(validProposal), true);
+});
+
+test("isAiProposal returns false for malformed proposal", () => {
+  assert.equal(isAiProposal({}), false);
+});

--- a/packages/shared/src/lib/contracts/ai.test.ts
+++ b/packages/shared/src/lib/contracts/ai.test.ts
@@ -56,8 +56,13 @@ test("aiProposalSchema accepts an insert_block proposal without afterSelectionId
 });
 
 test("aiProposalSchema accepts a create_document proposal", () => {
+  const {
+    documentId: _documentId,
+    baseDraftRevision: _baseDraftRevision,
+    ...rest
+  } = validProposal;
   const parsed = aiProposalSchema.safeParse({
-    ...validProposal,
+    ...rest,
     kind: "create_document",
     operations: [
       {
@@ -70,6 +75,41 @@ test("aiProposalSchema accepts a create_document proposal", () => {
     ],
   });
   assert.equal(parsed.success, true);
+});
+
+test("aiProposalSchema rejects create_document proposals carrying source documentId", () => {
+  const parsed = aiProposalSchema.safeParse({
+    ...validProposal,
+    kind: "create_document",
+    operations: [
+      {
+        op: "create_document",
+        path: "blog/new-post.mdx",
+        format: "mdx",
+        frontmatter: {},
+        body: "# Hi",
+      },
+    ],
+  });
+  assert.equal(parsed.success, false);
+});
+
+test("aiProposalSchema rejects create_document proposals carrying baseDraftRevision", () => {
+  const { documentId: _documentId, ...rest } = validProposal;
+  const parsed = aiProposalSchema.safeParse({
+    ...rest,
+    kind: "create_document",
+    operations: [
+      {
+        op: "create_document",
+        path: "blog/new-post.mdx",
+        format: "mdx",
+        frontmatter: {},
+        body: "# Hi",
+      },
+    ],
+  });
+  assert.equal(parsed.success, false);
 });
 
 test("aiProposalSchema rejects proposals with unknown kind", () => {

--- a/packages/shared/src/lib/contracts/ai.ts
+++ b/packages/shared/src/lib/contracts/ai.ts
@@ -93,10 +93,9 @@ const nonEmptyString = z.string().trim().min(1, {
   message: "must be a non-empty string.",
 });
 
-const isoDateString = nonEmptyString.refine(
-  (value) => !Number.isNaN(Date.parse(value)),
-  { message: "must be an ISO-8601 date string." },
-);
+const isoDateString = z.iso.datetime({
+  message: "must be an ISO-8601 datetime string.",
+});
 
 const recordOfUnknown = z.record(z.string(), z.unknown());
 

--- a/packages/shared/src/lib/contracts/ai.ts
+++ b/packages/shared/src/lib/contracts/ai.ts
@@ -191,6 +191,26 @@ export const aiProposalSchema = z
         });
       }
     });
+
+    if (proposal.kind === "create_document") {
+      if (proposal.documentId !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["documentId"],
+          message:
+            "create_document proposals must not carry a source documentId.",
+        });
+      }
+
+      if (proposal.baseDraftRevision !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["baseDraftRevision"],
+          message:
+            "create_document proposals must not carry a source baseDraftRevision.",
+        });
+      }
+    }
   });
 
 function formatPath(path: string, issuePath: readonly PropertyKey[]): string {

--- a/packages/shared/src/lib/contracts/ai.ts
+++ b/packages/shared/src/lib/contracts/ai.ts
@@ -180,7 +180,18 @@ export const aiProposalSchema = z
     expiresAt: isoDateString,
     provider: aiProposalProviderMetadataSchema,
   })
-  .strict();
+  .strict()
+  .superRefine((proposal, ctx) => {
+    proposal.operations.forEach((operation, index) => {
+      if (operation.op !== proposal.kind) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["operations", index, "op"],
+          message: `operation.op "${operation.op}" must match proposal.kind "${proposal.kind}".`,
+        });
+      }
+    });
+  });
 
 function formatPath(path: string, issuePath: readonly PropertyKey[]): string {
   if (issuePath.length === 0) {

--- a/packages/shared/src/lib/contracts/ai.ts
+++ b/packages/shared/src/lib/contracts/ai.ts
@@ -1,0 +1,233 @@
+import { z } from "zod";
+
+import { RuntimeError } from "../runtime/error.js";
+
+export const AI_TASK_KINDS = [
+  "copy_improvement",
+  "seo_improvement",
+  "mdx_component_insertion",
+  "current_document_edit",
+  "new_document_draft",
+] as const;
+
+export type AiTaskKind = (typeof AI_TASK_KINDS)[number];
+
+export const AI_PROPOSAL_KINDS = [
+  "replace_selection",
+  "insert_block",
+  "update_frontmatter",
+  "create_document",
+] as const;
+
+export type AiProposalKind = (typeof AI_PROPOSAL_KINDS)[number];
+
+export const AI_ERROR_CODES = [
+  "AI_DISABLED",
+  "AI_PROVIDER_UNAVAILABLE",
+  "AI_RATE_LIMITED",
+  "AI_CONTEXT_TOO_LARGE",
+  "AI_OUTPUT_INVALID",
+  "AI_UNSUPPORTED_TASK",
+] as const;
+
+export type AiErrorCode = (typeof AI_ERROR_CODES)[number];
+
+export type AiProposalOperation =
+  | {
+      op: "replace_selection";
+      selectionId: string;
+      originalText: string;
+      replacementText: string;
+    }
+  | {
+      op: "insert_block";
+      afterSelectionId?: string;
+      bodyMdx: string;
+    }
+  | {
+      op: "update_frontmatter";
+      patch: Record<string, unknown>;
+    }
+  | {
+      op: "create_document";
+      path: string;
+      format: "md" | "mdx";
+      frontmatter: Record<string, unknown>;
+      body: string;
+    };
+
+export type AiProposalValidation =
+  | { status: "valid" }
+  | {
+      status: "invalid";
+      errors: {
+        code: string;
+        message: string;
+        path?: string;
+      }[];
+    };
+
+export type AiProposalProviderMetadata = {
+  providerId: string;
+  model: string;
+  promptTemplateId: string;
+};
+
+export type AiProposal = {
+  proposalId: string;
+  kind: AiProposalKind;
+  project: string;
+  environment: string;
+  documentId?: string;
+  baseDraftRevision?: number;
+  type: string;
+  locale: string;
+  summary: string;
+  operations: AiProposalOperation[];
+  validation: AiProposalValidation;
+  expiresAt: string;
+  provider: AiProposalProviderMetadata;
+};
+
+const nonEmptyString = z.string().trim().min(1, {
+  message: "must be a non-empty string.",
+});
+
+const isoDateString = nonEmptyString.refine(
+  (value) => !Number.isNaN(Date.parse(value)),
+  { message: "must be an ISO-8601 date string." },
+);
+
+const recordOfUnknown = z.record(z.string(), z.unknown());
+
+export const aiProposalOperationSchema = z.discriminatedUnion("op", [
+  z
+    .object({
+      op: z.literal("replace_selection"),
+      selectionId: nonEmptyString,
+      originalText: z.string(),
+      replacementText: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("insert_block"),
+      afterSelectionId: nonEmptyString.optional(),
+      bodyMdx: z.string().min(1, {
+        message: "must be a non-empty MDX block.",
+      }),
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("update_frontmatter"),
+      patch: recordOfUnknown,
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("create_document"),
+      path: nonEmptyString,
+      format: z.enum(["md", "mdx"]),
+      frontmatter: recordOfUnknown,
+      body: z.string(),
+    })
+    .strict(),
+]);
+
+export const aiProposalValidationSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("valid") }).strict(),
+  z
+    .object({
+      status: z.literal("invalid"),
+      errors: z
+        .array(
+          z
+            .object({
+              code: nonEmptyString,
+              message: nonEmptyString,
+              path: nonEmptyString.optional(),
+            })
+            .strict(),
+        )
+        .min(1, { message: "must include at least one validation error." }),
+    })
+    .strict(),
+]);
+
+const aiProposalProviderMetadataSchema = z
+  .object({
+    providerId: nonEmptyString,
+    model: nonEmptyString,
+    promptTemplateId: nonEmptyString,
+  })
+  .strict();
+
+export const aiProposalSchema = z
+  .object({
+    proposalId: nonEmptyString,
+    kind: z.enum(AI_PROPOSAL_KINDS),
+    project: nonEmptyString,
+    environment: nonEmptyString,
+    documentId: nonEmptyString.optional(),
+    baseDraftRevision: z.number().int().nonnegative().optional(),
+    type: nonEmptyString,
+    locale: nonEmptyString,
+    summary: nonEmptyString,
+    operations: z.array(aiProposalOperationSchema).min(1, {
+      message: "must include at least one operation.",
+    }),
+    validation: aiProposalValidationSchema,
+    expiresAt: isoDateString,
+    provider: aiProposalProviderMetadataSchema,
+  })
+  .strict();
+
+function formatPath(path: string, issuePath: readonly PropertyKey[]): string {
+  if (issuePath.length === 0) {
+    return path;
+  }
+
+  return issuePath.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") {
+      return `${acc}[${segment}]`;
+    }
+
+    if (typeof segment === "symbol") {
+      return `${acc}.[${String(segment)}]`;
+    }
+
+    return `${acc}.${segment}`;
+  }, path);
+}
+
+export function assertAiProposal(
+  value: unknown,
+  path = "proposal",
+): asserts value is AiProposal {
+  const parsed = aiProposalSchema.safeParse(value);
+
+  if (parsed.success) {
+    return;
+  }
+
+  const [first] = parsed.error.issues;
+  const issuePath = first ? formatPath(path, first.path ?? []) : path;
+  const message = first
+    ? `${issuePath} ${first.message ?? "is invalid."}`
+    : `${path} is invalid.`;
+
+  throw new RuntimeError({
+    code: "AI_OUTPUT_INVALID",
+    message,
+    statusCode: 422,
+    details: {
+      path: issuePath,
+      issues: parsed.error.issues,
+    },
+  });
+}
+
+export function isAiProposal(value: unknown): value is AiProposal {
+  return aiProposalSchema.safeParse(value).success;
+}


### PR DESCRIPTION
## Summary

Implements the server-side foundation for in-product Studio AI assistance per [SPEC-014](docs/specs/SPEC-014-ai-assisted-studio-editing.md):

- New `core.ai` first-party module: `AiProvider` interface, null/echo providers, env-driven provider factory, task-specific orchestrator, structured `AiProposal` builder, and audit-record builder.
- Shared contract types + Zod schemas in `@mdcms/shared`: `AiProposal`, `AiProposalKind`, `AiProposalOperation`, `AiProposalValidation`, `AiTaskKind`, `AI_ERROR_CODES`.
- Deterministic error mapping for all provider failure paths: `AI_DISABLED`, `AI_PROVIDER_UNAVAILABLE`, `AI_RATE_LIMITED`, `AI_CONTEXT_TOO_LARGE`, `AI_OUTPUT_INVALID`, `AI_UNSUPPORTED_TASK`.

This ticket is foundation only. **No HTTP endpoints, no DB tables, no Studio UI changes** — those land in follow-up tickets that consume the orchestrator. SPEC-014 already specifies the endpoint contract table; the next ticket adds routes to `core.ai`'s server surface.

## Spec delta

Implements SPEC-014 §"Provider and Orchestration Requirements" and §"Structured Proposals". No changes to the spec itself; the foundation matches the existing `AiProposal*` shape verbatim, plus a server-side `provider` metadata block and an `AiTaskKind` set covering the five task workflows the spec calls out (copy, SEO, MDX insertion, current-doc edit, new-document draft).

## Acceptance criteria

- [x] Studio AI workflows can call a unified provider interface without coupling UI code to a provider SDK — `AiProvider` interface, factory resolves implementation from env.
- [x] Provider failures return deterministic errors — `mapProviderError` always produces a stable `AI_*` `RuntimeError`; raw provider error text is not echoed.
- [x] Orchestration emits structured proposals compatible with the AI-assisted Studio editing spec — `buildProposalsFromOutput` returns `AiProposal[]` validated by `aiProposalSchema`.
- [x] Unit tests cover provider success, provider failure, disabled AI, and invalid model output — see `orchestrator.test.ts`.

## Test plan

- [x] `bun test --cwd packages/shared ./src/lib/contracts/ai.test.ts` — 19 pass
- [x] `bun test --cwd packages/modules .` — 66 pass
- [x] `bun test --cwd apps/server ./src/lib/runtime-with-modules.test.ts` — 6 pass
- [x] `bun run check` (build + typecheck across workspace) — green
- [x] `bun run format:check` — green
- [x] `bun run changeset:check` — gate satisfied (`@mdcms/shared` minor)

Pre-existing baseline failures unrelated to this change: 4 CLI login authorize tests in `apps/server/src/lib/auth.test.ts` and `demo:seed` test — confirmed by stashing the branch and re-running on the baseline. They are caused by shared postgres state across local worktrees.

## Out of scope

- HTTP routes for `/api/v1/ai/*` (separate ticket; spec already defines the contracts).
- Real provider SDK adapters (Anthropic, OpenAI) — separate ticket; the factory currently throws `AI_PROVIDER_UNAVAILABLE` for non-`echo`/`disabled` ids.
- DB tables for proposal storage and audit log persistence.
- Studio UI changes.
- `apps/studio-review` updates — that app does not exist on this branch yet.

## Plan + design notes

`.ai/plans/2026-05-01-cms-223-studio-ai-foundation.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a server-side AI foundation: task-driven AI helpers (copy, SEO, MDX, drafting), deterministic orchestrator with provider selection (disabled/echo), structured proposal generation, and sanitized audit records with outcome/error classification.
  * Adds shared AI contract types, Zod validation, runtime assertion, and re-exports for cross-module consumption.
  * Registers a new core.ai module and exposes orchestrator/provider APIs for use by other modules.

* **Tests**
  * Extensive coverage for orchestration flows, proposal building/validation, error mapping, provider resolution, and audit record semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->