### PR TITLE
fix(server): exempt cli login from studio origin guard

### DIFF
--- a/apps/server/src/lib/health.test.ts
+++ b/apps/server/src/lib/health.test.ts
@@ -537,6 +537,38 @@ test("GET /api/v1/actions rejects disallowed Studio origins", async () => {
   assert.equal(body.code, "FORBIDDEN_ORIGIN");
 });
 
+test("GET /api/v1/auth/cli/login/authorize is not governed by Studio origins", async () => {
+  const handler = createServerRequestHandler({
+    env: {
+      ...baseEnv,
+      MDCMS_STUDIO_ALLOWED_ORIGINS: "http://localhost:4173",
+    },
+    now: () => new Date("2026-02-20T00:00:10.000Z"),
+    configureApp: (app) => {
+      const serverApp = app as {
+        get?: (path: string, handler: () => Response) => unknown;
+      };
+
+      serverApp.get?.(
+        "/api/v1/auth/cli/login/authorize",
+        () => new Response("cli authorize", { status: 200 }),
+      );
+    },
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/v1/auth/cli/login/authorize", {
+      headers: {
+        origin: "http://localhost:9999",
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "cli authorize");
+  assert.equal(response.headers.get("access-control-allow-origin"), null);
+});
+
 test("GET /api/v1/studio/assets/:buildId/* returns runtime asset when present", async () => {
   const encoder = new TextEncoder();
   const handler = createServerRequestHandler({

--- a/apps/server/src/lib/server.ts
+++ b/apps/server/src/lib/server.ts
@@ -75,6 +75,7 @@ const STUDIO_BROWSER_ROUTE_PREFIXES = [
   "/api/v1/webhooks",
   "/api/v1/ai",
 ] as const;
+const CLI_LOGIN_ROUTE_PREFIX = "/api/v1/auth/cli/login";
 
 function matchesScopedPathPrefix(pathname: string, prefix: string): boolean {
   if (!pathname.startsWith(prefix)) {
@@ -89,6 +90,10 @@ function matchesScopedPathPrefix(pathname: string, prefix: string): boolean {
 }
 
 function isStudioBrowserRoute(pathname: string): boolean {
+  if (matchesScopedPathPrefix(pathname, CLI_LOGIN_ROUTE_PREFIX)) {
+    return false;
+  }
+
   return STUDIO_BROWSER_ROUTE_PREFIXES.some((prefix) =>
     matchesScopedPathPrefix(pathname, prefix),
   );


### PR DESCRIPTION
## Summary

- Exempt `/api/v1/auth/cli/login/*` from the Studio browser-origin guard.
- Add a regression test proving CLI authorize reaches normal routing without Studio CORS headers.

## Test Plan

- `bun test --cwd apps/server ./src/lib/health.test.ts`
- `bun run format:check`
- `bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI login authorization to bypass Studio-specific origin allowlist restrictions, ensuring consistent authorization handling.

* **Tests**
  * Added test coverage for CLI login authorization route behavior independent of origin allowlist constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->