### PR TITLE
fix(ai): reject raw presentation MDX proposals

### DIFF
--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -533,6 +533,10 @@ Rules:
   text. The assistant should prefer catalog components and built-ins when the
   user asks for common visual composition, and use raw intrinsic HTML only when
   the requested result needs native HTML semantics such as forms or inputs.
+  Proposal validation rejects presentation-only intrinsic containers such as
+  raw `<section>`, `<div>`, `<p>`, or heading tags with
+  `MDX_UNGROUNDED_INTRINSIC_ELEMENT`; the assistant must express those visual
+  blocks through registered components or built-ins instead.
 - Inline styles are valid only through first-class `style` props. Style values
   must be flat objects whose values are strings or numbers.
 

--- a/packages/modules/core.ai/src/server/project-knowledge.test.ts
+++ b/packages/modules/core.ai/src/server/project-knowledge.test.ts
@@ -126,6 +126,11 @@ describe("renderProjectKnowledgeBlock", () => {
         "Use only these component names when generating MDX. Any other component name fails validation.",
       ),
     );
+    assert.ok(
+      block.includes(
+        "For visual composition, use registered components or built-ins instead of raw lowercase HTML containers.",
+      ),
+    );
     assert.ok(block.includes("- **Callout** — Inline notice"));
     assert.ok(block.includes('tone (enum "info" | "warning", required)'));
     assert.ok(block.includes("title (string, optional)"));

--- a/packages/modules/core.ai/src/server/project-knowledge.ts
+++ b/packages/modules/core.ai/src/server/project-knowledge.ts
@@ -79,6 +79,7 @@ export function renderProjectKnowledgeBlock(
     } else {
       lines.push(
         "Use only these component names when generating MDX. Any other component name fails validation.",
+        "For visual composition, use registered components or built-ins instead of raw lowercase HTML containers. Raw lowercase HTML is only valid when the user needs native form or input semantics.",
       );
       const sortedComponents = [...input.mdxCatalog.components].sort((a, b) =>
         a.name.localeCompare(b.name),

--- a/packages/modules/core.ai/src/server/validate-proposal.test.ts
+++ b/packages/modules/core.ai/src/server/validate-proposal.test.ts
@@ -547,6 +547,84 @@ describe("createMdxCatalogProposalValidator", () => {
     }
   });
 
+  test("flags presentation-only lowercase MDX blocks that bypass the component catalog", async () => {
+    const validator = createMdxCatalogProposalValidator({
+      validator: async () => ({ status: "valid" }),
+      catalog,
+    });
+    const result = await validator({
+      proposalId: "p1",
+      kind: "insert_block",
+      project: "demo",
+      environment: "draft",
+      type: "page",
+      locale: "en",
+      summary: "Insert testimonials",
+      operations: [
+        {
+          op: "insert_block",
+          bodyMdx: [
+            "<section>",
+            "  <div>",
+            "    <p>WHAT PEOPLE SAY</p>",
+            "    <h2>Loved by teams that <span>ship fast</span></h2>",
+            "  </div>",
+            "</section>",
+          ].join("\n"),
+        },
+      ],
+      expiresAt: "2026-05-15T00:05:00.000Z",
+      provider: {
+        providerId: "echo",
+        model: "echo-1",
+        promptTemplateId: "chat_tools.v1",
+      },
+    });
+
+    assert.equal(result.status, "invalid");
+    if (result.status === "invalid") {
+      assert.equal(result.errors[0]?.code, "MDX_UNGROUNDED_INTRINSIC_ELEMENT");
+      assert.equal(result.errors[0]?.path, "operations[0].bodyMdx");
+      assert.match(result.errors[0]?.message ?? "", /<section>/);
+    }
+  });
+
+  test("allows lowercase MDX when native form semantics are required", async () => {
+    const validator = createMdxCatalogProposalValidator({
+      validator: async () => ({ status: "valid" }),
+      catalog,
+    });
+    const result = await validator({
+      proposalId: "p1",
+      kind: "insert_block",
+      project: "demo",
+      environment: "draft",
+      type: "page",
+      locale: "en",
+      summary: "Insert signup form",
+      operations: [
+        {
+          op: "insert_block",
+          bodyMdx: [
+            "<form>",
+            '  <label htmlFor="email">Email</label>',
+            '  <input id="email" name="email" type="email" />',
+            "  <button>Join waitlist</button>",
+            "</form>",
+          ].join("\n"),
+        },
+      ],
+      expiresAt: "2026-05-15T00:05:00.000Z",
+      provider: {
+        providerId: "echo",
+        model: "echo-1",
+        promptTemplateId: "chat_tools.v1",
+      },
+    });
+
+    assert.equal(result.status, "valid");
+  });
+
   test("flags missing required props on registered MDX components", async () => {
     const validator = createMdxCatalogProposalValidator({
       validator: async () => ({ status: "valid" }),

--- a/packages/modules/core.ai/src/server/validate-proposal.ts
+++ b/packages/modules/core.ai/src/server/validate-proposal.ts
@@ -787,12 +787,54 @@ function validateMdxTargetsAgainstCatalog(
         }
       }
     }
+
+    for (const tag of extractMdxIntrinsicElementTags(target.source)) {
+      if (isAllowedAiIntrinsicElement(tag.name)) {
+        continue;
+      }
+      errors.push({
+        code: "MDX_UNGROUNDED_INTRINSIC_ELEMENT",
+        message: `<${tag.name}> is raw intrinsic HTML. Use a registered MDX component or MDCMS built-in component for visual composition; raw intrinsic HTML is only allowed for native form and input semantics.`,
+        path: target.path,
+      });
+    }
   }
 
   return errors;
 }
 
+const AI_ALLOWED_INTRINSIC_ELEMENT_NAMES = new Set([
+  "button",
+  "datalist",
+  "fieldset",
+  "form",
+  "input",
+  "label",
+  "legend",
+  "meter",
+  "optgroup",
+  "option",
+  "output",
+  "progress",
+  "select",
+  "textarea",
+]);
+
+function isAllowedAiIntrinsicElement(name: string): boolean {
+  return AI_ALLOWED_INTRINSIC_ELEMENT_NAMES.has(name);
+}
+
 function extractMdxComponentTags(source: string): MdxTag[] {
+  return extractMdxTags(source).filter((tag) => isMdxComponentName(tag.name));
+}
+
+function extractMdxIntrinsicElementTags(source: string): MdxTag[] {
+  return extractMdxTags(source).filter((tag) =>
+    isMdxIntrinsicElementName(tag.name),
+  );
+}
+
+function extractMdxTags(source: string): MdxTag[] {
   const stripped = stripMarkdownCode(source);
   const tags: MdxTag[] = [];
   let index = 0;
@@ -881,7 +923,6 @@ function parseOpeningMdxTag(raw: string): MdxTag | undefined {
   if (!match) return undefined;
 
   const name = match[1]!;
-  if (!isMdxComponentName(name)) return undefined;
 
   return {
     name,
@@ -893,6 +934,10 @@ function parseOpeningMdxTag(raw: string): MdxTag | undefined {
 function isMdxComponentName(name: string): boolean {
   const [head] = name.split(".");
   return Boolean(head && /^[A-Z]/.test(head));
+}
+
+function isMdxIntrinsicElementName(name: string): boolean {
+  return /^[a-z][a-z0-9-]*$/.test(name);
 }
 
 function parseMdxAttributes(raw: string): Record<string, MdxAttributeValue> {


### PR DESCRIPTION
## Summary
- tighten AI MDX proposal validation so raw lowercase presentation containers cannot bypass the registered component catalog
- allow lowercase MDX only for native form/input semantics
- update SPEC-014 and prompt grounding guidance so future generated visual blocks use registered or built-in components

## Root cause
The deployed demo page was rendering a testimonials block as raw lowercase MDX/HTML (`<section>`, `<div>`, `<p>`, headings) instead of a registered MDX component. That content parsed successfully but bypassed catalog grounding, so the consumer rendered unstyled intrinsic HTML on the dark page background.

## Verification
- `bun test packages/modules/core.ai/src/server/project-knowledge.test.ts packages/modules/core.ai/src/server/validate-proposal.test.ts`
- `bun test packages/modules/core.ai/src/server`
- `bun run format:check`
- `bun run check`
- `bun test ./apps/cli/src/lib/login.test.ts -t "loopback callback returns styled HTML success page"` outside sandbox
- `bun run ci:required` outside sandbox reached Docker integration, but Docker is not running locally: `Cannot connect to the Docker daemon at unix:///Users/karol/.docker/run/docker.sock`. Quality, typecheck, unit tests, and studio embed smoke completed before that Docker health failure.