### PR TITLE
feat(sdk): add React content renderer

### DIFF
--- a/.ai/memory/architecture.md
+++ b/.ai/memory/architecture.md
@@ -20,6 +20,7 @@ Architecture invariants and key technical decisions. Update when one changes.
 
 - `@mdcms/shared` exports types, validators, pure utilities. **No runtime side effects, no HTTP, no DB.**
 - `@mdcms/sdk` is read-only. Bearer-token client. **No write methods.**
+- `@mdcms/sdk/react` is the SDK's server-only React rendering subpath. It renders fetched Markdown/MDX bodies and loads custom components from `mdcms.config.ts`; keep React/MDX concerns out of the default `@mdcms/sdk` export.
 - `@mdcms/cli` owns push/pull/sync logic and the loopback OAuth flow.
 - `@mdcms/studio` runs inside the host app's process — embedded React component, not a separate page.
 - `@mdcms/server` is the only thing that talks to the database.

--- a/.ai/memory/stack.md
+++ b/.ai/memory/stack.md
@@ -18,6 +18,7 @@ Runtime, dependencies, and infrastructure. Update when any of them change.
 ## Frontend
 
 - **React** for Studio.
+- **`@mdx-js/mdx`** for server-side SDK React rendering of fetched Markdown/MDX bodies.
 - **TanStack Query** for client-side data fetching.
 - **TipTap** for the editor with MDX component support.
 

--- a/.changeset/breezy-owls-begin.md
+++ b/.changeset/breezy-owls-begin.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/sdk": minor
+---
+
+Add server-side React rendering for SDK content bodies

--- a/apps/studio-example/README.md
+++ b/apps/studio-example/README.md
@@ -10,14 +10,14 @@ Example Next.js host app demonstrating how to embed `@mdcms/studio` at a catch-a
 
 ## Routes
 
-| Route                           | Description                            |
-| ------------------------------- | -------------------------------------- |
-| `/`                             | Host app home page                     |
-| `/admin/*`                      | Embedded Studio UI (catch-all)         |
-| `/demo/content`                 | Raw content API demo (draft scope)     |
-| `/demo/content/:documentId`     | Raw content detail                     |
-| `/demo/sdk-content`             | SDK-backed content demo (`@mdcms/sdk`) |
-| `/demo/sdk-content/:documentId` | SDK-backed content detail              |
+| Route                           | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `/`                             | Host app home page                                       |
+| `/admin/*`                      | Embedded Studio UI (catch-all)                           |
+| `/demo/content`                 | Raw content API demo (draft scope)                       |
+| `/demo/content/:documentId`     | Raw content detail                                       |
+| `/demo/sdk-content`             | SDK-backed content demo (`@mdcms/sdk`)                   |
+| `/demo/sdk-content/:documentId` | SDK-backed content detail with `@mdcms/sdk/react` output |
 
 ## Local Run
 

--- a/apps/studio-example/app/demo/sdk-content/[documentId]/page.test.tsx
+++ b/apps/studio-example/app/demo/sdk-content/[documentId]/page.test.tsx
@@ -47,7 +47,7 @@ test("SDK content detail page clearly identifies the SDK data source", async () 
             title: "Hello World",
             slug: "hello-world",
           },
-          body: "Hello world",
+          body: "# Hello **rendered**",
           createdBy: "33333333-3333-3333-3333-333333333333",
           createdAt: "2026-03-27T08:00:00.000Z",
           updatedAt: "2026-03-27T09:00:00.000Z",
@@ -75,6 +75,9 @@ test("SDK content detail page clearly identifies the SDK data source", async () 
   assert.match(markup, /\/demo\/sdk-content/i);
   assert.match(markup, /\/demo\/content/i);
   assert.match(markup, /Hello World/);
+  assert.match(markup, /Rendered body/i);
+  assert.match(markup, /<h1>Hello <strong>rendered<\/strong><\/h1>/i);
+  assert.match(markup, /body \(raw\):/i);
 
   globalThis.fetch = originalFetch;
   delete process.env.MDCMS_DEMO_API_KEY;

--- a/apps/studio-example/app/demo/sdk-content/[documentId]/page.tsx
+++ b/apps/studio-example/app/demo/sdk-content/[documentId]/page.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
 
 import type { ContentDocumentResponse } from "@mdcms/cli";
+import { createMdcmsRenderer } from "@mdcms/sdk/react";
 
+import config from "../../../../mdcms.config";
 import { createDemoSdkClient, toDemoRequestFailure } from "../sdk-demo-client";
+
+const contentRenderer = createMdcmsRenderer(config);
 
 type DocumentResult =
   | {
@@ -53,6 +57,9 @@ export default async function DemoSdkContentDocumentPage({
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const type = resolvedSearchParams?.type?.trim() || "post";
   const result = await fetchDocument(type, documentId);
+  const renderedBody = result.ok
+    ? await contentRenderer.render(result.document)
+    : null;
 
   return (
     <main>
@@ -92,6 +99,8 @@ export default async function DemoSdkContentDocumentPage({
             publishedVersion=
             <code>{result.document.publishedVersion ?? "-"}</code>
           </p>
+          <h3>Rendered body</h3>
+          <div>{renderedBody}</div>
           <p>frontmatter (raw JSON):</p>
           <pre>{JSON.stringify(result.document.frontmatter, null, 2)}</pre>
           <p>body (raw):</p>

--- a/apps/studio-example/next.config.mjs
+++ b/apps/studio-example/next.config.mjs
@@ -6,6 +6,7 @@ const workspaceRoot = resolve(rootDir, "../..");
 const mdcmsSourceAliases = {
   "@mdcms/cli$": resolve(workspaceRoot, "apps/cli/src/index.ts"),
   "@mdcms/sdk$": resolve(workspaceRoot, "packages/sdk/src/index.ts"),
+  "@mdcms/sdk/react$": resolve(workspaceRoot, "packages/sdk/src/react.ts"),
   "@mdcms/shared$": resolve(workspaceRoot, "packages/shared/src/index.ts"),
   "@mdcms/shared/action-catalog-contract$": resolve(
     workspaceRoot,

--- a/apps/studio-example/next.config.test.ts
+++ b/apps/studio-example/next.config.test.ts
@@ -36,6 +36,7 @@ test("next dev aliases clean-checkout MDCMS packages to source files", () => {
     react: "react",
     "@mdcms/cli$": resolve(workspaceRoot, "apps/cli/src/index.ts"),
     "@mdcms/sdk$": resolve(workspaceRoot, "packages/sdk/src/index.ts"),
+    "@mdcms/sdk/react$": resolve(workspaceRoot, "packages/sdk/src/react.ts"),
     "@mdcms/shared$": resolve(workspaceRoot, "packages/shared/src/index.ts"),
     "@mdcms/shared/action-catalog-contract$": resolve(
       workspaceRoot,

--- a/bun.lock
+++ b/bun.lock
@@ -90,8 +90,15 @@
       "name": "@mdcms/sdk",
       "version": "0.1.3",
       "dependencies": {
-        "@mdcms/shared": "^0.1.0",
+        "@mdcms/shared": "^0.2.0",
+        "@mdx-js/mdx": "^3.1.1",
         "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.12",
+        "@types/react-dom": "^19.0.5",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
       },
     },
     "packages/shared": {
@@ -652,6 +659,8 @@
 
     "@mdcms/studio-example": ["@mdcms/studio-example@workspace:apps/studio-example"],
 
+    "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.6", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g=="],
@@ -1088,6 +1097,8 @@
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
+    "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
@@ -1126,6 +1137,10 @@
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
     "address": ["address@1.2.2", "", {}, "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA=="],
 
     "ai": ["ai@6.0.173", "", { "dependencies": { "@ai-sdk/gateway": "3.0.108", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-X2noFb82kouYQ4nlKGm1cR1Wvlp4Xit7fjJzwXv/msKQmtqkQn9NiXH6kCX4Gl4G+9DRWsJHIKANtWk8Ix1nTw=="],
@@ -1143,6 +1158,8 @@
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -1237,6 +1254,8 @@
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -1426,6 +1445,10 @@
 
     "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
+    "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
+
+    "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
@@ -1438,7 +1461,19 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
+
+    "estree-util-build-jsx": ["estree-util-build-jsx@3.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-walker": "^3.0.0" } }, "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ=="],
+
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-util-scope": ["estree-util-scope@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0" } }, "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ=="],
+
+    "estree-util-to-js": ["estree-util-to-js@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "astring": "^1.8.0", "source-map": "^0.7.0" } }, "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg=="],
+
+    "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -1545,6 +1580,8 @@
     "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
+    "hast-util-to-estree": ["hast-util-to-estree@3.1.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-attach-comments": "^3.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
@@ -1710,6 +1747,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
+
     "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
@@ -1733,6 +1772,8 @@
     "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
 
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx": ["mdast-util-mdx@3.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w=="],
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
@@ -1776,9 +1817,21 @@
 
     "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
 
+    "micromark-extension-mdx-expression": ["micromark-extension-mdx-expression@3.0.1", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q=="],
+
+    "micromark-extension-mdx-jsx": ["micromark-extension-mdx-jsx@3.0.2", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ=="],
+
+    "micromark-extension-mdx-md": ["micromark-extension-mdx-md@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ=="],
+
+    "micromark-extension-mdxjs": ["micromark-extension-mdxjs@3.0.0", "", { "dependencies": { "acorn": "^8.0.0", "acorn-jsx": "^5.0.0", "micromark-extension-mdx-expression": "^3.0.0", "micromark-extension-mdx-jsx": "^3.0.0", "micromark-extension-mdx-md": "^2.0.0", "micromark-extension-mdxjs-esm": "^3.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ=="],
+
+    "micromark-extension-mdxjs-esm": ["micromark-extension-mdxjs-esm@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A=="],
+
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
     "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-mdx-expression": ["micromark-factory-mdx-expression@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ=="],
 
     "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
 
@@ -1799,6 +1852,8 @@
     "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
 
     "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-events-to-acorn": ["micromark-util-events-to-acorn@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg=="],
 
     "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
 
@@ -2020,6 +2075,14 @@
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
+
+    "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
+
+    "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
+
+    "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
+
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
 
     "regenerate-unicode-properties": ["regenerate-unicode-properties@10.2.2", "", { "dependencies": { "regenerate": "^1.4.2" } }, "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g=="],
@@ -2036,9 +2099,13 @@
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
+    "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
     "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -2102,7 +2169,7 @@
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -2207,6 +2274,8 @@
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
@@ -2492,6 +2561,8 @@
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -2544,6 +2615,8 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@esbuild-kit/core-utils/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -2569,6 +2642,8 @@
     "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@swc-node/sourcemap-support/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-04-15
+last_updated: 2026-05-18
 ---
 
 # SPEC-008 CLI and SDK
@@ -65,6 +65,38 @@ The SDK follows the same reference-resolution contract documented in SPEC-003. R
 - `list(type, input)` maps to the content list query contract owned by SPEC-003, including pagination (`limit`, `offset`), sorting (`sort`, `order`), draft reads, and the supported filter fields.
 - The SDK parses the shared API envelopes directly: single-document reads unwrap `{ data }`, list reads unwrap `{ data, pagination }`, and document payloads preserve any `resolveErrors` map returned by the API.
 - API error responses are surfaced through a deterministic SDK error type parsed from the shared error envelope. Transport failures, malformed success payloads, and client misconfiguration use a separate client-side error type so callers can distinguish backend errors from local failures.
+
+### React Rendering Subpath
+
+`@mdcms/sdk/react` is an optional server-side rendering helper for React
+applications. It does not add an HTTP endpoint and does not change the
+framework-agnostic default `@mdcms/sdk` export.
+
+```typescript
+import { createClient } from "@mdcms/sdk";
+import { createMdcmsRenderer } from "@mdcms/sdk/react";
+import config from "../mdcms.config";
+
+const cms = createClient({
+  serverUrl: "http://localhost:4000",
+  apiKey: process.env.MDCMS_API_KEY,
+  project: "marketing-site",
+  environment: "production",
+});
+const renderer = createMdcmsRenderer(config);
+
+const document = await cms.get("page", { slug: "about", locale: "en" });
+const body = await renderer.render(document);
+```
+
+- The subpath exports `createMdcmsRenderer(config, options?)`, `renderMdcmsContent(document, { config, ...options })`, and `MdcmsRendererError`.
+- Rendering is server-only and returns `Promise<React.ReactNode>`.
+- The renderer uses `document.format` and `document.body` from `ContentDocumentResponse` as input.
+- Registered MDX components are loaded from `mdcms.config.ts` via `config.components[*].load`; callers do not pass a separate component map.
+- Component loader results are cached per renderer instance.
+- MDX `import` and `export` syntax is unsupported. Components must be registered in `mdcms.config.ts` instead.
+- Browser usage, component load failures, unsupported MDX ESM syntax, and MDX compile/render failures surface as deterministic `MdcmsRendererError` codes.
+- The renderer executes trusted MDCMS-authored MDX on the server. It is not a browser-side compiler and is not a sandbox for untrusted arbitrary user input.
 
 ### Type Safety and Schema Metadata
 

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -6,12 +6,14 @@ A thin TypeScript client for reading content from the MDCMS API. `createClient()
 
 The SDK is framework-agnostic. It works in Next.js, Remix, Astro, or any environment with `fetch`. The goal is to stay minimal and predictable.
 
+The optional `@mdcms/sdk/react` subpath is the exception: it is server-only, React-specific, and renders fetched Markdown/MDX bodies with components loaded from `mdcms.config.ts`.
+
 ## Boundaries
 
 - Read-only. Does not create, update, publish, or delete content.
 - Does not manage auth flows. It takes an API key and sends it as a Bearer token.
 - Does not handle caching, revalidation, or ISR. That's the consuming framework's responsibility.
-- Does not depend on any other MDCMS package at runtime except `@mdcms/shared` for types.
+- The default export does not depend on any other MDCMS package at runtime except `@mdcms/shared` for types.
 
 ## Relevant specs
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -60,10 +60,41 @@ List documents with filtering, pagination, and sorting. Supports `locale`, `reso
 
 Per-call `project` and `environment` override the client defaults for that request.
 
+### React rendering
+
+`@mdcms/sdk/react` renders fetched document bodies to React nodes on the server.
+It loads custom MDX components from `mdcms.config.ts`.
+
+```tsx
+import { createClient } from "@mdcms/sdk";
+import { createMdcmsRenderer } from "@mdcms/sdk/react";
+import config from "../mdcms.config";
+
+const cms = createClient({
+  serverUrl: process.env.MDCMS_SERVER_URL!,
+  apiKey: process.env.MDCMS_API_KEY!,
+  project: process.env.MDCMS_PROJECT!,
+  environment: process.env.MDCMS_ENVIRONMENT!,
+});
+const renderer = createMdcmsRenderer(config);
+
+export default async function Page() {
+  const document = await cms.get("page", { slug: "about", locale: "en" });
+  const body = await renderer.render(document);
+
+  return <article>{body}</article>;
+}
+```
+
+The React subpath is server-only. MDX `import` and `export` syntax is rejected;
+register components in `mdcms.config.ts` instead. Renderer failures throw
+`MdcmsRendererError`.
+
 ### Error Handling
 
 - `MdcmsApiError` — thrown for API error envelopes (4xx/5xx responses)
 - `MdcmsClientError` — thrown for transport failures, malformed responses, and SDK-derived lookup failures
+- `MdcmsRendererError` — thrown by `@mdcms/sdk/react` for server-only, component loading, unsupported MDX ESM, and render failures
 
 ## Documentation
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,13 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./react": {
+      "@mdcms/source": "./src/react.ts",
+      "bun": "./src/react.ts",
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "default": "./dist/react.js"
     }
   },
   "nx": {
@@ -36,7 +43,22 @@
   },
   "dependencies": {
     "@mdcms/shared": "^0.2.0",
+    "@mdx-js/mdx": "^3.1.1",
     "tslib": "^2.3.0"
   },
-  "license": "MIT"
+  "peerDependencies": {
+    "react": "^19.2.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/react": "^19.0.12",
+    "@types/react-dom": "^19.0.5",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  }
 }

--- a/packages/sdk/src/react.test.ts
+++ b/packages/sdk/src/react.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ContentDocumentResponse, MdcmsConfig } from "@mdcms/shared";
+
+import {
+  MdcmsRendererError,
+  createMdcmsRenderer,
+  renderMdcmsContent,
+} from "./react.js";
+
+function createDocument(
+  overrides: Partial<ContentDocumentResponse> = {},
+): ContentDocumentResponse {
+  return {
+    documentId: "11111111-1111-1111-1111-111111111111",
+    translationGroupId: "22222222-2222-2222-2222-222222222222",
+    project: "marketing-site",
+    environment: "production",
+    path: "blog/hello-world.mdx",
+    type: "post",
+    locale: "en",
+    format: "mdx",
+    isDeleted: false,
+    hasUnpublishedChanges: false,
+    version: 3,
+    publishedVersion: 3,
+    draftRevision: 5,
+    frontmatter: {
+      title: "Hello World",
+      slug: "hello-world",
+    },
+    body: "# Hello world",
+    createdBy: "33333333-3333-3333-3333-333333333333",
+    createdAt: "2026-03-26T10:00:00.000Z",
+    updatedBy: "33333333-3333-3333-3333-333333333333",
+    updatedAt: "2026-03-26T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createConfig(overrides: Partial<MdcmsConfig> = {}): MdcmsConfig {
+  return {
+    project: "marketing-site",
+    serverUrl: "http://localhost:4000",
+    environment: "production",
+    ...overrides,
+  };
+}
+
+test("renderMdcmsContent renders Markdown documents to React nodes", async () => {
+  const node = await renderMdcmsContent(
+    createDocument({
+      format: "md",
+      body: "# Hello\n\nThis is **rendered** content.",
+    }),
+    {
+      config: createConfig(),
+    },
+  );
+
+  assert.equal(
+    renderToStaticMarkup(createElement("article", null, node)),
+    "<article><h1>Hello</h1>\n<p>This is <strong>rendered</strong> content.</p></article>",
+  );
+});
+
+test("createMdcmsRenderer renders MDX components loaded from config and caches loaders", async () => {
+  let loadCount = 0;
+  const config = createConfig({
+    components: [
+      {
+        name: "Callout",
+        importPath: "./components/Callout",
+        load: async () => {
+          loadCount += 1;
+          return function Callout(props: {
+            tone?: string;
+            children?: ReactNode;
+          }) {
+            return createElement(
+              "aside",
+              { "data-tone": props.tone ?? "info" },
+              props.children,
+            );
+          };
+        },
+      },
+    ],
+  });
+  const renderer = createMdcmsRenderer(config);
+  const document = createDocument({
+    body: '<Callout tone="warning">Nested **copy**</Callout>',
+  });
+
+  const first = await renderer.render(document);
+  const second = await renderer.render(document);
+
+  assert.equal(loadCount, 1);
+  assert.equal(
+    renderToStaticMarkup(createElement("article", null, first)),
+    '<article><aside data-tone="warning">Nested <strong>copy</strong></aside></article>',
+  );
+  assert.equal(
+    renderToStaticMarkup(createElement("article", null, second)),
+    '<article><aside data-tone="warning">Nested <strong>copy</strong></aside></article>',
+  );
+});
+
+test("renderMdcmsContent rejects browser-like usage", async () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {},
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        renderMdcmsContent(createDocument(), {
+          config: createConfig(),
+        }),
+      (error: unknown) => {
+        assert.equal(error instanceof MdcmsRendererError, true);
+        assert.equal(
+          (error as MdcmsRendererError).code,
+          "MDCMS_RENDERER_SERVER_ONLY",
+        );
+        return true;
+      },
+    );
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
+  }
+});
+
+test("createMdcmsRenderer surfaces component load failures deterministically", async () => {
+  const renderer = createMdcmsRenderer(
+    createConfig({
+      components: [
+        {
+          name: "Broken",
+          importPath: "./components/Broken",
+          load: async () => {
+            throw new Error("boom");
+          },
+        },
+      ],
+    }),
+  );
+
+  await assert.rejects(
+    () => renderer.render(createDocument({ body: "<Broken />" })),
+    (error: unknown) => {
+      assert.equal(error instanceof MdcmsRendererError, true);
+      const rendererError = error as MdcmsRendererError;
+      assert.equal(rendererError.code, "MDCMS_RENDERER_COMPONENT_LOAD_FAILED");
+      assert.equal(rendererError.details?.componentName, "Broken");
+      return true;
+    },
+  );
+});
+
+test("renderMdcmsContent rejects MDX import and export syntax", async () => {
+  await assert.rejects(
+    () =>
+      renderMdcmsContent(
+        createDocument({
+          body: 'import Thing from "./Thing"\n\n# Hello',
+        }),
+        {
+          config: createConfig(),
+        },
+      ),
+    (error: unknown) => {
+      assert.equal(error instanceof MdcmsRendererError, true);
+      assert.equal(
+        (error as MdcmsRendererError).code,
+        "MDCMS_RENDERER_UNSUPPORTED_MDX_ESM",
+      );
+      return true;
+    },
+  );
+});

--- a/packages/sdk/src/react.ts
+++ b/packages/sdk/src/react.ts
@@ -1,0 +1,181 @@
+import { evaluate } from "@mdx-js/mdx";
+import type { ContentDocumentResponse, MdcmsConfig } from "@mdcms/shared";
+import type { ReactNode } from "react";
+import * as runtime from "react/jsx-runtime";
+
+export type MdcmsRendererErrorCode =
+  | "MDCMS_RENDERER_SERVER_ONLY"
+  | "MDCMS_RENDERER_COMPONENT_LOAD_FAILED"
+  | "MDCMS_RENDERER_MDX_RENDER_FAILED"
+  | "MDCMS_RENDERER_UNSUPPORTED_MDX_ESM";
+
+export type MdcmsRendererOptions = {
+  development?: boolean;
+};
+
+export type RenderMdcmsContentOptions = MdcmsRendererOptions & {
+  config: MdcmsConfig;
+};
+
+export type MdcmsRenderer = {
+  render: (document: ContentDocumentResponse) => Promise<ReactNode>;
+};
+
+export class MdcmsRendererError extends Error {
+  readonly code: MdcmsRendererErrorCode;
+  readonly details?: Record<string, unknown>;
+  override readonly cause?: unknown;
+
+  constructor(input: {
+    code: MdcmsRendererErrorCode;
+    message: string;
+    details?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super(input.message);
+    this.name = "MdcmsRendererError";
+    this.code = input.code;
+    this.details = input.details;
+    this.cause = input.cause;
+  }
+}
+
+function assertServerRuntime(): void {
+  if ((globalThis as { window?: unknown }).window !== undefined) {
+    throw new MdcmsRendererError({
+      code: "MDCMS_RENDERER_SERVER_ONLY",
+      message:
+        "@mdcms/sdk/react renders content on the server only. Do not import it from client components or browser bundles.",
+    });
+  }
+}
+
+function assertNoMdxEsm(document: ContentDocumentResponse): void {
+  if (/^\s*(import|export)\s/m.test(document.body)) {
+    throw new MdcmsRendererError({
+      code: "MDCMS_RENDERER_UNSUPPORTED_MDX_ESM",
+      message:
+        "@mdcms/sdk/react does not support MDX import or export syntax. Register components in mdcms.config.ts instead.",
+      details: {
+        documentId: document.documentId,
+      },
+    });
+  }
+}
+
+function toComponentMap(
+  loadedComponents: Map<string, unknown>,
+): Record<string, unknown> {
+  const components: Record<string, unknown> = {};
+
+  for (const [name, component] of loadedComponents) {
+    components[name] = component;
+  }
+
+  return components;
+}
+
+export function createMdcmsRenderer(
+  config: MdcmsConfig,
+  options: MdcmsRendererOptions = {},
+): MdcmsRenderer {
+  const componentLoadResults = new Map<string, Promise<unknown>>();
+
+  async function loadComponent(input: {
+    name: string;
+    load?: () => Promise<unknown>;
+  }): Promise<unknown> {
+    const existing = componentLoadResults.get(input.name);
+
+    if (existing) {
+      return existing;
+    }
+
+    if (!input.load) {
+      return undefined;
+    }
+
+    const loadResult = input.load().catch((error: unknown) => {
+      componentLoadResults.delete(input.name);
+
+      throw new MdcmsRendererError({
+        code: "MDCMS_RENDERER_COMPONENT_LOAD_FAILED",
+        message: `Failed to load MDX component "${input.name}".`,
+        details: {
+          componentName: input.name,
+        },
+        cause: error,
+      });
+    });
+
+    componentLoadResults.set(input.name, loadResult);
+    return loadResult;
+  }
+
+  async function loadComponents(): Promise<Map<string, unknown>> {
+    const loadedComponents = new Map<string, unknown>();
+
+    for (const component of config.components ?? []) {
+      const resolved = await loadComponent({
+        name: component.name,
+        load: component.load,
+      });
+
+      if (resolved !== undefined && resolved !== null) {
+        loadedComponents.set(component.name, resolved);
+      }
+    }
+
+    return loadedComponents;
+  }
+
+  return {
+    async render(document) {
+      assertServerRuntime();
+      assertNoMdxEsm(document);
+
+      const components = toComponentMap(await loadComponents());
+
+      try {
+        const evaluated = await evaluate(
+          {
+            path: `document.${document.format}`,
+            value: document.body,
+          },
+          {
+            ...runtime,
+            baseUrl: import.meta.url,
+            development: options.development ?? false,
+          },
+        );
+        const Content = evaluated.default;
+        const renderContent = Content as (props: {
+          components?: Record<string, unknown>;
+        }) => ReactNode;
+
+        return renderContent({ components });
+      } catch (error) {
+        if (error instanceof MdcmsRendererError) {
+          throw error;
+        }
+
+        throw new MdcmsRendererError({
+          code: "MDCMS_RENDERER_MDX_RENDER_FAILED",
+          message: `Failed to render MDCMS document "${document.documentId}".`,
+          details: {
+            documentId: document.documentId,
+            format: document.format,
+          },
+          cause: error,
+        });
+      }
+    },
+  };
+}
+
+export function renderMdcmsContent(
+  document: ContentDocumentResponse,
+  options: RenderMdcmsContentOptions,
+): Promise<ReactNode> {
+  return createMdcmsRenderer(options.config, options).render(document);
+}

--- a/packages/sdk/tsconfig.lib.json
+++ b/packages/sdk/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"]
+    "types": ["node", "react"]
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/skills/mdcms-sdk-integration/SKILL.md
+++ b/skills/mdcms-sdk-integration/SKILL.md
@@ -84,19 +84,28 @@ for (const post of response.data) {
 
 `list` returns the full paginated envelope — iterate `response.data`, and use `response.pagination` for offset/total/hasMore.
 
-Document return values include the frontmatter fields as declared in `mdcms.config.ts` plus the body. Use them directly in React:
+Document return values include the frontmatter fields as declared in `mdcms.config.ts` plus the body. Use them directly in React, or use `@mdcms/sdk/react` to render the body on the server from the same config component registrations:
 
 ```tsx
+import { createMdcmsRenderer } from "@mdcms/sdk/react";
+import config from "../mdcms.config";
+
+const renderer = createMdcmsRenderer(config);
+
 export default async function AboutPage() {
   const about = await cms.get("page", { slug: "about", locale: "en" });
+  const body = await renderer.render(about);
+
   return (
     <article>
       <h1>{about.title}</h1>
-      {/* render about.body — either as HTML, or via MDX runtime */}
+      {body}
     </article>
   );
 }
 ```
+
+The renderer is server-only. Do not import `@mdcms/sdk/react` from client components or browser bundles. MDX `import` and `export` syntax is not supported; register components in `mdcms.config.ts` and provide `load` functions there.
 
 ### 4. Draft vs published
 
@@ -190,7 +199,7 @@ export default async function PostPage({ params }) {
 
 ## Related skills
 
-- **`mdcms-mdx-components`** — if the content body is MDX with custom components, the host app needs an MDX runtime that knows about the same component registry Studio uses.
+- **`mdcms-mdx-components`** — if the content body is MDX with custom components, register them in `mdcms.config.ts` so Studio and `@mdcms/sdk/react` load the same components.
 - **`mdcms-schema-refine`** — if the SDK types returned don't include a field the host needs.
 - **`mdcms-content-sync-workflow`** — pair with this to understand when content is pushed vs pulled vs published.
 
@@ -198,5 +207,5 @@ export default async function PostPage({ params }) {
 
 - `@mdcms/sdk` is the first-party client. If the codebase uses a hand-rolled `fetch` directly against the API, migrate to the SDK — contract stability lives there.
 - Covers Next.js App Router as the reference target; adapt patterns for Pages Router, Remix, React Router, or a plain React SPA as needed.
-- Does not cover custom resolvers or server-side data transformation pipelines — SDK returns what the server returns.
+- Does not cover custom resolvers or server-side data transformation pipelines — SDK reads return what the server returns; `@mdcms/sdk/react` only renders the returned body.
 - Caching/revalidation examples use Next primitives; the SDK itself does not ship a cache layer.


### PR DESCRIPTION
## Summary
- Add server-only @mdcms/sdk/react renderer for Markdown and MDX document bodies
- Load custom MDX components from mdcms.config.ts with per-renderer caching and deterministic renderer errors
- Update SPEC-008, SDK docs, public SDK integration skill, studio-example rendering demo, and changeset

## Test Plan
- bun test --cwd packages/sdk ./src
- bun test --cwd apps/studio-example './app/demo/sdk-content/[documentId]/page.test.tsx'
- bun test --cwd apps/studio-example ./next.config.test.ts
- bun run format:check
- bun run check
- bun run changeset:check

Refs CMS-243