### PR TITLE
fix(ai): Groq default → gpt-oss-120b + stop merging bullets on rewrite

### DIFF
--- a/packages/modules/core.ai/src/server/providers/factory.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.ts
@@ -20,8 +20,9 @@ export const GROQ_BASE_URL_ENV_KEY = "GROQ_BASE_URL" as const;
  * - "groq" → real Groq adapter via `@ai-sdk/groq`. Reads
  *   `GROQ_API_KEY` (required), optional `AI_MODEL`
  *   (defaults to `GROQ_PROVIDER_DEFAULT_MODEL`, currently
- *   `openai/gpt-oss-20b` — chosen because it supports Groq's
- *   `response_format: json_schema` strict mode), and optional
+ *   `openai/gpt-oss-120b` — chosen because it supports Groq's
+ *   `response_format: json_schema` strict mode and produces
+ *   noticeably better copy edits than the 20b variant), and optional
  *   `GROQ_BASE_URL` for proxies.
  * - Any other id is reserved for future AI SDK provider package
  *   adapters and currently throws `AI_PROVIDER_UNAVAILABLE` so callers

--- a/packages/modules/core.ai/src/server/providers/groq.ts
+++ b/packages/modules/core.ai/src/server/providers/groq.ts
@@ -8,15 +8,16 @@ export const GROQ_PROVIDER_ID = "groq" as const;
  * Default Groq model used when `AI_MODEL` is not set. The orchestrator
  * relies on the AI SDK's `generateObject`, which (as of `ai@6`) drives
  * structured output through `response_format: json_schema`. Only a
- * subset of Groq models supports that mode; `openai/gpt-oss-20b` is on
- * the list and is the fastest/cheapest of those, making it the
- * sensible default. See
+ * subset of Groq models supports that mode; `openai/gpt-oss-120b` is
+ * on the list and produces noticeably better copy edits than the 20b
+ * variant on selection-anchored rewrites, so it's the default. See
  * https://console.groq.com/docs/structured-outputs#supported-models
- * for the full set. Operators can override via `AI_MODEL`, but
- * picking a model outside that set will surface
- * `AI_PROVIDER_UNAVAILABLE` at proposal time.
+ * for the full set. Operators can override via `AI_MODEL` (e.g. drop
+ * to `openai/gpt-oss-20b` for lower latency / cost), but picking a
+ * model outside that set will surface `AI_PROVIDER_UNAVAILABLE` at
+ * proposal time.
  */
-export const GROQ_PROVIDER_DEFAULT_MODEL = "openai/gpt-oss-20b" as const;
+export const GROQ_PROVIDER_DEFAULT_MODEL = "openai/gpt-oss-120b" as const;
 
 export type GroqProviderOptions = {
   apiKey: string;

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -27,6 +27,7 @@ import {
   useEditorState,
   type ReactNodeViewProps,
 } from "@tiptap/react";
+import { Fragment, Slice } from "@tiptap/pm/model";
 
 import {
   Bold,
@@ -783,12 +784,21 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
           if (input.from === input.to) {
             return { text: "", mode: "text" };
           }
-          const slice = editor.state.doc.slice(input.from, input.to, true);
-          // openStart/openEnd > 0 means the slice cuts through a block
-          // node at one end (e.g. the user selected partway into a
-          // bullet item). Standalone markdown can't express that, so
-          // return plain text and let the caller apply it inline.
-          if (slice.openStart > 0 || slice.openEnd > 0) {
+
+          // Decide markdown vs text by whether the cut is at a clean
+          // block boundary, NOT by the slice's open depth. Whole-bullet
+          // selections still have openStart/openEnd > 0 because the
+          // cuts are inside a paragraph inside a listItem inside a
+          // bulletList — but parentOffset === 0 at `from` and
+          // parentOffset === parent.content.size at `to` means we're
+          // structurally aligned and markdown round-trips cleanly.
+          const $from = editor.state.doc.resolve(input.from);
+          const $to = editor.state.doc.resolve(input.to);
+          const fromAtParentStart = $from.parentOffset === 0;
+          const toAtParentEnd = $to.parentOffset === $to.parent.content.size;
+          const isWholeBlockCut = fromAtParentStart && toAtParentEnd;
+
+          if (!isWholeBlockCut) {
             return {
               text: editor.state.doc.textBetween(
                 input.from,
@@ -799,6 +809,8 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
               mode: "text",
             };
           }
+
+          const slice = editor.state.doc.slice(input.from, input.to, true);
           const fragmentJson = slice.content.toJSON() as
             | Array<Record<string, unknown>>
             | undefined;
@@ -852,23 +864,30 @@ export const TipTapEditor = forwardRef<TipTapEditorHandle, TipTapEditorProps>(
           const mode = input.mode ?? "text";
 
           if (mode === "markdown") {
-            // The replacement is treated as markdown — only safe when
-            // the original selection spanned complete blocks (the
-            // caller decides via getSelectionMarkdown's mode field).
-            // Parsing markdown and inserting at a mid-block position
-            // would spawn a nested list; the caller must avoid that.
+            // Parse the AI's reply via the same markdown pipeline the
+            // editor uses, then build a ProseMirror Slice whose open
+            // depths MATCH the original cut. tr.replace fits the slice
+            // into the same structural context — so a whole-bullet
+            // selection's replacement splices listItems into the
+            // existing list instead of nesting a new bulletList inside
+            // it (the symptom that merged two bullets into one).
             const parsedDoc = parseMarkdownToDocument(input.replacementText);
-            const replacementBlocks = (parsedDoc.content ?? []) as Array<
-              Record<string, unknown>
-            >;
-            editor
-              .chain()
-              .focus()
-              .insertContentAt(
-                { from: input.from, to: input.to },
-                replacementBlocks,
-              )
-              .run();
+            const parsedFragment = Fragment.fromJSON(
+              editor.schema,
+              (parsedDoc.content ?? []) as Array<Record<string, unknown>>,
+            );
+            const newSlice = new Slice(
+              parsedFragment,
+              originalSlice.openStart,
+              originalSlice.openEnd,
+            );
+            const tr = editor.state.tr.replace(
+              input.from,
+              input.to,
+              newSlice,
+            );
+            editor.view.dispatch(tr);
+            editor.commands.focus();
           } else {
             // Plain-text mode — insert as inline content so the
             // surrounding block structure (the parent list item,


### PR DESCRIPTION
## Summary

Two small fixes on top of the merged CMS-224/225 inline AI work:

- **Bump `GROQ_PROVIDER_DEFAULT_MODEL` to `openai/gpt-oss-120b`.** Still on Groq's `response_format: json_schema` strict-mode list (so structured output keeps working), produces noticeably better copy edits on selection-anchored rewrites than the 20b. Operators can downgrade via `AI_MODEL` for lower latency / cost. JSDoc + factory comment updated.
- **Stop merging whole-bullet selections into a single list item on rewrite.** Mode detection used `slice.openStart === 0 && slice.openEnd === 0`, which is only true for cuts at the document's outermost boundary — never inside a list (cuts inside a list are at depth 3: paragraph → listItem → bulletList). So whole-bullet selections wrongly fell through to text mode, and plain-text insert across a multi-listItem range collapsed them into one bullet.
  - Switched mode detection to a `parentOffset` check: `from` at start of its parent block AND `to` at end of its parent block. Catches whole-bullet, whole-paragraph, and multi-block selections at any depth.
  - Markdown apply now builds a ProseMirror `Slice` with the original cut's `openStart`/`openEnd` and dispatches `tr.replace`. The slice fits into the same structural context — listItems splice into the surviving bulletList instead of nesting a new bulletList inside a listItem.

Text mode (mid-block selections) is unchanged from #139.

## Test plan
- [ ] `bun run nx run-many -t typecheck -p studio,core.ai` — clean
- [ ] `bun test --cwd packages/studio ./src` — 587 pass
- [ ] `bun test --cwd packages/modules ./core.ai` — 76 pass
- [ ] Manually: select two whole bullet items, hit Rewrite, confirm the result is two replacement bullets (not one merged bullet)
- [ ] Manually: select mid-bullet text, hit Rewrite, confirm the surrounding bullet structure is preserved (regression check on the text-mode path)
- [ ] Manually: with `GROQ_API_KEY` set, exercise an inline transform end-to-end against the new 120b default