### PR TITLE
fix(studio): refine live preview viewport controls

### DIFF
--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -485,6 +485,9 @@ Normative behavior:
   `Preview` hides the editor canvas and gives the preview surface the available
   document area. The mode is local UI state and does not change the document
   body, frontmatter, publish state, sidebar state, or write authorization.
+  Studio mirrors the selected layout mode into the document editor URL as
+  `previewMode=edit|split|preview` so reloads and shared admin URLs preserve
+  the current layout. Unsupported `previewMode` values are ignored.
 - The real-app preview surface is a page renderer. It embeds a host route in an
   iframe and must not render Studio-only component mocks. The existing inline
   MDX component preview remains a node renderer owned by SPEC-007.
@@ -517,10 +520,12 @@ Normative behavior:
   content type in `mdcms.config.ts`. If a resolver is present but returns no
   URL for the active document, the pane renders an unavailable state that points
   operators back to the resolver and document fields instead of guessing.
-- The iframe uses a restrictive sandbox for the first slice:
-  `allow-scripts allow-forms`, without `allow-same-origin` unless a future
-  same-origin adapter contract explicitly opts into it. The preview surface
-  must remain read-only from Studio's perspective.
+- The iframe uses a restrictive sandbox:
+  `allow-scripts allow-forms allow-same-origin`. `allow-same-origin` keeps host
+  preview routes on their real origin so route-owned assets such as framework
+  font files can load correctly. The preview route and preview token remain the
+  authorization boundary; the sandbox is not an auth substitute. The preview
+  surface must remain read-only from Studio's perspective.
 - Preview failure states are explicit and actionable. Studio distinguishes at
   least: no route configured, no host adapter, framing blocked, unauthorized,
   token/session expiry, invalid preview-token configuration, and invalid draft.

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -14,13 +14,17 @@ import type { StudioDocumentShell } from "../../document-shell.js";
 import { StudioNavigationProvider } from "../navigation.js";
 import {
   ContentDocumentPageView,
+  LIVE_PREVIEW_IFRAME_SANDBOX,
   MDCMS_LIVE_PREVIEW_READY_MESSAGE,
   SidebarInfoTab,
   createLivePreviewIframeRoute,
+  getLivePreviewViewportFrame,
   isLivePreviewReadyMessage,
+  readContentDocumentPreviewModeSearchParam,
   resolveLivePreviewDocument,
   runLivePreviewRefresh,
   shouldPersistBeforeLivePreviewRefresh,
+  writeContentDocumentPreviewModeSearchParam,
 } from "./content-document-page.js";
 import {
   applyFailedDraftSaveToReadyState,
@@ -1846,11 +1850,74 @@ test("ContentDocumentPageView prepares split live-preview mode until a tokenized
   assert.match(markup, />Split</);
   assert.match(markup, />Preview</);
   assert.match(markup, /data-mdcms-live-preview-pane="ready"/);
-  assert.match(markup, /data-mdcms-preview-viewport="medium"/);
-  assert.match(markup, /data-mdcms-preview-viewport-option="small"/);
+  assert.match(markup, /data-mdcms-preview-viewport="tablet"/);
+  assert.match(markup, /data-mdcms-preview-viewport-option="mobile"/);
+  assert.match(markup, /aria-label="Mobile viewport"/);
+  assert.match(markup, /aria-label="Tablet viewport"/);
+  assert.match(markup, /aria-label="Desktop viewport"/);
+  assert.doesNotMatch(markup, />S</);
+  assert.doesNotMatch(markup, />M</);
+  assert.doesNotMatch(markup, />L</);
   assert.match(markup, /Preparing preview/);
   assert.doesNotMatch(markup, /src="\/configured\/launch-notes"/);
   assert.match(markup, /Open preview in new tab/);
+});
+
+test("getLivePreviewViewportFrame preserves target viewport width while scaling to fit", () => {
+  assert.deepEqual(getLivePreviewViewportFrame("mobile", 720), {
+    targetWidth: 390,
+    visualWidth: 390,
+    scale: 1,
+    heightPercent: 100,
+  });
+  assert.deepEqual(getLivePreviewViewportFrame("tablet", 640), {
+    targetWidth: 768,
+    visualWidth: 640,
+    scale: 0.833,
+    heightPercent: 120,
+  });
+  assert.deepEqual(getLivePreviewViewportFrame("desktop", 640), {
+    targetWidth: 1280,
+    visualWidth: 640,
+    scale: 0.5,
+    heightPercent: 200,
+  });
+});
+
+test("content document preview mode query param accepts only supported modes", () => {
+  assert.equal(
+    readContentDocumentPreviewModeSearchParam("?previewMode=preview"),
+    "preview",
+  );
+  assert.equal(
+    readContentDocumentPreviewModeSearchParam("?previewMode=split"),
+    "split",
+  );
+  assert.equal(
+    readContentDocumentPreviewModeSearchParam("?previewMode=wide"),
+    undefined,
+  );
+});
+
+test("content document preview mode query param preserves unrelated params", () => {
+  assert.equal(
+    writeContentDocumentPreviewModeSearchParam("?env=preview", "preview"),
+    "?env=preview&previewMode=preview",
+  );
+  assert.equal(
+    writeContentDocumentPreviewModeSearchParam(
+      "?previewMode=edit&env=preview",
+      "split",
+    ),
+    "?previewMode=split&env=preview",
+  );
+});
+
+test("live preview iframe sandbox preserves same-origin asset loading", () => {
+  assert.equal(
+    LIVE_PREVIEW_IFRAME_SANDBOX,
+    "allow-scripts allow-forms allow-same-origin",
+  );
 });
 
 test("createLivePreviewIframeRoute mints a token before returning an iframe href", async () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -66,10 +66,13 @@ import {
   Check,
   ExternalLink,
   Globe,
+  Monitor,
   PanelRight,
   PanelRightClose,
   RefreshCw,
   Send,
+  Smartphone,
+  Tablet,
   X,
 } from "lucide-react";
 import { cn } from "../lib/utils.js";
@@ -126,6 +129,71 @@ import {
 const DOCUMENT_SAVE_DEBOUNCE_MS = 5000;
 
 type ContentDocumentPreviewMode = "edit" | "split" | "preview";
+
+const CONTENT_DOCUMENT_PREVIEW_MODE_QUERY_PARAM = "previewMode";
+export const LIVE_PREVIEW_IFRAME_SANDBOX =
+  "allow-scripts allow-forms allow-same-origin";
+
+function isContentDocumentPreviewMode(
+  value: unknown,
+): value is ContentDocumentPreviewMode {
+  return value === "edit" || value === "split" || value === "preview";
+}
+
+export function readContentDocumentPreviewModeSearchParam(
+  search: string,
+): ContentDocumentPreviewMode | undefined {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+  const mode = params.get(CONTENT_DOCUMENT_PREVIEW_MODE_QUERY_PARAM);
+
+  return isContentDocumentPreviewMode(mode) ? mode : undefined;
+}
+
+export function writeContentDocumentPreviewModeSearchParam(
+  search: string,
+  mode: ContentDocumentPreviewMode,
+): string {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+  params.set(CONTENT_DOCUMENT_PREVIEW_MODE_QUERY_PARAM, mode);
+
+  const serialized = params.toString();
+
+  return serialized ? `?${serialized}` : "";
+}
+
+function readBrowserContentDocumentPreviewMode():
+  | ContentDocumentPreviewMode
+  | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return readContentDocumentPreviewModeSearchParam(window.location.search);
+}
+
+function replaceBrowserContentDocumentPreviewMode(
+  mode: ContentDocumentPreviewMode,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const nextUrl = new URL(window.location.href);
+  nextUrl.search = writeContentDocumentPreviewModeSearchParam(
+    window.location.search,
+    mode,
+  );
+
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
+  );
+}
 
 function useLatestCallback<Args extends unknown[], Return>(
   callback: (...args: Args) => Return,
@@ -184,7 +252,53 @@ type ContentDocumentPageViewProps = {
   onPreviewRefresh?: () => boolean | Promise<boolean>;
 };
 
-type LivePreviewViewportSize = "small" | "medium" | "large";
+type LivePreviewViewportSize = "mobile" | "tablet" | "desktop";
+
+const LIVE_PREVIEW_VIEWPORT_PRESETS: Record<
+  LivePreviewViewportSize,
+  { label: string; width: number }
+> = {
+  mobile: { label: "Mobile", width: 390 },
+  tablet: { label: "Tablet", width: 768 },
+  desktop: { label: "Desktop", width: 1280 },
+};
+
+type LivePreviewViewportFrame = {
+  targetWidth: number;
+  visualWidth: number;
+  scale: number;
+  heightPercent: number;
+};
+
+function roundViewportNumber(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+export function getLivePreviewViewportFrame(
+  size: LivePreviewViewportSize,
+  availableWidth: number,
+): LivePreviewViewportFrame {
+  const targetWidth = LIVE_PREVIEW_VIEWPORT_PRESETS[size].width;
+  const hasMeasuredWidth =
+    Number.isFinite(availableWidth) && availableWidth > 0;
+  const visualWidth = hasMeasuredWidth
+    ? Math.min(targetWidth, availableWidth)
+    : targetWidth;
+  const scale = hasMeasuredWidth
+    ? roundViewportNumber(Math.min(1, visualWidth / targetWidth))
+    : 1;
+  const heightPercent =
+    hasMeasuredWidth && visualWidth < targetWidth
+      ? roundViewportNumber((targetWidth / visualWidth) * 100)
+      : 100;
+
+  return {
+    targetWidth,
+    visualWidth: roundViewportNumber(visualWidth),
+    scale,
+    heightPercent,
+  };
+}
 
 function formatDocumentLabel(path: string, documentId: string): string {
   const trimmedPath = path.trim();
@@ -1230,38 +1344,53 @@ function LivePreviewViewportControl(props: {
   onSizeChange: (size: LivePreviewViewportSize) => void;
 }) {
   const options: Array<{
-    label: string;
     size: LivePreviewViewportSize;
+    Icon: typeof Smartphone;
   }> = [
-    { label: "S", size: "small" },
-    { label: "M", size: "medium" },
-    { label: "L", size: "large" },
+    { size: "mobile", Icon: Smartphone },
+    { size: "tablet", Icon: Tablet },
+    { size: "desktop", Icon: Monitor },
   ];
 
   return (
-    <div
-      className="hidden shrink-0 overflow-hidden rounded-md border border-border sm:inline-flex"
-      aria-label="Preview viewport"
-    >
-      {options.map((option) => (
-        <button
-          key={option.size}
-          type="button"
-          data-mdcms-preview-viewport-option={option.size}
-          data-state={props.size === option.size ? "active" : "inactive"}
-          className={cn(
-            "h-8 px-2 font-mono text-[10px] transition-colors",
-            props.size === option.size
-              ? "bg-foreground text-background"
-              : "text-foreground-muted hover:bg-muted hover:text-foreground",
-          )}
-          onClick={() => props.onSizeChange(option.size)}
-          aria-pressed={props.size === option.size}
-        >
-          {option.label}
-        </button>
-      ))}
-    </div>
+    <TooltipProvider delayDuration={150}>
+      <div
+        className="hidden shrink-0 overflow-hidden rounded-md border border-border sm:inline-flex"
+        aria-label="Preview viewport"
+      >
+        {options.map((option) => {
+          const preset = LIVE_PREVIEW_VIEWPORT_PRESETS[option.size];
+          const active = props.size === option.size;
+          const label = `${preset.label} viewport`;
+
+          return (
+            <Tooltip key={option.size}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-mdcms-preview-viewport-option={option.size}
+                  data-state={active ? "active" : "inactive"}
+                  className={cn(
+                    "inline-flex size-8 items-center justify-center transition-colors",
+                    active
+                      ? "bg-foreground text-background"
+                      : "text-foreground-muted hover:bg-muted hover:text-foreground",
+                  )}
+                  onClick={() => props.onSizeChange(option.size)}
+                  aria-label={label}
+                  aria-pressed={active}
+                >
+                  <option.Icon className="size-3.5" aria-hidden />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {preset.label} · {preset.width}px
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
   );
 }
 
@@ -1273,7 +1402,9 @@ function LivePreviewPane(props: {
   onRefresh: () => void;
 }) {
   const [viewportSize, setViewportSize] =
-    useState<LivePreviewViewportSize>("medium");
+    useState<LivePreviewViewportSize>("tablet");
+  const [previewFrameAvailableWidth, setPreviewFrameAvailableWidth] =
+    useState(0);
   const [iframeRoute, setIframeRoute] = useState<
     | { status: "loading" }
     | {
@@ -1292,11 +1423,16 @@ function LivePreviewPane(props: {
     | { status: "error"; message: string }
   >({ status: "loading" });
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const previewFrameSlotRef = useRef<HTMLDivElement | null>(null);
   const previewDocument = resolveLivePreviewDocument(props.state);
   const route = resolveDocumentPreviewRoute({
     document: previewDocument,
     preview: props.context?.preview,
   });
+  const viewportFrame = getLivePreviewViewportFrame(
+    viewportSize,
+    previewFrameAvailableWidth,
+  );
   const readyRouteHref = route.status === "ready" ? route.href : undefined;
   const readyIframeRoute =
     route.status === "ready" &&
@@ -1310,6 +1446,34 @@ function LivePreviewPane(props: {
   const iframeInstanceKey = readyIframeRoute
     ? `${readyIframeRoute.sourceHref}:${props.refreshToken}`
     : undefined;
+
+  useLayoutEffect(() => {
+    const slot = previewFrameSlotRef.current;
+
+    if (!slot || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const updateWidth = (width: number) => {
+      setPreviewFrameAvailableWidth((current) =>
+        Math.abs(current - width) < 0.5 ? current : width,
+      );
+    };
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+
+      if (entry) {
+        updateWidth(entry.contentRect.width);
+      }
+    });
+
+    updateWidth(slot.clientWidth);
+    observer.observe(slot);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   useEffect(() => {
     if (route.status !== "ready") {
@@ -1462,7 +1626,10 @@ function LivePreviewPane(props: {
           <span className="lg:hidden">Open</span>
         </a>
       </div>
-      <div className="flex min-h-0 flex-1 justify-center p-3">
+      <div
+        ref={previewFrameSlotRef}
+        className="flex min-h-0 flex-1 justify-center overflow-hidden p-3"
+      >
         {readyIframeRoute ? (
           previewFrameState.status === "error" ? (
             <LivePreviewFrameUnavailableState
@@ -1474,43 +1641,54 @@ function LivePreviewPane(props: {
             <div
               data-mdcms-live-preview-frame-state={previewFrameState.status}
               className={cn(
-                "relative h-full rounded-md border border-border bg-card shadow-sm transition-[width]",
-                viewportSize === "small"
-                  ? "w-[390px] max-w-full"
-                  : viewportSize === "medium"
-                    ? "w-[768px] max-w-full"
-                    : "w-full",
+                "relative h-full overflow-hidden rounded-md border border-border bg-card shadow-sm transition-[width]",
               )}
+              style={{
+                width: viewportFrame.visualWidth,
+                maxWidth: "100%",
+              }}
+              data-mdcms-preview-target-width={viewportFrame.targetWidth}
+              data-mdcms-preview-scale={viewportFrame.scale}
             >
-              <iframe
-                key={iframeInstanceKey}
-                ref={iframeRef}
-                title={`Preview ${props.state.document.path}`}
-                src={readyIframeRoute.href}
-                sandbox="allow-scripts allow-forms"
-                referrerPolicy="no-referrer-when-downgrade"
-                onLoad={() => {
-                  setPreviewFrameState((current) =>
-                    current.status === "ready" || current.status === "error"
-                      ? current
-                      : { status: "loading" },
-                  );
+              <div
+                className="h-full"
+                style={{
+                  width: viewportFrame.targetWidth,
+                  height: `${viewportFrame.heightPercent}%`,
+                  transform: `scale(${viewportFrame.scale})`,
+                  transformOrigin: "top left",
                 }}
-                onError={() => {
-                  setPreviewFrameState({
-                    status: "error",
-                    message: createLivePreviewFrameErrorMessage(
-                      props.state.document.path,
-                    ),
-                  });
-                }}
-                className={cn(
-                  "size-full rounded-md bg-white transition-opacity",
-                  previewFrameState.status === "ready"
-                    ? "opacity-100"
-                    : "opacity-0",
-                )}
-              />
+              >
+                <iframe
+                  key={iframeInstanceKey}
+                  ref={iframeRef}
+                  title={`Preview ${props.state.document.path}`}
+                  src={readyIframeRoute.href}
+                  sandbox={LIVE_PREVIEW_IFRAME_SANDBOX}
+                  referrerPolicy="no-referrer-when-downgrade"
+                  onLoad={() => {
+                    setPreviewFrameState((current) =>
+                      current.status === "ready" || current.status === "error"
+                        ? current
+                        : { status: "loading" },
+                    );
+                  }}
+                  onError={() => {
+                    setPreviewFrameState({
+                      status: "error",
+                      message: createLivePreviewFrameErrorMessage(
+                        props.state.document.path,
+                      ),
+                    });
+                  }}
+                  className={cn(
+                    "size-full rounded-md bg-white transition-opacity",
+                    previewFrameState.status === "ready"
+                      ? "opacity-100"
+                      : "opacity-0",
+                  )}
+                />
+              </div>
               {previewFrameState.status === "loading" ? (
                 <div className="absolute inset-0 flex items-center justify-center rounded-md bg-card px-4 text-center text-sm text-foreground-muted">
                   Loading preview…
@@ -1574,7 +1752,9 @@ function useContentDocumentPageViewElement({
   onPreviewRefresh,
 }: ContentDocumentPageViewProps) {
   const [internalPreviewMode, setInternalPreviewMode] =
-    useState<ContentDocumentPreviewMode>("edit");
+    useState<ContentDocumentPreviewMode>(
+      () => previewMode ?? readBrowserContentDocumentPreviewMode() ?? "edit",
+    );
   const [previewRefreshToken, setPreviewRefreshToken] = useState(0);
   const activePreviewMode = previewMode ?? internalPreviewMode;
   const setPreviewMode = useCallback(
@@ -1582,6 +1762,7 @@ function useContentDocumentPageViewElement({
       if (previewMode === undefined) {
         setInternalPreviewMode(mode);
       }
+      replaceBrowserContentDocumentPreviewMode(mode);
       onPreviewModeChange?.(mode);
     },
     [onPreviewModeChange, previewMode],


### PR DESCRIPTION
## Summary
- use mobile/tablet/desktop icon controls for live preview viewport presets
- scale wide iframe viewports down to fit narrow preview panes while preserving their virtual width
- persist Studio edit/split/preview layout in the admin URL and keep preview iframe assets same-origin so font files load

## Validation
- bun test packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
- bun nx run studio:typecheck
- bun run format:check
- bun run check
- bun nx run studio:test
- bun nx run shared:test
- bun nx run sdk:test
- bun nx run modules:test
- bun nx run react-primitives:test
- bun nx run server:test
- bun nx run cli:test
- bun run studio:embed:smoke

React Doctor was not run: npm package download failed under sandbox DNS, and the escalated unpinned npx retry was rejected by policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview mode (edit/split/preview) now syncs with the document URL for persistent state across sessions.
  * Replaced fixed viewport sizes with mobile, tablet, and desktop presets for improved live preview testing.
  * Enhanced responsive preview scaling with better container measurement and viewport calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->