### PR TITLE
fix(server): stabilize Studio CSRF bootstrap

### DIFF
--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -6,6 +6,12 @@ Entries are reverse-chronological (newest first).
 
 ---
 
+## 2026-05-18 — keep Studio CSRF bootstrap stable
+
+**Rule:** Session bootstrap must reuse an existing `mdcms_csrf` cookie instead of rotating it on every `/api/v1/auth/session` call.
+**Why:** Studio has multiple route clients that cache bootstrap tokens; rotating the cookie in one client makes another client's cached header mismatch the browser cookie and surfaces `FORBIDDEN: Valid CSRF token is required...` during assistant apply/reject flows.
+**How to apply:** When changing auth/session behavior, preserve the double-submit invariant by returning and refreshing the current cookie token when present; only generate a new CSRF token when the readable cookie is missing.
+
 ## 2026-05-18 — register cross-rail Studio context upward
 
 **Rule:** When a Studio page needs to feed state into a docked global surface such as the assistant rail, register that state upward through the owning provider instead of relying on React context from the page subtree.

--- a/.ai/memory/topics/auth-flow.md
+++ b/.ai/memory/topics/auth-flow.md
@@ -15,6 +15,7 @@ All three resolve to the same internal concept downstream: an authenticated prin
 ### Session (Studio)
 
 Browser sessions are persisted server-side; the `sessions` table in `apps/server/src/lib/db/schema.ts` holds them with a unique-token index. Studio fetches the active principal on mount and caches it in its TanStack Query layer; writes carry CSRF protection.
+Session bootstrap returns the existing readable `mdcms_csrf` cookie when present and only creates a new token when the cookie is missing, so cached Studio clients can replay the token without another bootstrap invalidating it.
 
 ### API key (SDK / non-interactive)
 
@@ -35,6 +36,7 @@ If the listener doesn't receive a callback within a timeout, the CLI surfaces "T
 
 - Every authenticated request resolves a project context **before** reaching domain code. No cross-tenant leak via missing scoping.
 - API keys carry scopes; sessions inherit scopes from the user's role.
+- CSRF bootstrap must not rotate an existing `mdcms_csrf` cookie; multiple Studio clients and route helpers may cache that token concurrently.
 - The loopback flow validates `state` to defeat CSRF; binding to `127.0.0.1` confines redirect targets to the local machine.
 - API keys are revocable; sessions are revocable; both invalidate immediately on the server.
 

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -1921,12 +1921,10 @@ testWithDatabase(
     try {
       await signUp(handler, { email, password });
       const loginResult = await login(handler, { email, password });
+      const loginCsrf = extractCookieValue(loginResult.setCookie, "mdcms_csrf");
 
-      assert.ok(extractCookieValue(loginResult.setCookie, "mdcms_csrf"));
-      assert.equal(
-        loginResult.csrfToken,
-        extractCookieValue(loginResult.setCookie, "mdcms_csrf"),
-      );
+      assert.ok(loginCsrf);
+      assert.equal(loginResult.csrfToken, loginCsrf);
 
       const sessionResponse = await handler(
         new Request("http://localhost/api/v1/auth/session", {
@@ -1945,6 +1943,7 @@ testWithDatabase(
         "mdcms_csrf",
       );
       assert.ok(sessionCsrf);
+      assert.equal(sessionCsrf, loginCsrf);
       assert.equal(sessionBody.data.csrfToken, sessionCsrf);
     } finally {
       await dbConnection.close();

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -216,7 +216,7 @@ export type AuthService = {
     requirement: AuthorizationRequirement,
   ) => Promise<AuthorizedRequest>;
   requireCsrfProtection: (request: Request) => Promise<void>;
-  issueCsrfBootstrap: () => {
+  issueCsrfBootstrap: (request?: Request) => {
     token: string;
     setCookie: string;
   };
@@ -2287,8 +2287,17 @@ export function createAuthService(
       adminAllowlist.userIds.has(session.userId) ||
       adminAllowlist.emails.has(session.email.toLowerCase()));
 
-  function createCsrfBootstrap(): { token: string; setCookie: string } {
-    const token = randomBytes(CSRF_TOKEN_BYTES).toString("base64url");
+  function createCsrfBootstrap(request?: Request): {
+    token: string;
+    setCookie: string;
+  } {
+    const existingToken = request
+      ? readCookieValue(request, CSRF_COOKIE_NAME)?.trim()
+      : undefined;
+    const token =
+      existingToken && existingToken.length > 0
+        ? existingToken
+        : randomBytes(CSRF_TOKEN_BYTES).toString("base64url");
 
     return {
       token,
@@ -3831,8 +3840,8 @@ export function createAuthService(
       await assertCsrfProtection(request);
     },
 
-    issueCsrfBootstrap() {
-      return createCsrfBootstrap();
+    issueCsrfBootstrap(request) {
+      return createCsrfBootstrap(request);
     },
 
     clearCsrfCookie() {
@@ -5055,7 +5064,7 @@ export function mountAuthRoutes(
         const session = requireSessionPayload(
           await options.authService.getSession(request),
         );
-        const csrf = options.authService.issueCsrfBootstrap();
+        const csrf = options.authService.issueCsrfBootstrap(request);
         return createJsonResponse(
           {
             data: {


### PR DESCRIPTION
## Summary
- Reuse an existing mdcms_csrf cookie during auth/session bootstrap instead of rotating it on every call.
- Add regression coverage so session bootstrap returns the login CSRF token when the cookie is present.
- Document the Studio CSRF stability invariant in AI memory.

## Test Plan
- bun run format:check
- bun run check
- bun test --cwd packages/studio ./src/lib/ai-route-api.test.ts
- bun test --cwd apps/server ./src/lib/auth.test.ts -t "auth login and session bootstrap issue a CSRF cookie for Studio mutations"