### PR TITLE
fix(studio): render assistant progress inline

### DIFF
--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -164,6 +164,16 @@ proposal, and show per-step token usage when the provider reports it. Progress
 events must not expose hidden chain-of-thought or raw tool arguments; they are
 status summaries only.
 
+During a pending streaming turn, Studio renders assistant text and progress
+events in the same chronological order in which the stream emits them. A run of
+progress events that occurs between two assistant text runs is rendered between
+those text runs, not gathered below the whole assistant message. When later
+assistant text or proposal content appears after a progress run, Studio
+auto-collapses that earlier run into a summary row that names the number of
+tool calls or progress updates and can be expanded to inspect the individual
+status rows. The current trailing progress run remains expanded while the
+pending turn is still active.
+
 Rejecting a proposal does not silently discard the model's turn. Reject opens
 an inline feedback textarea on the card; the user types what should change and
 submits. Studio sends the original proposal id, the user's feedback, and the

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
@@ -19,8 +19,10 @@ import type {
   AssistantContextDoc,
   AssistantMessage,
   AssistantMessageContextSnapshot,
+  AssistantProgressEvent,
   AssistantProposal,
   AssistantStore,
+  AssistantStreamBlock,
   AssistantThread,
 } from "./assistant-types.js";
 
@@ -59,6 +61,43 @@ type AssistantState = {
   activeThreadId: string;
   railWidth: number;
 };
+
+function appendTextStreamBlock(
+  blocks: AssistantStreamBlock[] | undefined,
+  delta: string,
+): AssistantStreamBlock[] {
+  if (!delta) return blocks ?? [];
+  const current = blocks ?? [];
+  const last = current.at(-1);
+  if (last?.kind === "text") {
+    return [
+      ...current.slice(0, -1),
+      {
+        kind: "text",
+        text: last.text + delta,
+      },
+    ];
+  }
+  return [...current, { kind: "text", text: delta }];
+}
+
+function appendProgressStreamBlock(
+  blocks: AssistantStreamBlock[] | undefined,
+  progress: AssistantProgressEvent,
+): AssistantStreamBlock[] {
+  const current = blocks ?? [];
+  const last = current.at(-1);
+  if (last?.kind === "progress") {
+    return [
+      ...current.slice(0, -1),
+      {
+        kind: "progress",
+        events: [...last.events, progress],
+      },
+    ];
+  }
+  return [...current, { kind: "progress", events: [progress] }];
+}
 
 type AssistantAction =
   | { type: "open-rail" }
@@ -828,6 +867,7 @@ function reducer(
               role: "assistant",
               at: action.placeholderAt,
               text: "",
+              streamBlocks: [],
             };
             return {
               ...thread,
@@ -855,7 +895,14 @@ function reducer(
               ...thread,
               messages: thread.messages.map((m) =>
                 m.id === action.placeholderId
-                  ? { ...m, text: (m.text ?? "") + action.delta }
+                  ? {
+                      ...m,
+                      text: (m.text ?? "") + action.delta,
+                      streamBlocks: appendTextStreamBlock(
+                        m.streamBlocks,
+                        action.delta,
+                      ),
+                    }
                   : m,
               ),
             };
@@ -878,6 +925,10 @@ function reducer(
                       ...m,
                       progress: [...(m.progress ?? []), action.progress].slice(
                         -8,
+                      ),
+                      streamBlocks: appendProgressStreamBlock(
+                        m.streamBlocks,
+                        action.progress,
                       ),
                     }
                   : m,

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel-layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel-layout.test.tsx
@@ -10,6 +10,7 @@ import {
   useAssistantMainPadding,
   useAssistantMainPaddingStyle,
 } from "./assistant-rail.js";
+import type { AssistantMessage } from "./assistant-types.js";
 
 function AssistantPaddingProbe() {
   return (
@@ -39,6 +40,97 @@ test("assistant message sparkle aligns with the first prose line", () => {
   );
 
   assert.match(markup, /w-6 shrink-0 pt-2 text-primary/);
+});
+
+test("assistant pending progress renders between streamed text blocks and collapses earlier groups", () => {
+  const message = {
+    id: "msg-stream",
+    role: "assistant",
+    text: "Let me check what components are available.\nGot what I need. Now I'll build the page.",
+    streamBlocks: [
+      {
+        kind: "text",
+        text: "Let me check what components are available.",
+      },
+      {
+        kind: "progress",
+        events: [
+          {
+            phase: "tool-call",
+            status: "started",
+            toolName: "component_reference",
+            message: "Read component reference tool started",
+          },
+          {
+            phase: "tool-result",
+            status: "completed",
+            toolName: "component_reference",
+            message: "Read component reference completed",
+          },
+          {
+            phase: "tool-call",
+            status: "started",
+            toolName: "component_reference",
+            message: "Read component reference tool started",
+          },
+          {
+            phase: "tool-result",
+            status: "completed",
+            toolName: "component_reference",
+            message: "Read component reference completed",
+          },
+        ],
+      },
+      {
+        kind: "text",
+        text: "Got what I need. Now I'll build the page.",
+      },
+      {
+        kind: "progress",
+        events: [
+          {
+            phase: "thinking",
+            message: "Thinking through the request",
+          },
+        ],
+      },
+    ],
+    progress: [
+      {
+        phase: "thinking",
+        message: "Thinking through the request",
+      },
+    ],
+    at: "2026-05-22T12:00:00.000Z",
+  } satisfies AssistantMessage;
+
+  const markup = renderToStaticMarkup(
+    <AssistantBubble
+      message={message}
+      proposalsById={{}}
+      documentPathById={new Map()}
+      isStreamingPlaceholder
+      onAccept={() => undefined}
+      onReject={() => undefined}
+    />,
+  );
+
+  assert.match(markup, /data-mdcms-assistant-progress-collapsed/);
+  assert.match(markup, /2 tool calls appended/);
+
+  const firstTextIndex = markup.indexOf(
+    "Let me check what components are available.",
+  );
+  const collapsedIndex = markup.indexOf("2 tool calls appended");
+  const secondTextIndex = markup.indexOf(
+    "Got what I need. Now I&#x27;ll build the page.",
+  );
+  const trailingProgressIndex = markup.indexOf("Thinking through the request");
+
+  assert.ok(firstTextIndex >= 0);
+  assert.ok(collapsedIndex > firstTextIndex);
+  assert.ok(secondTextIndex > collapsedIndex);
+  assert.ok(trailingProgressIndex > secondTextIndex);
 });
 
 test("assistant rail exposes a resize handle and default width", () => {

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel.tsx
@@ -38,6 +38,7 @@ import type {
   AssistantMessage,
   AssistantProgressEvent,
   AssistantProposal,
+  AssistantStreamBlock,
   AssistantThread,
 } from "./assistant-types.js";
 import { triggerTopAppliedUndo } from "./applied-undo-stack.js";
@@ -487,19 +488,20 @@ function progressTone(event: AssistantProgressEvent): string {
   return "text-primary";
 }
 
-function AssistantProgressTimeline({
-  events,
-}: {
-  events: AssistantProgressEvent[];
-}) {
-  if (events.length === 0) return null;
-  const visible = events.slice(-6);
+function progressSummary(events: AssistantProgressEvent[]): string {
+  const toolCalls = events.filter(
+    (event) => event.phase === "tool-call",
+  ).length;
+  if (toolCalls > 0) {
+    return `${toolCalls} tool call${toolCalls === 1 ? "" : "s"} appended`;
+  }
+  return `${events.length} progress update${events.length === 1 ? "" : "s"} appended`;
+}
+
+function ProgressRows({ events }: { events: AssistantProgressEvent[] }) {
   return (
-    <div
-      className="mt-1 flex max-w-[92%] flex-col gap-1.5 border-l border-divider/60 pl-3"
-      aria-label="AI progress"
-    >
-      {visible.map((event, idx) => {
+    <>
+      {events.map((event, idx) => {
         const usage = formatProgressUsage(event.usage);
         return (
           <div
@@ -518,7 +520,92 @@ function AssistantProgressTimeline({
           </div>
         );
       })}
+    </>
+  );
+}
+
+function AssistantProgressTimeline({
+  events,
+  collapsed = false,
+}: {
+  events: AssistantProgressEvent[];
+  collapsed?: boolean;
+}) {
+  if (events.length === 0) return null;
+  if (collapsed) {
+    return (
+      <details
+        className="group mt-1 max-w-[92%] border-l border-divider/60 pl-3"
+        data-mdcms-assistant-progress-collapsed=""
+      >
+        <summary className="flex min-w-0 cursor-pointer list-none items-center gap-2 text-[12px] leading-5 text-foreground-muted marker:hidden">
+          <ChevronRight
+            className="size-3 shrink-0 text-foreground-subtle transition-transform group-open:rotate-90"
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate">
+            {progressSummary(events)}
+          </span>
+        </summary>
+        <div className="mt-1 flex flex-col gap-1.5">
+          <ProgressRows events={events} />
+        </div>
+      </details>
+    );
+  }
+  const visible = events.slice(-6);
+  return (
+    <div
+      className="mt-1 flex max-w-[92%] flex-col gap-1.5 border-l border-divider/60 pl-3"
+      aria-label="AI progress"
+    >
+      <ProgressRows events={visible} />
     </div>
+  );
+}
+
+function hasVisibleStreamContent(block: AssistantStreamBlock): boolean {
+  return block.kind === "text"
+    ? block.text.trim().length > 0
+    : block.events.length > 0;
+}
+
+function AssistantStreamBlocks({
+  blocks,
+  hasProposalContent,
+}: {
+  blocks: AssistantStreamBlock[];
+  hasProposalContent: boolean;
+}) {
+  const visibleBlocks = blocks.filter(hasVisibleStreamContent);
+  return (
+    <>
+      {visibleBlocks.map((block, idx) => {
+        if (block.kind === "text") {
+          return (
+            <div
+              key={`text-${idx}`}
+              className="max-w-[92%] py-0.5"
+              data-mdcms-assistant-stream-block="text"
+            >
+              <AssistantMarkdown text={block.text.trim()} />
+            </div>
+          );
+        }
+        const hasLaterContent =
+          visibleBlocks
+            .slice(idx + 1)
+            .some((candidate) => candidate.kind === "text") ||
+          hasProposalContent;
+        return (
+          <AssistantProgressTimeline
+            key={`progress-${idx}`}
+            events={block.events}
+            collapsed={hasLaterContent}
+          />
+        );
+      })}
+    </>
   );
 }
 
@@ -557,11 +644,18 @@ export function AssistantBubble({
   onUndo?: (proposalId: string) => Promise<void>;
 }) {
   const proposalIds = message.proposals ?? [];
-  const text = message.text?.trim();
-  const progressEvents = isStreamingPlaceholder ? (message.progress ?? []) : [];
+  const streamBlocks =
+    isStreamingPlaceholder && message.streamBlocks?.length
+      ? message.streamBlocks
+      : [];
+  const hasStreamBlocks = streamBlocks.some(hasVisibleStreamContent);
+  const text = hasStreamBlocks ? undefined : message.text?.trim();
+  const progressEvents =
+    isStreamingPlaceholder && !hasStreamBlocks ? (message.progress ?? []) : [];
   if (
     proposalIds.length === 0 &&
     !text &&
+    !hasStreamBlocks &&
     !isStreamingPlaceholder &&
     progressEvents.length === 0
   ) {
@@ -580,7 +674,12 @@ export function AssistantBubble({
         <SparkleMark size={14} />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-2">
-        {text ? (
+        {hasStreamBlocks ? (
+          <AssistantStreamBlocks
+            blocks={streamBlocks}
+            hasProposalContent={proposalIds.length > 0}
+          />
+        ) : text ? (
           <div className="max-w-[92%] py-0.5">
             <AssistantMarkdown text={text} />
           </div>

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
@@ -201,6 +201,7 @@ export type AssistantProgressEvent = {
     | "tool-error"
     | "step-finished";
   message: string;
+  toolCallId?: string;
   toolName?: string;
   status?: "started" | "completed" | "queued" | "rejected" | "failed";
   usage?: {
@@ -210,6 +211,16 @@ export type AssistantProgressEvent = {
   };
 };
 
+export type AssistantStreamBlock =
+  | {
+      kind: "text";
+      text: string;
+    }
+  | {
+      kind: "progress";
+      events: AssistantProgressEvent[];
+    };
+
 export type AssistantMessage = {
   id: string;
   role: AssistantMessageRole;
@@ -218,6 +229,12 @@ export type AssistantMessage = {
   /** Context chips that were attached when this user turn was sent. */
   context?: AssistantMessageContextSnapshot;
   progress?: AssistantProgressEvent[];
+  /**
+   * Pending-stream-only render blocks. They preserve the order in
+   * which text deltas and progress events arrived so the assistant can
+   * show tool activity between prose blocks while a turn is streaming.
+   */
+  streamBlocks?: AssistantStreamBlock[];
   proposals?: string[];
   at: string;
   /**


### PR DESCRIPTION
## Summary

- Adds pending-stream render blocks so assistant text deltas and tool/progress events stay in emitted order.
- Renders progress runs between assistant prose blocks, and auto-collapses earlier runs once later text or proposal content appears.
- Documents the behavior in `SPEC-014` and adds a Studio regression test for inline/collapsed progress ordering.

## Spec Delta

- `SPEC-014` now states that pending Studio assistant turns render text and progress chronologically.
- Earlier progress runs collapse into an expandable summary after later assistant content appears.
- The trailing in-progress run remains expanded while the turn is active.

## Verification

- `bun test --cwd packages/studio ./src/lib/runtime-ui/components/assistant` passed: 26 tests, 0 failures.
- `bun run format:check` passed.
- `bun run check` passed.
- `bun run changeset:check` passed: no published package source changes found.
- `bun run unit` was run and failed on local networking/listener paths outside this change:
  - `apps/cli`: `loopback callback returns styled HTML success page` fails with `Failed to start server. Is port 0 in use?`
  - `apps/server`: `Studio asset response negotiates brotli when MDCMS_HTTP_COMPRESS is on (default)` fails in Bun `internalConnectMultipleTimeout`.
  - `apps/server`: `Studio asset response negotiates a supported encoding when client sends Accept-Encoding: *` fails in Bun `internalConnectMultipleTimeout`.

## Notes

- React Doctor was not completed: sandboxed `npx -y react-doctor@latest . --verbose --diff` could not resolve `registry.npmjs.org`, and the escalation to download/execute the package was rejected by the approval policy.
