### PR TITLE
CMS-246 Apply new Studio design to Settings page

### DIFF
--- a/.ai/plans/2026-05-28-cms-246-settings-page-design.md
+++ b/.ai/plans/2026-05-28-cms-246-settings-page-design.md
@@ -1,0 +1,148 @@
+# CMS-246 Settings Page Design Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the new MDCMS Studio visual system to Settings while preserving the existing API key and capability contracts.
+
+**Architecture:** Keep Settings as a Studio-runtime page and avoid backend contract changes. Add a small read-only schema summary query for the General tab using the existing schema route contract, and keep API key create/list/revoke through the current `useApiKeyList` flow.
+
+**Tech Stack:** React 19, TanStack Query, Bun tests, Tailwind runtime styles, Lucide icons.
+
+---
+
+## Spec Delta
+
+- No new spec behavior is required. The implementation uses existing spec-owned contracts:
+  - `SPEC-006` owns `/admin/settings` as an admin/settings-managed Studio route and capability-gated UI.
+  - `SPEC-005` owns API key metadata, create, one-time secret reveal, revoke, operation scopes, and context allowlists.
+  - `SPEC-004` owns schema sync as code-first/CLI-owned and supports read-only schema metadata.
+- Affected UI/contract surface: Settings page only. Existing API calls remain `GET /api/v1/auth/api-keys`, `POST /api/v1/auth/api-keys`, `POST /api/v1/auth/api-keys/:id/revoke`, and `GET /api/v1/schema`.
+- Acceptance criteria covered: visual redesign, read-only General context, API key lifecycle preservation, `capabilities.settings.manage` gate, loading/empty/error/mutation states, responsive layout, and Studio review check. `apps/studio-review` is not present in this branch.
+
+## Files
+
+- Modify: `packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx`
+- Modify: `apps/docs/guide/studio/settings.mdx`
+- Create: no new source files unless the Settings page becomes too large during refactor.
+
+## Task 1: Failing Settings Coverage
+
+- [x] **Step 1: Add tests for General read-only design**
+
+Add tests in `packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx` that assert:
+
+```ts
+assert.match(markup, /data-mdcms-settings-subnav/);
+assert.match(markup, /Schema hash/);
+assert.match(markup, /Last schema sync/);
+assert.match(markup, /mdcms schema sync/);
+assert.doesNotMatch(markup, /Save changes/);
+```
+
+- [x] **Step 2: Add tests for API key ready state and revoke controls**
+
+Add a pure view test or hook-friendly render test that supplies one `ApiKeyMetadata` and asserts the API keys tab renders `keyPrefix`, operation scopes, context allowlist, computed `Active` status, and a `Revoke` action.
+
+- [x] **Step 3: Add tests for create dialog lifecycle helpers**
+
+Export internal helper functions from `api-key-create-dialog.tsx` and test:
+
+```ts
+const input = buildApiKeyCreateInput({
+  label: " CI ",
+  selectedScopes: new Set(["content:read"]),
+  expiresAt: "2026-06-01",
+  project: "marketing-site",
+  environment: "production",
+});
+assert.equal(input.label, "CI");
+assert.deepEqual(input.contextAllowlist, [
+  { project: "marketing-site", environment: "production" },
+]);
+```
+
+Also verify a successful reducer transition reaches `step: "created"` with the one-time `key` present.
+
+- [x] **Step 4: Verify red**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/app/admin/settings-page.test.tsx ./src/lib/runtime-ui/components/api-key-create-dialog.test.ts
+```
+
+Expected: new tests fail because schema summary, view helper, and dialog helpers are not implemented yet.
+
+## Task 2: Settings Page Implementation
+
+- [x] **Step 1: Add read-only schema summary query**
+
+Use `createStudioSchemaRouteApi` and `useQuery` in `settings-page.tsx` to fetch `GET /api/v1/schema` only when `project`, `environment`, and `apiBaseUrl` are present. Derive `schemaHash` from `response.schemaHash` first, then from consistent entry hashes if needed. Derive `syncedAt` from consistent entry timestamps.
+
+- [x] **Step 2: Redesign Settings shell**
+
+Use an offwhite page canvas, responsive two-column layout (`lg:grid-cols-[220px_1fr]`), left sub-nav with General and API keys, flat 8px surfaces, 1px hairline borders, cobalt primary actions, and mono metadata rows. The mobile layout stacks the sub-nav above content.
+
+- [x] **Step 3: Redesign General**
+
+Render read-only rows for project, environment, server URL, schema hash, and synced timestamp. Include a terse CLI hint for `mdcms schema sync`. Show loading and error treatments for schema metadata without adding write controls.
+
+- [x] **Step 4: Redesign API keys**
+
+Keep existing `useApiKeyList`, create dialog, one-time reveal, and revoke calls. Restyle loading, empty, error, ready, and mutation states. Keep table horizontally scrollable and avoid text overlap by using `break-all`, `min-w`, and responsive grid/card wrappers where needed.
+
+- [x] **Step 5: Verify green**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/app/admin/settings-page.test.tsx ./src/lib/runtime-ui/components/api-key-create-dialog.test.ts
+```
+
+Expected: tests pass.
+
+## Task 3: Docs And Review App Check
+
+- [x] **Step 1: Update Settings docs**
+
+Update `apps/docs/guide/studio/settings.mdx` so it describes the current Settings page as General + API Keys, keeps schema/config editing CLI-owned, and leaves post-MVP Webhooks/Media as planned only.
+
+- [x] **Step 2: Check Studio review**
+
+Run:
+
+```bash
+test -d apps/studio-review
+```
+
+Expected in this branch: command exits non-zero because the app is absent. Document this in the final summary instead of inventing fixtures.
+
+## Task 4: Verification
+
+- [x] **Step 1: Run targeted Studio tests**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/app/admin/settings-page.test.tsx ./src/lib/runtime-ui/components/api-key-create-dialog.test.ts ./src/lib/api-keys-api.test.ts
+```
+
+- [x] **Step 2: Run package check**
+
+Run:
+
+```bash
+bun run check
+```
+
+- [x] **Step 3: Run unit suite if feasible**
+
+Run:
+
+```bash
+bun run unit
+```
+
+Result: failed in an unrelated CLI loopback callback test with `Failed to start loopback callback listener` / `Failed to start server. Is port 0 in use?`. The clean branch had already shown the same port-0 listener failure mode in `apps/server/src/lib/auth.test.ts`; the changed Studio tests pass independently.

--- a/apps/docs/guide/studio/settings.mdx
+++ b/apps/docs/guide/studio/settings.mdx
@@ -1,12 +1,28 @@
 ---
 title: "Settings"
-description: "API keys, users, webhooks, and Studio configuration"
+description: "Read-only project context and API key management"
 ---
 
 <Warning>
   Settings access requires the **admin** or **owner** role. Users without these
   roles see an "Access denied" message.
 </Warning>
+
+## General
+
+The **General** tab shows read-only context for the active Studio target:
+
+| Field                | Description                                                |
+| -------------------- | ---------------------------------------------------------- |
+| **Project**          | The current project identifier                             |
+| **Environment**      | The current environment identifier                         |
+| **Server URL**       | The backend URL Studio is using for API requests           |
+| **Schema hash**      | The latest synced schema hash returned by the schema API   |
+| **Last schema sync** | The timestamp returned by the latest schema registry state |
+
+The schema and project configuration remain code-first. To change content type
+definitions or sync schema metadata, update `mdcms.config.ts` in the host
+project and run `mdcms schema sync` from the CLI.
 
 ## API Keys
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.test.tsx
@@ -12,6 +12,12 @@ import {
 } from "./capabilities-context.js";
 import { StudioMountInfoProvider } from "./mount-info-context.js";
 import SettingsPage from "./settings-page.js";
+import {
+  SettingsPageView,
+  type SettingsPageApiKeysState,
+  type SettingsPageSchemaSummaryState,
+} from "./settings-page.js";
+import type { ApiKeyMetadata } from "../../../api-keys-api.js";
 
 function renderSettingsPage(input: {
   initialTab: string;
@@ -86,6 +92,7 @@ test("SettingsPage renders the API keys tab header and create button", () => {
 
   assert.match(markup, /Create API Key/);
   assert.match(markup, /Manage API keys for external integrations/);
+  assert.match(markup, /data-mdcms-settings-subnav/);
 });
 
 test("SettingsPage does not render a Schema tab", () => {
@@ -130,5 +137,102 @@ test("SettingsPage General tab shows read-only project context", () => {
     capabilities: { canManageSettings: true },
   });
   assert.match(markup, /read-only/i);
+  assert.match(markup, /Schema hash/);
+  assert.match(markup, /Last schema sync/);
+  assert.match(markup, /mdcms schema sync/);
   assert.doesNotMatch(markup, /Save changes/);
+});
+
+const readySchemaSummary: SettingsPageSchemaSummaryState = {
+  status: "ready",
+  schemaHash: "server-hash",
+  syncedAt: "2026-03-31T12:00:00.000Z",
+};
+
+const readyKey: ApiKeyMetadata = {
+  id: "key-1",
+  label: "CI deploy",
+  keyPrefix: "mdcms_key_abc123",
+  scopes: ["content:read", "content:publish", "schema:read"],
+  contextAllowlist: [{ project: "test-project", environment: "production" }],
+  createdByUserId: "user-1",
+  createdAt: "2026-03-01T00:00:00.000Z",
+  expiresAt: null,
+  revokedAt: null,
+  lastUsedAt: null,
+};
+
+function renderSettingsPageView(input: {
+  initialTab: string;
+  apiKeysState?: Partial<SettingsPageApiKeysState>;
+  schemaSummary?: SettingsPageSchemaSummaryState;
+  canManageSettings?: boolean;
+}): string {
+  return renderToStaticMarkup(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(SettingsPageView, {
+        activeTab: input.initialTab,
+        setActiveTab: () => {},
+        canManageSettings: input.canManageSettings ?? true,
+        mountInfo: {
+          project: "test-project",
+          environment: "production",
+          apiBaseUrl: "https://api.example.com",
+        },
+        schemaSummary: input.schemaSummary ?? readySchemaSummary,
+        apiKeysState: {
+          status: "ready",
+          keys: [readyKey],
+          isRevoking: false,
+          revokeError: null,
+          onRevoke: () => {},
+          ...input.apiKeysState,
+        },
+        createDialogOpen: false,
+        setCreateDialogOpen: () => {},
+        createKey: async () => ({
+          ...readyKey,
+          key: "mdcms_key_secret",
+        }),
+        isCreating: false,
+        createError: null,
+      }),
+    ),
+  );
+}
+
+test("SettingsPageView renders schema summary metadata from the existing schema contract", () => {
+  const markup = renderSettingsPageView({ initialTab: "general" });
+
+  assert.match(markup, /data-mdcms-settings-general-state="ready"/);
+  assert.match(markup, /server-hash/);
+  assert.match(markup, /2026-03-31T12:00:00.000Z/);
+  assert.match(markup, /mdcms schema sync/);
+});
+
+test("SettingsPageView renders API key metadata and revoke affordance", () => {
+  const markup = renderSettingsPageView({ initialTab: "api-keys" });
+
+  assert.match(markup, /data-mdcms-settings-api-keys-state="ready"/);
+  assert.match(markup, /CI deploy/);
+  assert.match(markup, /mdcms_key_abc123/);
+  assert.match(markup, /content:read/);
+  assert.match(markup, /schema:read/);
+  assert.match(markup, /test-project/);
+  assert.match(markup, /production/);
+  assert.match(markup, /Active/);
+  assert.match(markup, /Revoke/);
+});
+
+test("SettingsPageView keeps forbidden state capability-gated", () => {
+  const markup = renderSettingsPageView({
+    initialTab: "api-keys",
+    canManageSettings: false,
+  });
+
+  assert.match(markup, /data-mdcms-settings-state="forbidden"/);
+  assert.match(markup, /Access denied/);
+  assert.doesNotMatch(markup, /Create API Key/);
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/settings-page.tsx
@@ -1,11 +1,31 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Settings, Key, Plus, ShieldOff } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertCircle,
+  Fingerprint,
+  Key,
+  Plus,
+  Server,
+  Settings,
+  ShieldOff,
+  TerminalSquare,
+} from "lucide-react";
+
+import type { SchemaRegistryListResponse } from "@mdcms/shared";
+
+import {
+  type ApiKeyCreateInput,
+  type ApiKeyCreateResult,
+  type ApiKeyMetadata,
+} from "../../../api-keys-api.js";
+import { createStudioSchemaRouteApi } from "../../../schema-route-api.js";
 import { useApiKeyList } from "../../hooks/use-api-key-list.js";
 import { ApiKeyCreateDialog } from "../../components/api-key-create-dialog.js";
 import { Button } from "../../components/ui/button.js";
 import { Badge } from "../../components/ui/badge.js";
+import { Skeleton } from "../../components/ui/skeleton.js";
 import {
   Table,
   TableBody,
@@ -16,17 +36,57 @@ import {
 } from "../../components/ui/table.js";
 import { useCanManageSettings } from "./capabilities-context.js";
 import { PageHeader } from "../../components/layout/page-header.js";
-import { useStudioMountInfo } from "./mount-info-context.js";
+import {
+  useStudioMountInfo,
+  type StudioMountInfo,
+} from "./mount-info-context.js";
 import { cn } from "../../lib/utils.js";
 
 const settingsTabs = [
   { id: "general", label: "General", icon: Settings },
-  { id: "api-keys", label: "API Keys", icon: Key },
-];
+  { id: "api-keys", label: "API keys", icon: Key },
+] as const;
+
+type SettingsTabId = (typeof settingsTabs)[number]["id"];
+
+export type SettingsPageSchemaSummaryState =
+  | { status: "loading" }
+  | { status: "ready"; schemaHash: string | null; syncedAt: string | null }
+  | { status: "error"; message: string }
+  | { status: "unavailable"; message: string };
+
+export type SettingsPageApiKeysState = {
+  status: "loading" | "ready" | "empty" | "error";
+  keys: ApiKeyMetadata[];
+  errorMessage?: string;
+  isRevoking: boolean;
+  revokeError: Error | null;
+  onRevoke: (keyId: string) => void;
+};
+
+type SettingsPageMountContext = Pick<
+  StudioMountInfo,
+  "project" | "environment" | "apiBaseUrl"
+>;
 
 function formatClientDate(value: string | null | undefined): string {
   if (!value) return "";
   return new Date(value).toLocaleDateString();
+}
+
+function resolveApiKeyStatus(input: {
+  expiresAt: string | null;
+  revokedAt: string | null;
+  now: number;
+}): "Active" | "Expired" | "Revoked" {
+  if (input.revokedAt !== null) return "Revoked";
+  if (
+    input.expiresAt !== null &&
+    new Date(input.expiresAt).getTime() < input.now
+  ) {
+    return "Expired";
+  }
+  return "Active";
 }
 
 function ApiKeyStatusBadge({
@@ -38,28 +98,621 @@ function ApiKeyStatusBadge({
 }) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    // Refresh once a minute so a key crossing its expiry while this page
-    // is open flips from Active → Expired without a manual reload.
     const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
-  const isExpired = expiresAt !== null && new Date(expiresAt).getTime() < now;
-  const label =
-    revokedAt !== null ? "Revoked" : isExpired ? "Expired" : "Active";
+  const label = resolveApiKeyStatus({ expiresAt, revokedAt, now });
   const isActive = label === "Active";
   return (
     <Badge
       variant="outline"
       suppressHydrationWarning
       className={cn(
-        "text-xs",
+        "rounded-sm border px-2 py-0.5 font-mono text-[11px]",
         isActive
-          ? "bg-success/10 text-success border-success/20"
-          : "bg-destructive/10 text-destructive border-destructive/20",
+          ? "border-success/20 bg-success/10 text-success"
+          : "border-destructive/20 bg-destructive/10 text-destructive",
       )}
     >
       {label}
     </Badge>
+  );
+}
+
+function getConsistentEntryValue(
+  entries: SchemaRegistryListResponse["types"],
+  field: "schemaHash" | "syncedAt",
+): string | null {
+  const first = entries[0]?.[field]?.trim();
+  if (!first) return null;
+  return entries.every((entry) => entry[field] === first) ? first : null;
+}
+
+function resolveSettingsSchemaSummary(
+  response: SchemaRegistryListResponse,
+): Extract<SettingsPageSchemaSummaryState, { status: "ready" }> {
+  return {
+    status: "ready",
+    schemaHash:
+      response.schemaHash ??
+      getConsistentEntryValue(response.types, "schemaHash"),
+    syncedAt:
+      response.syncedAt ?? getConsistentEntryValue(response.types, "syncedAt"),
+  };
+}
+
+function useSettingsSchemaSummary(): SettingsPageSchemaSummaryState {
+  const mountInfo = useStudioMountInfo();
+  const project = mountInfo.project;
+  const environment = mountInfo.environment;
+  const serverUrl = mountInfo.apiBaseUrl;
+  const auth = mountInfo.auth;
+  const canLoad = Boolean(project && environment && serverUrl);
+
+  const schemaQuery = useQuery({
+    queryKey: [
+      "settings-schema-summary",
+      project,
+      environment,
+      serverUrl,
+      auth.mode,
+      auth.mode === "token" ? auth.token : null,
+    ],
+    enabled: canLoad,
+    queryFn: async () => {
+      const api = createStudioSchemaRouteApi(
+        {
+          project: project!,
+          environment: environment!,
+          serverUrl,
+        },
+        { auth },
+      );
+      return api.list();
+    },
+  });
+
+  if (!canLoad) {
+    return {
+      status: "unavailable",
+      message: "Studio is missing project or environment context.",
+    };
+  }
+
+  if (schemaQuery.isLoading) {
+    return { status: "loading" };
+  }
+
+  if (schemaQuery.error) {
+    return {
+      status: "error",
+      message:
+        schemaQuery.error instanceof Error
+          ? schemaQuery.error.message
+          : "Failed to load schema metadata.",
+    };
+  }
+
+  if (!schemaQuery.data) {
+    return { status: "loading" };
+  }
+
+  return resolveSettingsSchemaSummary(schemaQuery.data);
+}
+
+function SettingsMetaRow({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string | null | undefined;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="grid gap-1 border-b border-divider/60 py-3 last:border-b-0 sm:grid-cols-[160px_1fr] sm:items-start">
+      <dt className="font-mono text-[11px] uppercase text-foreground-muted">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          "min-w-0 break-words font-mono text-[12px] text-foreground",
+          valueClassName,
+        )}
+      >
+        {value && value.trim().length > 0 ? value : "-"}
+      </dd>
+    </div>
+  );
+}
+
+function SettingsNotice({
+  tone,
+  title,
+  children,
+}: {
+  tone: "neutral" | "error";
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-4 py-3",
+        tone === "error"
+          ? "border-destructive/25 bg-destructive/10 text-destructive"
+          : "border-card-border bg-background-subtle text-foreground",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        {tone === "error" ? (
+          <AlertCircle className="mt-0.5 size-4 shrink-0" />
+        ) : (
+          <TerminalSquare className="mt-0.5 size-4 shrink-0 text-primary" />
+        )}
+        <div className="min-w-0 space-y-1">
+          <p className="text-sm font-semibold">{title}</p>
+          <div className="text-sm text-foreground-muted">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingsSubnav({
+  activeTab,
+  setActiveTab,
+}: {
+  activeTab: string;
+  setActiveTab: (tab: SettingsTabId) => void;
+}) {
+  return (
+    <aside
+      data-mdcms-settings-subnav
+      className="h-fit rounded-lg border border-card-border bg-card p-1 lg:sticky lg:top-20"
+    >
+      <nav className="flex gap-1 lg:flex-col">
+        {settingsTabs.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              type="button"
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              data-active={isActive ? "true" : "false"}
+              className={cn(
+                "flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-medium transition-colors lg:flex-none",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-foreground-muted hover:bg-background-subtle hover:text-foreground",
+              )}
+            >
+              <Icon className="size-4 shrink-0" />
+              <span className="truncate">{tab.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+function SettingsForbiddenState() {
+  return (
+    <div data-mdcms-settings-state="forbidden" className="min-h-screen">
+      <PageHeader breadcrumbs={[{ label: "Settings" }]} />
+      <div className="flex flex-col items-center justify-center px-6 py-20 text-center">
+        <div className="grid size-12 place-items-center rounded-lg border border-card-border bg-card">
+          <ShieldOff className="size-6 text-foreground-muted" />
+        </div>
+        <h3 className="mt-4 font-heading text-[22px] font-semibold text-foreground">
+          Access denied
+        </h3>
+        <p className="mt-2 max-w-md text-sm text-foreground-muted">
+          You do not have permission to manage settings for this project and
+          environment.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function GeneralSettingsPanel({
+  mountInfo,
+  schemaSummary,
+}: {
+  mountInfo: SettingsPageMountContext;
+  schemaSummary: SettingsPageSchemaSummaryState;
+}) {
+  const schemaState = schemaSummary.status;
+  const schemaHash =
+    schemaSummary.status === "ready" ? schemaSummary.schemaHash : null;
+  const syncedAt =
+    schemaSummary.status === "ready" ? schemaSummary.syncedAt : null;
+
+  return (
+    <section
+      data-mdcms-settings-general-state={schemaState}
+      className="space-y-5"
+    >
+      <div>
+        <h2 className="font-heading text-[30px] font-semibold leading-tight text-foreground">
+          General
+        </h2>
+        <p className="mt-1 max-w-2xl text-sm text-foreground-muted">
+          Read-only session and project context for the active Studio target.
+        </p>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1fr_280px]">
+        <div className="rounded-lg border border-card-border bg-card p-5">
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Server className="size-4 text-primary" />
+            Runtime context
+          </div>
+          <dl>
+            <SettingsMetaRow label="Project" value={mountInfo.project} />
+            <SettingsMetaRow
+              label="Environment"
+              value={mountInfo.environment}
+            />
+            <SettingsMetaRow
+              label="Server URL"
+              value={mountInfo.apiBaseUrl}
+              valueClassName="break-all"
+            />
+            {schemaSummary.status === "loading" ? (
+              <>
+                <div className="grid gap-1 border-b border-divider/60 py-3 sm:grid-cols-[160px_1fr]">
+                  <dt className="font-mono text-[11px] uppercase text-foreground-muted">
+                    Schema hash
+                  </dt>
+                  <dd>
+                    <Skeleton className="h-4 w-40" />
+                  </dd>
+                </div>
+                <div className="grid gap-1 py-3 sm:grid-cols-[160px_1fr]">
+                  <dt className="font-mono text-[11px] uppercase text-foreground-muted">
+                    Last schema sync
+                  </dt>
+                  <dd>
+                    <Skeleton className="h-4 w-52" />
+                  </dd>
+                </div>
+              </>
+            ) : (
+              <>
+                <SettingsMetaRow label="Schema hash" value={schemaHash} />
+                <SettingsMetaRow label="Last schema sync" value={syncedAt} />
+              </>
+            )}
+          </dl>
+        </div>
+
+        <div className="space-y-3">
+          <div className="rounded-lg border border-card-border bg-card p-4">
+            <div className="flex items-center gap-2">
+              <Fingerprint className="size-4 text-primary" />
+              <p className="font-mono text-[11px] uppercase text-foreground-muted">
+                Contract
+              </p>
+            </div>
+            <p className="mt-3 text-sm text-foreground">
+              Schema and project configuration are code-first. Studio does not
+              author those definitions here.
+            </p>
+          </div>
+          <SettingsNotice tone="neutral" title="CLI-owned schema sync">
+            Update `mdcms.config.ts`, then run{" "}
+            <code className="rounded-sm bg-code-bg px-1.5 py-0.5 font-mono text-[12px] text-foreground">
+              mdcms schema sync
+            </code>{" "}
+            from the host project.
+          </SettingsNotice>
+          {schemaSummary.status === "error" && (
+            <SettingsNotice tone="error" title="Schema metadata unavailable">
+              {schemaSummary.message}
+            </SettingsNotice>
+          )}
+          {schemaSummary.status === "unavailable" && (
+            <SettingsNotice tone="error" title="Target context unavailable">
+              {schemaSummary.message}
+            </SettingsNotice>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ApiKeysLoadingState() {
+  return (
+    <div
+      data-mdcms-settings-api-keys-state="loading"
+      className="rounded-lg border border-card-border bg-card p-5"
+    >
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-3/4" />
+      </div>
+    </div>
+  );
+}
+
+function ApiKeysEmptyState() {
+  return (
+    <div
+      data-mdcms-settings-api-keys-state="empty"
+      className="rounded-lg border border-dashed border-border bg-card p-10 text-center"
+    >
+      <Key className="mx-auto size-8 text-foreground-muted" />
+      <p className="mt-3 text-sm font-semibold text-foreground">
+        No API keys yet
+      </p>
+      <p className="mt-1 text-sm text-foreground-muted">
+        Create a scoped API key for CI, preview builds, or automation.
+      </p>
+    </div>
+  );
+}
+
+function ApiKeysErrorState({ message }: { message: string }) {
+  return (
+    <div
+      data-mdcms-settings-api-keys-state="error"
+      className="rounded-lg border border-destructive/25 bg-destructive/10 p-4 text-sm text-destructive"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 size-4 shrink-0" />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}
+
+function ApiKeyScopeList({ scopes }: { scopes: ApiKeyMetadata["scopes"] }) {
+  return (
+    <div className="flex max-w-[24rem] flex-wrap gap-1">
+      {scopes.map((scope) => (
+        <Badge
+          key={scope}
+          variant="default"
+          className="rounded-sm bg-code-bg font-mono text-[10px] text-foreground"
+        >
+          {scope}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function ApiKeyContextList({
+  contexts,
+}: {
+  contexts: ApiKeyMetadata["contextAllowlist"];
+}) {
+  if (contexts.length === 0) {
+    return (
+      <span className="font-mono text-[11px] text-foreground-muted">
+        no allowlist
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex max-w-[18rem] flex-wrap gap-1">
+      {contexts.map((ctx) => (
+        <Badge
+          key={`${ctx.project}/${ctx.environment}`}
+          variant="outline"
+          className="rounded-sm font-mono text-[10px]"
+        >
+          {ctx.project} / {ctx.environment}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function ApiKeysReadyState({ state }: { state: SettingsPageApiKeysState }) {
+  return (
+    <div
+      data-mdcms-settings-api-keys-state="ready"
+      className="overflow-hidden rounded-lg border border-card-border bg-card"
+    >
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-background-subtle hover:bg-background-subtle">
+            <TableHead>Label</TableHead>
+            <TableHead>Key prefix</TableHead>
+            <TableHead>Scopes</TableHead>
+            <TableHead>Context allowlist</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead>Expires</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-20"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {state.keys.map((key) => (
+            <TableRow key={key.id} className="hover:bg-background-subtle/60">
+              <TableCell className="min-w-[12rem] font-medium">
+                <div className="text-foreground">{key.label}</div>
+                <div className="font-mono text-[11px] text-foreground-muted">
+                  {key.createdByUserId}
+                </div>
+              </TableCell>
+              <TableCell className="min-w-[12rem] break-all font-mono text-[12px]">
+                {key.keyPrefix}
+              </TableCell>
+              <TableCell className="min-w-[16rem] whitespace-normal">
+                <ApiKeyScopeList scopes={key.scopes} />
+              </TableCell>
+              <TableCell className="min-w-[14rem] whitespace-normal">
+                <ApiKeyContextList contexts={key.contextAllowlist} />
+              </TableCell>
+              <TableCell className="text-sm text-foreground-muted">
+                <div suppressHydrationWarning>
+                  {formatClientDate(key.createdAt)}
+                </div>
+              </TableCell>
+              <TableCell
+                className="text-sm text-foreground-muted"
+                suppressHydrationWarning
+              >
+                {key.expiresAt ? formatClientDate(key.expiresAt) : "Never"}
+              </TableCell>
+              <TableCell>
+                <ApiKeyStatusBadge
+                  expiresAt={key.expiresAt}
+                  revokedAt={key.revokedAt}
+                />
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => state.onRevoke(key.id)}
+                  disabled={state.isRevoking || key.revokedAt !== null}
+                >
+                  Revoke
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function ApiKeysPanel({
+  apiKeysState,
+  setCreateDialogOpen,
+}: {
+  apiKeysState: SettingsPageApiKeysState;
+  setCreateDialogOpen: (open: boolean) => void;
+}) {
+  return (
+    <section className="space-y-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-heading text-[30px] font-semibold leading-tight text-foreground">
+            API keys
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-foreground-muted">
+            Manage API keys for external integrations.
+          </p>
+        </div>
+        <Button
+          onClick={() => setCreateDialogOpen(true)}
+          className="sm:self-start"
+        >
+          <Plus className="size-4" />
+          Create API Key
+        </Button>
+      </div>
+
+      {apiKeysState.revokeError && (
+        <SettingsNotice tone="error" title="Revoke failed">
+          {apiKeysState.revokeError.message || "Failed to revoke API key."}
+        </SettingsNotice>
+      )}
+
+      {apiKeysState.status === "loading" && <ApiKeysLoadingState />}
+      {apiKeysState.status === "error" && (
+        <ApiKeysErrorState
+          message={apiKeysState.errorMessage ?? "Failed to load API keys."}
+        />
+      )}
+      {apiKeysState.status === "empty" && <ApiKeysEmptyState />}
+      {apiKeysState.status === "ready" && (
+        <ApiKeysReadyState state={apiKeysState} />
+      )}
+    </section>
+  );
+}
+
+export function SettingsPageView({
+  activeTab,
+  setActiveTab,
+  canManageSettings,
+  mountInfo,
+  schemaSummary,
+  apiKeysState,
+  createDialogOpen,
+  setCreateDialogOpen,
+  createKey,
+  isCreating,
+  createError,
+}: {
+  activeTab: string;
+  setActiveTab: (tab: SettingsTabId) => void;
+  canManageSettings: boolean;
+  mountInfo: SettingsPageMountContext;
+  schemaSummary: SettingsPageSchemaSummaryState;
+  apiKeysState: SettingsPageApiKeysState;
+  createDialogOpen: boolean;
+  setCreateDialogOpen: (open: boolean) => void;
+  createKey: (input: ApiKeyCreateInput) => Promise<ApiKeyCreateResult>;
+  isCreating: boolean;
+  createError: Error | null;
+}) {
+  if (!canManageSettings) {
+    return <SettingsForbiddenState />;
+  }
+
+  return (
+    <div
+      data-mdcms-settings-state="ready"
+      className="min-h-screen bg-background"
+    >
+      <PageHeader breadcrumbs={[{ label: "Settings" }]} />
+
+      <div className="space-y-6 p-6 lg:p-8">
+        <div className="flex flex-col gap-2">
+          <p className="font-mono text-[11px] uppercase text-foreground-muted">
+            Studio control plane
+          </p>
+          <h1 className="font-heading text-[38px] font-semibold leading-[1.05] text-foreground">
+            Settings
+          </h1>
+          <p className="max-w-2xl text-sm text-foreground-muted">
+            Read live context and manage scoped API access without changing
+            code-owned schema or project definitions.
+          </p>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
+          <SettingsSubnav activeTab={activeTab} setActiveTab={setActiveTab} />
+          <main className="min-w-0">
+            {activeTab === "api-keys" ? (
+              <ApiKeysPanel
+                apiKeysState={apiKeysState}
+                setCreateDialogOpen={setCreateDialogOpen}
+              />
+            ) : (
+              <GeneralSettingsPanel
+                mountInfo={mountInfo}
+                schemaSummary={schemaSummary}
+              />
+            )}
+          </main>
+        </div>
+      </div>
+
+      <ApiKeyCreateDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        onSubmit={createKey}
+        isSubmitting={isCreating}
+        error={createError}
+      />
+    </div>
   );
 }
 
@@ -68,10 +721,13 @@ export default function SettingsPage({
 }: {
   initialTab?: string;
 }) {
-  const [activeTab, setActiveTab] = useState(initialTab);
+  const [activeTab, setActiveTab] = useState<SettingsTabId>(
+    initialTab === "api-keys" ? "api-keys" : "general",
+  );
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const canManageSettings = useCanManageSettings();
   const mountInfo = useStudioMountInfo();
+  const schemaSummary = useSettingsSchemaSummary();
   const {
     status: apiKeysStatus,
     keys: apiKeys,
@@ -84,228 +740,46 @@ export default function SettingsPage({
     revokeError,
   } = useApiKeyList();
 
-  if (!canManageSettings) {
-    return (
-      <div className="min-h-screen">
-        <PageHeader breadcrumbs={[{ label: "Settings" }]} />
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <ShieldOff className="mb-4 size-8 text-foreground-muted" />
-          <h3 className="mb-2 text-lg font-semibold">Access denied</h3>
-          <p className="text-sm text-foreground-muted">
-            You don&apos;t have permission to manage settings.
-          </p>
-        </div>
-      </div>
-    );
-  }
+  const apiKeysState = useMemo<SettingsPageApiKeysState>(
+    () => ({
+      status: apiKeysStatus,
+      keys: apiKeys,
+      errorMessage: apiKeysErrorMessage,
+      isRevoking,
+      revokeError,
+      onRevoke: (keyId: string) => {
+        revokeKey(keyId).catch(() => {
+          // Error is surfaced through revokeError in the hook state.
+        });
+      },
+    }),
+    [
+      apiKeys,
+      apiKeysErrorMessage,
+      apiKeysStatus,
+      isRevoking,
+      revokeError,
+      revokeKey,
+    ],
+  );
 
   return (
-    <div className="min-h-screen">
-      <PageHeader breadcrumbs={[{ label: "Settings" }]} />
-
-      <div className="flex">
-        {/* Settings Sidebar */}
-        <aside className="w-56 shrink-0 border-r border-border bg-background p-4">
-          <nav className="space-y-1">
-            {settingsTabs.map((tab) => (
-              <button
-                type="button"
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={cn(
-                  "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  activeTab === tab.id
-                    ? "bg-accent-subtle text-primary"
-                    : "text-foreground-muted hover:bg-background-subtle hover:text-foreground",
-                )}
-              >
-                <tab.icon className="size-4" />
-                {tab.label}
-              </button>
-            ))}
-          </nav>
-        </aside>
-
-        {/* Settings Content */}
-        <main className="flex-1 p-6">
-          {/* General Settings */}
-          {activeTab === "general" && (
-            <div className="max-w-2xl space-y-6">
-              <div>
-                <h2 className="text-xl font-semibold">General</h2>
-                <p className="text-sm text-foreground-muted">
-                  Project configuration is managed through the CLI and
-                  server-side settings. This view shows read-only context for
-                  the current session.
-                </p>
-              </div>
-              <div className="rounded-lg border border-border bg-background-subtle p-4 space-y-3">
-                <div className="flex justify-between text-sm">
-                  <span className="text-foreground-muted">Project</span>
-                  <span className="font-mono">
-                    {mountInfo.project ?? "\u2014"}
-                  </span>
-                </div>
-                <div className="flex justify-between text-sm">
-                  <span className="text-foreground-muted">Environment</span>
-                  <span className="font-mono">
-                    {mountInfo.environment ?? "\u2014"}
-                  </span>
-                </div>
-                <div className="flex justify-between text-sm">
-                  <span className="text-foreground-muted">Server URL</span>
-                  <span className="font-mono text-xs break-all">
-                    {mountInfo.apiBaseUrl ?? "\u2014"}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* API Keys */}
-          {activeTab === "api-keys" && (
-            <div className="space-y-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h2 className="text-xl font-semibold">API Keys</h2>
-                  <p className="text-sm text-foreground-muted">
-                    Manage API keys for external integrations
-                  </p>
-                </div>
-                <Button onClick={() => setCreateDialogOpen(true)}>
-                  <Plus className="mr-2 size-4" />
-                  Create API Key
-                </Button>
-              </div>
-
-              {apiKeysStatus === "loading" && (
-                <p className="text-sm text-foreground-muted">Loading…</p>
-              )}
-
-              {apiKeysStatus === "error" && (
-                <p className="text-sm text-destructive">
-                  {apiKeysErrorMessage ?? "Failed to load API keys."}
-                </p>
-              )}
-
-              {revokeError && (
-                <p className="text-sm text-destructive">
-                  {revokeError.message ?? "Failed to revoke API key."}
-                </p>
-              )}
-
-              {apiKeysStatus === "empty" && (
-                <p className="text-sm text-foreground-muted">No API keys yet</p>
-              )}
-
-              {apiKeysStatus === "ready" && (
-                <div className="rounded-lg border border-border">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Label</TableHead>
-                        <TableHead>Key prefix</TableHead>
-                        <TableHead>Scopes</TableHead>
-                        <TableHead>Context</TableHead>
-                        <TableHead>Created</TableHead>
-                        <TableHead>Expires</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead className="w-14"></TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {apiKeys.map((key) => (
-                        <TableRow key={key.id}>
-                          <TableCell className="font-medium">
-                            {key.label}
-                          </TableCell>
-                          <TableCell className="font-mono text-sm">
-                            {key.keyPrefix}
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-wrap gap-1">
-                              {key.scopes.slice(0, 2).map((scope) => (
-                                <Badge
-                                  key={scope}
-                                  variant="default"
-                                  className="text-xs"
-                                >
-                                  {scope}
-                                </Badge>
-                              ))}
-                              {key.scopes.length > 2 && (
-                                <Badge variant="default" className="text-xs">
-                                  +{key.scopes.length - 2}
-                                </Badge>
-                              )}
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-wrap gap-1">
-                              {key.contextAllowlist.map((ctx) => (
-                                <Badge
-                                  key={`${ctx.project}/${ctx.environment}`}
-                                  variant="outline"
-                                  className="text-xs"
-                                >
-                                  {ctx.environment}
-                                </Badge>
-                              ))}
-                            </div>
-                          </TableCell>
-                          <TableCell className="text-sm text-foreground-muted">
-                            <div suppressHydrationWarning>
-                              {formatClientDate(key.createdAt)}
-                            </div>
-                            <div className="text-xs">{key.createdByUserId}</div>
-                          </TableCell>
-                          <TableCell
-                            className="text-sm text-foreground-muted"
-                            suppressHydrationWarning
-                          >
-                            {key.expiresAt
-                              ? formatClientDate(key.expiresAt)
-                              : "Never"}
-                          </TableCell>
-                          <TableCell>
-                            <ApiKeyStatusBadge
-                              expiresAt={key.expiresAt}
-                              revokedAt={key.revokedAt}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="text-destructive hover:text-destructive"
-                              onClick={() => {
-                                revokeKey(key.id).catch(() => {
-                                  // Error is surfaced via revokeError from the hook
-                                });
-                              }}
-                              disabled={isRevoking || key.revokedAt !== null}
-                            >
-                              Revoke
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              )}
-
-              <ApiKeyCreateDialog
-                open={createDialogOpen}
-                onOpenChange={setCreateDialogOpen}
-                onSubmit={createKey}
-                isSubmitting={isCreating}
-                error={createError}
-              />
-            </div>
-          )}
-        </main>
-      </div>
-    </div>
+    <SettingsPageView
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      canManageSettings={canManageSettings}
+      mountInfo={{
+        project: mountInfo.project,
+        environment: mountInfo.environment,
+        apiBaseUrl: mountInfo.apiBaseUrl,
+      }}
+      schemaSummary={schemaSummary}
+      apiKeysState={apiKeysState}
+      createDialogOpen={createDialogOpen}
+      setCreateDialogOpen={setCreateDialogOpen}
+      createKey={createKey}
+      isCreating={isCreating}
+      createError={createError}
+    />
   );
 }

--- a/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import type { ApiKeyCreateResult } from "../../api-keys-api.js";
+import {
+  apiKeyCreateDialogFormReducer,
+  buildApiKeyCreateInput,
+  createInitialApiKeyCreateDialogFormState,
+  isApiKeyCreateDialogSubmittable,
+} from "./api-key-create-dialog.js";
+
+test("buildApiKeyCreateInput trims labels and scopes the key to the mounted target", () => {
+  const input = buildApiKeyCreateInput({
+    label: " CI deploy ",
+    selectedScopes: new Set(["content:read", "schema:read"]),
+    expiresAt: "2026-06-01",
+    project: "marketing-site",
+    environment: "production",
+  });
+
+  assert.equal(input.label, "CI deploy");
+  assert.deepEqual(input.scopes, ["content:read", "schema:read"]);
+  assert.deepEqual(input.contextAllowlist, [
+    { project: "marketing-site", environment: "production" },
+  ]);
+  assert.equal(input.expiresAt, "2026-06-01T00:00:00.000Z");
+});
+
+test("isApiKeyCreateDialogSubmittable requires a label, at least one scope, and idle mutation state", () => {
+  const state = apiKeyCreateDialogFormReducer(
+    apiKeyCreateDialogFormReducer(createInitialApiKeyCreateDialogFormState(), {
+      type: "label-change",
+      value: "Preview",
+    }),
+    { type: "scope-toggle", scope: "content:read" },
+  );
+
+  assert.equal(isApiKeyCreateDialogSubmittable(state, false), true);
+  assert.equal(isApiKeyCreateDialogSubmittable(state, true), false);
+  assert.equal(
+    isApiKeyCreateDialogSubmittable(
+      { ...state, selectedScopes: new Set() },
+      false,
+    ),
+    false,
+  );
+});
+
+test("apiKeyCreateDialogFormReducer preserves the one-time API key reveal after creation", () => {
+  const result: ApiKeyCreateResult = {
+    id: "key-1",
+    label: "Preview",
+    keyPrefix: "mdcms_key_abc123",
+    key: "mdcms_key_secret_once",
+    scopes: ["content:read"],
+    contextAllowlist: [{ project: "marketing-site", environment: "staging" }],
+    createdByUserId: "user-1",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    expiresAt: null,
+    revokedAt: null,
+    lastUsedAt: null,
+  };
+
+  const state = apiKeyCreateDialogFormReducer(
+    createInitialApiKeyCreateDialogFormState(),
+    { type: "submit-success", result },
+  );
+
+  assert.equal(state.step, "created");
+  assert.equal(state.createdResult?.key, "mdcms_key_secret_once");
+  assert.equal(state.createdResult?.keyPrefix, "mdcms_key_abc123");
+});

--- a/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/api-key-create-dialog.tsx
@@ -85,7 +85,7 @@ export type ApiKeyCreateDialogProps = {
 
 type Step = "form" | "created";
 
-type FormState = {
+export type ApiKeyCreateDialogFormState = {
   step: Step;
   label: string;
   selectedScopes: Set<ApiKeyOperationScope>;
@@ -95,7 +95,7 @@ type FormState = {
   submitError: string | null;
 };
 
-function createInitialFormState(): FormState {
+export function createInitialApiKeyCreateDialogFormState(): ApiKeyCreateDialogFormState {
   return {
     step: "form",
     label: "",
@@ -107,13 +107,14 @@ function createInitialFormState(): FormState {
   };
 }
 
-const initialFormState: FormState = createInitialFormState();
+const initialFormState: ApiKeyCreateDialogFormState =
+  createInitialApiKeyCreateDialogFormState();
 
 function formatDateInputValue(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
-type FormAction =
+export type ApiKeyCreateDialogFormAction =
   | { type: "reset" }
   | { type: "label-change"; value: string }
   | { type: "scope-toggle"; scope: ApiKeyOperationScope }
@@ -123,13 +124,16 @@ type FormAction =
   | { type: "submit-error"; message: string }
   | { type: "copy-set"; copied: boolean };
 
-function formReducer(state: FormState, action: FormAction): FormState {
+export function apiKeyCreateDialogFormReducer(
+  state: ApiKeyCreateDialogFormState,
+  action: ApiKeyCreateDialogFormAction,
+): ApiKeyCreateDialogFormState {
   switch (action.type) {
     case "reset":
       // Build a fresh state so `selectedScopes` is a new Set rather than the
       // shared one held by `initialFormState` — otherwise a subsequent
       // `scope-toggle` would mutate the module-level reference.
-      return createInitialFormState();
+      return createInitialApiKeyCreateDialogFormState();
     case "label-change":
       return { ...state, label: action.value };
     case "scope-toggle": {
@@ -154,6 +158,39 @@ function formReducer(state: FormState, action: FormAction): FormState {
   }
 }
 
+export function isApiKeyCreateDialogSubmittable(
+  state: Pick<ApiKeyCreateDialogFormState, "label" | "selectedScopes">,
+  isSubmitting: boolean,
+): boolean {
+  return (
+    state.label.trim().length > 0 &&
+    state.selectedScopes.size > 0 &&
+    !isSubmitting
+  );
+}
+
+export function buildApiKeyCreateInput(input: {
+  label: string;
+  selectedScopes: Set<ApiKeyOperationScope>;
+  expiresAt: string;
+  project: string | null | undefined;
+  environment: string | null | undefined;
+}): ApiKeyCreateInput {
+  const contextAllowlist =
+    input.project && input.environment
+      ? [{ project: input.project, environment: input.environment }]
+      : [];
+
+  return {
+    label: input.label.trim(),
+    scopes: Array.from(input.selectedScopes),
+    contextAllowlist,
+    ...(input.expiresAt
+      ? { expiresAt: new Date(input.expiresAt).toISOString() }
+      : {}),
+  };
+}
+
 export function ApiKeyCreateDialog({
   open,
   onOpenChange,
@@ -162,7 +199,10 @@ export function ApiKeyCreateDialog({
   error,
 }: ApiKeyCreateDialogProps) {
   const mountInfo = useStudioMountInfo();
-  const [form, dispatch] = useReducer(formReducer, initialFormState);
+  const [form, dispatch] = useReducer(
+    apiKeyCreateDialogFormReducer,
+    initialFormState,
+  );
   const {
     step,
     label,
@@ -174,25 +214,20 @@ export function ApiKeyCreateDialog({
   } = form;
   const todayMinDate = open ? formatDateInputValue(new Date()) : undefined;
 
-  const canSubmit =
-    label.trim().length > 0 && selectedScopes.size > 0 && !isSubmitting;
+  const canSubmit = isApiKeyCreateDialogSubmittable(form, isSubmitting);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!canSubmit) return;
     dispatch({ type: "submit-start" });
 
-    const contextAllowlist =
-      mountInfo.project && mountInfo.environment
-        ? [{ project: mountInfo.project, environment: mountInfo.environment }]
-        : [];
-
-    const input: ApiKeyCreateInput = {
-      label: label.trim(),
-      scopes: Array.from(selectedScopes),
-      contextAllowlist,
-      ...(expiresAt ? { expiresAt: new Date(expiresAt).toISOString() } : {}),
-    };
+    const input = buildApiKeyCreateInput({
+      label,
+      selectedScopes,
+      expiresAt,
+      project: mountInfo.project,
+      environment: mountInfo.environment,
+    });
 
     try {
       const result = await onSubmit(input);


### PR DESCRIPTION
Summary:
- Redesigns the Studio Settings page around General and API keys views.
- Adds read-only project/environment/server/schema metadata using the existing schema contract.
- Preserves API key create/list/revoke flows and documents the current Settings workflow.

Validation:
- bun test --cwd packages/studio ./src/lib/runtime-ui/app/admin/settings-page.test.tsx ./src/lib/runtime-ui/components/api-key-create-dialog.test.ts ./src/lib/api-keys-api.test.ts
- bun run format:check
- bun run changeset:check
- bun run check
- bun run unit (fails locally in unrelated port-0 loopback listener test: apps/cli/src/lib/login.test.ts)

Notes:
- Design bundle URL returned 404, so this applies the Jira design constraints manually.
- apps/studio-review is absent in this checkout.