### PR TITLE
fix(studio): preserve sessions and revalidate on resume

### DIFF
--- a/.ai/memory/topics/auth-flow.md
+++ b/.ai/memory/topics/auth-flow.md
@@ -16,6 +16,9 @@ All three resolve to the same internal concept downstream: an authenticated prin
 
 Browser sessions are persisted server-side; the `sessions` table in `apps/server/src/lib/db/schema.ts` holds them with a unique-token index. Studio fetches the active principal on mount and caches it in its TanStack Query layer; writes carry CSRF protection.
 Session bootstrap returns the existing readable `mdcms_csrf` cookie when present and only creates a new token when the cookie is missing, so cached Studio clients can replay the token without another bootstrap invalidating it.
+Cookie-authenticated Studio tabs revalidate the session when the tab regains
+focus or becomes visible, so expired or revoked sessions redirect to login
+without a manual refresh.
 
 ### API key (SDK / non-interactive)
 
@@ -39,6 +42,9 @@ If the listener doesn't receive a callback within a timeout, the CLI surfaces "T
 - CSRF bootstrap must not rotate an existing `mdcms_csrf` cookie; multiple Studio clients and route helpers may cache that token concurrently.
 - The loopback flow validates `state` to defeat CSRF; binding to `127.0.0.1` confines redirect targets to the local machine.
 - API keys are revocable; sessions are revocable; both invalidate immediately on the server.
+- Password sign-in does not revoke a user's other active Studio sessions; users
+  can stay signed in from multiple browser contexts until inactivity, absolute
+  max age, logout, or explicit admin revocation invalidates a session.
 
 ## Cross-refs
 

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -2590,7 +2590,13 @@ testWithDatabase(
           },
         }),
       );
+      const currentSessionBody = (await currentSessionResponse.json()) as {
+        data: { session: { id: string; email: string } };
+      };
+
       assert.equal(currentSessionResponse.status, 200);
+      assert.equal(currentSessionBody.data.session.id, secondLogin.session.id);
+      assert.equal(currentSessionBody.data.session.email, email);
 
       const firstSessionResponse = await handler(
         new Request("http://localhost/api/v1/auth/session", {

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -2567,7 +2567,7 @@ testWithDatabase(
 );
 
 testWithDatabase(
-  "auth login rotates previous sessions for the same user",
+  "auth login preserves existing sessions for the same user",
   async () => {
     const { handler, dbConnection } = createServerRequestHandlerWithModules({
       env,
@@ -2600,11 +2600,12 @@ testWithDatabase(
         }),
       );
       const firstSessionBody = (await firstSessionResponse.json()) as {
-        code: string;
+        data: { session: { id: string; email: string } };
       };
 
-      assert.equal(firstSessionResponse.status, 401);
-      assert.equal(firstSessionBody.code, "UNAUTHORIZED");
+      assert.equal(firstSessionResponse.status, 200);
+      assert.equal(firstSessionBody.data.session.id, firstLogin.session.id);
+      assert.equal(firstSessionBody.data.session.email, email);
     } finally {
       await dbConnection.close();
     }

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -15,7 +15,7 @@ import {
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthMiddleware } from "better-auth/api";
-import { and, desc, eq, gt, isNull, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import type { DrizzleDatabase } from "./db.js";
@@ -3575,14 +3575,6 @@ export function createAuthService(
 
     const studioSession = toStudioSession(session);
     await clearLoginBackoff(loginKey);
-    await options.db
-      .delete(authSessions)
-      .where(
-        and(
-          eq(authSessions.userId, studioSession.userId),
-          ne(authSessions.id, studioSession.id),
-        ),
-      );
     const csrf = createCsrfBootstrap();
 
     return {

--- a/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
+++ b/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
@@ -346,6 +346,8 @@ MDCMS rejects sign-in with `AUTH_SAML_REQUIRED_ATTRIBUTE_MISSING` (`401`) when:
 - Session cookie is `httpOnly`, `Secure`, `SameSite=None`, and scoped to `/`.
 - `mdcms_csrf` cookie is readable, `Secure`, `SameSite=None`, and scoped to `/`.
 - Session lifetime: 2h rolling inactivity timeout with a 12h absolute max age.
+- Password sign-in creates a new session without revoking the user's other
+  active sessions.
 - Session IDs rotate on sign-in and privilege changes.
 - CSRF token required for Studio state-changing requests.
 - Failed password login attempts apply exponential backoff keyed by normalized email.
@@ -355,7 +357,8 @@ MDCMS rejects sign-in with `AUTH_SAML_REQUIRED_ATTRIBUTE_MISSING` (`401`) when:
 - Successful password sign-in resets the stored backoff state.
 - A quiet window of 15 minutes without failed attempts resets the backoff state.
 - MVP backoff schedule is capped exponential delay: `1s`, `2s`, `4s`, `8s`, `16s`, `32s`.
-- Per-user session revocation is supported (`logout` invalidates current session; owner/admin can revoke all active sessions).
+- Session revocation is explicit: `logout` invalidates the current session, and
+  owner/admin users can revoke all active sessions for a user.
 
 #### CSRF Enforcement (Normative)
 

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -133,6 +133,9 @@ session bootstrap request cannot verify the active browser session, including
 for the current Studio route. Token-authenticated embeds must not redirect to
 the login route; token authentication failures remain inline operator-facing
 states because the host application, not the Studio login form, owns the token.
+When a cookie-authenticated Studio tab returns to focus or becomes visible again,
+the runtime revalidates the active session so expired or revoked sessions move to
+the login route without requiring a manual page refresh.
 
 MDCMS built-in MDX components defined by `SPEC-007` are injected by the Studio
 shell/runtime without host registration. Studio resolves their preview

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
@@ -15,6 +15,7 @@ import {
   getAdminSidebarStorageKey,
   isDocumentEditorPathname,
   resolveAdminLayoutLoginRedirectPath,
+  shouldRefetchAdminLayoutSessionOnResume,
 } from "./layout.js";
 
 function createContext(): StudioMountContext {
@@ -202,6 +203,50 @@ test("resolveAdminLayoutLoginRedirectPath keeps token auth failures inline", () 
       sessionState: { status: "error", message: "Failed to fetch" },
     }),
     null,
+  );
+});
+
+test("shouldRefetchAdminLayoutSessionOnResume only refetches verified cookie sessions", () => {
+  assert.equal(
+    shouldRefetchAdminLayoutSessionOnResume({
+      isTokenMode: false,
+      sessionState: {
+        status: "authenticated",
+        csrfToken: "csrf",
+        session: {
+          id: "session-1",
+          userId: "user-1",
+          email: "editor@example.com",
+          issuedAt: "2026-06-02T10:00:00.000Z",
+          expiresAt: "2026-06-02T12:00:00.000Z",
+        },
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    shouldRefetchAdminLayoutSessionOnResume({
+      isTokenMode: false,
+      sessionState: { status: "unauthenticated" },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldRefetchAdminLayoutSessionOnResume({
+      isTokenMode: true,
+      sessionState: {
+        status: "authenticated",
+        csrfToken: "",
+        session: {
+          id: "token-auth-session",
+          userId: "token-auth-user",
+          email: "API token",
+          issuedAt: "",
+          expiresAt: "",
+        },
+      },
+    }),
+    false,
   );
 });
 

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.test.tsx
@@ -14,6 +14,7 @@ import {
   getDefaultAdminSidebarCollapsed,
   getAdminSidebarStorageKey,
   isDocumentEditorPathname,
+  registerAdminLayoutSessionResumeRefetch,
   resolveAdminLayoutLoginRedirectPath,
   shouldRefetchAdminLayoutSessionOnResume,
 } from "./layout.js";
@@ -248,6 +249,70 @@ test("shouldRefetchAdminLayoutSessionOnResume only refetches verified cookie ses
     }),
     false,
   );
+});
+
+test("registerAdminLayoutSessionResumeRefetch refetches on resume and cleans up listeners", () => {
+  const windowListeners = new Map<string, Set<() => void>>();
+  const documentListeners = new Map<string, Set<() => void>>();
+  let visibilityState: DocumentVisibilityState = "hidden";
+  let refetchCount = 0;
+  const addListener = (
+    listeners: Map<string, Set<() => void>>,
+    event: string,
+    handler: () => void,
+  ) => {
+    const handlers = listeners.get(event) ?? new Set<() => void>();
+    handlers.add(handler);
+    listeners.set(event, handlers);
+  };
+  const removeListener = (
+    listeners: Map<string, Set<() => void>>,
+    event: string,
+    handler: () => void,
+  ) => {
+    listeners.get(event)?.delete(handler);
+  };
+  const dispatch = (listeners: Map<string, Set<() => void>>, event: string) => {
+    for (const handler of listeners.get(event) ?? []) {
+      handler();
+    }
+  };
+
+  const unregister = registerAdminLayoutSessionResumeRefetch({
+    windowTarget: {
+      addEventListener: (event, handler) =>
+        addListener(windowListeners, event, handler),
+      removeEventListener: (event, handler) =>
+        removeListener(windowListeners, event, handler),
+    },
+    documentTarget: {
+      addEventListener: (event, handler) =>
+        addListener(documentListeners, event, handler),
+      removeEventListener: (event, handler) =>
+        removeListener(documentListeners, event, handler),
+      get visibilityState() {
+        return visibilityState;
+      },
+    },
+    refetchSession: () => {
+      refetchCount += 1;
+    },
+  });
+
+  dispatch(windowListeners, "focus");
+  assert.equal(refetchCount, 1);
+
+  dispatch(documentListeners, "visibilitychange");
+  assert.equal(refetchCount, 1);
+
+  visibilityState = "visible";
+  dispatch(documentListeners, "visibilitychange");
+  assert.equal(refetchCount, 2);
+
+  unregister();
+  dispatch(windowListeners, "focus");
+  dispatch(documentListeners, "visibilitychange");
+  assert.equal(refetchCount, 2);
 });
 
 test("AdminTokenErrorStateView renders retry action and technical details", () => {

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -236,6 +236,43 @@ export function shouldRefetchAdminLayoutSessionOnResume(input: {
   return !input.isTokenMode && input.sessionState.status === "authenticated";
 }
 
+type AdminLayoutSessionResumeWindowTarget = {
+  addEventListener: (event: "focus", handler: () => void) => void;
+  removeEventListener: (event: "focus", handler: () => void) => void;
+};
+
+type AdminLayoutSessionResumeDocumentTarget = {
+  readonly visibilityState: DocumentVisibilityState;
+  addEventListener: (event: "visibilitychange", handler: () => void) => void;
+  removeEventListener: (event: "visibilitychange", handler: () => void) => void;
+};
+
+export function registerAdminLayoutSessionResumeRefetch(input: {
+  windowTarget: AdminLayoutSessionResumeWindowTarget;
+  documentTarget: AdminLayoutSessionResumeDocumentTarget;
+  refetchSession: () => void;
+}): () => void {
+  const refetchVisibleSession = () => {
+    if (input.documentTarget.visibilityState === "visible") {
+      input.refetchSession();
+    }
+  };
+
+  input.windowTarget.addEventListener("focus", input.refetchSession);
+  input.documentTarget.addEventListener(
+    "visibilitychange",
+    refetchVisibleSession,
+  );
+
+  return () => {
+    input.windowTarget.removeEventListener("focus", input.refetchSession);
+    input.documentTarget.removeEventListener(
+      "visibilitychange",
+      refetchVisibleSession,
+    );
+  };
+}
+
 export function AdminTokenErrorStateView({
   state,
   context,
@@ -553,22 +590,26 @@ function useAdminLayoutRoutedElement({
       return;
     }
 
-    const refetchSession = () => {
-      void sessionQuery.refetch();
-    };
-    const refetchVisibleSession = () => {
-      if (document.visibilityState === "visible") {
-        refetchSession();
-      }
-    };
-
-    window.addEventListener("focus", refetchSession);
-    document.addEventListener("visibilitychange", refetchVisibleSession);
-
-    return () => {
-      window.removeEventListener("focus", refetchSession);
-      document.removeEventListener("visibilitychange", refetchVisibleSession);
-    };
+    return registerAdminLayoutSessionResumeRefetch({
+      windowTarget: {
+        addEventListener: (event, handler) =>
+          window.addEventListener(event, handler),
+        removeEventListener: (event, handler) =>
+          window.removeEventListener(event, handler),
+      },
+      documentTarget: {
+        addEventListener: (event, handler) =>
+          document.addEventListener(event, handler),
+        removeEventListener: (event, handler) =>
+          document.removeEventListener(event, handler),
+        get visibilityState() {
+          return document.visibilityState;
+        },
+      },
+      refetchSession: () => {
+        void sessionQuery.refetch();
+      },
+    });
   }, [sessionQuery.refetch, shouldRefetchSessionOnResume]);
 
   // Environments

--- a/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/layout.tsx
@@ -229,6 +229,13 @@ export function resolveAdminLayoutLoginRedirectPath(input: {
   return `/admin/login?returnTo=${returnTo}`;
 }
 
+export function shouldRefetchAdminLayoutSessionOnResume(input: {
+  sessionState: StudioSessionState;
+  isTokenMode: boolean;
+}): boolean {
+  return !input.isTokenMode && input.sessionState.status === "authenticated";
+}
+
 export function AdminTokenErrorStateView({
   state,
   context,
@@ -531,6 +538,38 @@ function useAdminLayoutRoutedElement({
     sessionQuery.error,
     sessionQuery.data,
   ]);
+
+  const shouldRefetchSessionOnResume = shouldRefetchAdminLayoutSessionOnResume({
+    sessionState,
+    isTokenMode,
+  });
+
+  useEffect(() => {
+    if (
+      !shouldRefetchSessionOnResume ||
+      typeof window === "undefined" ||
+      typeof document === "undefined"
+    ) {
+      return;
+    }
+
+    const refetchSession = () => {
+      void sessionQuery.refetch();
+    };
+    const refetchVisibleSession = () => {
+      if (document.visibilityState === "visible") {
+        refetchSession();
+      }
+    };
+
+    window.addEventListener("focus", refetchSession);
+    document.addEventListener("visibilitychange", refetchVisibleSession);
+
+    return () => {
+      window.removeEventListener("focus", refetchSession);
+      document.removeEventListener("visibilitychange", refetchVisibleSession);
+    };
+  }, [sessionQuery.refetch, shouldRefetchSessionOnResume]);
 
   // Environments
   const environmentsEnabled = Boolean(


### PR DESCRIPTION
## Summary
- Stop password sign-in from revoking the same user's other active Studio sessions.
- Revalidate cookie-backed Studio sessions when a tab regains focus or becomes visible, so expired/revoked sessions redirect to login without a manual refresh.
- Update auth and Studio specs plus auth-flow memory for the new session behavior.

## Test Plan
- bun test --cwd packages/studio ./src/lib/runtime-ui/app/admin/layout.test.tsx
- bun test --cwd apps/server ./src/lib/auth.test.ts --test-name-pattern "auth login preserves existing sessions" (skipped locally because Postgres/Docker is unavailable)
- bun run format:check
- bun run typecheck

Note: Docker daemon is not running locally, so DB-backed auth regression coverage is expected to run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions now automatically revalidate when switching back to a Studio tab, redirecting expired sessions to login without requiring a manual page refresh.
  * Multiple concurrent browser sessions are now supported—signing in won't end your other active sessions until they expire or are manually revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->