### PR TITLE
fix(studio): render lowercase intrinsic text elements

### DIFF
--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -6,6 +6,12 @@ Entries are reverse-chronological (newest first).
 
 ---
 
+## 2026-06-02 — split lowercase MDX text elements by HTML semantics
+
+**Rule:** Studio's MDX parser must not assume `mdxJsxTextElement` means inline editable text; first classify lowercase tags by HTML semantics and split block-like tags out of paragraph buffers.
+**Why:** mdast can represent standalone lowercase tags such as `<p>` and `<h2>` inside an intrinsic wrapper as `mdxJsxTextElement` children of a paragraph, so treating every lowercase text element as literal text leaks raw JSX into the Studio canvas.
+**How to apply:** When changing MDX parsing, add regression coverage for lowercase block tags inside wrappers and inline tags such as `<span style={{...}}>...</span>` inside heading/text content, then assert no raw JSX source remains in the parsed TipTap JSON.
+
 ## 2026-05-28 — parse AI-generated MDX before marking proposals valid
 
 **Rule:** AI proposal validation must run generated body MDX through the Studio MDX parser family, not only scan component tags or props.

--- a/.changeset/wacky-seals-burn.md
+++ b/.changeset/wacky-seals-burn.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/studio": patch
+---
+
+Fix Studio rendering for lowercase intrinsic MDX text elements

--- a/packages/studio/src/lib/editor-extensions.ts
+++ b/packages/studio/src/lib/editor-extensions.ts
@@ -14,6 +14,7 @@ import { common, createLowlight } from "lowlight";
 
 import { MdxComponentExtension } from "./mdx-component-extension.js";
 import { MdxIntrinsicElementExtension } from "./mdx-intrinsic-element-extension.js";
+import { MdxIntrinsicInlineExtension } from "./mdx-intrinsic-inline-extension.js";
 import { MdxRawJsxExtension } from "./mdx-raw-jsx-extension.js";
 
 // Returns a lowlight instance seeded with the common language set and with
@@ -205,6 +206,7 @@ export function createEditorExtensions(options?: {
       nested: true,
     }),
     options?.codeBlock ?? HeadlessCodeBlock,
+    MdxIntrinsicInlineExtension,
     options?.mdxComponent ?? MdxComponentExtension,
     options?.mdxIntrinsicElement ?? MdxIntrinsicElementExtension,
     options?.mdxRawJsx ?? MdxRawJsxExtension,

--- a/packages/studio/src/lib/markdown-pipeline.test.ts
+++ b/packages/studio/src/lib/markdown-pipeline.test.ts
@@ -228,6 +228,70 @@ test("markdown pipeline parses lowercase intrinsic wrappers as structured blocks
   assert.equal(wrapperChildren[1]?.attrs?.componentName, "FeatureGrid");
 });
 
+test("markdown pipeline parses intrinsic text elements without leaking JSX source", () => {
+  const source = [
+    '<section style={{backgroundColor: "#f7f3f3"}}>',
+    "<div>",
+    '<p style={{textAlign: "center", fontFamily: "var(--font-mono)", fontSize: "12px", fontWeight: 500, letterSpacing: "2px", color: "rgb(47, 73, 229)", textTransform: "uppercase", marginBottom: "16px"}}>WHAT PEOPLE SAY</p>',
+    '<h2>Loved by teams that <span style={{color: "rgb(47, 73, 229)"}}>ship fast</span></h2>',
+    "</div>",
+    "</section>",
+  ].join("\n");
+
+  const parsed = parseMarkdownToDocument(source);
+  const section = parsed.content?.[0];
+  const div = section?.content?.[0];
+  const eyebrow = div?.content?.[0];
+  const heading = div?.content?.[1];
+  const spanText = heading?.content?.[0]?.content?.[1];
+
+  assert.equal(section?.type, "mdxIntrinsicElement");
+  assert.equal(section?.attrs?.tagName, "section");
+  assert.equal(div?.type, "mdxIntrinsicElement");
+  assert.equal(div?.attrs?.tagName, "div");
+  assert.equal(eyebrow?.type, "mdxIntrinsicElement");
+  assert.equal(eyebrow?.attrs?.tagName, "p");
+  assert.deepEqual(eyebrow?.attrs?.props, {
+    style: {
+      textAlign: "center",
+      fontFamily: "var(--font-mono)",
+      fontSize: "12px",
+      fontWeight: 500,
+      letterSpacing: "2px",
+      color: "rgb(47, 73, 229)",
+      textTransform: "uppercase",
+      marginBottom: "16px",
+    },
+  });
+  assert.equal(heading?.type, "mdxIntrinsicElement");
+  assert.equal(heading?.attrs?.tagName, "h2");
+  assert.equal(spanText?.type, "text");
+  assert.equal(spanText?.text, "ship fast");
+  assert.deepEqual(spanText?.marks, [
+    {
+      type: "mdxIntrinsicInline",
+      attrs: {
+        tagName: "span",
+        props: {
+          style: {
+            color: "rgb(47, 73, 229)",
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.doesNotMatch(JSON.stringify(parsed), /<span style=/);
+  assert.doesNotMatch(JSON.stringify(parsed), /<p style=/);
+
+  const serialized = serializeDocumentToMarkdown(parsed);
+
+  assert.match(
+    serialized,
+    /<span style=\{\{"color":"rgb\(47, 73, 229\)"\}\}>ship fast<\/span>/,
+  );
+});
+
 test("markdown pipeline round-trips native form elements as structured intrinsic blocks", () => {
   const source = [
     '<form name="contact">',

--- a/packages/studio/src/lib/mdx-intrinsic-inline-extension.ts
+++ b/packages/studio/src/lib/mdx-intrinsic-inline-extension.ts
@@ -1,0 +1,147 @@
+import { Mark, mergeAttributes, type JSONContent } from "@tiptap/core";
+
+import { isMdxIntrinsicInlineName } from "./mdx-intrinsic-inline.js";
+import { serializeMdxJsxAttributes } from "./mdx-component-extension.js";
+
+type InlineStyle = Record<string, string | number>;
+
+const URL_BEARING_ATTRIBUTES = new Set([
+  "action",
+  "formaction",
+  "href",
+  "poster",
+  "src",
+  "xlinkhref",
+]);
+const UNSAFE_ATTRIBUTES = new Set(["srcdoc", "dangerouslysetinnerhtml"]);
+
+function normalizeHtmlAttributeName(name: string): string {
+  if (name === "className") return "class";
+  if (name === "htmlFor") return "for";
+  return name;
+}
+
+function isFlatStyleRecord(value: unknown): value is InlineStyle {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.values(value as Record<string, unknown>).every(
+      (entry) => typeof entry === "string" || typeof entry === "number",
+    )
+  );
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+function renderStyleValue(value: InlineStyle): string {
+  return Object.entries(value)
+    .map(([name, declaration]) => `${toKebabCase(name)}:${String(declaration)}`)
+    .join(";");
+}
+
+function createSafeInlineHtmlAttributes(
+  props: Record<string, unknown>,
+): Record<string, string | number> {
+  const safeProps: Record<string, string | number> = {};
+
+  for (const [rawName, value] of Object.entries(props)) {
+    const name = normalizeHtmlAttributeName(rawName);
+    const normalizedName = name.toLowerCase();
+
+    if (
+      normalizedName.startsWith("on") ||
+      URL_BEARING_ATTRIBUTES.has(normalizedName) ||
+      UNSAFE_ATTRIBUTES.has(normalizedName) ||
+      value === undefined ||
+      value === null ||
+      value === false
+    ) {
+      continue;
+    }
+
+    if (name === "style") {
+      if (isFlatStyleRecord(value)) {
+        safeProps.style = renderStyleValue(value);
+      }
+      continue;
+    }
+
+    if (
+      value === true ||
+      typeof value === "string" ||
+      typeof value === "number"
+    ) {
+      safeProps[name] = value === true ? "" : value;
+    }
+  }
+
+  return safeProps;
+}
+
+function getInlineTagName(attrs: Record<string, unknown> | undefined): string {
+  const tagName = attrs?.tagName;
+
+  return typeof tagName === "string" && isMdxIntrinsicInlineName(tagName)
+    ? tagName
+    : "span";
+}
+
+function getInlineProps(
+  attrs: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const props = attrs?.props;
+
+  return props && typeof props === "object" && !Array.isArray(props)
+    ? (props as Record<string, unknown>)
+    : {};
+}
+
+export const MdxIntrinsicInlineExtension = Mark.create({
+  name: "mdxIntrinsicInline",
+  inclusive: false,
+  spanning: false,
+
+  addAttributes() {
+    return {
+      tagName: {
+        default: "span",
+      },
+      props: {
+        default: {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "[data-mdcms-mdx-intrinsic-inline]" }];
+  },
+
+  renderHTML({ mark }) {
+    const tagName = getInlineTagName(mark.attrs);
+    const props = getInlineProps(mark.attrs);
+
+    return [
+      tagName,
+      mergeAttributes(createSafeInlineHtmlAttributes(props), {
+        "data-mdcms-mdx-intrinsic-inline": tagName,
+      }),
+      0,
+    ];
+  },
+
+  renderMarkdown(node: JSONContent, helpers) {
+    const attrs = node.attrs as Record<string, unknown> | undefined;
+    const tagName = getInlineTagName(attrs);
+    const props = getInlineProps(attrs);
+    const serializedProps = serializeMdxJsxAttributes(props);
+    const attrSegment = serializedProps.length > 0 ? ` ${serializedProps}` : "";
+
+    return `<${tagName}${attrSegment}>${helpers.renderChildren(
+      node.content ?? [],
+      "",
+    )}</${tagName}>`;
+  },
+});

--- a/packages/studio/src/lib/mdx-intrinsic-inline.ts
+++ b/packages/studio/src/lib/mdx-intrinsic-inline.ts
@@ -1,0 +1,83 @@
+const MDX_INTRINSIC_INLINE_ELEMENTS = new Set([
+  "abbr",
+  "b",
+  "cite",
+  "code",
+  "data",
+  "del",
+  "dfn",
+  "em",
+  "i",
+  "ins",
+  "kbd",
+  "mark",
+  "q",
+  "s",
+  "samp",
+  "small",
+  "span",
+  "strong",
+  "sub",
+  "sup",
+  "time",
+  "u",
+  "var",
+]);
+
+export const MDX_INTRINSIC_TEXT_BLOCK_ELEMENTS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "button",
+  "caption",
+  "details",
+  "dialog",
+  "div",
+  "dl",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "label",
+  "legend",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+]);
+
+export function isMdxIntrinsicInlineName(
+  value: string | null | undefined,
+): value is string {
+  return typeof value === "string" && MDX_INTRINSIC_INLINE_ELEMENTS.has(value);
+}
+
+export function isMdxIntrinsicTextBlockName(
+  value: string | null | undefined,
+): value is string {
+  return (
+    typeof value === "string" && MDX_INTRINSIC_TEXT_BLOCK_ELEMENTS.has(value)
+  );
+}

--- a/packages/studio/src/lib/mdx-markdown-parser.ts
+++ b/packages/studio/src/lib/mdx-markdown-parser.ts
@@ -6,6 +6,10 @@ import { mdx } from "micromark-extension-mdx";
 
 import { HTML_VOID_ELEMENTS } from "./html-void-elements.js";
 import { parseMdxAttributeValue } from "./mdx-component-extension.js";
+import {
+  isMdxIntrinsicInlineName,
+  isMdxIntrinsicTextBlockName,
+} from "./mdx-intrinsic-inline.js";
 
 type AstPosition = {
   start?: { offset?: number };
@@ -91,11 +95,38 @@ function withMark(
   return [...(marks ?? []), mark];
 }
 
-function isInlineAstNode(node: MdxAstNode): boolean {
-  if (
+function applyMarkToInlineContent(
+  content: JSONContent[],
+  mark: NonNullable<JSONContent["marks"]>[number],
+): JSONContent[] {
+  return content.map((node) => {
+    if (node.type === "text") {
+      return {
+        ...node,
+        marks: withMark(node.marks, mark),
+      };
+    }
+
+    return node.content
+      ? {
+          ...node,
+          content: applyMarkToInlineContent(node.content, mark),
+        }
+      : node;
+  });
+}
+
+function isBlockMdxTextElement(node: MdxAstNode): boolean {
+  return (
     node.type === "mdxJsxTextElement" &&
-    isUppercaseComponentName(node.name)
-  ) {
+    (isUppercaseComponentName(node.name) ||
+      (isLowercaseIntrinsicName(node.name) &&
+        isMdxIntrinsicTextBlockName(node.name)))
+  );
+}
+
+function isInlineAstNode(node: MdxAstNode): boolean {
+  if (isBlockMdxTextElement(node)) {
     return false;
   }
 
@@ -165,9 +196,33 @@ function convertInlineNode(
           },
         }),
       );
+    case "mdxJsxTextElement":
+      if (
+        isLowercaseIntrinsicName(node.name) &&
+        isMdxIntrinsicInlineName(node.name)
+      ) {
+        const props = parseMdxElementProps(node, source);
+
+        if (props !== null) {
+          return applyMarkToInlineContent(
+            convertInlineChildren(node.children ?? [], source, marks),
+            {
+              type: "mdxIntrinsicInline",
+              attrs: {
+                tagName: node.name,
+                props,
+              },
+            },
+          );
+        }
+      }
+
+      return createText(
+        getSourceSlice(source, node) ?? node.value ?? "",
+        marks,
+      );
     case "html":
     case "image":
-    case "mdxJsxTextElement":
       return createText(
         getSourceSlice(source, node) ?? node.value ?? "",
         marks,
@@ -189,11 +244,7 @@ function convertInlineNodesToParagraph(nodes: MdxAstNode[], source: string) {
 
 function convertParagraphNode(node: MdxAstNode, source: string): JSONContent[] {
   const children = node.children ?? [];
-  const hasBlockMdxTextElement = children.some(
-    (child) =>
-      child.type === "mdxJsxTextElement" &&
-      isUppercaseComponentName(child.name),
-  );
+  const hasBlockMdxTextElement = children.some(isBlockMdxTextElement);
 
   if (!hasBlockMdxTextElement) {
     return [createParagraph(convertInlineChildren(children, source))];
@@ -209,10 +260,7 @@ function convertParagraphNode(node: MdxAstNode, source: string): JSONContent[] {
   };
 
   for (const child of children) {
-    if (
-      child.type === "mdxJsxTextElement" &&
-      isUppercaseComponentName(child.name)
-    ) {
+    if (isBlockMdxTextElement(child)) {
       flushInlineBuffer();
       blocks.push(convertMdxJsxElementNode(child, source));
       continue;


### PR DESCRIPTION
## Summary
- parse lowercase block-like MDX text elements such as <p> and <h2> as structured intrinsic Studio nodes instead of leaking raw JSX text
- add a Studio inline intrinsic mark so <span style={{...}}>...</span> renders as real inline HTML and serializes back to MDX
- add regression coverage for the broken Studio rendering shape and a patch changeset for @mdcms/studio

## Verification
- bun test --cwd packages/studio ./src
- bun test --cwd packages/studio ./src/lib/markdown-pipeline.test.ts ./src/lib/studio.test.ts
- bun run format:check
- bun run check
- bun run changeset:check

Note: React Doctor was not run because sandboxed npm resolution failed and the network retry was rejected due to third-party code execution risk.