### PR TITLE
fix(ai): preserve streamed assistant text blocks

### DIFF
--- a/packages/modules/core.ai/src/server/orchestrator.test.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.test.ts
@@ -484,6 +484,76 @@ describe("createAiOrchestrator", () => {
     assert.ok(events.some((event) => event.type === "done"));
   });
 
+  test("chat stream separates text blocks emitted across model steps", async () => {
+    resetIds();
+    const provider = createEchoAiProvider({
+      steps: [
+        {
+          type: "tool-calls",
+          calls: [
+            {
+              toolName: "propose_replace_document_text",
+              input: JSON.stringify({
+                summary: "Replace contact block",
+                originalText: "## Contact us\n\nExisting text",
+                replacementText: "## Contact us\n\nUpdated text",
+              }),
+            },
+          ],
+          trailingText:
+            "I'll inspect the existing page and compose the edit closely.",
+        },
+        { type: "text", text: "I've proposed the testimonial section." },
+      ],
+    });
+    const orchestrator = createAiOrchestrator({
+      provider,
+      clock: fixedClock,
+      idFactory,
+    });
+
+    const events: AiChatStreamEvent[] = [];
+    for await (const event of orchestrator.runChatStream({
+      message: "Add testimonials",
+      project: "demo",
+      environment: "draft",
+      activeDocument: {
+        documentId: "doc_1",
+        path: "content/pages/home",
+        type: "page",
+        locale: "en",
+        draftRevision: 4,
+        body: "## Contact us\n\nExisting text",
+        frontmatter: {},
+        hasPublishedVersion: false,
+      },
+      capabilities: {
+        canEditDocument: true,
+        canCreateDocument: false,
+        canDeleteDocument: false,
+        canReadEntries: false,
+      },
+    })) {
+      events.push(event);
+    }
+
+    const deltas = events
+      .filter((event) => event.type === "text-delta")
+      .map((event) => event.text)
+      .join("");
+    assert.equal(
+      deltas,
+      "I'll inspect the existing page and compose the edit closely.\n\nI've proposed the testimonial section.",
+    );
+
+    const done = events.find((event) => event.type === "done");
+    assert.ok(done);
+    assert.equal(
+      done.text,
+      "I'll inspect the existing page and compose the edit closely.\n\nI've proposed the testimonial section.",
+    );
+  });
+
   test("chat stream maps model error parts to a terminal error event", async () => {
     const orchestrator = createAiOrchestrator({
       provider: createStreamErrorAiProvider(

--- a/packages/modules/core.ai/src/server/orchestrator.ts
+++ b/packages/modules/core.ai/src/server/orchestrator.ts
@@ -347,6 +347,7 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
       const { collected, tools, system, prompt, languageModel, baseContext } =
         setup;
       let accumulatedText = "";
+      let nextTextDeltaStartsNewBlock = false;
       try {
         const result = streamText({
           model: languageModel,
@@ -358,9 +359,19 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
         });
         for await (const part of result.fullStream) {
           if (part.type === "text-delta") {
-            accumulatedText += part.text;
-            yield { type: "text-delta", text: part.text };
+            const text =
+              nextTextDeltaStartsNewBlock && part.text.trim().length > 0
+                ? textDeltaWithBlockSeparator(accumulatedText, part.text)
+                : part.text;
+            accumulatedText += text;
+            if (part.text.trim().length > 0) {
+              nextTextDeltaStartsNewBlock = false;
+            }
+            yield { type: "text-delta", text };
           } else if (part.type === "start-step") {
+            if (accumulatedText.trim().length > 0) {
+              nextTextDeltaStartsNewBlock = true;
+            }
             yield {
               type: "progress",
               phase: "thinking",
@@ -445,6 +456,19 @@ export function createAiOrchestrator(deps: AiOrchestratorDeps): AiOrchestrator {
       }
     },
   };
+}
+
+function textDeltaWithBlockSeparator(
+  accumulatedText: string,
+  delta: string,
+): string {
+  if (accumulatedText.trim().length === 0) return delta;
+  if (hasMarkdownBlockBoundary(accumulatedText, delta)) return delta;
+  return `\n\n${delta}`;
+}
+
+function hasMarkdownBlockBoundary(previous: string, next: string): boolean {
+  return /\n[ \t]*\n[ \t]*$/.test(previous) || /^[ \t]*\n[ \t]*\n/.test(next);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Insert markdown paragraph boundaries when streamed assistant text resumes in a later model step.
- Keep live text deltas and the final done payload consistent so Studio renders separate assistant text blocks with spacing.
- Add a regression test for streamed text around proposal tool calls.

## Test Plan
- bun test --cwd packages/modules/core.ai ./src/server/orchestrator.test.ts
- bun run format:check
- bun run check
- bun run changeset:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown formatting in streamed text responses by inserting appropriate separators between consecutive text chunks.

* **Tests**
  * Added test coverage for chat streaming text concatenation and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->