### PR TITLE
fix(ai): clarify stale proposal reanchor conflicts

### DIFF
--- a/packages/modules/core.ai/src/server/apply.ts
+++ b/packages/modules/core.ai/src/server/apply.ts
@@ -169,10 +169,15 @@ function ensureSingleOperation(proposal: AiProposal): AiProposalOperation {
   return operation;
 }
 
-function applyReplaceSelection(
+type ReplaceSelectionOperation = Extract<
+  AiProposalOperation,
+  { op: "replace_selection" }
+>;
+
+function findReplaceSelectionMatch(
   body: string,
-  operation: Extract<AiProposalOperation, { op: "replace_selection" }>,
-): string {
+  operation: ReplaceSelectionOperation,
+): number {
   const original = operation.originalText;
   const index = body.indexOf(original);
 
@@ -195,6 +200,16 @@ function applyReplaceSelection(
       },
     );
   }
+
+  return index;
+}
+
+function applyReplaceSelection(
+  body: string,
+  operation: ReplaceSelectionOperation,
+): string {
+  const original = operation.originalText;
+  const index = findReplaceSelectionMatch(body, operation);
 
   return (
     body.slice(0, index) +
@@ -325,6 +340,14 @@ export async function applyAiProposal(
     !baseDraftRevisionMatches &&
     operation.op === "replace_selection" &&
     textAppearsExactlyOnce(existing.body, operation.originalText);
+
+  if (
+    !baseDraftRevisionMatches &&
+    operation.op === "replace_selection" &&
+    !canApplyReplaceSelectionAgainstLiveRevision
+  ) {
+    findReplaceSelectionMatch(existing.body, operation);
+  }
 
   if (
     !baseDraftRevisionMatches &&

--- a/packages/modules/core.ai/src/server/routes.test.ts
+++ b/packages/modules/core.ai/src/server/routes.test.ts
@@ -545,6 +545,69 @@ describe("mountAiRoutes — proposals/:id/apply", () => {
     assert.equal(setup.updateCalls.length, 1);
   });
 
+  test("returns source-not-found conflict when stale replace proposal cannot reanchor", async () => {
+    const proposal: AiProposal = {
+      proposalId: "p_reanchor_missing",
+      kind: "replace_selection",
+      project: "demo",
+      environment: "draft",
+      documentId: "doc_1",
+      baseDraftRevision: 4,
+      type: "post",
+      locale: "en",
+      summary: "Rewrite.",
+      operations: [
+        {
+          op: "replace_selection",
+          selectionId: "sel_anchor",
+          originalText: "Welcome to the site.",
+          replacementText: "Hi there!",
+        },
+      ],
+      validation: { status: "valid" },
+      expiresAt: "2026-05-01T00:05:00.000Z",
+      provider: {
+        providerId: "echo",
+        model: "echo-1",
+        promptTemplateId: "copy_improvement.v1",
+      },
+    };
+    const setup = createTestSetup({
+      document: buildDocument({
+        draftRevision: 6,
+        body: "The intro has already changed.",
+      }),
+    });
+
+    const response = await setup.app.fetch(
+      "POST",
+      `https://test.local/api/v1/ai/proposals/${proposal.proposalId}/apply`,
+      {
+        method: "POST",
+        headers: TARGET_HEADERS,
+        body: JSON.stringify({
+          proposal,
+          schemaHash: "hash_1",
+          draftRevision: 6,
+        }),
+      },
+    );
+
+    assert.equal(response.status, 409);
+    const body = (await response.json()) as {
+      code: string;
+      message: string;
+      details?: Record<string, unknown>;
+    };
+    assert.equal(body.code, "AI_PROPOSAL_CONFLICT");
+    assert.equal(
+      body.message,
+      "Original selection text was not found in the current draft body.",
+    );
+    assert.equal(body.details?.selectionId, "sel_anchor");
+    assert.equal(setup.updateCalls.length, 0);
+  });
+
   test("expired proposal returns 410 and emits expired audit", async () => {
     const orchestrator = createAiOrchestrator({
       provider: createEchoAiProvider({


### PR DESCRIPTION
## Summary
- Return source-anchor conflict messages when stale replace proposals cannot reanchor.
- Reuse replace-selection match validation for stale revision fallback.
- Add regression coverage for missing source text.

## Test Plan
- [x] bun test --cwd packages/modules/core.ai ./src/server/routes.test.ts
- [x] bun run format:check
- [x] bun run changeset:check
- [x] bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced conflict detection when applying AI proposals with replace-selection operations on stale drafts, now providing more specific error messages when original text cannot be re-anchored.

* **Tests**
  * Added test coverage validating proper error handling for stale replace-selection proposals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mdcms-ai/mdcms/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->