### PR TITLE
fix(studio): default live preview to desktop

### DIFF
--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -493,6 +493,7 @@ Normative behavior:
   MDX component preview remains a node renderer owned by SPEC-007.
 - The preview pane chrome contains a read-only resolved-route chip, a manual
   refresh control, viewport-size controls, and an open-in-new-tab link. The
+  `Desktop` viewport preset is selected by default. The
   open-in-new-tab link is always available when a route is resolved so editors
   have a fallback when browser framing policy blocks embedding.
 - Refreshing the real-app preview first runs the normal draft persistence path

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -1850,7 +1850,7 @@ test("ContentDocumentPageView prepares split live-preview mode until a tokenized
   assert.match(markup, />Split</);
   assert.match(markup, />Preview</);
   assert.match(markup, /data-mdcms-live-preview-pane="ready"/);
-  assert.match(markup, /data-mdcms-preview-viewport="tablet"/);
+  assert.match(markup, /data-mdcms-preview-viewport="desktop"/);
   assert.match(markup, /data-mdcms-preview-viewport-option="mobile"/);
   assert.match(markup, /aria-label="Mobile viewport"/);
   assert.match(markup, /aria-label="Tablet viewport"/);

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -1402,7 +1402,7 @@ function LivePreviewPane(props: {
   onRefresh: () => void;
 }) {
   const [viewportSize, setViewportSize] =
-    useState<LivePreviewViewportSize>("tablet");
+    useState<LivePreviewViewportSize>("desktop");
   const [previewFrameAvailableWidth, setPreviewFrameAvailableWidth] =
     useState(0);
   const [iframeRoute, setIframeRoute] = useState<


### PR DESCRIPTION
## Summary
- make the Desktop live-preview viewport preset selected by default
- document the default in SPEC-006
- update the Studio document-page test expectation

## Validation
- bun test packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
- bun x prettier --check docs/specs/SPEC-006-studio-runtime-and-ui.md packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
- git diff --check
- bun nx run studio:typecheck
- bun run format:check
- bun run check
- bun nx run studio:test

React Doctor was not run: sandboxed npm fetch failed with ENOTFOUND for registry.npmjs.org, and the escalated unpinned npx retry was rejected by policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specifications to reflect that the desktop viewport preset is now selected by default in the content editor preview pane.

* **Tests**
  * Updated test assertions to verify the desktop viewport is set as the default in split preview rendering mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->