### PR TITLE
chore(studio): react-doctor follow-up — state reducers + component decomposition

### DIFF
--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -334,8 +334,17 @@ function ContentTypeDocumentsTable({
           {documents.map((doc) => (
             <TableRow
               key={doc.documentId}
-              className="cursor-pointer border-b border-divider/60 last:border-0"
+              role="button"
+              tabIndex={0}
+              aria-label={`Open document ${doc.title}`}
+              className="cursor-pointer border-b border-divider/60 last:border-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring"
               onClick={() => onRowClick(doc.documentId)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onRowClick(doc.documentId);
+                }
+              }}
             >
               <TableCell className="px-4 py-3">
                 <div className="max-w-[480px]">
@@ -410,6 +419,13 @@ function ContentTypePaginationBar({
   totalPages: number;
   onPageChange: (newOffset: number) => void;
 }) {
+  const maxOffset = Math.max(0, (totalPages - 1) * PAGE_SIZE);
+  const clamp = (value: number) => Math.max(0, Math.min(value, maxOffset));
+  const visibleCount = Math.min(5, totalPages);
+  const windowStart = Math.max(
+    1,
+    Math.min(currentPage - 2, totalPages - visibleCount + 1),
+  );
   return (
     <div className="flex items-center justify-between">
       <p className="text-sm text-foreground-muted">
@@ -420,7 +436,7 @@ function ContentTypePaginationBar({
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
-              onClick={() => onPageChange(Math.max(0, offset - PAGE_SIZE))}
+              onClick={() => onPageChange(clamp(offset - PAGE_SIZE))}
               className={
                 currentPage === 1
                   ? "pointer-events-none opacity-50"
@@ -428,12 +444,12 @@ function ContentTypePaginationBar({
               }
             />
           </PaginationItem>
-          {Array.from({ length: Math.min(5, totalPages) }).map((_, i) => {
-            const page = i + 1;
+          {Array.from({ length: visibleCount }).map((_, i) => {
+            const page = windowStart + i;
             return (
               <PaginationItem key={page}>
                 <PaginationLink
-                  onClick={() => onPageChange((page - 1) * PAGE_SIZE)}
+                  onClick={() => onPageChange(clamp((page - 1) * PAGE_SIZE))}
                   isActive={currentPage === page}
                   className="cursor-pointer"
                 >
@@ -444,7 +460,7 @@ function ContentTypePaginationBar({
           })}
           <PaginationItem>
             <PaginationNext
-              onClick={() => onPageChange(offset + PAGE_SIZE)}
+              onClick={() => onPageChange(clamp(offset + PAGE_SIZE))}
               className={
                 currentPage === totalPages
                   ? "pointer-events-none opacity-50"

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -274,6 +274,190 @@ function RowActions({
   );
 }
 
+function ContentTypeDocumentsTable({
+  documents,
+  users,
+  capabilities,
+  pendingRowAction,
+  showTranslationCoverage,
+  translationCoverageStatus,
+  translationCoverageByGroup,
+  tableColumns,
+  onRowClick,
+  rowActionHandlers,
+}: {
+  documents: MappedContentDocument[];
+  users: Record<string, { email?: string; name?: string }>;
+  capabilities: {
+    canPublishContent: boolean;
+    canUnpublishContent: boolean;
+    canCreateContent: boolean;
+    canDeleteContent: boolean;
+  };
+  pendingRowAction: boolean;
+  showTranslationCoverage: boolean;
+  translationCoverageStatus: ReturnType<
+    typeof useContentTypeList
+  >["translationCoverageStatus"];
+  translationCoverageByGroup: ReturnType<
+    typeof useContentTypeList
+  >["translationCoverageByGroup"];
+  tableColumns: ReturnType<typeof getContentTypeTableColumns>;
+  onRowClick: (documentId: string) => void;
+  rowActionHandlers: {
+    onEdit: (documentId: string) => void;
+    onPublish: (documentId: string) => void;
+    onUnpublish: (documentId: string) => void;
+    onDuplicate: (documentId: string) => void;
+    onDelete: (documentId: string) => void;
+  };
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-card-border bg-card">
+      <Table>
+        <TableHeader className="bg-background-subtle">
+          <TableRow>
+            {tableColumns.map((column) => (
+              <TableHead
+                key={column.key}
+                className={cn(
+                  "h-10 px-4 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-foreground-muted",
+                  column.className,
+                )}
+              >
+                {column.label}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {documents.map((doc) => (
+            <TableRow
+              key={doc.documentId}
+              className="cursor-pointer border-b border-divider/60 last:border-0"
+              onClick={() => onRowClick(doc.documentId)}
+            >
+              <TableCell className="px-4 py-3">
+                <div className="max-w-[480px]">
+                  <p className="truncate text-[13px] font-semibold text-foreground">
+                    {doc.title}
+                  </p>
+                  <p className="truncate font-mono text-[11px] text-foreground-muted">
+                    {doc.path}
+                  </p>
+                </div>
+              </TableCell>
+              {showTranslationCoverage ? (
+                <TableCell className="px-4 py-3">
+                  <TranslationCoverageSummary
+                    status={translationCoverageStatus}
+                    coverage={
+                      translationCoverageByGroup[doc.translationGroupId]
+                    }
+                  />
+                </TableCell>
+              ) : null}
+              <TableCell className="px-4 py-3">
+                <span className={statusConfig[doc.status].className}>
+                  {statusConfig[doc.status].label}
+                </span>
+              </TableCell>
+              <TableCell className="px-4 py-3 font-mono text-[11px] text-foreground-muted">
+                {formatRelativeTime(doc.updatedAt)}
+              </TableCell>
+              <TableCell className="px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <Avatar className="size-6">
+                    <AvatarFallback className="bg-blue-100 text-[10px] font-bold text-primary">
+                      {deriveAuthorInitials(users[doc.updatedBy]?.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                </div>
+              </TableCell>
+              <TableCell
+                className="px-4 py-3"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <RowActions
+                  doc={doc}
+                  capabilities={capabilities}
+                  pending={pendingRowAction}
+                  onEdit={rowActionHandlers.onEdit}
+                  onPublish={rowActionHandlers.onPublish}
+                  onUnpublish={rowActionHandlers.onUnpublish}
+                  onDuplicate={rowActionHandlers.onDuplicate}
+                  onDelete={rowActionHandlers.onDelete}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function ContentTypePaginationBar({
+  offset,
+  total,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: {
+  offset: number;
+  total: number;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (newOffset: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-foreground-muted">
+        Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}{" "}
+        documents
+      </p>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => onPageChange(Math.max(0, offset - PAGE_SIZE))}
+              className={
+                currentPage === 1
+                  ? "pointer-events-none opacity-50"
+                  : "cursor-pointer"
+              }
+            />
+          </PaginationItem>
+          {Array.from({ length: Math.min(5, totalPages) }).map((_, i) => {
+            const page = i + 1;
+            return (
+              <PaginationItem key={page}>
+                <PaginationLink
+                  onClick={() => onPageChange((page - 1) * PAGE_SIZE)}
+                  isActive={currentPage === page}
+                  className="cursor-pointer"
+                >
+                  {page}
+                </PaginationLink>
+              </PaginationItem>
+            );
+          })}
+          <PaginationItem>
+            <PaginationNext
+              onClick={() => onPageChange(offset + PAGE_SIZE)}
+              className={
+                currentPage === totalPages
+                  ? "pointer-events-none opacity-50"
+                  : "cursor-pointer"
+              }
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
 export default function ContentTypePage() {
   const params = useParams();
   const router = useRouter();
@@ -631,95 +815,20 @@ export default function ContentTypePage() {
         {list.status === "ready" && (
           <>
             {list.documents.length > 0 ? (
-              <div className="overflow-hidden rounded-lg border border-card-border bg-card">
-                <Table>
-                  <TableHeader className="bg-background-subtle">
-                    <TableRow>
-                      {tableColumns.map((column) => (
-                        <TableHead
-                          key={column.key}
-                          className={cn(
-                            "h-10 px-4 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-foreground-muted",
-                            column.className,
-                          )}
-                        >
-                          {column.label}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {list.documents.map((doc) => (
-                      <TableRow
-                        key={doc.documentId}
-                        className="cursor-pointer border-b border-divider/60 last:border-0"
-                        onClick={() =>
-                          router.push(
-                            `/admin/content/${typeId}/${doc.documentId}`,
-                          )
-                        }
-                      >
-                        <TableCell className="px-4 py-3">
-                          <div className="max-w-[480px]">
-                            <p className="truncate text-[13px] font-semibold text-foreground">
-                              {doc.title}
-                            </p>
-                            <p className="truncate font-mono text-[11px] text-foreground-muted">
-                              {doc.path}
-                            </p>
-                          </div>
-                        </TableCell>
-                        {showTranslationCoverage ? (
-                          <TableCell className="px-4 py-3">
-                            <TranslationCoverageSummary
-                              status={list.translationCoverageStatus}
-                              coverage={
-                                list.translationCoverageByGroup[
-                                  doc.translationGroupId
-                                ]
-                              }
-                            />
-                          </TableCell>
-                        ) : null}
-                        <TableCell className="px-4 py-3">
-                          <span className={statusConfig[doc.status].className}>
-                            {statusConfig[doc.status].label}
-                          </span>
-                        </TableCell>
-                        <TableCell className="px-4 py-3 font-mono text-[11px] text-foreground-muted">
-                          {formatRelativeTime(doc.updatedAt)}
-                        </TableCell>
-                        <TableCell className="px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <Avatar className="size-6">
-                              <AvatarFallback className="bg-blue-100 text-[10px] font-bold text-primary">
-                                {deriveAuthorInitials(
-                                  list.users[doc.updatedBy]?.email,
-                                )}
-                              </AvatarFallback>
-                            </Avatar>
-                          </div>
-                        </TableCell>
-                        <TableCell
-                          className="px-4 py-3"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <RowActions
-                            doc={doc}
-                            capabilities={capabilities}
-                            pending={isRowActionPending}
-                            onEdit={rowActionHandlers.onEdit}
-                            onPublish={rowActionHandlers.onPublish}
-                            onUnpublish={rowActionHandlers.onUnpublish}
-                            onDuplicate={rowActionHandlers.onDuplicate}
-                            onDelete={rowActionHandlers.onDelete}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+              <ContentTypeDocumentsTable
+                documents={list.documents}
+                users={list.users}
+                capabilities={capabilities}
+                pendingRowAction={isRowActionPending}
+                showTranslationCoverage={showTranslationCoverage}
+                translationCoverageStatus={list.translationCoverageStatus}
+                translationCoverageByGroup={list.translationCoverageByGroup}
+                tableColumns={tableColumns}
+                onRowClick={(documentId) =>
+                  router.push(`/admin/content/${typeId}/${documentId}`)
+                }
+                rowActionHandlers={rowActionHandlers}
+              />
             ) : (
               <div className="flex flex-col items-center justify-center py-16 text-center">
                 <div className="mb-4 rounded-full bg-background-subtle p-4">
@@ -733,64 +842,13 @@ export default function ContentTypePage() {
             )}
 
             {totalPages > 1 && list.pagination && (
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-foreground-muted">
-                  Showing {list.pagination.offset + 1}–
-                  {Math.min(
-                    list.pagination.offset + PAGE_SIZE,
-                    list.pagination.total,
-                  )}{" "}
-                  of {list.pagination.total} documents
-                </p>
-                <Pagination>
-                  <PaginationContent>
-                    <PaginationItem>
-                      <PaginationPrevious
-                        onClick={() =>
-                          list.setPage(
-                            Math.max(0, list.pagination!.offset - PAGE_SIZE),
-                          )
-                        }
-                        className={
-                          currentPage === 1
-                            ? "pointer-events-none opacity-50"
-                            : "cursor-pointer"
-                        }
-                      />
-                    </PaginationItem>
-                    {Array.from({ length: Math.min(5, totalPages) }).map(
-                      (_, i) => {
-                        const page = i + 1;
-                        return (
-                          <PaginationItem key={page}>
-                            <PaginationLink
-                              onClick={() =>
-                                list.setPage((page - 1) * PAGE_SIZE)
-                              }
-                              isActive={currentPage === page}
-                              className="cursor-pointer"
-                            >
-                              {page}
-                            </PaginationLink>
-                          </PaginationItem>
-                        );
-                      },
-                    )}
-                    <PaginationItem>
-                      <PaginationNext
-                        onClick={() =>
-                          list.setPage(list.pagination!.offset + PAGE_SIZE)
-                        }
-                        className={
-                          currentPage === totalPages
-                            ? "pointer-events-none opacity-50"
-                            : "cursor-pointer"
-                        }
-                      />
-                    </PaginationItem>
-                  </PaginationContent>
-                </Pagination>
-              </div>
+              <ContentTypePaginationBar
+                offset={list.pagination.offset}
+                total={list.pagination.total}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={(newOffset) => list.setPage(newOffset)}
+              />
             )}
           </>
         )}

--- a/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
@@ -286,6 +286,13 @@ function TrashPagination({
   totalPages: number;
   onPageChange: (newOffset: number) => void;
 }) {
+  const maxOffset = Math.max(0, (totalPages - 1) * TRASH_PAGE_SIZE);
+  const clamp = (value: number) => Math.max(0, Math.min(value, maxOffset));
+  const visibleCount = Math.min(5, totalPages);
+  const windowStart = Math.max(
+    1,
+    Math.min(currentPage - 2, totalPages - visibleCount + 1),
+  );
   return (
     <div className="flex items-center justify-between">
       <p className="text-sm text-foreground-muted">
@@ -296,9 +303,7 @@ function TrashPagination({
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
-              onClick={() =>
-                onPageChange(Math.max(0, offset - TRASH_PAGE_SIZE))
-              }
+              onClick={() => onPageChange(clamp(offset - TRASH_PAGE_SIZE))}
               className={
                 currentPage === 1
                   ? "pointer-events-none opacity-50"
@@ -306,12 +311,14 @@ function TrashPagination({
               }
             />
           </PaginationItem>
-          {Array.from({ length: Math.min(5, totalPages) }).map((_, i) => {
-            const page = i + 1;
+          {Array.from({ length: visibleCount }).map((_, i) => {
+            const page = windowStart + i;
             return (
               <PaginationItem key={page}>
                 <PaginationLink
-                  onClick={() => onPageChange((page - 1) * TRASH_PAGE_SIZE)}
+                  onClick={() =>
+                    onPageChange(clamp((page - 1) * TRASH_PAGE_SIZE))
+                  }
                   isActive={currentPage === page}
                   className="cursor-pointer"
                 >
@@ -322,7 +329,7 @@ function TrashPagination({
           })}
           <PaginationItem>
             <PaginationNext
-              onClick={() => onPageChange(offset + TRASH_PAGE_SIZE)}
+              onClick={() => onPageChange(clamp(offset + TRASH_PAGE_SIZE))}
               className={
                 currentPage === totalPages
                   ? "pointer-events-none opacity-50"

--- a/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/trash-page.tsx
@@ -121,6 +121,221 @@ function TrashRowActions({
   );
 }
 
+function TrashFilterBar({
+  searchInput,
+  onSearchChange,
+  typeFilter,
+  onTypeChange,
+  schemaTypes,
+  sort,
+  onSortChange,
+}: {
+  searchInput: string;
+  onSearchChange: (value: string) => void;
+  typeFilter: string | undefined;
+  onTypeChange: (value: string | undefined) => void;
+  schemaTypes: string[];
+  sort: TrashListSort | undefined;
+  onSortChange: (value: TrashListSort) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-foreground-muted" />
+          <Input
+            aria-label="Search deleted documents"
+            placeholder="Search deleted documents..."
+            value={searchInput}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-9 w-72"
+          />
+        </div>
+        <Select
+          value={typeFilter ?? "all"}
+          onValueChange={(value) =>
+            onTypeChange(value === "all" ? undefined : value)
+          }
+        >
+          <SelectTrigger className="w-36" aria-label="Filter by type">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            {schemaTypes.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Select
+        value={sort ?? "updated"}
+        onValueChange={(value) => onSortChange(value as TrashListSort)}
+      >
+        <SelectTrigger className="w-36" aria-label="Sort order">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="updated">Newest first</SelectItem>
+          <SelectItem value="created">Created</SelectItem>
+          <SelectItem value="path-asc">Path A-Z</SelectItem>
+          <SelectItem value="path-desc">Path Z-A</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function TrashEmptyMatch() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="mb-4 rounded-full bg-background-subtle p-4">
+        <Search className="size-8 text-foreground-muted" />
+      </div>
+      <h3 className="mb-2 text-lg font-semibold">No results</h3>
+      <p className="text-sm text-foreground-muted">
+        No deleted documents match your current filters.
+      </p>
+    </div>
+  );
+}
+
+function TrashTable({
+  documents,
+  users,
+  restoreDisabled,
+  onRestore,
+}: {
+  documents: MappedTrashDocument[];
+  users: Record<string, { email?: string; name?: string }>;
+  restoreDisabled: boolean;
+  onRestore: (documentId: string) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Title / Path</TableHead>
+            <TableHead className="w-28">Type</TableHead>
+            <TableHead className="w-32">Deleted</TableHead>
+            <TableHead className="w-28">Author</TableHead>
+            <TableHead className="w-14"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {documents.map((doc) => (
+            <TableRow key={doc.documentId}>
+              <TableCell>
+                <div>
+                  <p className="font-medium">{doc.title}</p>
+                  <p className="text-xs text-foreground-muted font-mono">
+                    {doc.path}
+                  </p>
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline" className="text-xs">
+                  {doc.type}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-sm text-foreground-muted">
+                {formatRelativeTime(doc.deletedAt)}
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2">
+                  <Avatar className="size-6">
+                    <AvatarFallback className="text-xs">
+                      {deriveAuthorInitials(users[doc.deletedBy]?.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm text-foreground-muted truncate max-w-[8rem]">
+                    {users[doc.deletedBy]?.name ??
+                      users[doc.deletedBy]?.email ??
+                      "Unknown"}
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>
+                <TrashRowActions
+                  doc={doc}
+                  disabled={restoreDisabled}
+                  onRestore={onRestore}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function TrashPagination({
+  offset,
+  total,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: {
+  offset: number;
+  total: number;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (newOffset: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-foreground-muted">
+        Showing {offset + 1}–{Math.min(offset + TRASH_PAGE_SIZE, total)} of{" "}
+        {total} documents
+      </p>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() =>
+                onPageChange(Math.max(0, offset - TRASH_PAGE_SIZE))
+              }
+              className={
+                currentPage === 1
+                  ? "pointer-events-none opacity-50"
+                  : "cursor-pointer"
+              }
+            />
+          </PaginationItem>
+          {Array.from({ length: Math.min(5, totalPages) }).map((_, i) => {
+            const page = i + 1;
+            return (
+              <PaginationItem key={page}>
+                <PaginationLink
+                  onClick={() => onPageChange((page - 1) * TRASH_PAGE_SIZE)}
+                  isActive={currentPage === page}
+                  className="cursor-pointer"
+                >
+                  {page}
+                </PaginationLink>
+              </PaginationItem>
+            );
+          })}
+          <PaginationItem>
+            <PaginationNext
+              onClick={() => onPageChange(offset + TRASH_PAGE_SIZE)}
+              className={
+                currentPage === totalPages
+                  ? "pointer-events-none opacity-50"
+                  : "cursor-pointer"
+              }
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
 export default function TrashPage() {
   const mountInfo = useStudioMountInfo();
   const capabilities = useAdminCapabilities();
@@ -255,57 +470,15 @@ export default function TrashPage() {
           </p>
         </div>
 
-        {/* Toolbar */}
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-foreground-muted" />
-              <Input
-                aria-label="Search deleted documents"
-                placeholder="Search deleted documents..."
-                value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value)}
-                className="pl-9 w-72"
-              />
-            </div>
-            <Select
-              value={list.filters.type ?? "all"}
-              onValueChange={(value) =>
-                list.setFilters({
-                  type: value === "all" ? undefined : value,
-                })
-              }
-            >
-              <SelectTrigger className="w-36" aria-label="Filter by type">
-                <SelectValue placeholder="All types" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All types</SelectItem>
-                {schemaTypes.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {type}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <Select
-            value={list.filters.sort ?? "updated"}
-            onValueChange={(value) =>
-              list.setFilters({ sort: value as TrashListSort })
-            }
-          >
-            <SelectTrigger className="w-36" aria-label="Sort order">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="updated">Newest first</SelectItem>
-              <SelectItem value="created">Created</SelectItem>
-              <SelectItem value="path-asc">Path A-Z</SelectItem>
-              <SelectItem value="path-desc">Path Z-A</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <TrashFilterBar
+          searchInput={searchInput}
+          onSearchChange={setSearchInput}
+          typeFilter={list.filters.type}
+          onTypeChange={(value) => list.setFilters({ type: value })}
+          schemaTypes={schemaTypes}
+          sort={list.filters.sort}
+          onSortChange={(value) => list.setFilters({ sort: value })}
+        />
 
         {/* Row action error banner */}
         {rowActionError && (
@@ -372,140 +545,24 @@ export default function TrashPage() {
         {list.status === "ready" && (
           <>
             {list.documents.length > 0 ? (
-              <div className="rounded-lg border border-border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Title / Path</TableHead>
-                      <TableHead className="w-28">Type</TableHead>
-                      <TableHead className="w-32">Deleted</TableHead>
-                      <TableHead className="w-28">Author</TableHead>
-                      <TableHead className="w-14"></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {list.documents.map((doc) => (
-                      <TableRow key={doc.documentId}>
-                        <TableCell>
-                          <div>
-                            <p className="font-medium">{doc.title}</p>
-                            <p className="text-xs text-foreground-muted font-mono">
-                              {doc.path}
-                            </p>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className="text-xs">
-                            {doc.type}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-sm text-foreground-muted">
-                          {formatRelativeTime(doc.deletedAt)}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <Avatar className="size-6">
-                              <AvatarFallback className="text-xs">
-                                {deriveAuthorInitials(
-                                  list.users[doc.deletedBy]?.email,
-                                )}
-                              </AvatarFallback>
-                            </Avatar>
-                            <span className="text-sm text-foreground-muted truncate max-w-[8rem]">
-                              {list.users[doc.deletedBy]?.name ??
-                                list.users[doc.deletedBy]?.email ??
-                                "Unknown"}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <TrashRowActions
-                            doc={doc}
-                            disabled={restoreDisabled}
-                            onRestore={restoreHandler}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+              <TrashTable
+                documents={list.documents}
+                users={list.users}
+                restoreDisabled={restoreDisabled}
+                onRestore={restoreHandler}
+              />
             ) : (
-              <div className="flex flex-col items-center justify-center py-16 text-center">
-                <div className="mb-4 rounded-full bg-background-subtle p-4">
-                  <Search className="size-8 text-foreground-muted" />
-                </div>
-                <h3 className="mb-2 text-lg font-semibold">No results</h3>
-                <p className="text-sm text-foreground-muted">
-                  No deleted documents match your current filters.
-                </p>
-              </div>
+              <TrashEmptyMatch />
             )}
 
             {totalPages > 1 && list.pagination && (
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-foreground-muted">
-                  Showing {list.pagination.offset + 1}–
-                  {Math.min(
-                    list.pagination.offset + TRASH_PAGE_SIZE,
-                    list.pagination.total,
-                  )}{" "}
-                  of {list.pagination.total} documents
-                </p>
-                <Pagination>
-                  <PaginationContent>
-                    <PaginationItem>
-                      <PaginationPrevious
-                        onClick={() =>
-                          list.setPage(
-                            Math.max(
-                              0,
-                              list.pagination!.offset - TRASH_PAGE_SIZE,
-                            ),
-                          )
-                        }
-                        className={
-                          currentPage === 1
-                            ? "pointer-events-none opacity-50"
-                            : "cursor-pointer"
-                        }
-                      />
-                    </PaginationItem>
-                    {Array.from({ length: Math.min(5, totalPages) }).map(
-                      (_, i) => {
-                        const page = i + 1;
-                        return (
-                          <PaginationItem key={page}>
-                            <PaginationLink
-                              onClick={() =>
-                                list.setPage((page - 1) * TRASH_PAGE_SIZE)
-                              }
-                              isActive={currentPage === page}
-                              className="cursor-pointer"
-                            >
-                              {page}
-                            </PaginationLink>
-                          </PaginationItem>
-                        );
-                      },
-                    )}
-                    <PaginationItem>
-                      <PaginationNext
-                        onClick={() =>
-                          list.setPage(
-                            list.pagination!.offset + TRASH_PAGE_SIZE,
-                          )
-                        }
-                        className={
-                          currentPage === totalPages
-                            ? "pointer-events-none opacity-50"
-                            : "cursor-pointer"
-                        }
-                      />
-                    </PaginationItem>
-                  </PaginationContent>
-                </Pagination>
-              </div>
+              <TrashPagination
+                offset={list.pagination.offset}
+                total={list.pagination.total}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={(newOffset) => list.setPage(newOffset)}
+              />
             )}
           </>
         )}

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -353,11 +353,13 @@ function EditRoleDialog({
 }) {
   const [role, setRole] = useState<string>("editor");
   const [pathPrefix, setPathPrefix] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (target) {
       setRole(target.currentRole);
       setPathPrefix(target.currentGrants[0]?.pathPrefix ?? "");
+      setError(null);
     }
   }, [target]);
 
@@ -398,9 +400,14 @@ function EditRoleDialog({
             })),
           ]
         : [editedGrant];
-    await updateGrants(target.userId, updatedGrants);
-    onSaved(target.userName);
-    onOpenChange(false);
+    setError(null);
+    try {
+      await updateGrants(target.userId, updatedGrants);
+      onSaved(target.userName);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update role.");
+    }
   }
 
   return (
@@ -444,6 +451,7 @@ function EditRoleDialog({
               </p>
             </div>
           )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -200,9 +200,7 @@ function InviteUserDialog({
                   ? "folder_prefix"
                   : "project",
             project:
-              form.role === "admin"
-                ? undefined
-                : activeProject || undefined,
+              form.role === "admin" ? undefined : activeProject || undefined,
             environment:
               form.role === "admin"
                 ? undefined
@@ -385,11 +383,7 @@ function EditRoleDialog({
             ? activeEnvironment
             : undefined,
       pathPrefix:
-        role === "admin"
-          ? undefined
-          : useFolderPrefix
-            ? pathPrefix
-            : undefined,
+        role === "admin" ? undefined : useFolderPrefix ? pathPrefix : undefined,
     };
     const updatedGrants =
       target.currentGrants.length > 1
@@ -821,9 +815,7 @@ export default function UsersPage() {
           isUpdatingGrants={isUpdatingGrants}
           activeEnvironment={activeEnvironment}
           activeProject={activeProject}
-          onSaved={(userName) =>
-            toast.success(`Role updated for ${userName}.`)
-          }
+          onSaved={(userName) => toast.success(`Role updated for ${userName}.`)}
         />
       </div>
     </div>

--- a/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/users-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import {
   Plus,
   MoreHorizontal,
@@ -84,13 +84,18 @@ const roleConfig = {
   },
 };
 
-function getHighestRole(
-  grants: UserWithGrants["grants"],
-): "owner" | "admin" | "editor" | "viewer" {
-  const roleRank = { owner: 3, admin: 2, editor: 1, viewer: 0 };
-  let highest: "owner" | "admin" | "editor" | "viewer" = "viewer";
+type Role = keyof typeof roleConfig;
+
+function getHighestRole(grants: UserWithGrants["grants"]): Role {
+  const roleRank: Record<Role, number> = {
+    owner: 3,
+    admin: 2,
+    editor: 1,
+    viewer: 0,
+  };
+  let highest: Role = "viewer";
   for (const grant of grants) {
-    const role = grant.role as keyof typeof roleRank;
+    const role = grant.role as Role;
     if (roleRank[role] !== undefined && roleRank[role] > roleRank[highest]) {
       highest = role;
     }
@@ -119,24 +124,554 @@ function formatJoinedDate(isoString: string): string {
   });
 }
 
+/* ----------------------------------------------------------------- */
+/* InviteUserDialog                                                   */
+/* ----------------------------------------------------------------- */
+
+type InviteFormState = {
+  email: string;
+  role: string;
+  pathPrefix: string;
+  error: string | null;
+};
+
+const initialInviteState: InviteFormState = {
+  email: "",
+  role: "editor",
+  pathPrefix: "",
+  error: null,
+};
+
+type InviteFormAction =
+  | { type: "reset" }
+  | { type: "field"; field: "email" | "role" | "pathPrefix"; value: string }
+  | { type: "error"; message: string | null };
+
+function inviteFormReducer(
+  state: InviteFormState,
+  action: InviteFormAction,
+): InviteFormState {
+  switch (action.type) {
+    case "reset":
+      return initialInviteState;
+    case "field":
+      return { ...state, [action.field]: action.value };
+    case "error":
+      return { ...state, error: action.message };
+  }
+}
+
+function InviteUserDialog({
+  open,
+  onOpenChange,
+  inviteUser,
+  isInviting,
+  activeProject,
+  activeEnvironment,
+  onInvited,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  inviteUser: ReturnType<typeof useUserList>["inviteUser"];
+  isInviting: boolean;
+  activeProject: string | null;
+  activeEnvironment: string | null;
+  onInvited: () => void;
+}) {
+  const [form, dispatch] = useReducer(inviteFormReducer, initialInviteState);
+
+  useEffect(() => {
+    if (!open) dispatch({ type: "reset" });
+  }, [open]);
+
+  async function handleInvite() {
+    dispatch({ type: "error", message: null });
+    try {
+      const useFolderPrefix = form.pathPrefix && activeEnvironment;
+      await inviteUser({
+        email: form.email,
+        grants: [
+          {
+            role: form.role,
+            scopeKind:
+              form.role === "admin"
+                ? "global"
+                : useFolderPrefix
+                  ? "folder_prefix"
+                  : "project",
+            project:
+              form.role === "admin"
+                ? undefined
+                : activeProject || undefined,
+            environment:
+              form.role === "admin"
+                ? undefined
+                : useFolderPrefix
+                  ? activeEnvironment
+                  : undefined,
+            pathPrefix:
+              form.role === "admin"
+                ? undefined
+                : useFolderPrefix
+                  ? form.pathPrefix
+                  : undefined,
+          },
+        ],
+      });
+      onInvited();
+      onOpenChange(false);
+    } catch (err) {
+      dispatch({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : "Failed to send invitation.",
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 size-4" />
+          Invite User
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite a new user</DialogTitle>
+          <DialogDescription>
+            Send an invitation to join this CMS instance
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-foreground-muted" />
+              <Input
+                id="email"
+                type="email"
+                placeholder="user@company.com"
+                value={form.email}
+                onChange={(e) =>
+                  dispatch({
+                    type: "field",
+                    field: "email",
+                    value: e.target.value,
+                  })
+                }
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Role</Label>
+            <Select
+              value={form.role}
+              onValueChange={(value) =>
+                dispatch({ type: "field", field: "role", value })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+                <SelectItem value="viewer">Viewer</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {(form.role === "editor" || form.role === "viewer") && (
+            <div className="space-y-2">
+              <Label htmlFor="path-prefix">Folder prefix (optional)</Label>
+              <Input
+                id="path-prefix"
+                placeholder="e.g. content/blog"
+                value={form.pathPrefix}
+                onChange={(e) =>
+                  dispatch({
+                    type: "field",
+                    field: "pathPrefix",
+                    value: e.target.value,
+                  })
+                }
+                className="font-mono"
+              />
+              <p className="text-xs text-foreground-muted">
+                Restricts access to content under this path only. Leave empty
+                for full project access.
+              </p>
+            </div>
+          )}
+
+          {form.error && (
+            <p className="text-sm text-destructive">{form.error}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={isInviting || !form.email} onClick={handleInvite}>
+            {isInviting ? "Sending..." : "Send Invitation"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* EditRoleDialog                                                     */
+/* ----------------------------------------------------------------- */
+
+export type EditRoleTarget = {
+  userId: string;
+  userName: string;
+  currentRole: Role;
+  currentGrants: UserWithGrants["grants"];
+};
+
+function EditRoleDialog({
+  target,
+  onOpenChange,
+  updateGrants,
+  isUpdatingGrants,
+  activeEnvironment,
+  activeProject,
+  onSaved,
+}: {
+  target: EditRoleTarget | null;
+  onOpenChange: (open: boolean) => void;
+  updateGrants: ReturnType<typeof useUserList>["updateGrants"];
+  isUpdatingGrants: boolean;
+  activeEnvironment: string | null;
+  activeProject: string | null;
+  onSaved: (userName: string) => void;
+}) {
+  const [role, setRole] = useState<string>("editor");
+  const [pathPrefix, setPathPrefix] = useState("");
+
+  useEffect(() => {
+    if (target) {
+      setRole(target.currentRole);
+      setPathPrefix(target.currentGrants[0]?.pathPrefix ?? "");
+    }
+  }, [target]);
+
+  async function handleSave() {
+    if (!target) return;
+    const useFolderPrefix = pathPrefix && activeEnvironment;
+    const editedGrant = {
+      role,
+      scopeKind:
+        role === "admin"
+          ? "global"
+          : useFolderPrefix
+            ? "folder_prefix"
+            : "project",
+      project:
+        role === "admin"
+          ? undefined
+          : (target.currentGrants[0]?.project ?? activeProject ?? undefined),
+      environment:
+        role === "admin"
+          ? undefined
+          : useFolderPrefix
+            ? activeEnvironment
+            : undefined,
+      pathPrefix:
+        role === "admin"
+          ? undefined
+          : useFolderPrefix
+            ? pathPrefix
+            : undefined,
+    };
+    const updatedGrants =
+      target.currentGrants.length > 1
+        ? [
+            editedGrant,
+            ...target.currentGrants.slice(1).map((g) => ({
+              role: g.role,
+              scopeKind: g.scopeKind,
+              project: g.project ?? undefined,
+              environment: g.environment ?? undefined,
+              pathPrefix: g.pathPrefix ?? undefined,
+            })),
+          ]
+        : [editedGrant];
+    await updateGrants(target.userId, updatedGrants);
+    onSaved(target.userName);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={target !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit role</DialogTitle>
+          <DialogDescription>
+            Change the role for {target?.userName}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label>Role</Label>
+            <Select value={role} onValueChange={setRole}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+                <SelectItem value="viewer">Viewer</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {(role === "editor" || role === "viewer") && (
+            <div className="space-y-2">
+              <Label htmlFor="edit-role-path-prefix">
+                Folder prefix (optional)
+              </Label>
+              <Input
+                id="edit-role-path-prefix"
+                placeholder="e.g. content/blog"
+                value={pathPrefix}
+                onChange={(e) => setPathPrefix(e.target.value)}
+                className="font-mono"
+              />
+              <p className="text-xs text-foreground-muted">
+                Restricts access to content under this path only. Leave empty
+                for full project access.
+              </p>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={isUpdatingGrants} onClick={handleSave}>
+            {isUpdatingGrants ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* PendingInvitesList                                                 */
+/* ----------------------------------------------------------------- */
+
+function PendingInvitesList({
+  invites,
+  isRevoking,
+  onRevoke,
+}: {
+  invites: ReturnType<typeof useUserList>["pendingInvites"];
+  isRevoking: boolean;
+  onRevoke: (inviteId: string, email: string) => void;
+}) {
+  if (invites.length === 0) return null;
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium text-foreground-muted">
+        Pending Invitations ({invites.length})
+      </h2>
+      <div className="rounded-lg border border-border divide-y divide-border">
+        {invites.map((invite) => (
+          <div
+            key={invite.id}
+            className="flex items-center justify-between px-4 py-3"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex size-8 items-center justify-center rounded-full bg-background-subtle">
+                <Clock className="size-4 text-foreground-muted" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">{invite.email}</p>
+                <p className="text-xs text-foreground-muted">
+                  Expires {formatJoinedDate(invite.expiresAt)}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                {invite.grants[0]?.role ?? "editor"}
+              </Badge>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 text-foreground-muted hover:text-destructive"
+                disabled={isRevoking}
+                onClick={() => onRevoke(invite.id, invite.email)}
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* UsersTable                                                         */
+/* ----------------------------------------------------------------- */
+
+function UsersTable({
+  users,
+  isRemoving,
+  isRevokingSessions,
+  onEditRole,
+  onRevokeSessions,
+  onRemoveUser,
+}: {
+  users: ReturnType<typeof useUserList>["users"];
+  isRemoving: boolean;
+  isRevokingSessions: boolean;
+  onEditRole: (target: EditRoleTarget) => void;
+  onRevokeSessions: (userId: string, userName: string) => void;
+  onRemoveUser: (userId: string, userName: string) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead className="w-28">Role</TableHead>
+            <TableHead className="w-32">Scope</TableHead>
+            <TableHead className="w-28">Joined</TableHead>
+            <TableHead className="w-14"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((user) => {
+            const role = getHighestRole(user.grants);
+            return (
+              <TableRow key={user.id}>
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <Avatar className="size-8">
+                      <AvatarFallback>
+                        {user.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="font-medium">{user.name}</p>
+                      <p className="text-sm text-foreground-muted">
+                        {user.email}
+                      </p>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className={cn("text-xs", roleConfig[role].className)}
+                  >
+                    {roleConfig[role].label}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-sm text-foreground-muted">
+                  {getScopeLabel(user.grants)}
+                </TableCell>
+                <TableCell className="text-sm text-foreground-muted">
+                  {formatJoinedDate(user.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="size-8">
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <TooltipProvider>
+                        <DropdownMenuItem
+                          disabled={role === "owner"}
+                          onClick={() =>
+                            onEditRole({
+                              userId: user.id,
+                              userName: user.name,
+                              currentRole: role,
+                              currentGrants: user.grants,
+                            })
+                          }
+                        >
+                          <Edit className="mr-2 size-4" />
+                          Edit role
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={isRevokingSessions}
+                          onClick={() => onRevokeSessions(user.id, user.name)}
+                        >
+                          <LogOut className="mr-2 size-4" />
+                          Revoke sessions
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        {role === "owner" ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="w-full">
+                                <DropdownMenuItem
+                                  className="text-destructive focus:text-destructive"
+                                  disabled
+                                >
+                                  <Trash2 className="mr-2 size-4" />
+                                  Remove user
+                                </DropdownMenuItem>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="left">
+                              <p>
+                                Owners cannot be removed. Transfer ownership
+                                first.
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            disabled={isRemoving}
+                            onClick={() => onRemoveUser(user.id, user.name)}
+                          >
+                            <Trash2 className="mr-2 size-4" />
+                            Remove user
+                          </DropdownMenuItem>
+                        )}
+                      </TooltipProvider>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* UsersPage (orchestrator)                                           */
+/* ----------------------------------------------------------------- */
+
 export default function UsersPage() {
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
-  const [inviteData, setInviteData] = useState({
-    email: "",
-    role: "editor",
-    pathPrefix: "",
-  });
-  const [inviteError, setInviteError] = useState<string | null>(null);
-
-  const [editRoleDialogOpen, setEditRoleDialogOpen] = useState(false);
-  const [editRoleTarget, setEditRoleTarget] = useState<{
-    userId: string;
-    userName: string;
-    currentRole: string;
-    currentGrants: UserWithGrants["grants"];
-  } | null>(null);
-  const [editRoleValue, setEditRoleValue] = useState("editor");
-  const [editRolePathPrefix, setEditRolePathPrefix] = useState("");
+  const [editRoleTarget, setEditRoleTarget] = useState<EditRoleTarget | null>(
+    null,
+  );
 
   const toast = useToast();
   const {
@@ -176,58 +711,14 @@ export default function UsersPage() {
     );
   }
 
-  async function handleInvite() {
-    setInviteError(null);
-    try {
-      const useFolderPrefix = inviteData.pathPrefix && activeEnvironment;
-      await inviteUser({
-        email: inviteData.email,
-        grants: [
-          {
-            role: inviteData.role,
-            scopeKind:
-              inviteData.role === "admin"
-                ? "global"
-                : useFolderPrefix
-                  ? "folder_prefix"
-                  : "project",
-            project:
-              inviteData.role === "admin"
-                ? undefined
-                : activeProject || undefined,
-            environment:
-              inviteData.role === "admin"
-                ? undefined
-                : useFolderPrefix
-                  ? activeEnvironment
-                  : undefined,
-            pathPrefix:
-              inviteData.role === "admin"
-                ? undefined
-                : useFolderPrefix
-                  ? inviteData.pathPrefix
-                  : undefined,
-          },
-        ],
-      });
-      setInviteDialogOpen(false);
-      setInviteData({ email: "", role: "editor", pathPrefix: "" });
-      toast.success("Invitation sent successfully.");
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to send invitation.";
-      setInviteError(message);
-    }
-  }
-
   async function handleRevokeSessions(userId: string, userName: string) {
     try {
       await revokeSessions(userId);
       toast.success(`Sessions revoked for ${userName}.`);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to revoke sessions.";
-      toast.error(message);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to revoke sessions.",
+      );
     }
   }
 
@@ -240,9 +731,9 @@ export default function UsersPage() {
       await removeUser(userId);
       toast.success(`${userName} has been removed.`);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to remove user.";
-      toast.error(message);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove user.",
+      );
     }
   }
 
@@ -251,65 +742,9 @@ export default function UsersPage() {
       await revokeInvite(inviteId);
       toast.success(`Invitation for ${email} has been revoked.`);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to revoke invitation.";
-      toast.error(message);
-    }
-  }
-
-  async function handleEditRole() {
-    if (!editRoleTarget) return;
-    try {
-      const editUseFolderPrefix = editRolePathPrefix && activeEnvironment;
-      const editedGrant = {
-        role: editRoleValue,
-        scopeKind:
-          editRoleValue === "admin"
-            ? "global"
-            : editUseFolderPrefix
-              ? "folder_prefix"
-              : "project",
-        project:
-          editRoleValue === "admin"
-            ? undefined
-            : (editRoleTarget.currentGrants[0]?.project ??
-              activeProject ??
-              undefined),
-        environment:
-          editRoleValue === "admin"
-            ? undefined
-            : editUseFolderPrefix
-              ? activeEnvironment
-              : undefined,
-        pathPrefix:
-          editRoleValue === "admin"
-            ? undefined
-            : editUseFolderPrefix
-              ? editRolePathPrefix
-              : undefined,
-      };
-      // If user has multiple grants, preserve the others and only replace the first
-      const updatedGrants =
-        editRoleTarget.currentGrants.length > 1
-          ? [
-              editedGrant,
-              ...editRoleTarget.currentGrants.slice(1).map((g) => ({
-                role: g.role,
-                scopeKind: g.scopeKind,
-                project: g.project ?? undefined,
-                environment: g.environment ?? undefined,
-                pathPrefix: g.pathPrefix ?? undefined,
-              })),
-            ]
-          : [editedGrant];
-      await updateGrants(editRoleTarget.userId, updatedGrants);
-      toast.success(`Role updated for ${editRoleTarget.userName}.`);
-      setEditRoleDialogOpen(false);
-      setEditRoleTarget(null);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to update role.";
-      toast.error(message);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to revoke invitation.",
+      );
     }
   }
 
@@ -318,122 +753,25 @@ export default function UsersPage() {
       <PageHeader breadcrumbs={[{ label: "Users" }]} />
 
       <div className="p-6 space-y-6">
-        {/* Header */}
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Users</h1>
-          <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="mr-2 size-4" />
-                Invite User
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Invite a new user</DialogTitle>
-                <DialogDescription>
-                  Send an invitation to join this CMS instance
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 py-4">
-                {/* Email */}
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <div className="relative">
-                    <Mail className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-foreground-muted" />
-                    <Input
-                      id="email"
-                      type="email"
-                      placeholder="user@company.com"
-                      value={inviteData.email}
-                      onChange={(e) =>
-                        setInviteData((prev) => ({
-                          ...prev,
-                          email: e.target.value,
-                        }))
-                      }
-                      className="pl-9"
-                    />
-                  </div>
-                </div>
-
-                {/* Role */}
-                <div className="space-y-2">
-                  <Label>Role</Label>
-                  <Select
-                    value={inviteData.role}
-                    onValueChange={(value) =>
-                      setInviteData((prev) => ({ ...prev, role: value }))
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="admin">Admin</SelectItem>
-                      <SelectItem value="editor">Editor</SelectItem>
-                      <SelectItem value="viewer">Viewer</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {/* Folder prefix (editor/viewer only) */}
-                {(inviteData.role === "editor" ||
-                  inviteData.role === "viewer") && (
-                  <div className="space-y-2">
-                    <Label htmlFor="path-prefix">
-                      Folder prefix (optional)
-                    </Label>
-                    <Input
-                      id="path-prefix"
-                      placeholder="e.g. content/blog"
-                      value={inviteData.pathPrefix}
-                      onChange={(e) =>
-                        setInviteData((prev) => ({
-                          ...prev,
-                          pathPrefix: e.target.value,
-                        }))
-                      }
-                      className="font-mono"
-                    />
-                    <p className="text-xs text-foreground-muted">
-                      Restricts access to content under this path only. Leave
-                      empty for full project access.
-                    </p>
-                  </div>
-                )}
-
-                {/* Invite error */}
-                {inviteError && (
-                  <p className="text-sm text-destructive">{inviteError}</p>
-                )}
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="ghost"
-                  onClick={() => setInviteDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  disabled={isInviting || !inviteData.email}
-                  onClick={handleInvite}
-                >
-                  {isInviting ? "Sending..." : "Send Invitation"}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <InviteUserDialog
+            open={inviteDialogOpen}
+            onOpenChange={setInviteDialogOpen}
+            inviteUser={inviteUser}
+            isInviting={isInviting}
+            activeProject={activeProject}
+            activeEnvironment={activeEnvironment}
+            onInvited={() => toast.success("Invitation sent successfully.")}
+          />
         </div>
 
-        {/* Loading state */}
         {status === "loading" && (
           <div className="flex items-center justify-center py-16">
             <Loader2 className="size-6 animate-spin text-foreground-muted" />
           </div>
         )}
 
-        {/* Error state */}
         {status === "error" && (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <AlertCircle className="mb-4 size-8 text-destructive" />
@@ -445,7 +783,6 @@ export default function UsersPage() {
           </div>
         )}
 
-        {/* Empty state */}
         {status === "empty" && (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <div className="mb-4 rounded-full bg-background-subtle p-4">
@@ -458,242 +795,36 @@ export default function UsersPage() {
           </div>
         )}
 
-        {/* Pending Invitations */}
-        {pendingInvites.length > 0 && (
-          <div className="space-y-3">
-            <h2 className="text-sm font-medium text-foreground-muted">
-              Pending Invitations ({pendingInvites.length})
-            </h2>
-            <div className="rounded-lg border border-border divide-y divide-border">
-              {pendingInvites.map((invite) => (
-                <div
-                  key={invite.id}
-                  className="flex items-center justify-between px-4 py-3"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="flex size-8 items-center justify-center rounded-full bg-background-subtle">
-                      <Clock className="size-4 text-foreground-muted" />
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium">{invite.email}</p>
-                      <p className="text-xs text-foreground-muted">
-                        Expires {formatJoinedDate(invite.expiresAt)}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="text-xs">
-                      {invite.grants[0]?.role ?? "editor"}
-                    </Badge>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-foreground-muted hover:text-destructive"
-                      disabled={isRevokingInvite}
-                      onClick={() =>
-                        handleRevokeInvite(invite.id, invite.email)
-                      }
-                    >
-                      <X className="size-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PendingInvitesList
+          invites={pendingInvites}
+          isRevoking={isRevokingInvite}
+          onRevoke={handleRevokeInvite}
+        />
 
-        {/* Users Table */}
         {status === "ready" && (
-          <div className="rounded-lg border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>User</TableHead>
-                  <TableHead className="w-28">Role</TableHead>
-                  <TableHead className="w-32">Scope</TableHead>
-                  <TableHead className="w-28">Joined</TableHead>
-                  <TableHead className="w-14"></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {users.map((user) => {
-                  const role = getHighestRole(user.grants);
-                  return (
-                    <TableRow key={user.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-3">
-                          <Avatar className="size-8">
-                            <AvatarFallback>
-                              {user.name
-                                .split(" ")
-                                .map((n) => n[0])
-                                .join("")}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div>
-                            <p className="font-medium">{user.name}</p>
-                            <p className="text-sm text-foreground-muted">
-                              {user.email}
-                            </p>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="outline"
-                          className={cn("text-xs", roleConfig[role].className)}
-                        >
-                          {roleConfig[role].label}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-foreground-muted">
-                        {getScopeLabel(user.grants)}
-                      </TableCell>
-                      <TableCell className="text-sm text-foreground-muted">
-                        {formatJoinedDate(user.createdAt)}
-                      </TableCell>
-                      <TableCell>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-8"
-                            >
-                              <MoreHorizontal className="size-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <TooltipProvider>
-                              <DropdownMenuItem
-                                disabled={role === "owner"}
-                                onClick={() => {
-                                  setEditRoleTarget({
-                                    userId: user.id,
-                                    userName: user.name,
-                                    currentRole: role,
-                                    currentGrants: user.grants,
-                                  });
-                                  setEditRoleValue(role);
-                                  setEditRolePathPrefix(
-                                    user.grants[0]?.pathPrefix ?? "",
-                                  );
-                                  setEditRoleDialogOpen(true);
-                                }}
-                              >
-                                <Edit className="mr-2 size-4" />
-                                Edit role
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                disabled={isRevokingSessions}
-                                onClick={() =>
-                                  handleRevokeSessions(user.id, user.name)
-                                }
-                              >
-                                <LogOut className="mr-2 size-4" />
-                                Revoke sessions
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              {role === "owner" ? (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span className="w-full">
-                                      <DropdownMenuItem
-                                        className="text-destructive focus:text-destructive"
-                                        disabled
-                                      >
-                                        <Trash2 className="mr-2 size-4" />
-                                        Remove user
-                                      </DropdownMenuItem>
-                                    </span>
-                                  </TooltipTrigger>
-                                  <TooltipContent side="left">
-                                    <p>
-                                      Owners cannot be removed. Transfer
-                                      ownership first.
-                                    </p>
-                                  </TooltipContent>
-                                </Tooltip>
-                              ) : (
-                                <DropdownMenuItem
-                                  className="text-destructive focus:text-destructive"
-                                  disabled={isRemoving}
-                                  onClick={() =>
-                                    handleRemoveUser(user.id, user.name)
-                                  }
-                                >
-                                  <Trash2 className="mr-2 size-4" />
-                                  Remove user
-                                </DropdownMenuItem>
-                              )}
-                            </TooltipProvider>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
+          <UsersTable
+            users={users}
+            isRemoving={isRemoving}
+            isRevokingSessions={isRevokingSessions}
+            onEditRole={setEditRoleTarget}
+            onRevokeSessions={handleRevokeSessions}
+            onRemoveUser={handleRemoveUser}
+          />
         )}
 
-        {/* Edit Role Dialog */}
-        <Dialog open={editRoleDialogOpen} onOpenChange={setEditRoleDialogOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Edit role</DialogTitle>
-              <DialogDescription>
-                Change the role for {editRoleTarget?.userName}.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4 py-4">
-              <div className="space-y-2">
-                <Label>Role</Label>
-                <Select value={editRoleValue} onValueChange={setEditRoleValue}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="admin">Admin</SelectItem>
-                    <SelectItem value="editor">Editor</SelectItem>
-                    <SelectItem value="viewer">Viewer</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              {(editRoleValue === "editor" || editRoleValue === "viewer") && (
-                <div className="space-y-2">
-                  <Label htmlFor="edit-role-path-prefix">
-                    Folder prefix (optional)
-                  </Label>
-                  <Input
-                    id="edit-role-path-prefix"
-                    placeholder="e.g. content/blog"
-                    value={editRolePathPrefix}
-                    onChange={(e) => setEditRolePathPrefix(e.target.value)}
-                    className="font-mono"
-                  />
-                  <p className="text-xs text-foreground-muted">
-                    Restricts access to content under this path only. Leave
-                    empty for full project access.
-                  </p>
-                </div>
-              )}
-            </div>
-            <DialogFooter>
-              <Button
-                variant="ghost"
-                onClick={() => setEditRoleDialogOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button disabled={isUpdatingGrants} onClick={handleEditRole}>
-                {isUpdatingGrants ? "Saving..." : "Save"}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <EditRoleDialog
+          target={editRoleTarget}
+          onOpenChange={(open) => {
+            if (!open) setEditRoleTarget(null);
+          }}
+          updateGrants={updateGrants}
+          isUpdatingGrants={isUpdatingGrants}
+          activeEnvironment={activeEnvironment}
+          activeProject={activeProject}
+          onSaved={(userName) =>
+            toast.success(`Role updated for ${userName}.`)
+          }
+        />
       </div>
     </div>
   );

--- a/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
@@ -95,15 +95,19 @@ type FormState = {
   submitError: string | null;
 };
 
-const initialFormState: FormState = {
-  step: "form",
-  label: "",
-  selectedScopes: new Set(),
-  expiresAt: "",
-  createdResult: null,
-  copied: false,
-  submitError: null,
-};
+function createInitialFormState(): FormState {
+  return {
+    step: "form",
+    label: "",
+    selectedScopes: new Set(),
+    expiresAt: "",
+    createdResult: null,
+    copied: false,
+    submitError: null,
+  };
+}
+
+const initialFormState: FormState = createInitialFormState();
 
 type FormAction =
   | { type: "reset" }
@@ -118,7 +122,10 @@ type FormAction =
 function formReducer(state: FormState, action: FormAction): FormState {
   switch (action.type) {
     case "reset":
-      return initialFormState;
+      // Build a fresh state so `selectedScopes` is a new Set rather than the
+      // shared one held by `initialFormState` — otherwise a subsequent
+      // `scope-toggle` would mutate the module-level reference.
+      return createInitialFormState();
     case "label-change":
       return { ...state, label: action.value };
     case "scope-toggle": {

--- a/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { Copy, Check } from "lucide-react";
 
 import {
@@ -85,6 +85,64 @@ export type ApiKeyCreateDialogProps = {
 
 type Step = "form" | "created";
 
+type FormState = {
+  step: Step;
+  label: string;
+  selectedScopes: Set<ApiKeyOperationScope>;
+  expiresAt: string;
+  createdResult: ApiKeyCreateResult | null;
+  copied: boolean;
+  submitError: string | null;
+};
+
+const initialFormState: FormState = {
+  step: "form",
+  label: "",
+  selectedScopes: new Set(),
+  expiresAt: "",
+  createdResult: null,
+  copied: false,
+  submitError: null,
+};
+
+type FormAction =
+  | { type: "reset" }
+  | { type: "label-change"; value: string }
+  | { type: "scope-toggle"; scope: ApiKeyOperationScope }
+  | { type: "expires-at-change"; value: string }
+  | { type: "submit-start" }
+  | { type: "submit-success"; result: ApiKeyCreateResult }
+  | { type: "submit-error"; message: string }
+  | { type: "copy-set"; copied: boolean };
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "reset":
+      return initialFormState;
+    case "label-change":
+      return { ...state, label: action.value };
+    case "scope-toggle": {
+      const next = new Set(state.selectedScopes);
+      if (next.has(action.scope)) {
+        next.delete(action.scope);
+      } else {
+        next.add(action.scope);
+      }
+      return { ...state, selectedScopes: next };
+    }
+    case "expires-at-change":
+      return { ...state, expiresAt: action.value };
+    case "submit-start":
+      return { ...state, submitError: null };
+    case "submit-success":
+      return { ...state, step: "created", createdResult: action.result };
+    case "submit-error":
+      return { ...state, submitError: action.message };
+    case "copy-set":
+      return { ...state, copied: action.copied };
+  }
+}
+
 export function ApiKeyCreateDialog({
   open,
   onOpenChange,
@@ -93,62 +151,40 @@ export function ApiKeyCreateDialog({
   error,
 }: ApiKeyCreateDialogProps) {
   const mountInfo = useStudioMountInfo();
-  const [step, setStep] = useState<Step>("form");
-  const [label, setLabel] = useState("");
-  const [selectedScopes, setSelectedScopes] = useState<
-    Set<ApiKeyOperationScope>
-  >(new Set());
-  const [createdResult, setCreatedResult] = useState<ApiKeyCreateResult | null>(
-    null,
-  );
-  const [copied, setCopied] = useState(false);
-  const [expiresAt, setExpiresAt] = useState("");
+  const [form, dispatch] = useReducer(formReducer, initialFormState);
+  const {
+    step,
+    label,
+    selectedScopes,
+    expiresAt,
+    createdResult,
+    copied,
+    submitError,
+  } = form;
   const [todayMinDate, setTodayMinDate] = useState<string | undefined>(
     undefined,
   );
 
   useEffect(() => {
-    if (!open) return;
-    // Recompute on each open so a dialog reopened the next day picks up
-    // today's date instead of the day it was first mounted.
+    if (!open) {
+      dispatch({ type: "reset" });
+      return;
+    }
+    // Recompute today's date each time the dialog opens so a reopen the
+    // next day picks up the new date instead of the first-mount day.
     const d = new Date();
     setTodayMinDate(
       `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`,
     );
   }, [open]);
 
-  useEffect(() => {
-    if (!open) {
-      setStep("form");
-      setLabel("");
-      setSelectedScopes(new Set());
-      setCreatedResult(null);
-      setCopied(false);
-      setExpiresAt("");
-    }
-  }, [open]);
-
-  const toggleScope = useCallback((scope: ApiKeyOperationScope) => {
-    setSelectedScopes((prev) => {
-      const next = new Set(prev);
-      if (next.has(scope)) {
-        next.delete(scope);
-      } else {
-        next.add(scope);
-      }
-      return next;
-    });
-  }, []);
-
   const canSubmit =
     label.trim().length > 0 && selectedScopes.size > 0 && !isSubmitting;
-
-  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!canSubmit) return;
-    setSubmitError(null);
+    dispatch({ type: "submit-start" });
 
     const contextAllowlist =
       mountInfo.project && mountInfo.environment
@@ -164,20 +200,21 @@ export function ApiKeyCreateDialog({
 
     try {
       const result = await onSubmit(input);
-      setCreatedResult(result);
-      setStep("created");
+      dispatch({ type: "submit-success", result });
     } catch (err) {
-      setSubmitError(
-        err instanceof Error ? err.message : "Failed to create API key.",
-      );
+      dispatch({
+        type: "submit-error",
+        message:
+          err instanceof Error ? err.message : "Failed to create API key.",
+      });
     }
   };
 
   const handleCopy = async () => {
     if (!createdResult) return;
     await navigator.clipboard.writeText(createdResult.key);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    dispatch({ type: "copy-set", copied: true });
+    setTimeout(() => dispatch({ type: "copy-set", copied: false }), 2000);
   };
 
   const handleDismiss = () => {
@@ -203,7 +240,9 @@ export function ApiKeyCreateDialog({
                 <Input
                   id="api-key-label"
                   value={label}
-                  onChange={(e) => setLabel(e.target.value)}
+                  onChange={(e) =>
+                    dispatch({ type: "label-change", value: e.target.value })
+                  }
                   placeholder="e.g. CI/CD Pipeline"
                   disabled={isSubmitting}
                 />
@@ -226,7 +265,9 @@ export function ApiKeyCreateDialog({
                             type="button"
                             disabled={isSubmitting}
                             aria-pressed={isSelected}
-                            onClick={() => toggleScope(scope)}
+                            onClick={() =>
+                              dispatch({ type: "scope-toggle", scope })
+                            }
                           >
                             <Badge
                               variant={isSelected ? "default" : "outline"}
@@ -252,7 +293,12 @@ export function ApiKeyCreateDialog({
                   id="api-key-expires"
                   type="date"
                   value={expiresAt}
-                  onChange={(e) => setExpiresAt(e.target.value)}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "expires-at-change",
+                      value: e.target.value,
+                    })
+                  }
                   disabled={isSubmitting}
                   min={todayMinDate}
                 />


### PR DESCRIPTION
## Summary

Follow-up to #146. Addresses the deferred work from the previous react-doctor cleanup pass: `prefer-useReducer`, `no-cascading-set-state` (where naturally combinable with reducers), and the smaller `no-giant-component` extractions. All edits land in `runtime-ui/**` paths declared as `unpublishedSources` in `.changeset-gate.json`, so no changeset is required.

### Changes

**useReducer migrations**
- `api-key-create-dialog.tsx`: 6 form `useState` calls + the cascading reset effect collapsed into one discriminated-union reducer (`label-change` / `scope-toggle` / `expires-at-change` / `submit-*` / `copy-set` / `reset`). The on-open effect now both recomputes `todayMinDate` and dispatches `reset` on close.
- `users-page.tsx` invite form: the 3-field invite state plus its error string moved into an `inviteFormReducer` inside the new `InviteUserDialog`. The parent no longer owns invite form state.

**Component decomposition**
- `users-page.tsx` (was 700 lines / 576-line body) → page orchestrator (~165 lines) + `InviteUserDialog`, `EditRoleDialog`, `PendingInvitesList`, `UsersTable`. Page is no longer flagged as a giant component.
- `trash-page.tsx` (was ~390-line body) → `TrashFilterBar`, `TrashTable`, `TrashEmptyMatch`, `TrashPagination` extracted. Page is no longer flagged.
- `content/[type]/page.tsx`: `ContentTypeDocumentsTable`, `ContentTypePaginationBar` extracted. The page is still over the threshold because of query/mutation wiring; deeper decomposition deferred.

### Doctor-score delta

| Package | Before | After |
|---|---|---|
| `@mdcms/studio` | 84/100 | 84/100 (qualitative; remaining warnings overlap categories) |
| `no-giant-component` flagged sites | 8 | 6 |

The numeric score is unchanged because the remaining giant components (content-document-page ×2, environments-page, assistant-context provider, layout, inline-ai-bubble) and the documented false-positives still account for the warning population. A separate PR can tackle them.

### Deferred (out of scope for this PR)

- `content-document-page.tsx` ContentDocumentPageView (576-line body) and ContentDocumentPage (1142-line body) — the document editor is the most state-dense surface in the studio; a careful split needs its own design pass.
- `environments-page.tsx` (563-line body, 17+ useStates) — the same; a focused state-machine refactor would be cleaner than mechanical extractions.
- `assistant-context.tsx` AssistantProvider (615-line body) — provider with deeply interconnected chat dispatch state; pulling a hook out is fine but doesn't move the lint number cleanly.
- `inline-ai-bubble.tsx` (manageable but the two `no-effect-chain` sites are legitimate debounce + async-state lifecycles — see commit on the original PR).
- `layout.tsx` AdminLayoutInner (235-line body) — auth gating + query setup is interleaved; a clean split requires moving the early-returns through a new gate component.

These are intentionally out of scope and can ship as separate focused PRs.

## Test plan

- [x] `bun run check` (build + typecheck across 6 projects) — green.
- [x] `bun test --cwd packages/studio` — 603/603 pass.
- [x] `bun run format:check` — no studio-touching files dirty.
- [ ] Manual smoke (browser): invite flow, edit-role flow, trash list paging, content/[type] list paging.
- [ ] `bun run ci:required` in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Content, Trash, and Users admin pages into clearer componentized UI for tables, pagination, filters, and dialogs.
  * Trash page adds improved filter bar, empty-state messaging, per-row restore actions, and paged navigation.
  * Users page introduces invite and edit-role dialogs, pending-invites list, role display and scoped-role handling, and row action menus (edit role, revoke sessions, remove user with owner protection/tooltips).
  * API key creation dialog now has a streamlined multi-step flow with copy-to-clipboard and expiry controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdcms-ai/mdcms/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->