### PR TITLE
CMS-155 collaboration epic

### DIFF
--- a/.ai/memory/architecture.md
+++ b/.ai/memory/architecture.md
@@ -7,6 +7,9 @@ Architecture invariants and key technical decisions. Update when one changes.
 - **Database is canonical**, not the filesystem. The server is the only thing that owns truth.
 - The CLI's local files are a working copy. Pull/push reconciles against the server, not vice versa.
 - Schema (content types + fields) lives in the server's schema registry. The local `mdcms.config.ts` is the developer's authoring surface; `schema sync` reconciles it to the registry.
+- Collaboration Redis state is ephemeral. Yjs state and presence make active
+  editing fast, but PostgreSQL remains the durable draft recovery point through
+  collaboration autosave/final save.
 
 ## Module system
 

--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -18,6 +18,12 @@ Entries are reverse-chronological (newest first).
 **Why:** The delivery worker records status codes from the sink return value; a wrapper that only awaits the sink silently turns successful attempts into `statusCode: null` history rows.
 **How to apply:** When adding logging, tracing, or metrics around `WebhookDeliverySink`, capture `const result = await sink(delivery)`, perform side effects, then `return result`; add worker or composition coverage when new metadata is persisted from sink results.
 
+## 2026-06-14 — use single-address loopback in Postgres availability probes
+
+**Rule:** Test helpers that make short-lived Postgres availability probes should use `127.0.0.1` instead of `localhost`.
+**Why:** Bun can leave a delayed multi-address `node:net` connect-timeout callback behind after a `localhost` probe is closed, which makes later unrelated tests fail with `TypeError: null is not an object (evaluating 'context')`.
+**How to apply:** When adding database probe URLs to test support, prefer an explicit IPv4 loopback address unless the test is specifically covering hostname resolution behavior.
+
 ## 2026-06-03 — inject deterministic DNS in webhook target tests
 
 **Rule:** Webhook route and dispatcher tests that exercise target validation must inject a deterministic target-address resolver instead of relying on real DNS.

--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -6,6 +6,12 @@ Entries are reverse-chronological (newest first).
 
 ---
 
+## 2026-06-15 — treat blank provider URL env as absent
+
+**Rule:** AI provider wrappers must normalize blank provider-specific base URL env values to the provider default before constructing SDK clients.
+**Why:** Docker Compose can pass `ANTHROPIC_BASE_URL=` as an empty environment variable; `@ai-sdk/anthropic` treats that as an explicit override, builds `/messages`, and Bun fails with `fetch() URL is invalid` before any provider request is sent.
+**How to apply:** When adding provider SDK wrappers, trim optional URL overrides and pass an explicit default endpoint when the override is blank; add a regression that sets the SDK's own env var to `""`.
+
 ## 2026-06-15 — normalize session actor ids before DB writes
 
 **Rule:** Collaboration and session-backed write paths must not pass Better Auth session user ids directly into `documents.updated_by`.

--- a/.ai/memory/lessons.md
+++ b/.ai/memory/lessons.md
@@ -6,6 +6,12 @@ Entries are reverse-chronological (newest first).
 
 ---
 
+## 2026-06-15 — normalize session actor ids before DB writes
+
+**Rule:** Collaboration and session-backed write paths must not pass Better Auth session user ids directly into `documents.updated_by`.
+**Why:** Better Auth user ids are not guaranteed to be PostgreSQL UUIDs, while `documents.updated_by` is a UUID column; DB-backed collaboration autosave can fail even though in-memory tests pass.
+**How to apply:** When persisting content from session identity, preserve the real actor in lifecycle events but coerce the DB `updatedBy` value to a valid UUID or the neutral content-store actor.
+
 ## 2026-06-06 — patch the active worktree by absolute path
 
 **Rule:** When editing from a feature worktree, pass absolute worktree paths to `apply_patch` instead of relying on the thread root.

--- a/.ai/memory/product.md
+++ b/.ai/memory/product.md
@@ -25,9 +25,12 @@ The core thesis is that **none of the three should block the others**. An editor
 - **`packages/shared`** holds Zod contracts and types every other package imports.
 - **`packages/modules`** is the first-party module registry — both server-side (`installedModules`) and CLI-side discovery is deterministic and ordered.
 
-## Out of scope (current)
+## Current collaboration scope
 
-- Real-time multi-user collaboration via CRDTs — Post-MVP.
+- Real-time multi-user collaboration via CRDTs is in scope for Studio document
+  rooms. Redis holds ephemeral Yjs state and presence heartbeats; PostgreSQL
+  remains the durable draft source through server-owned collaboration autosave
+  and final save.
 - MCP integration for agent-driven content operations — upcoming.
 - Multiple spaces (team-scoped content organization) — upcoming.
 

--- a/.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md
+++ b/.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md
@@ -1,0 +1,289 @@
+# CMS-112 Collaboration Load/Soak Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic CI coverage for the SPEC-007 collaboration baseline concurrency profile.
+
+**Architecture:** Build a server-side test harness around `createCollaborationRuntimeHooks` with in-memory content, Redis/Yjs, lifecycle, and presence fakes. The harness simulates the SPEC-007 baseline without real network sockets, real timers, Redis, or PostgreSQL, so it remains deterministic and fast in CI while still exercising the collaboration runtime persistence path, CrossWS presence transport hooks, Yjs update convergence, and Redis-loss rebuild behavior.
+
+**Tech Stack:** Bun test, TypeScript, Yjs, existing collaboration runtime hooks, in-memory test doubles.
+
+---
+
+## Spec Delta Summary
+
+- No `docs/specs` change is required for CMS-112.
+- `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` already defines the collaboration regression coverage, baseline concurrency profile, Redis-loss validation, and 30-second CI pass/fail threshold.
+- Affected behavior: deterministic server CI coverage for collaboration runtime convergence, Redis state/metadata, autosave persistence, lifecycle events, active locks, cleanup, presence transport hook records, and PostgreSQL rebuild after Redis loss.
+- Acceptance criteria covered:
+  - AC1: baseline profile and pass/fail thresholds are documented in SPEC-007 and mirrored as named test constants.
+  - AC2: new coverage is deterministic because it uses runtime hooks and in-memory test doubles.
+  - AC3: no new public operator workflow or public contract is introduced; the harness documents the baseline at point of use in test-support code and assertions.
+
+## File Structure
+
+- Create `apps/server/src/lib/collaboration/load-soak-test-support.ts`
+  - Owns the deterministic baseline profile constants, in-memory fakes, and `runCollaborationBaselineScenario`.
+  - This is test support, not production runtime behavior.
+- Create `apps/server/src/lib/collaboration/load-soak.test.ts`
+  - Owns assertions that the harness result satisfies SPEC-007.
+- Modify `.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md`
+  - Track task completion checkboxes.
+
+## Task 1: Add the Failing Baseline Test
+
+**Files:**
+- Create: `apps/server/src/lib/collaboration/load-soak.test.ts`
+- Modify: `.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md`
+
+- [x] **Step 1: Create the baseline test**
+
+Create `apps/server/src/lib/collaboration/load-soak.test.ts` with:
+
+```typescript
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import {
+  COLLABORATION_BASELINE_PROFILE,
+  runCollaborationBaselineScenario,
+} from "./load-soak-test-support.js";
+
+test("collaboration baseline load/soak scenario satisfies SPEC-007", async () => {
+  const result = await runCollaborationBaselineScenario();
+
+  assert.equal(COLLABORATION_BASELINE_PROFILE.roomCount, 4);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.sessionsPerRoom, 3);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.mutationsPerSession, 25);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.timeoutMs, 30_000);
+  assert.equal(result.rooms.length, COLLABORATION_BASELINE_PROFILE.roomCount);
+  assert.equal(result.totals.sessionCount, 12);
+  assert.equal(result.totals.mutationCount, 300);
+  assert.equal(result.totals.contentUpdatedEvents, 4);
+  assert.equal(result.totals.versionRowsCreated, 0);
+  assert.equal(
+    result.activeLockCountBeforeCleanup,
+    COLLABORATION_BASELINE_PROFILE.roomCount,
+  );
+  assert.deepEqual(
+    result.targetPresenceDuring,
+    result.rooms.flatMap((room) => room.expectedPresenceDuring),
+  );
+  assert.deepEqual(result.targetPresenceAfter, []);
+  assert.ok(
+    result.elapsedMs < COLLABORATION_BASELINE_PROFILE.timeoutMs,
+    `baseline took ${result.elapsedMs}ms`,
+  );
+  assert.equal(result.redisLossRecovery.rebuiltFromPostgres, true);
+  assert.equal(
+    result.redisLossRecovery.recoveredMarkdown,
+    result.redisLossRecovery.expectedMarkdown,
+  );
+  assert.deepEqual(
+    result.redisLossRecovery.recoveredFrontmatter,
+    result.redisLossRecovery.expectedFrontmatter,
+  );
+  assert.equal(result.redisLossRecovery.redisFreshAfterReopen, true);
+
+  for (const room of result.rooms) {
+    assert.equal(room.sessionCount, 3);
+    assert.equal(room.mutationCount, 75);
+    assert.equal(room.updateCount, 1);
+    assert.equal(room.draftRevisionAfter, room.draftRevisionBefore + 1);
+    assert.equal(room.finalMarkdown, room.expectedMarkdown);
+    assert.deepEqual(room.finalFrontmatter, room.expectedFrontmatter);
+    assert.deepEqual(
+      room.convergedClientMarkdown,
+      Array.from({ length: room.sessionCount }, () => room.expectedMarkdown),
+    );
+    assert.equal(room.redisFreshBeforeCleanup, true);
+    assert.equal(room.activeLockPresentBeforeCleanup, true);
+    assert.equal(room.activeLockPresentAfterCleanup, false);
+    assert.equal(room.finalizedAfterCleanup, true);
+    assert.equal(room.lifecycleEventCount, 1);
+    assert.equal(room.versionRowsCreated, 0);
+    assert.deepEqual(room.presenceDuring, room.expectedPresenceDuring);
+    assert.deepEqual(room.presenceAfter, []);
+  }
+});
+```
+
+- [x] **Step 2: Run the focused test to verify failure**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/load-soak.test.ts
+```
+
+Expected: fail because `./load-soak-test-support.js` does not exist yet.
+
+## Task 2: Implement the Deterministic Baseline Harness
+
+**Files:**
+- Create: `apps/server/src/lib/collaboration/load-soak-test-support.ts`
+- Modify: `.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md`
+
+- [x] **Step 1: Create the harness module**
+
+Create `apps/server/src/lib/collaboration/load-soak-test-support.ts` with a deterministic harness that:
+
+- exports `COLLABORATION_BASELINE_PROFILE` with room/session/mutation/timeout values from SPEC-007;
+- creates four draft documents in one `marketing/draft` target;
+- loads one runtime room per document through `onLoadDocument` before applying mutations, so all four rooms are active in the same target until the cleanup phase;
+- represents three Studio sessions per room through distinct collaboration contexts and presence peers driven through `createCollaborationWebSocketTransport`;
+- applies 25 body mutations per session by encoding the origin client's Yjs update and applying that update to the runtime room plus the other client documents, interleaved across the active rooms;
+- calls one `onStoreDocument` flush per room;
+- checks Redis freshness before disconnect cleanup;
+- calls last-disconnect cleanup;
+- closes presence peers through the transport close hook and verifies presence removal.
+
+Use these public exports:
+
+```typescript
+export const COLLABORATION_BASELINE_PROFILE = {
+  roomCount: 4,
+  sessionsPerRoom: 3,
+  mutationsPerSession: 25,
+  timeoutMs: 30_000,
+} as const;
+
+export type CollaborationBaselineRoomResult = {
+  documentId: string;
+  sessionCount: number;
+  mutationCount: number;
+  draftRevisionBefore: number;
+  draftRevisionAfter: number;
+  expectedMarkdown: string;
+  finalMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+  finalFrontmatter: Record<string, unknown>;
+  convergedClientMarkdown: string[];
+  redisFreshBeforeCleanup: boolean;
+  activeLockPresentBeforeCleanup: boolean;
+  activeLockPresentAfterCleanup: boolean;
+  finalizedAfterCleanup: boolean;
+  updateCount: number;
+  lifecycleEventCount: number;
+  versionRowsCreated: number;
+  expectedPresenceDuring: CollaborationPresenceUser[];
+  presenceDuring: CollaborationPresenceUser[];
+  presenceAfter: CollaborationPresenceUser[];
+};
+
+export type CollaborationRedisLossRecoveryResult = {
+  documentId: string;
+  expectedMarkdown: string;
+  recoveredMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+  recoveredFrontmatter: Record<string, unknown>;
+  rebuiltFromPostgres: boolean;
+  redisFreshAfterReopen: boolean;
+};
+
+export type CollaborationBaselineResult = {
+  elapsedMs: number;
+  rooms: CollaborationBaselineRoomResult[];
+  redisLossRecovery: CollaborationRedisLossRecoveryResult;
+  activeLockCountBeforeCleanup: number;
+  targetPresenceDuring: CollaborationPresenceUser[];
+  targetPresenceAfter: CollaborationPresenceUser[];
+  totals: {
+    roomCount: number;
+    sessionCount: number;
+    mutationCount: number;
+    contentUpdatedEvents: number;
+    versionRowsCreated: number;
+  };
+};
+```
+
+Implementation details:
+
+- Use `performance.now()` to measure elapsed time.
+- Use `createCollaborationRuntimeHooks` from `./runtime.js`.
+- Use `yDocToMarkdown`, `yDocToFrontmatter`, and `yjsUpdateToYDoc` from `./runtime.js`.
+- Use `createCollaborationDocumentName` for room names.
+- Set active-lock heartbeat and finalized-room timers to inert deterministic fakes:
+
+```typescript
+setActiveLockHeartbeat: () => Symbol("heartbeat"),
+clearActiveLockHeartbeat: () => undefined,
+setFinalizedRoomLeaseTimeout: () => Symbol("finalized-room"),
+clearFinalizedRoomLeaseTimeout: () => undefined,
+```
+
+- The in-memory content store must implement `CollaborationRuntimeContentStore` for multiple documents and increment `draftRevision` exactly once per `update`.
+- The in-memory Redis/presence store must implement `CollaborationRuntimeRedisStore` and expose:
+
+```typescript
+activeLocks: Map<string, string>;
+finalizedDocumentIds: Set<string>;
+setPresence(record: CollaborationPresenceUser & { project: string; environment: string }): Promise<void>;
+deletePresence(input: { project: string; environment: string; sessionId: string }): Promise<void>;
+listPresence(input: { project: string; environment: string }): Promise<CollaborationPresenceUser[]>;
+```
+
+- The lifecycle fake must count `content.updated` events from active autosaves.
+- The auth guard must always return `{ ok: true }`.
+- The generated final Markdown for a room must include all 75 mutations so the expected persisted body is unambiguous. Build it from a heading, the initial body, and one paragraph per mutation.
+- Presence assertions must compare exact target-wide and per-room payloads, including user/session identity, label, color, cursor, and `updatedAt`.
+- After at least one active autosave, flush the in-memory Redis/Yjs state, reopen the same document through `onLoadDocument`, and assert the rebuilt Yjs state matches the PostgreSQL draft body/frontmatter and refreshes Redis metadata.
+
+- [x] **Step 2: Run the focused test to verify pass**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/load-soak.test.ts
+```
+
+Expected: pass with one test.
+
+## Task 3: Review, Gates, and Commit
+
+**Files:**
+- Modify: `.ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md`
+
+- [x] **Step 1: Run the relevant collaboration tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/load-soak.test.ts ./src/lib/collaboration/runtime.test.ts ./src/lib/collaboration/redis-store.test.ts
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run workspace gates**
+
+Run:
+
+```bash
+bun run check
+bun run format:check
+git diff --check
+bun run changeset:check
+```
+
+Expected: all pass. CMS-112 only touches server test/support files and a plan, so no new changeset should be required beyond the already committed shared changeset in this epic branch.
+
+- [x] **Step 3: Commit the CMS-112 slice**
+
+Run:
+
+```bash
+git add .ai/plans/2026-06-14-cms-112-collaboration-load-soak-harness.md apps/server/src/lib/collaboration/load-soak.test.ts apps/server/src/lib/collaboration/load-soak-test-support.ts
+git commit -m "test(collaboration): add baseline load soak harness"
+```
+
+Expected: commit succeeds and the worktree is clean.
+
+## Self-Review Checklist
+
+- SPEC-007 baseline room/session/mutation counts are mirrored by named constants.
+- The test asserts the 30-second timeout threshold.
+- The test asserts converged client state, Redis freshness, PostgreSQL draft body/frontmatter persistence through the content-store fake, exact single draft revision increment, no version rows, content.updated events, concurrent active locks, cleanup, exact presence payloads, and presence removal.
+- The harness uses no real network, Redis, PostgreSQL, timers, or sleeps.
+- There are no task IDs inside `docs/specs`.

--- a/.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md
+++ b/.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md
@@ -1,0 +1,161 @@
+# CMS-115 Redis-Loss Recovery Validation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Confirm CMS-115 Redis-loss recovery validation without duplicating the deterministic harness already added for the collaboration baseline.
+
+**Architecture:** Use the SPEC-007 collaboration load/soak harness as the validation artifact for Redis-loss autosave durability. Keep the CMS-114 backup/restore drill dependency out of this epic branch because it belongs to the separate operations hardening epic.
+
+**Tech Stack:** Bun test, TypeScript, Yjs, collaboration runtime hooks, in-memory Redis/content test doubles.
+
+---
+
+## Spec Delta Summary
+
+- No `docs/specs` change is required for CMS-115.
+- `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` defines deterministic Redis-loss validation for collaboration autosave durability.
+- `docs/specs/SPEC-011-local-development-and-operations.md` documents the operator-facing Redis-loss recovery drill, including the expectation that PostgreSQL is the durable recovery point and Redis presence/cache state is ephemeral.
+- Affected behavior: the deterministic collaboration baseline test persists an active autosave, flushes the in-memory Redis/Yjs state, reopens the same document room, and asserts the rebuilt Yjs state comes from the PostgreSQL draft head.
+- Acceptance criteria covered:
+  - AC1: Redis flush/restart recoverability from the database head is covered by `redisLossRecovery` in the CMS-112 harness.
+  - AC2: data and API integrity are covered by assertions for PostgreSQL body/frontmatter, exact single draft revision increment, no version rows, fresh Redis metadata after reopen, and cleanup.
+  - AC3: no new public contract or operator workflow is introduced by CMS-115 in this branch; the existing operator workflow remains documented in SPEC-011.
+
+## Dependency Decision
+
+CMS-115 lists CMS-54 and CMS-114 as dependencies. CMS-54 is implemented in this branch. CMS-114 is still `To Do` and belongs to the separate CMS-154 Security & Release Hardening epic.
+
+This branch therefore implements the deterministic product validation required by SPEC-007 and records that the operational drill prerequisite remains outside the CMS-155 collaboration scope. Do not add a second Redis-loss test solely to mirror the ticket number; the CMS-112 harness already exercises the required runtime behavior.
+
+## File Structure
+
+- Existing: `apps/server/src/lib/collaboration/load-soak-test-support.ts`
+  - Owns `redisLossRecovery`, including the post-autosave Redis flush, room reopen, PostgreSQL rebuild assertion, and Redis metadata freshness assertion.
+- Existing: `apps/server/src/lib/collaboration/load-soak.test.ts`
+  - Asserts `redisLossRecovery.rebuiltFromPostgres`, recovered Markdown/frontmatter equality, and fresh Redis state after reopen.
+- Existing: `docs/specs/SPEC-011-local-development-and-operations.md`
+  - Documents the operator-facing Redis-loss recovery drill.
+- Create: `.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md`
+  - Records the CMS-115 scope mapping and dependency decision.
+
+## Task 1: Confirm Scope and Dependency State
+
+**Files:**
+- Create: `.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md`
+
+- [x] **Step 1: Read the ticket**
+
+Read CMS-115 from Jira.
+
+Observed scope:
+
+```text
+Summary: Redis-loss recovery validation for autosave durability
+Dependencies: CMS-54, CMS-114
+Acceptance Criteria:
+1. Redis flush/restart preserves recoverability from DB head.
+2. Data and API behavior is internally consistent and does not violate scope/integrity guarantees.
+3. Any newly introduced public contract or operator workflow in this task is documented at the point of use.
+```
+
+- [x] **Step 2: Read the external dependency**
+
+Read CMS-114 from Jira.
+
+Observed state:
+
+```text
+Summary: Backup/restore drills and runbook for Postgres/Redis/MinIO
+Status: To Do
+Parent: CMS-154 Security & Release Hardening
+```
+
+- [x] **Step 3: Confirm owning specs**
+
+Read:
+
+```bash
+sed -n '870,914p' docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+sed -n '208,236p' docs/specs/SPEC-011-local-development-and-operations.md
+```
+
+Expected:
+- SPEC-007 defines the deterministic collaboration Redis-loss validation harness.
+- SPEC-011 defines the operator Redis-loss recovery drill.
+
+## Task 2: Map CMS-115 to the Implemented Validation Artifact
+
+**Files:**
+- Existing: `apps/server/src/lib/collaboration/load-soak-test-support.ts`
+- Existing: `apps/server/src/lib/collaboration/load-soak.test.ts`
+- Create: `.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md`
+
+- [x] **Step 1: Verify CMS-112 harness covers CMS-115 runtime behavior**
+
+Inspect `runCollaborationBaselineScenario` and confirm it:
+
+```text
+1. Persists at least one active autosave to the content store.
+2. Flushes volatile Redis/Yjs state through `flushVolatileCollaborationState`.
+3. Reopens the same document room through `onLoadDocument`.
+4. Serializes the recovered Y.Doc.
+5. Asserts the recovered Markdown/frontmatter match the PostgreSQL draft head.
+6. Asserts Redis is fresh after reopen.
+```
+
+- [x] **Step 2: Verify test assertions**
+
+Inspect `load-soak.test.ts` and confirm it asserts:
+
+```text
+result.redisLossRecovery.rebuiltFromPostgres === true
+result.redisLossRecovery.recoveredMarkdown === result.redisLossRecovery.expectedMarkdown
+result.redisLossRecovery.recoveredFrontmatter deep-equals expectedFrontmatter
+result.redisLossRecovery.redisFreshAfterReopen === true
+```
+
+- [x] **Step 3: Avoid duplicate coverage**
+
+Decision:
+
+```text
+No additional runtime test is required for CMS-115 in this branch because the CMS-112 deterministic harness is the stronger coverage path required by SPEC-007.
+```
+
+## Task 3: Verification and Commit
+
+**Files:**
+- Create: `.ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md`
+
+- [x] **Step 1: Use CMS-112 verification as the runtime evidence**
+
+Runtime verification already completed for the harness commit:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/load-soak.test.ts ./src/lib/collaboration/runtime.test.ts ./src/lib/collaboration/redis-store.test.ts
+bun run check
+bun run format:check
+git diff --check
+bun run changeset:check
+```
+
+Expected: all pass.
+
+- [x] **Step 2: Commit the CMS-115 decision record**
+
+Run:
+
+```bash
+git add .ai/plans/2026-06-14-cms-115-redis-loss-recovery-validation.md
+git commit -m "docs(collaboration): record redis loss validation scope"
+```
+
+Expected: commit succeeds and the worktree is clean.
+
+## Self-Review Checklist
+
+- CMS-115 behavior is explicitly mapped to the committed SPEC-007 harness.
+- CMS-114 remains identified as an external dependency under CMS-154.
+- No duplicate runtime test is introduced.
+- No task identifiers are written inside `docs/specs`.
+- No new public contract or operator workflow is introduced.

--- a/.ai/plans/2026-06-14-cms-54-active-collaboration-autosave.md
+++ b/.ai/plans/2026-06-14-cms-54-active-collaboration-autosave.md
@@ -1,0 +1,729 @@
+# CMS-54 Active Collaboration Autosave Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist active collaboration room changes from Redis/Yjs to the PostgreSQL draft head through server-owned autosave without creating document versions.
+
+**Architecture:** Keep Hocuspocus as the collaboration transport and use its existing 2s/10s debounced `onStoreDocument` hook as the active autosave trigger. Serialize body/frontmatter from one Y.Doc snapshot, update the content store only when the draft actually changed, and publish the matching Y.Doc binary/metadata to Redis only after the durable save path succeeds. Share one persistence helper between debounced autosave and last-disconnect final save so final disconnect becomes a no-op after a successful autosave.
+
+**Tech Stack:** Bun test, TypeScript, Hocuspocus, Yjs, `@hocuspocus/transformer`, `@mdcms/editor-core`, Elysia content-store interfaces.
+
+---
+
+## Spec Delta
+
+Owning specs were updated before implementation:
+
+- `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` now defines active collaboration autosave, frontmatter in the collaboration Y.Doc, explicit flush control messages, Redis-loss recovery, and deterministic coverage.
+- `docs/specs/SPEC-006-studio-runtime-and-ui.md` now says active collaboration saves must use collaboration autosave/final-save, not HTTP `PUT`.
+- `docs/specs/SPEC-003-content-storage-versioning-and-migrations.md` now defines collaboration autosave as a silent draft `UPDATE` that increments `draft_revision`, emits `content.updated`, and never creates `document_versions`.
+- `docs/specs/SPEC-010-media-webhooks-search-and-integrations.md` now includes active collaboration autosave/final-save in `content.updated`.
+
+CMS-54 acceptance criteria covered by this plan:
+
+1. Autosave writes Yjs binary state to Redis, serializes Y.Doc to ProseMirror JSON to Markdown, updates `documents`, increments `draft_revision`, and creates no `document_versions`.
+2. Autosave emits `content.updated`.
+3. Behavior remains internally consistent with active locks, optimistic draft revision checks, and Redis recovery metadata.
+4. Public/operator workflow is documented in the specs above.
+
+## File Structure
+
+- Modify `apps/server/src/lib/collaboration/runtime.ts`
+  - Add frontmatter Y.Map helpers.
+  - Extend runtime content-store update payload to include `frontmatter`.
+  - Add one `persistRoomDraft` helper used by `onStoreDocument` and `onDisconnect`.
+  - Refresh room metadata after successful autosave.
+  - Fail closed on stale draft revisions or active-lock loss.
+- Modify `apps/server/src/lib/collaboration/runtime.test.ts`
+  - Extend fake content store to preserve/update frontmatter.
+  - Add focused runtime tests for active autosave, frontmatter, no-op final save, lifecycle events, and stale-revision fail-closed behavior.
+- Modify only if types fail: `apps/server/src/lib/content-api/types.ts`
+  - Prefer no change. The real content store already accepts `ContentWritePayload`; update only local collaboration runtime type imports if TypeScript needs the shared type.
+
+## Task 1: Frontmatter in Collaboration Y.Doc
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/runtime.ts`
+- Test: `apps/server/src/lib/collaboration/runtime.test.ts`
+
+- [ ] **Step 1: Write the failing frontmatter helper test**
+
+Add this test near the markdown/Yjs helper coverage in `apps/server/src/lib/collaboration/runtime.test.ts`:
+
+```typescript
+test("markdownToYDoc stores frontmatter in the collaboration Y.Doc", () => {
+  const frontmatter = {
+    title: "Launch",
+    featured: true,
+    order: 3,
+  };
+
+  const ydoc = markdownToYDoc("# Launch\n\nBody.", frontmatter);
+
+  assert.deepEqual(yDocToFrontmatter(ydoc), frontmatter);
+  assert.equal(yDocToMarkdown(ydoc), "# Launch\n\nBody.");
+});
+```
+
+Update the runtime imports in the same test file:
+
+```typescript
+import {
+  computeCollaborationBodyHash,
+  createCollaborationRuntime,
+  createCollaborationRuntimeHooks,
+  encodeYDocState,
+  markdownToYDoc,
+  yDocToFrontmatter,
+  yDocToMarkdown,
+  type CollaborationRuntimeAuthGuard,
+  type CollaborationRuntimeContentStore,
+  type CollaborationRuntimeContext,
+  type CollaborationRuntimeRedisStore,
+} from "./runtime.js";
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "markdownToYDoc stores frontmatter"
+```
+
+Expected: fails because `markdownToYDoc` does not accept frontmatter and `yDocToFrontmatter` is not exported.
+
+- [ ] **Step 3: Implement frontmatter Y.Doc helpers**
+
+In `apps/server/src/lib/collaboration/runtime.ts`, add a second field constant and helper functions near `COLLABORATION_YJS_FIELD_NAME` and the existing markdown conversion helpers:
+
+```typescript
+export const COLLABORATION_FRONTMATTER_FIELD_NAME = "frontmatter";
+
+function cloneJsonObject(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+export function writeFrontmatterToYDoc(
+  document: Y.Doc,
+  frontmatter: Record<string, unknown>,
+): void {
+  const map = document.getMap<unknown>(COLLABORATION_FRONTMATTER_FIELD_NAME);
+  map.clear();
+
+  for (const [key, value] of Object.entries(cloneJsonObject(frontmatter))) {
+    map.set(key, value);
+  }
+}
+
+export function yDocToFrontmatter(document: Y.Doc): Record<string, unknown> {
+  const map = document.getMap<unknown>(COLLABORATION_FRONTMATTER_FIELD_NAME);
+  return cloneJsonObject(Object.fromEntries(map.entries()));
+}
+```
+
+Update `markdownToYDoc` to accept frontmatter and seed the map:
+
+```typescript
+export function markdownToYDoc(
+  markdown: string,
+  frontmatter: Record<string, unknown> = {},
+): Y.Doc {
+  const tiptapDocument = parseMarkdownToDocument(markdown);
+  const ydoc = TiptapTransformer.toYdoc(
+    tiptapDocument,
+    COLLABORATION_YJS_FIELD_NAME,
+    createEditorCoreExtensions(),
+  );
+  writeFrontmatterToYDoc(ydoc, frontmatter);
+  return ydoc;
+}
+```
+
+Update `markdownToYjsUpdate`:
+
+```typescript
+export function markdownToYjsUpdate(
+  markdown: string,
+  frontmatter: Record<string, unknown> = {},
+): Uint8Array {
+  return encodeYDocState(markdownToYDoc(markdown, frontmatter));
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "markdownToYDoc stores frontmatter"
+```
+
+Expected: pass.
+
+## Task 2: Autosave Persistence Helper
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/runtime.ts`
+- Test: `apps/server/src/lib/collaboration/runtime.test.ts`
+
+- [ ] **Step 1: Write failing autosave tests**
+
+Extend `FakeContentStore` update payload typing in `runtime.test.ts`:
+
+```typescript
+readonly updates: Array<{
+  scope: ContentScope;
+  documentId: string;
+  payload: {
+    body?: string;
+    frontmatter?: Record<string, unknown>;
+    updatedBy?: string;
+  };
+  options?: { expectedDraftRevision?: number };
+}> = [];
+```
+
+Update `FakeContentStore.update` payload type and assignment:
+
+```typescript
+async update(
+  scope: ContentScope,
+  documentId: string,
+  payload: {
+    body?: string;
+    frontmatter?: Record<string, unknown>;
+    updatedBy?: string;
+  },
+  options?: { expectedDraftRevision?: number },
+): Promise<ContentDocument> {
+  this.updates.push({ scope, documentId, payload, options });
+
+  if (this.updateError) {
+    throw this.updateError;
+  }
+
+  if (
+    options?.expectedDraftRevision !== undefined &&
+    options.expectedDraftRevision !== this.document.draftRevision
+  ) {
+    throw new RuntimeError({
+      code: "STALE_DRAFT_REVISION",
+      message: "Draft has been modified since the room loaded.",
+      statusCode: 409,
+      details: {
+        documentId,
+        expectedDraftRevision: options.expectedDraftRevision,
+        currentDraftRevision: this.document.draftRevision,
+      },
+    });
+  }
+
+  this.document = {
+    ...this.document,
+    body: payload.body ?? this.document.body,
+    frontmatter: payload.frontmatter ?? this.document.frontmatter,
+    draftRevision: this.document.draftRevision + 1,
+    updatedBy: payload.updatedBy ?? this.document.updatedBy,
+    updatedAt: "2026-06-11T10:01:00.000Z",
+  };
+
+  return this.document;
+}
+```
+
+Add this test after `onStoreDocument writes Redis state and metadata only`; it must fail until autosave updates PostgreSQL:
+
+```typescript
+test("onStoreDocument autosaves changed body and frontmatter to PostgreSQL", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 4,
+    frontmatter: { title: "Original", featured: false },
+  });
+  const { hooks, contentStore, lifecycleEvents, redisStore } =
+    createHarness(document);
+  const context = createContext();
+  const ydoc = markdownToYDoc("# Changed\n\nBody.", {
+    title: "Changed",
+    featured: true,
+  });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  await hooks.onStoreDocument({
+    document: ydoc,
+    documentName: DOCUMENT_ID,
+    lastContext: createContext({
+      userId: "writer-1",
+      userEmail: "writer-1@example.com",
+      loadedDraftRevision: context.loadedDraftRevision,
+      loadedBodyHash: context.loadedBodyHash,
+      roomLeaseValue: context.roomLeaseValue,
+    }),
+  });
+
+  assert.equal(contentStore.updates.length, 1);
+  assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 4);
+  assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-1");
+  assert.match(contentStore.updates[0]?.payload.body ?? "", /# Changed/);
+  assert.deepEqual(contentStore.updates[0]?.payload.frontmatter, {
+    title: "Changed",
+    featured: true,
+  });
+  assert.equal(contentStore.document.draftRevision, 5);
+  assert.deepEqual(redisStore.metadata, {
+    draftRevision: 5,
+    bodyHash: computeCollaborationBodyHash(contentStore.document.body),
+  });
+  assert.equal(lifecycleEvents.events.length, 1);
+  assert.equal(lifecycleEvents.events[0]?.event, "content.updated");
+  assert.equal(lifecycleEvents.events[0]?.actor.id, "writer-1");
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "autosaves changed body and frontmatter"
+```
+
+Expected: fails because `onStoreDocument` does not update the content store.
+
+- [ ] **Step 3: Extend runtime store payload and room state**
+
+In `runtime.ts`, update `CollaborationRuntimeContentStore.update` payload:
+
+```typescript
+payload: {
+  body: string;
+  frontmatter: Record<string, unknown>;
+  updatedBy: string;
+},
+```
+
+Extend `CollaborationRuntimeContext` and `RoomState`:
+
+```typescript
+loadedFrontmatterHash?: string;
+loadedCanonicalFrontmatter?: Record<string, unknown>;
+```
+
+Add stable JSON hashing helpers near `computeCollaborationBodyHash`:
+
+```typescript
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function computeFrontmatterHash(frontmatter: Record<string, unknown>): string {
+  return `sha256:${createHash("sha256").update(stableJson(frontmatter), "utf8").digest("hex")}`;
+}
+```
+
+- [ ] **Step 4: Seed and assign frontmatter room state**
+
+In `onLoadDocument`, call `convertMarkdownToYjsUpdate(draft.body, draft.frontmatter)` after updating the option type:
+
+```typescript
+convertMarkdownToYjsUpdate?: (
+  markdown: string,
+  frontmatter?: Record<string, unknown>,
+) => Uint8Array;
+```
+
+Set room state with frontmatter:
+
+```typescript
+loadedFrontmatterHash: computeFrontmatterHash(draft.frontmatter),
+loadedCanonicalFrontmatter: cloneJsonObject(draft.frontmatter),
+```
+
+Update `assignLoadedRoomState` to copy `loadedFrontmatterHash` and `loadedCanonicalFrontmatter` to context.
+
+- [ ] **Step 5: Implement `persistRoomDraft` and call it from `onStoreDocument`**
+
+Add a helper inside `createCollaborationRuntimeHooks` before the returned hook object:
+
+```typescript
+async function persistRoomDraft(input: {
+  context: CollaborationRuntimeContext;
+  document: Y.Doc;
+  key: string;
+  state: RoomState | undefined;
+  writer: CollaborationRuntimeLastWriter;
+}): Promise<CollaborationYjsMetadata> {
+  const nextBody = yDocToMarkdown(input.document);
+  const nextFrontmatter = yDocToFrontmatter(input.document);
+  const loadedCanonicalBody =
+    input.state?.loadedCanonicalBody ?? input.context.loadedCanonicalBody;
+  const loadedFrontmatterHash =
+    input.state?.loadedFrontmatterHash ?? input.context.loadedFrontmatterHash;
+
+  if (typeof loadedCanonicalBody !== "string") {
+    throw new RuntimeError({
+      code: "INVALID_COLLABORATION_CONTEXT",
+      message: "Collaboration room is missing loaded canonical body.",
+      statusCode: 500,
+      details: { documentId: input.context.documentId },
+    });
+  }
+
+  if (typeof loadedFrontmatterHash !== "string") {
+    throw new RuntimeError({
+      code: "INVALID_COLLABORATION_CONTEXT",
+      message: "Collaboration room is missing loaded frontmatter metadata.",
+      statusCode: 500,
+      details: { documentId: input.context.documentId },
+    });
+  }
+
+  const nextFrontmatterHash = computeFrontmatterHash(nextFrontmatter);
+  const bodyChanged = nextBody !== loadedCanonicalBody;
+  const frontmatterChanged = nextFrontmatterHash !== loadedFrontmatterHash;
+
+  if (!bodyChanged && !frontmatterChanged) {
+    const currentDraft = await loadDraftDocument(options.contentStore, input.context);
+    return {
+      draftRevision: currentDraft.draftRevision,
+      bodyHash: computeCollaborationBodyHash(currentDraft.body),
+    };
+  }
+
+  const expectedDraftRevision =
+    input.state?.loadedDraftRevision ?? input.context.loadedDraftRevision;
+
+  if (typeof expectedDraftRevision !== "number") {
+    throw new RuntimeError({
+      code: "INVALID_COLLABORATION_CONTEXT",
+      message: "Collaboration autosave is missing expected draft revision.",
+      statusCode: 500,
+      details: { documentId: input.context.documentId },
+    });
+  }
+
+  const updated = await options.contentStore.update(
+    scopeFromContext(input.context),
+    input.context.documentId,
+    {
+      body: nextBody,
+      frontmatter: nextFrontmatter,
+      updatedBy: input.writer.userId,
+    },
+    { expectedDraftRevision },
+  );
+
+  const metadata = {
+    draftRevision: updated.draftRevision,
+    bodyHash: computeCollaborationBodyHash(updated.body),
+  };
+
+  if (input.state) {
+    input.state.loadedDraftRevision = updated.draftRevision;
+    input.state.loadedBodyHash = metadata.bodyHash;
+    input.state.loadedCanonicalBody = nextBody;
+    input.state.loadedFrontmatterHash = computeFrontmatterHash(updated.frontmatter);
+    input.state.loadedCanonicalFrontmatter = cloneJsonObject(updated.frontmatter);
+    input.state.lastWriter = input.writer;
+  }
+
+  assignLoadedRoomState(input.context, input.state ?? {
+    documentId: input.context.documentId,
+    documentName: input.key,
+    loadedDraftRevision: updated.draftRevision,
+    loadedBodyHash: metadata.bodyHash,
+    loadedCanonicalBody: nextBody,
+    loadedFrontmatterHash: computeFrontmatterHash(updated.frontmatter),
+    loadedCanonicalFrontmatter: cloneJsonObject(updated.frontmatter),
+    roomLeaseValue: input.context.roomLeaseValue ?? "",
+    lastWriter: input.writer,
+  });
+
+  await options.lifecycleEvents?.emitContentEvent({
+    event: "content.updated",
+    scope: scopeFromContext(input.context),
+    document: updated,
+    actor: createLifecycleActor(input.writer),
+  });
+
+  return metadata;
+}
+```
+
+Then in `onStoreDocument`, after `setYjsState`, call `persistRoomDraft` and store refreshed metadata:
+
+```typescript
+const writer = state?.lastWriter ??
+  context.lastWriter ?? {
+    userId: context.userId,
+    ...(context.userEmail ? { email: context.userEmail } : {}),
+  };
+const metadata = await persistRoomDraft({
+  context,
+  document,
+  key,
+  state,
+  writer,
+});
+await options.redisStore.setYjsMetadata(context.documentId, metadata);
+updateLastWriter(roomStates, context);
+```
+
+- [ ] **Step 6: Run the focused autosave test**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "autosaves changed body and frontmatter"
+```
+
+Expected: pass.
+
+## Task 3: Final Save Reuses Autosave State
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/runtime.ts`
+- Test: `apps/server/src/lib/collaboration/runtime.test.ts`
+
+- [ ] **Step 1: Write failing no-op final-save-after-autosave test**
+
+Add this test near the final disconnect tests:
+
+```typescript
+test("last disconnect after active autosave does not increment draft revision again", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 8,
+    frontmatter: { title: "Original" },
+  });
+  const { hooks, contentStore, lifecycleEvents } = createHarness(document);
+  const context = createContext();
+  const changed = markdownToYDoc("# Changed\n\nBody.", { title: "Changed" });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  await hooks.onStoreDocument({
+    document: changed,
+    documentName: DOCUMENT_ID,
+    lastContext: createContext({
+      userId: "writer-2",
+      loadedDraftRevision: context.loadedDraftRevision,
+      loadedBodyHash: context.loadedBodyHash,
+      loadedFrontmatterHash: context.loadedFrontmatterHash,
+      roomLeaseValue: context.roomLeaseValue,
+    }),
+  });
+  await hooks.onDisconnect({
+    clientsCount: 0,
+    context,
+    document: changed,
+    documentName: DOCUMENT_ID,
+  });
+
+  assert.equal(contentStore.updates.length, 1);
+  assert.equal(contentStore.document.draftRevision, 9);
+  assert.equal(lifecycleEvents.events.length, 1);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails if final save duplicates**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "last disconnect after active autosave"
+```
+
+Expected before implementation is complete: fails with a second update or stale revision.
+
+- [ ] **Step 3: Replace final-save body in `onDisconnect` with `persistRoomDraft`**
+
+In `onDisconnect`, keep active-lock verification and final Redis/finalize behavior, but replace the manual `currentDraft`, body comparison, content store update, and lifecycle code with:
+
+```typescript
+const writer = state?.lastWriter ??
+  context.lastWriter ?? {
+    userId: context.userId,
+    ...(context.userEmail ? { email: context.userEmail } : {}),
+  };
+const metadata = await persistRoomDraft({
+  context,
+  document,
+  key,
+  state,
+  writer,
+});
+
+await options.redisStore.setYjsState(context.documentId, nextState);
+await options.redisStore.setYjsMetadata(context.documentId, metadata);
+```
+
+Keep the existing `finalizeInactiveRoom`, heartbeat cleanup, finalized lease, and fail-closed behavior.
+
+- [ ] **Step 4: Run final-save focused tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "last disconnect"
+```
+
+Expected: all last-disconnect tests pass after updating assertions for the new frontmatter-aware payload shape.
+
+## Task 4: Fail-Closed Autosave Errors
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/runtime.ts`
+- Test: `apps/server/src/lib/collaboration/runtime.test.ts`
+
+- [ ] **Step 1: Write stale autosave failure test**
+
+Add this test near the stale revision final-save test:
+
+```typescript
+test("active autosave stale draft revision fails closed without overwriting PostgreSQL", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 3,
+  });
+  const { hooks, contentStore, redisStore, closedRooms } =
+    createHarness(document);
+  const context = createContext();
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  contentStore.document = {
+    ...contentStore.document,
+    body: "# External change",
+    draftRevision: 4,
+  };
+
+  await assert.rejects(
+    hooks.onStoreDocument({
+      document: markdownToYDoc("# Collaboration change"),
+      documentName: DOCUMENT_ID,
+      lastContext: context,
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "STALE_DRAFT_REVISION",
+  );
+
+  assert.equal(contentStore.document.body, "# External change");
+  assert.deepEqual(closedRooms, [DOCUMENT_ID]);
+  assert.equal(
+    redisStore.calls.some((call) => call.method === "finalizeInactiveRoom"),
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Run the stale autosave test and verify it fails if room stays open**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts -t "active autosave stale draft revision"
+```
+
+Expected: fails until `onStoreDocument` marks the active lock lost on persistence errors.
+
+- [ ] **Step 3: Mark room fail-closed on autosave persistence errors**
+
+Wrap the `persistRoomDraft` call in `onStoreDocument`:
+
+```typescript
+let metadata: CollaborationYjsMetadata;
+try {
+  metadata = await persistRoomDraft({
+    context,
+    document,
+    key,
+    state,
+    writer,
+  });
+} catch (error) {
+  if (state) {
+    await markActiveLockLost(key, state);
+  }
+  throw error;
+}
+```
+
+Do not call `finalizeInactiveRoom` in this path.
+
+- [ ] **Step 4: Run runtime collaboration tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts
+```
+
+Expected: all runtime tests pass.
+
+## Task 5: Broader Verification
+
+**Files:**
+- Validate only; no planned file edits.
+
+- [ ] **Step 1: Run collaboration server tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/runtime.test.ts ./src/lib/collaboration/redis-store.test.ts ./src/lib/collaboration/transport.test.ts ./src/lib/collaboration/transport.integration.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run content API active-lock regression tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/content-api.test.ts -t "collaboration"
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run format check**
+
+Run:
+
+```bash
+bun run format:check
+```
+
+Expected: pass.
+
+## Completion Notes
+
+When this plan is implemented, the CMS-54 ticket is ready for review if:
+
+- active `onStoreDocument` writes Redis state and PostgreSQL draft state;
+- frontmatter is carried in the collaboration Y.Doc;
+- autosave increments `draft_revision` exactly once per changed persisted snapshot;
+- no version rows are created by tests or implementation paths;
+- `content.updated` emits for changed autosaves;
+- stale autosave/final-save failures fail closed;
+- last-disconnect final save is no-op after successful active autosave.

--- a/.ai/plans/2026-06-14-cms-55-presence-indicators.md
+++ b/.ai/plans/2026-06-14-cms-55-presence-indicators.md
@@ -263,7 +263,7 @@ export type CollaborationPresenceContext = {
 };
 ```
 
-Use a deterministic color derived from `userId` with a stable palette. Label should prefer a display name if a future session exposes one, otherwise use the email local-part, then `userId`.
+Use a deterministic color derived from `userId` with a stable palette. Label should prefer a display name if a future session exposes one, otherwise fall back directly to `userId`.
 
 - [ ] **Step 3: Add presence auth guard methods**
 

--- a/.ai/plans/2026-06-14-cms-55-presence-indicators.md
+++ b/.ai/plans/2026-06-14-cms-55-presence-indicators.md
@@ -1,0 +1,516 @@
+# CMS-55 Presence Indicators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement baseline real-time Studio presence for content lists and editor pages, including online/view/edit state, user labels/colors, and editor cursor/selection snapshots.
+
+**Architecture:** Use a target-scoped JSON WebSocket at `/api/v1/collaboration/presence` for presence updates and snapshots. Store ephemeral per-session presence records in Redis with a 30-second TTL, authorize view/edit document updates server-side, and render compact Studio indicators from backend-filtered snapshots. Do not introduce the full Hocuspocus/Yjs Studio editor provider in this ticket.
+
+**Tech Stack:** Bun test, TypeScript, Zod contracts in `@mdcms/shared`, Redis-backed collaboration store, crossws Bun WebSocket transport, React 19 Studio runtime UI.
+
+---
+
+## Spec Delta
+
+Owning specs were updated before implementation:
+
+- `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` now defines `presence.update` JSON messages on the target-scoped presence stream.
+- The presence stream URL remains target-scoped (`project` + `environment`, no URL `documentId`), while document-specific state is reported in socket messages.
+- `view` updates with a `documentId` require draft read access. `edit` updates require draft read and content write access. Unauthorized updates close with the existing collaboration `4401` / `4403` close codes.
+- Baseline cursor/selection snapshots are carried by the presence stream so Studio can render editor cursors before a full document-room client provider exists.
+
+CMS-55 acceptance criteria covered by this plan:
+
+1. Content list and editor render real-time presence from presence snapshots.
+2. Presence tracks online users, document view/edit targets, and editor cursor/selection positions.
+3. Indicators use user-identifiable labels/colors from the server contract.
+4. Role-aware constraints are enforced by server authorization for presence updates and by Studio mode selection.
+5. The public contract is documented in the spec and typed in `@mdcms/shared`.
+
+## File Structure
+
+- Create `packages/shared/src/lib/contracts/collaboration.ts`
+  - Zod schemas and types for presence modes, cursors, update messages, users, and snapshots.
+- Modify `packages/shared/src/index.ts`
+  - Export the collaboration contract.
+- Modify `apps/server/src/lib/collaboration/redis-store.ts`
+  - Add presence key builder, TTL constant, record schema parsing, `setPresence`, `deletePresence`, and `listPresence`.
+- Modify `apps/server/src/lib/collaboration/redis-store.test.ts`
+  - Cover presence key shape, TTL writes, target isolation, and invalid record filtering.
+- Modify `apps/server/src/lib/collaboration-auth.ts`
+  - Split document-room query validation from presence-stream query validation.
+  - Add presence handshake/update authorization.
+- Modify `apps/server/src/lib/collaboration-auth.test.ts`
+  - Cover presence auth, forbidden URL `documentId`, API-key rejection, and edit-mode write checks.
+- Modify `apps/server/src/lib/collaboration/transport.ts`
+  - Route both document-room and presence-stream upgrades through one Bun websocket handler.
+  - Add presence peer lifecycle, JSON message handling, snapshot broadcast, and cleanup.
+- Modify `apps/server/src/lib/collaboration/transport.test.ts`
+  - Cover route detection, handshake failure mapping, JSON snapshot delivery, invalid updates, and close cleanup.
+- Modify `apps/server/src/lib/collaboration/transport.integration.test.ts`
+  - Add end-to-end presence snapshots for online/editing users and disconnect cleanup.
+- Modify `apps/server/src/lib/runtime-with-modules.ts`
+  - Wire the Redis-backed presence store through the collaboration transport.
+- Create `packages/studio/src/lib/collaboration-presence.ts`
+  - WebSocket URL builder, snapshot parser, grouping/filtering helpers, and update serialization.
+- Create `packages/studio/src/lib/collaboration-presence.test.ts`
+  - Unit tests for URL conversion, schema parsing, current-session filtering, and edit-precedence grouping.
+- Create `packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts`
+  - React hook that opens the presence stream in cookie-authenticated Studio sessions, sends updates, and stores snapshots.
+- Create `packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.tsx`
+  - Compact avatar stack, mode chips, editor collaborator bar, and remote cursor layer primitives.
+- Create `packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.test.tsx`
+  - Static markup tests for list/editor indicators and accessible labels.
+- Modify `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx`
+  - Subscribe to presence, group by visible document ids, and render row indicators in the title/path cell.
+- Modify `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx`
+  - Cover presence table columns staying stable and row indicators rendering from supplied data.
+- Modify `packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx`
+  - Emit collapsed and non-collapsed cursor selections, and render remote cursor labels from presence users.
+- Modify `packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts`
+  - Cover cursor callback normalization and read-only behavior.
+- Modify `packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx`
+  - Subscribe to presence for the routed document, send `view` or `edit` mode based on `canWrite`/version state, pass remote cursors into `TipTapEditor`, and render the editor collaborator bar.
+- Modify `packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx`
+  - Cover editor presence markup and view-mode behavior when write is forbidden.
+
+## Task 1: Shared Presence Contract
+
+**Files:**
+- Create: `packages/shared/src/lib/contracts/collaboration.ts`
+- Create: `packages/shared/src/lib/contracts/collaboration.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: Add failing contract tests**
+
+Add tests that assert valid update/snapshot payloads parse and invalid cursor/update payloads fail:
+
+```typescript
+test("collaboration presence schemas parse updates and snapshots", () => {
+  const update = CollaborationPresenceUpdateSchema.parse({
+    type: "presence.update",
+    documentId: "11111111-1111-4111-8111-111111111111",
+    mode: "edit",
+    cursor: { anchor: 2, head: 7 },
+  });
+  assert.equal(update.mode, "edit");
+
+  const snapshot = CollaborationPresenceSnapshotSchema.parse({
+    type: "presence.snapshot",
+    project: "marketing",
+    environment: "draft",
+    users: [
+      {
+        userId: "user-1",
+        sessionId: "session-1",
+        label: "Ada",
+        color: "#2563eb",
+        documentId: "11111111-1111-4111-8111-111111111111",
+        mode: "view",
+        cursor: { anchor: 1, head: 1 },
+        updatedAt: "2026-06-14T10:00:00.000Z",
+      },
+    ],
+  });
+  assert.equal(snapshot.users[0]?.label, "Ada");
+});
+
+test("collaboration presence schemas reject invalid modes and cursors", () => {
+  assert.equal(
+    CollaborationPresenceUpdateSchema.safeParse({
+      type: "presence.update",
+      mode: "publish",
+    }).success,
+    false,
+  );
+  assert.equal(
+    CollaborationPresenceCursorSchema.safeParse({ anchor: -1, head: 1 })
+      .success,
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Implement schemas and exports**
+
+Implement:
+
+```typescript
+export const CollaborationPresenceModeSchema = z.enum(["view", "edit"]);
+export const CollaborationPresenceCursorSchema = z.object({
+  anchor: z.number().int().nonnegative(),
+  head: z.number().int().nonnegative(),
+});
+export const CollaborationPresenceUpdateSchema = z.object({
+  type: z.literal("presence.update"),
+  documentId: z.string().uuid().nullable().optional(),
+  mode: CollaborationPresenceModeSchema,
+  cursor: CollaborationPresenceCursorSchema.nullable().optional(),
+});
+export const CollaborationPresenceUserSchema = z.object({
+  userId: z.string().min(1),
+  sessionId: z.string().min(1),
+  label: z.string().min(1),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  documentId: z.string().uuid().nullable(),
+  mode: CollaborationPresenceModeSchema,
+  cursor: CollaborationPresenceCursorSchema.optional(),
+  updatedAt: z.string().datetime(),
+});
+export const CollaborationPresenceSnapshotSchema = z.object({
+  type: z.literal("presence.snapshot"),
+  project: z.string().min(1),
+  environment: z.string().min(1),
+  users: z.array(CollaborationPresenceUserSchema),
+});
+```
+
+Export inferred types and add `export * from "./lib/contracts/collaboration.js";` to `packages/shared/src/index.ts`.
+
+- [ ] **Step 3: Verify shared tests**
+
+Run:
+
+```bash
+bun test --cwd packages/shared ./src/lib/contracts/collaboration.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Redis Presence Store
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/redis-store.ts`
+- Modify: `apps/server/src/lib/collaboration/redis-store.test.ts`
+
+- [ ] **Step 1: Add failing Redis tests**
+
+Add tests for:
+
+- `buildCollaborationPresenceKey("marketing", "draft", "session-1")` equals `mdcms:collaboration:presence:marketing:draft:session-1`.
+- `setPresence` writes JSON with `EX 30`.
+- `listPresence` returns only valid records for the requested target.
+- `deletePresence` deletes the exact session key.
+
+- [ ] **Step 2: Extend the Redis client contract**
+
+Add `scan(cursor, "MATCH", pattern, "COUNT", count)` to `CollaborationRedisClient`, and implement it in `FakeRedisClient` for tests by filtering `values.keys()` against the supplied pattern.
+
+- [ ] **Step 3: Add presence store methods**
+
+Add:
+
+```typescript
+export const COLLABORATION_PRESENCE_TTL_SECONDS = 30;
+export function buildCollaborationPresenceKey(input: {
+  project: string;
+  environment: string;
+  sessionId: string;
+}): string {
+  return `mdcms:collaboration:presence:${input.project}:${input.environment}:${input.sessionId}`;
+}
+```
+
+Add store methods:
+
+```typescript
+setPresence(record: CollaborationPresenceUser): Promise<void>;
+deletePresence(input: { project: string; environment: string; sessionId: string }): Promise<void>;
+listPresence(input: { project: string; environment: string }): Promise<CollaborationPresenceUser[]>;
+```
+
+Use `CollaborationPresenceUserSchema.safeParse` when reading. Ignore malformed records.
+
+- [ ] **Step 4: Verify Redis tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts
+```
+
+Expected: pass.
+
+## Task 3: Presence Authorization
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration-auth.ts`
+- Modify: `apps/server/src/lib/collaboration-auth.test.ts`
+
+- [ ] **Step 1: Add failing auth tests**
+
+Cover:
+
+- Document-room handshake still requires `documentId`.
+- Presence handshake accepts `project` and `environment` with no `documentId`.
+- Presence handshake rejects URL `documentId`.
+- API-key bearer tokens are rejected for presence.
+- Presence `edit` update for a document calls write authorization and maps authorization failure to `4403`.
+
+- [ ] **Step 2: Add presence context and query parsing**
+
+Add:
+
+```typescript
+export type CollaborationPresenceContext = {
+  userId: string;
+  sessionId: string;
+  project: string;
+  environment: string;
+  role: string;
+  label: string;
+  color: string;
+};
+```
+
+Use a deterministic color derived from `userId` with a stable palette. Label should prefer a display name if a future session exposes one, otherwise use the email local-part, then `userId`.
+
+- [ ] **Step 3: Add presence auth guard methods**
+
+Extend `createCollaborationAuthGuard` return type with:
+
+```typescript
+authorizePresenceHandshake(request): Promise<PresenceHandshakeResult>;
+authorizePresenceUpdate(request, context, update): Promise<{ ok: true } | { ok: false; closeCode: CollaborationCloseCode }>;
+filterPresenceSnapshot(request, context, users): Promise<CollaborationPresenceUser[]>;
+```
+
+Handshake requires session auth and `content:read:draft` for the target scope. `view` update with `documentId` requires draft read for that document path. `edit` update requires draft read and content write for that document path.
+
+- [ ] **Step 4: Verify auth tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration-auth.test.ts
+```
+
+Expected: pass.
+
+## Task 4: Presence Transport And Runtime Wiring
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/transport.ts`
+- Modify: `apps/server/src/lib/collaboration/transport.test.ts`
+- Modify: `apps/server/src/lib/collaboration/transport.integration.test.ts`
+- Modify: `apps/server/src/lib/runtime-with-modules.ts`
+
+- [ ] **Step 1: Add failing transport tests**
+
+Cover:
+
+- `isCollaborationWebSocketUpgradeRequest` returns true for `/api/v1/collaboration/presence`.
+- Presence upgrade returns `503` when presence storage is unavailable.
+- Presence open sends an initial `presence.snapshot`.
+- Valid `presence.update` stores the record and broadcasts a filtered snapshot.
+- Invalid JSON or invalid update closes with `4403`.
+- Closing the last socket for a session deletes that session's presence record; closing one of two sockets for the same session does not.
+
+- [ ] **Step 2: Extend transport context**
+
+Use one crossws adapter. Store peer context as either `{ kind: "document"; collaboration }` or `{ kind: "presence"; presence }`. Existing document-room behavior must remain byte-for-byte compatible with Hocuspocus.
+
+- [ ] **Step 3: Implement presence peer lifecycle**
+
+On presence open:
+
+1. Add peer to a per-target/session connection set.
+2. Store an online record with `documentId: null`, `mode: "view"`, server label/color, and `updatedAt`.
+3. Send an immediate snapshot to the peer.
+
+On presence message:
+
+1. Parse UTF-8 JSON.
+2. Validate `CollaborationPresenceUpdateSchema`.
+3. Reauthorize update with the presence auth guard.
+4. Store the updated record.
+5. Broadcast a fresh filtered snapshot to open presence peers for the same target.
+
+On close:
+
+1. Remove peer from the connection set.
+2. Delete Redis presence only when no other local socket for that session remains.
+3. Broadcast the fresh snapshot.
+
+- [ ] **Step 4: Wire runtime-with-modules**
+
+Pass the Redis collaboration store to the transport as presence storage when Redis is available. Keep the existing unavailable error details for both document-room and presence-stream upgrades.
+
+- [ ] **Step 5: Verify server collaboration tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts ./src/lib/collaboration/transport.test.ts ./src/lib/collaboration/transport.integration.test.ts
+```
+
+If the integration test fails with `EPERM` on `127.0.0.1`, rerun the same command with sandbox escalation for localhost binding.
+
+Expected: pass.
+
+## Task 5: Studio Presence Client And List Indicators
+
+**Files:**
+- Create: `packages/studio/src/lib/collaboration-presence.ts`
+- Create: `packages/studio/src/lib/collaboration-presence.test.ts`
+- Create: `packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts`
+- Create: `packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.tsx`
+- Create: `packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.test.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx`
+
+- [ ] **Step 1: Add pure helper tests**
+
+Cover:
+
+- `http://localhost:4000` becomes `ws://localhost:4000/api/v1/collaboration/presence?...`.
+- `https://cms.example.com/api` becomes `wss://cms.example.com/api/api/v1/collaboration/presence?...`.
+- Snapshot parsing rejects unknown shapes.
+- Grouping filters current `sessionId`, filters to visible ids, and sorts edit-mode users before view-mode users.
+
+- [ ] **Step 2: Implement pure helpers**
+
+Implement:
+
+```typescript
+createPresenceWebSocketUrl(config): string;
+parsePresenceSnapshot(raw): CollaborationPresenceSnapshot | null;
+groupPresenceByDocument(users, { visibleDocumentIds, currentSessionId }): Map<string, CollaborationPresenceUser[]>;
+```
+
+- [ ] **Step 3: Implement the React hook**
+
+`useCollaborationPresence` should:
+
+- Return idle state when `auth.mode !== "cookie"` or the session is not authenticated.
+- Open the presence WebSocket with credentials via browser cookies.
+- Send `presence.update` on open and whenever `documentId`, `mode`, or `cursor` changes.
+- Keep the latest parsed snapshot in React state.
+- Close the socket on unmount or target changes.
+
+- [ ] **Step 4: Implement compact indicators**
+
+Create small avatar-stack components using existing `Avatar`, `AvatarFallback`, and `Tooltip` primitives. Include `data-mdcms-presence-mode="edit|view"` and a tooltip label like `Ada editing` or `Grace viewing`.
+
+- [ ] **Step 5: Render list indicators**
+
+In `ContentTypePage`, call `useCollaborationPresence({ mode: "view" })`, group by visible row ids, and pass `presenceByDocumentId` to `ContentTypeDocumentsTable`. Render indicators inside the title/path cell next to the document title. Do not add an `Online now` sidebar or a new table column.
+
+- [ ] **Step 6: Verify Studio list tests**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/collaboration-presence.test.ts ./src/lib/runtime-ui/components/presence/presence-indicators.test.tsx './src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx'
+```
+
+Expected: pass.
+
+## Task 6: Editor Presence And Remote Cursor Rendering
+
+**Files:**
+- Modify: `packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts`
+- Modify: `packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx`
+- Modify: `packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx`
+
+- [ ] **Step 1: Add failing editor tests**
+
+Cover:
+
+- `TipTapEditor` publishes `{ anchor, head }` on collapsed cursor and selection changes.
+- Read-only editor still reports `view` presence from the page but does not send `edit`.
+- Editor collaborator bar renders non-current sessions for the routed document.
+- Remote cursor labels render with `data-mdcms-remote-cursor` and server-provided labels/colors.
+
+- [ ] **Step 2: Add cursor callback and remote cursor props**
+
+Add TipTap props:
+
+```typescript
+type TipTapEditorCursorSelection = { anchor: number; head: number };
+onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
+remoteCursors?: Array<{
+  sessionId: string;
+  label: string;
+  color: string;
+  cursor: TipTapEditorCursorSelection;
+}>;
+```
+
+Call `onCursorSelectionChange` from `onSelectionUpdate` with ProseMirror `selection.anchor` and `selection.head`.
+
+- [ ] **Step 3: Render remote cursors**
+
+Inside the editor canvas wrapper, compute cursor coordinates with `editor.view.coordsAtPos(cursor.head)` relative to the editor wrapper. Render compact absolutely positioned labels with `data-mdcms-remote-cursor={sessionId}`. If coordinate calculation throws because a cursor is stale, skip that cursor until the next snapshot.
+
+- [ ] **Step 4: Wire document page presence**
+
+In `ContentDocumentPage`, call `useCollaborationPresence` with:
+
+```typescript
+documentId: state.status === "ready" ? state.documentId : null;
+mode: state.status === "ready" && state.canWrite && !state.viewingVersion ? "edit" : "view";
+cursor: latestCursorSelection;
+```
+
+Pass filtered remote cursors into `TipTapEditor` and render the editor collaborator bar near the preview mode/action controls.
+
+- [ ] **Step 5: Verify editor tests**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts ./src/lib/runtime-ui/pages/content-document-page.test.tsx
+```
+
+Expected: pass.
+
+## Task 7: CMS-55 Verification And Release Hygiene
+
+**Files:**
+- Update only if needed: `.ai/memory/architecture.md`, `.ai/memory/product.md`, `.ai/memory/lessons.md`
+- Generated by CLI if package source changed: `.changeset/*.md`
+
+- [ ] **Step 1: Run focused server tests**
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts ./src/lib/collaboration/transport.test.ts ./src/lib/collaboration/transport.integration.test.ts ./src/lib/collaboration-auth.test.ts
+```
+
+- [ ] **Step 2: Run focused Studio/shared tests**
+
+```bash
+bun test --cwd packages/shared ./src/lib/contracts/collaboration.test.ts
+bun test --cwd packages/studio ./src/lib/collaboration-presence.test.ts ./src/lib/runtime-ui/components/presence/presence-indicators.test.tsx './src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx' ./src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts ./src/lib/runtime-ui/pages/content-document-page.test.tsx
+```
+
+- [ ] **Step 3: Run workspace gates**
+
+```bash
+bun run typecheck
+bun run format:check
+git diff --check
+```
+
+- [ ] **Step 4: Create a changeset**
+
+This ticket touches published packages `@mdcms/shared` and `@mdcms/studio`. Run:
+
+```bash
+bun run changeset
+```
+
+Select `@mdcms/shared` and `@mdcms/studio`, choose patch releases, and summarize the presence contract/UI additions. Do not hand-write the generated changeset.
+
+## Completion Notes
+
+CMS-55 is ready for review when:
+
+- presence contracts parse and reject invalid messages deterministically;
+- presence stream auth rejects API keys, enforces target scope, forbids URL `documentId`, and enforces view/edit document permissions;
+- Redis presence records use the documented key shape and expire within 30 seconds;
+- list/editor Studio surfaces render compact labels/colors from backend-filtered snapshots;
+- editor cursor/selection snapshots are sent and remote cursor labels render for readable same-document collaborators;
+- token-mode Studio does not attempt session-cookie collaboration sockets;
+- focused tests, typecheck, format check, and changeset generation are complete.

--- a/.ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md
+++ b/.ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md
@@ -1,0 +1,582 @@
+# CMS-58 Collaboration Round-Trip Fidelity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic CI coverage proving Studio collaboration bodies and frontmatter fixtures round-trip without phantom edits.
+
+**Architecture:** Keep the suite fixture-driven and colocated with Studio runtime editor tests because Studio consumes the `@mdcms/editor-core` markdown pipeline and owns frontmatter/property UI state. Assert byte-for-byte stability only for the canonical markdown/MDX shape the Studio serializer produces; do not attempt to preserve arbitrary hand-authored JSX whitespace or prop formatting outside the current schema-produced contract.
+
+**Tech Stack:** Bun test, TypeScript, Studio markdown pipeline re-export, TipTap editor-core serialization, Studio content document state helpers.
+
+---
+
+## Spec Delta
+
+No new spec delta is required for CMS-58. `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` already defines:
+
+- `serialize(parse(markdown)) === markdown` for schema-produced content.
+- CI coverage across Markdown/MDX bodies, frontmatter fields supported by Studio properties, MDX component nodes with props, nested component children, native image/link serialization, and collapsed MDX component UI state.
+
+Affected behavior:
+
+- Studio/editor serialization regression coverage only.
+- No endpoint, auth mode, routing context, request contract, success response, or deterministic API error change.
+
+Acceptance criteria covered:
+
+1. `serialize(parse(markdown)) === markdown` passes for every configured fixture type in the new suite.
+2. Primary and edge UI serialization states are covered through collapsed MDX component state and frontmatter property fixtures.
+3. The operator/public workflow is the existing CI test command; no new workflow docs are needed beyond the spec and test names.
+
+## File Structure
+
+- Create `packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts`
+  - Own the CMS-58 fixture matrix.
+  - Import `roundTripMarkdown` from `../../../markdown-pipeline.js`.
+  - Import `cloneFrontmatter`, `areJsonValuesEqual`, `getPropertyDescriptors`, and `type ContentDocumentPageReadyState` from `../../pages/content-document-page-state.js`.
+  - Import `type SchemaRegistryFieldSnapshot` from `@mdcms/shared`.
+- No production files should change unless one of the canonical fixtures fails and exposes a real serializer defect.
+- No changeset should be required if the work remains under `packages/studio/src/lib/runtime-ui/**`, which is listed in `packages/studio/.changeset-gate.json` as runtime-only unpublished source.
+
+## Task 1: Fixture-Driven Body Idempotency
+
+**Files:**
+- Create: `packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts`
+
+- [x] **Step 1: Add the fixture matrix test**
+
+Create the file with:
+
+```typescript
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import { roundTripMarkdown } from "../../../markdown-pipeline.js";
+
+type CollaborationRoundTripFixture = {
+  type: string;
+  body: string;
+};
+
+const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
+  {
+    type: "Article",
+    body: [
+      "# Product Update",
+      "",
+      "Intro with [docs](https://docs.example.com).",
+      "",
+      "![Hero image](https://cdn.example.com/hero.png)",
+      "",
+      "- [ ] Draft",
+      "- [x] Published",
+      "",
+      "```ts",
+      "const value = 42;",
+      "```",
+    ].join("\n"),
+  },
+  {
+    type: "MarketingPage",
+    body: [
+      '<Hero title="Launch" image={{"src":"https://cdn.example.com/hero.png"}} />',
+      "",
+      '<Callout type="warning">',
+      "This is **important** content.",
+      "",
+      '<Button href="/start">',
+      "Start",
+      "</Button>",
+      "</Callout>",
+    ].join("\n"),
+  },
+  {
+    type: "LandingPage",
+    body: [
+      '<section style={{"backgroundColor":"#fff"}}>',
+      "<h2>",
+      'Title with <span style={{"color":"#2563eb"}}>accent</span>',
+      "</h2>",
+      "</section>",
+    ].join("\n"),
+  },
+];
+
+test("collaboration body fixtures round-trip byte-for-byte", () => {
+  for (const fixture of BODY_FIXTURES) {
+    assert.equal(
+      roundTripMarkdown(fixture.body).markdown,
+      fixture.body,
+      `${fixture.type} body must not produce a phantom collaboration diff`,
+    );
+  }
+});
+```
+
+- [x] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+```
+
+Expected: pass if current canonical serialization is already correct. If it fails, inspect the diff. Only change production serialization when the fixture is already in the canonical Studio-produced form above.
+
+## Task 2: Frontmatter Fixture Coverage
+
+**Files:**
+- Modify: `packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts`
+
+- [x] **Step 1: Add frontmatter/schema fixtures**
+
+Append:
+
+```typescript
+import {
+  createEmptyCurrentPrincipalCapabilities,
+  type SchemaRegistryFieldSnapshot,
+} from "@mdcms/shared";
+import {
+  areJsonValuesEqual,
+  cloneFrontmatter,
+  getPropertyDescriptors,
+  type ContentDocumentPageReadyState,
+} from "../../pages/content-document-page-state.js";
+
+type FrontmatterFixture = {
+  type: string;
+  frontmatter: Record<string, unknown>;
+  fields: Record<string, SchemaRegistryFieldSnapshot>;
+  editableFields: string[];
+  unsupportedFields: string[];
+};
+
+const FRONTMATTER_FIXTURES: FrontmatterFixture[] = [
+  {
+    type: "Article",
+    frontmatter: {
+      title: "Product Update",
+      priority: 3,
+      featured: true,
+      heroImage: "media_hero",
+      status: "published",
+    },
+    fields: {
+      title: { kind: "string", required: true, nullable: false },
+      priority: { kind: "number", required: false, nullable: true },
+      featured: { kind: "boolean", required: false, nullable: false },
+      heroImage: {
+        kind: "file",
+        required: false,
+        nullable: true,
+        file: {
+          preset: "image",
+          accept: ["image/png", "image/jpeg"],
+          emptyStringAsUnset: true,
+        },
+      },
+      status: {
+        kind: "string",
+        required: false,
+        nullable: true,
+        options: ["draft", "review", "published"],
+      },
+    },
+    editableFields: ["title", "priority", "featured", "heroImage", "status"],
+    unsupportedFields: [],
+  },
+  {
+    type: "LandingPage",
+    frontmatter: {
+      seo: { title: "Launch", description: "Ship the new page." },
+      tags: ["launch", "product"],
+    },
+    fields: {
+      seo: {
+        kind: "object",
+        required: false,
+        nullable: false,
+        fields: {
+          title: { kind: "string", required: true, nullable: false },
+          description: { kind: "string", required: false, nullable: true },
+        },
+      },
+      tags: {
+        kind: "array",
+        required: false,
+        nullable: false,
+        item: { kind: "string", required: true, nullable: false },
+      },
+    },
+    editableFields: [],
+    unsupportedFields: ["seo", "tags"],
+  },
+];
+
+function createFixtureReadyState(
+  fixture: FrontmatterFixture,
+): ContentDocumentPageReadyState {
+  return {
+    status: "ready",
+    typeId: fixture.type,
+    typeLabel: fixture.type,
+    documentId: "11111111-1111-4111-8111-111111111111",
+    locale: "en",
+    route: {
+      project: "marketing",
+      initialEnvironment: "draft",
+      write: { canWrite: true, schemaHash: "schema-hash" },
+    },
+    schemaState: {
+      status: "ready",
+      project: "marketing",
+      environment: "draft",
+      localSchemaHash: "schema-hash",
+      serverSchemaHash: "schema-hash",
+      isMismatch: false,
+      hasLocalSyncPayload: true,
+      canSync: true,
+      capabilities: {
+        ...createEmptyCurrentPrincipalCapabilities(),
+        content: {
+          read: true,
+          readDraft: true,
+          write: true,
+          publish: true,
+          unpublish: true,
+          delete: true,
+        },
+        schema: { read: true, write: true },
+        media: { read: true, upload: true, delete: true },
+        ai: { use: true },
+      },
+      entries: [
+        {
+          type: fixture.type,
+          directory: "content",
+          localized: false,
+          schemaHash: "schema-hash",
+          syncedAt: "2026-06-14T10:00:00.000Z",
+          resolvedSchema: {
+            type: fixture.type,
+            directory: "content",
+            localized: false,
+            fields: fixture.fields,
+          },
+        },
+      ],
+      reload: async () => {
+        throw new Error("not used");
+      },
+      sync: async () => {
+        throw new Error("not used");
+      },
+    },
+    document: {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      type: fixture.type,
+      locale: "en",
+      path: "content/example",
+      format: "mdx",
+      frontmatter: fixture.frontmatter,
+      body: "",
+      publishedVersion: null,
+      hasUnpublishedChanges: true,
+      draftRevision: 1,
+      updatedAt: "2026-06-14T10:00:00.000Z",
+    },
+    draftBody: "",
+    draftFrontmatter: cloneFrontmatter(fixture.frontmatter),
+    saveState: "saved",
+    canWrite: true,
+    canAi: true,
+    canReadMedia: true,
+    canUploadMedia: true,
+    publishDialogOpen: false,
+    publishChangeSummary: "",
+    publishState: "idle",
+    restoreVersionState: "idle",
+    versionHistory: { status: "ready", versions: [] },
+    selectedComparison: {},
+    versionDiff: { status: "idle" },
+    translationVariants: [],
+    localized: false,
+    variantsFetchFailed: false,
+  };
+}
+```
+
+- [x] **Step 2: Add frontmatter assertions**
+
+Append:
+
+```typescript
+test("collaboration frontmatter fixtures preserve supported values", () => {
+  for (const fixture of FRONTMATTER_FIXTURES) {
+    const cloned = cloneFrontmatter(fixture.frontmatter);
+    assert.notEqual(cloned, fixture.frontmatter);
+    assert.equal(
+      areJsonValuesEqual(cloned, fixture.frontmatter),
+      true,
+      `${fixture.type} frontmatter clone must preserve JSON values`,
+    );
+
+    const descriptors = getPropertyDescriptors(createFixtureReadyState(fixture));
+    const editable = descriptors
+      .filter((descriptor) => descriptor.status === "editable")
+      .map((descriptor) => descriptor.fieldName)
+      .sort();
+    const unsupported = descriptors
+      .filter((descriptor) => descriptor.status === "unsupported")
+      .map((descriptor) => descriptor.fieldName)
+      .sort();
+
+    assert.deepEqual(editable, fixture.editableFields.sort());
+    assert.deepEqual(unsupported, fixture.unsupportedFields.sort());
+  }
+});
+```
+
+- [x] **Step 3: Run the focused test**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+```
+
+Expected: pass.
+
+## Task 3: Collapsed MDX UI State Regression
+
+**Files:**
+- Modify: `packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts`
+
+- [x] **Step 1: Add collapsed-state serialization and read-only affordance assertions**
+
+Append:
+
+```typescript
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createDocumentEditor } from "../../../document-editor.js";
+import { extractMarkdownFromEditor } from "../../../markdown-pipeline.js";
+import { MdxComponentCollapseProvider } from "./mdx-component-collapse.js";
+import { MdxComponentNodeView } from "./mdx-component-node-view.js";
+import {
+  nextMdxComponentCollapseSnapshot,
+  toggleMdxComponentCollapseSnapshot,
+  type MdxComponentCollapseSnapshot,
+} from "./mdx-component-collapse-state.js";
+import { TipTapEditor } from "./tiptap-editor.js";
+
+function extractMarkdownFromSaveEditor(body: string): string {
+  const editor = createDocumentEditor({ content: body });
+
+  try {
+    return extractMarkdownFromEditor(editor);
+  } finally {
+    editor.destroy();
+  }
+}
+
+function renderMdxNodeViewSavePathUnderCollapse(props: {
+  body: string;
+  snapshot: MdxComponentCollapseSnapshot;
+}): {
+  state: MdxComponentCollapseSnapshot["globalState"];
+  markup: string;
+  markdown: string;
+} {
+  const editor = createDocumentEditor({ content: props.body });
+
+  try {
+    const CalloutPreview = (previewProps: { children?: ReactNode }) =>
+      createElement("aside", null, previewProps.children);
+    const markup = renderToStaticMarkup(
+      createElement(
+        MdxComponentCollapseProvider,
+        { snapshot: props.snapshot },
+        createElement(MdxComponentNodeView, {
+          node: {
+            attrs: {
+              componentName: "Callout",
+              isVoid: false,
+              props: { type: "warning" },
+            },
+          },
+          selected: false,
+          readOnly: false,
+          forbidden: false,
+          context: {
+            hostBridge: {
+              resolveComponent: () => CalloutPreview,
+              renderMdxPreview: () => () => {},
+            },
+            mdx: {
+              catalog: { components: [] },
+            },
+          },
+          editor,
+          getPos: () => 1,
+          deleteNode: () => {},
+        } as never),
+      ),
+    );
+
+    return {
+      state: props.snapshot.globalState,
+      markup,
+      markdown: extractMarkdownFromEditor(editor),
+    };
+  } finally {
+    editor.destroy();
+  }
+}
+
+function getCollapseToolbarButtonMarkup(markup: string): string {
+  const match = markup.match(
+    /<button(?=[^>]*title="Collapse all components")[\s\S]*?<\/button>/,
+  );
+
+  assert.ok(match?.[0], "expected the Collapse all toolbar button to render");
+
+  return match[0];
+}
+
+test("collapsed MDX component UI state does not affect serialization", () => {
+  const body = [
+    '<Callout type="warning">',
+    "Keep this **body** stable.",
+    "",
+    '<Button href="/start">',
+    "Start",
+    "</Button>",
+    "</Callout>",
+  ].join("\n");
+  const initial: MdxComponentCollapseSnapshot = {
+    globalState: null,
+    generation: 0,
+  };
+  const collapsed = toggleMdxComponentCollapseSnapshot(initial);
+  const expanded = nextMdxComponentCollapseSnapshot(collapsed, "expanded");
+
+  assert.equal(collapsed.globalState, "collapsed");
+  assert.equal(expanded.globalState, "expanded");
+
+  const collapsedResult = renderMdxNodeViewSavePathUnderCollapse({
+    body,
+    snapshot: collapsed,
+  });
+  const expandedResult = renderMdxNodeViewSavePathUnderCollapse({
+    body,
+    snapshot: expanded,
+  });
+
+  assert.deepEqual(
+    [
+      { state: collapsedResult.state, markdown: collapsedResult.markdown },
+      { state: expandedResult.state, markdown: expandedResult.markdown },
+    ],
+    [
+      { state: "collapsed", markdown: body },
+      { state: "expanded", markdown: body },
+    ],
+  );
+  assert.match(
+    collapsedResult.markup,
+    /data-mdcms-mdx-component-collapsed="true"/,
+  );
+  assert.match(
+    collapsedResult.markup,
+    /<div(?=[^>]*data-node-view-content)(?=[^>]*data-mdcms-mdx-editable-slot="Callout")[^>]*>/,
+  );
+  assert.match(
+    expandedResult.markup,
+    /data-mdcms-mdx-component-collapsed="false"/,
+  );
+  assert.match(
+    expandedResult.markup,
+    /<div(?=[^>]*data-node-view-content)(?=[^>]*data-mdcms-mdx-editable-slot="Callout")[^>]*>/,
+  );
+});
+
+test("collapse all remains available in read-only and forbidden modes", () => {
+  const initialContent = [
+    '<Callout type="warning">',
+    "Read-only reviewers can still collapse this block.",
+    "</Callout>",
+  ].join("\n");
+  const readOnlyButton = getCollapseToolbarButtonMarkup(
+    renderToStaticMarkup(
+      createElement(TipTapEditor, {
+        initialContent,
+        readOnly: true,
+      }),
+    ),
+  );
+  const forbiddenButton = getCollapseToolbarButtonMarkup(
+    renderToStaticMarkup(
+      createElement(TipTapEditor, {
+        initialContent,
+        forbidden: true,
+      }),
+    ),
+  );
+
+  assert.doesNotMatch(readOnlyButton, /\sdisabled(?:=""|\s|>)/);
+  assert.doesNotMatch(forbiddenButton, /\sdisabled(?:=""|\s|>)/);
+});
+```
+
+- [x] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+```
+
+Expected: pass.
+
+## Task 4: Ticket Verification and Commit
+
+**Files:**
+- Modify: `.ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md`
+- Possibly create a CLI-generated changeset only if production or non-runtime published package source changes are introduced.
+
+- [x] **Step 1: Run focused CMS-58 tests**
+
+Run:
+
+```bash
+bun test --cwd packages/studio ./src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts ./src/lib/markdown-pipeline.test.ts
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run workspace gates**
+
+Run:
+
+```bash
+bun run check
+bun run format:check
+git diff --check
+bun run changeset:check
+```
+
+Expected: all pass. If `changeset:check` fails because a production published package file changed, generate a changeset with `bun run changeset`; do not hand-write `.changeset/*.md`.
+
+- [x] **Step 3: Commit the CMS-58 slice**
+
+Run:
+
+```bash
+git add .ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+git commit -m "test(collaboration): add round-trip fidelity fixtures"
+```
+
+Expected: commit succeeds and worktree is clean.

--- a/.ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md
+++ b/.ai/plans/2026-06-14-cms-58-collaboration-round-trip-fidelity.md
@@ -36,7 +36,7 @@ Acceptance criteria covered:
   - Import `cloneFrontmatter`, `areJsonValuesEqual`, `getPropertyDescriptors`, and `type ContentDocumentPageReadyState` from `../../pages/content-document-page-state.js`.
   - Import `type SchemaRegistryFieldSnapshot` from `@mdcms/shared`.
 - No production files should change unless one of the canonical fixtures fails and exposes a real serializer defect.
-- No changeset should be required if the work remains under `packages/studio/src/lib/runtime-ui/**`, which is listed in `packages/studio/.changeset-gate.json` as runtime-only unpublished source.
+- Changes under `packages/studio/src/lib/runtime-ui/**` are exempted by `packages/studio/.changeset-gate.json`, which lists that runtime-only, backend-served source as unpublished. Changes outside that documented exception in published package `src/**` still require a changeset.
 
 ## Task 1: Fixture-Driven Body Idempotency
 

--- a/.ai/plans/2026-06-14-cms-86-push-collaboration-cache-invalidation.md
+++ b/.ai/plans/2026-06-14-cms-86-push-collaboration-cache-invalidation.md
@@ -1,0 +1,602 @@
+# CMS-86 Push Collaboration Cache Invalidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make successful existing-document `cms push` updates/deletes invalidate inactive collaboration Yjs Redis state and metadata without exposing Redis behavior to the CLI.
+
+**Architecture:** Keep Redis invalidation server-owned. Add a small collaboration Redis store method that atomically deletes the documented inactive Yjs state/meta keys only when the active-room lock key is absent, expose it to content routes as an optional post-commit side effect, and wire it from the runtime's shared collaboration Redis store. Existing active collaboration locking remains the pre-mutation gate; invalidation runs only after the database mutation succeeds and failures are swallowed like lifecycle/webhook side effects.
+
+**Tech Stack:** Bun tests, Elysia route handlers, TypeScript, Redis store abstraction, existing content API route harness.
+
+---
+
+## Spec Delta Summary
+
+- Owning specs already cover the CMS-86 behavior; no `docs/specs` change is required.
+- `docs/specs/SPEC-008-cli-and-sdk.md` defines `cms push` active collaboration handling and inactive cache invalidation.
+- `docs/specs/SPEC-003-content-storage-versioning-and-migrations.md` defines that inactive cache invalidation must not fail the already-committed mutation.
+- `docs/specs/SPEC-007-editor-mdx-and-collaboration.md` defines the Redis Yjs state/meta key names.
+
+## Task 1: Redis Store Inactive Cache Deletion
+
+**Files:**
+- Modify: `apps/server/src/lib/collaboration/redis-store.ts`
+- Modify: `apps/server/src/lib/collaboration/redis-store.test.ts`
+
+- [x] **Step 1: Write the failing Redis deletion tests**
+
+Add this test near the existing inactive-cache lifecycle test in `apps/server/src/lib/collaboration/redis-store.test.ts`:
+
+```typescript
+test("inactive collaboration cache invalidation deletes Yjs state and metadata", async () => {
+  const documentId = "9c003bee-4f4c-42d4-b445-d393a17067bb";
+  const { client, store } = createStore();
+
+  client.values.set(buildCollaborationYjsStateKey(documentId), Buffer.from("state"));
+  client.values.set(
+    buildCollaborationYjsMetaKey(documentId),
+    JSON.stringify({ draftRevision: 4, bodyHash: "body-hash" }),
+  );
+
+  await store.invalidateInactiveCache(documentId);
+
+  assert.equal(client.values.has(buildCollaborationYjsStateKey(documentId)), false);
+  assert.equal(client.values.has(buildCollaborationYjsMetaKey(documentId)), false);
+  assert.deepEqual(
+    client.calls.filter((call) => call.method === "del"),
+    [
+      {
+        method: "del",
+        keys: [
+          buildCollaborationYjsStateKey(documentId),
+          buildCollaborationYjsMetaKey(documentId),
+        ],
+      },
+    ],
+  );
+});
+
+test("inactive collaboration cache invalidation preserves cache when active lock exists", async () => {
+  const documentId = "54f00952-2fb9-49d4-8510-086850825c86";
+  const { client, store } = createStore();
+  const stateKey = buildCollaborationYjsStateKey(documentId);
+  const metaKey = buildCollaborationYjsMetaKey(documentId);
+
+  client.values.set(stateKey, Buffer.from("state"));
+  client.values.set(
+    metaKey,
+    JSON.stringify({ draftRevision: 4, bodyHash: "body-hash" }),
+  );
+  client.values.set(buildCollaborationActiveKey(documentId), "room-1");
+
+  await store.invalidateInactiveCache(documentId);
+
+  assert.equal(client.values.has(stateKey), true);
+  assert.equal(client.values.has(metaKey), true);
+  assert.deepEqual(
+    client.calls.filter((call) => call.method === "eval"),
+    [
+      {
+        method: "eval",
+        keys: [stateKey, metaKey, buildCollaborationActiveKey(documentId)],
+      },
+    ],
+  );
+});
+```
+
+- [x] **Step 2: Run the focused Redis test to verify failure**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts
+```
+
+Expected: fail with `store.invalidateInactiveCache is not a function`.
+
+- [x] **Step 3: Add the atomic Redis script and store method**
+
+In `apps/server/src/lib/collaboration/redis-store.ts`, add this script near the existing active-lock scripts:
+
+```typescript
+const INVALIDATE_INACTIVE_CACHE_SCRIPT = `
+if redis.call("EXISTS", KEYS[3]) == 0 then
+  return redis.call("DEL", KEYS[1], KEYS[2])
+end
+return 0
+`;
+```
+
+Then add this method next to `clearInactiveCacheTtl` and `expireInactiveCache`:
+
+```typescript
+async invalidateInactiveCache(documentId: string): Promise<void> {
+  const client = requireCollaborationRedisClient(dependency);
+
+  await client.eval(
+    INVALIDATE_INACTIVE_CACHE_SCRIPT,
+    3,
+    buildCollaborationYjsStateKey(documentId),
+    buildCollaborationYjsMetaKey(documentId),
+    buildCollaborationActiveKey(documentId),
+  );
+},
+```
+
+- [x] **Step 4: Run the focused Redis test to verify pass**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Content API Post-Commit Invalidation Hook
+
+**Files:**
+- Modify: `apps/server/src/lib/content-api/types.ts`
+- Modify: `apps/server/src/lib/content-api/routes.ts`
+- Modify: `apps/server/src/lib/content-api-test-support.ts`
+- Modify: `apps/server/src/lib/content-api.test.ts`
+
+- [x] **Step 1: Extend the content route option type**
+
+In `apps/server/src/lib/content-api/types.ts`, add this type near `ContentActiveCollaborationChecker`:
+
+```typescript
+export type ContentInactiveCollaborationCacheInvalidator = {
+  invalidateDocument: (documentId: string) => Promise<void>;
+};
+```
+
+Then add this optional field to `MountContentApiRoutesOptions`:
+
+```typescript
+inactiveCollaborationCache?: ContentInactiveCollaborationCacheInvalidator;
+```
+
+- [x] **Step 2: Add failing route tests for update/delete invalidation**
+
+In `apps/server/src/lib/content-api.test.ts`, add these tests near the active collaboration route tests:
+
+```typescript
+test("content API update invalidates inactive collaboration cache after successful commit", async () => {
+  const invalidated: string[] = [];
+  const handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidate-after-update",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidate-after-update" },
+      body: "before",
+    },
+  );
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${created.documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "invalidate-after-update" },
+        body: "after",
+        draftRevision: created.draftRevision,
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [created.documentId]);
+});
+
+test("content API delete invalidates inactive collaboration cache after successful commit", async () => {
+  const invalidated: string[] = [];
+  const handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidate-after-delete",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidate-after-delete" },
+      body: "delete me",
+    },
+  );
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${created.documentId}`, {
+      method: "DELETE",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [created.documentId]);
+});
+```
+
+- [x] **Step 3: Add failing tests for blocked/failed mutation behavior**
+
+Add these tests after the update/delete invalidation tests:
+
+```typescript
+test("content API does not invalidate inactive collaboration cache when active collaboration blocks update", async () => {
+  const invalidated: string[] = [];
+  const activeDocumentIds = new Set<string>();
+  const handler = createHandler({
+    activeCollaboration: {
+      isDocumentActive: async (documentId) => activeDocumentIds.has(documentId),
+    },
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/no-invalidate-when-active",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "no-invalidate-when-active" },
+      body: "before",
+    },
+  );
+
+  activeDocumentIds.add(String(created.documentId));
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${created.documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "no-invalidate-when-active" },
+        body: "after",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(invalidated, []);
+});
+
+test("content API update remains successful when inactive collaboration cache invalidation fails", async () => {
+  const invalidationFailure = new Error("redis unavailable");
+  const handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async () => {
+        throw invalidationFailure;
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidation-failure-still-updates",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidation-failure-still-updates" },
+      body: "before",
+    },
+  );
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${created.documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "invalidation-failure-still-updates" },
+        body: "after",
+        draftRevision: created.draftRevision,
+      }),
+    }),
+  );
+  const body = (await response.json()) as { data: { body: string } };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.data.body, "after");
+});
+```
+
+- [x] **Step 4: Update the test handler helper**
+
+In `apps/server/src/lib/content-api-test-support.ts`, extend `createHandler` options:
+
+```typescript
+inactiveCollaborationCache?: MountContentApiRoutesOptions["inactiveCollaborationCache"];
+```
+
+Then pass it through to `mountContentApiRoutes`:
+
+```typescript
+inactiveCollaborationCache: options.inactiveCollaborationCache,
+```
+
+- [x] **Step 5: Run the focused content API tests to verify failure**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/content-api.test.ts
+```
+
+Expected: fail because the new invalidator option is not implemented.
+
+- [x] **Step 6: Add post-commit invalidation in routes**
+
+In `apps/server/src/lib/content-api/routes.ts`, add this helper near `assertNoActiveCollaboration`:
+
+```typescript
+async function invalidateInactiveCollaborationCache(
+  inactiveCollaborationCache: MountContentApiRoutesOptions["inactiveCollaborationCache"],
+  documentId: string,
+): Promise<void> {
+  if (!inactiveCollaborationCache) {
+    return;
+  }
+
+  await inactiveCollaborationCache.invalidateDocument(documentId).catch(() => {
+    // The database mutation is already committed. Stale inactive Redis cache is
+    // guarded by draft-revision/body-hash metadata on the next room load, so a
+    // Redis deletion failure must not turn a successful content write into a
+    // failed API response.
+  });
+}
+```
+
+Call it immediately after successful `commitMutation` results for:
+
+```typescript
+// PUT /api/v1/content/:documentId
+await invalidateInactiveCollaborationCache(
+  options.inactiveCollaborationCache,
+  params.documentId,
+);
+
+// DELETE /api/v1/content/:documentId
+await invalidateInactiveCollaborationCache(
+  options.inactiveCollaborationCache,
+  params.documentId,
+);
+```
+
+For bulk operations, call it only for successful `delete` and `move` actions after the `commitMutation` result is assigned:
+
+```typescript
+if (payload.action === "delete" || payload.action === "move") {
+  await invalidateInactiveCollaborationCache(
+    options.inactiveCollaborationCache,
+    documentId,
+  );
+}
+```
+
+Do not add invalidation to create, publish, unpublish, or plain restore in this task.
+Version restore was added during code-review follow-up because it rewrites the
+draft head and increments `draftRevision`, so it falls under the owning spec's
+inactive-cache invalidation rule.
+
+- [x] **Step 7: Run the focused content API tests to verify pass**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/content-api.test.ts
+```
+
+Expected: pass.
+
+## Task 3: Runtime Wiring and Verification
+
+**Files:**
+- Modify: `apps/server/src/lib/runtime-with-modules.ts`
+- Modify: `apps/server/src/lib/runtime-with-modules.test.ts`
+- Modify: `.ai/plans/2026-06-14-cms-86-push-collaboration-cache-invalidation.md`
+
+- [x] **Step 1: Extend the runtime Redis store type**
+
+In `apps/server/src/lib/runtime-with-modules.ts`, extend `RuntimeCollaborationRedisStore` with:
+
+```typescript
+  invalidateInactiveCache: (documentId: string) => Promise<void>;
+```
+
+- [x] **Step 2: Wire the content API route option**
+
+In the `mountContentApiRoutes` call inside `createServerRequestHandlerWithModules`, add:
+
+```typescript
+inactiveCollaborationCache: collaborationRedisStore
+  ? {
+      invalidateDocument: (documentId) =>
+        collaborationRedisStore.invalidateInactiveCache(documentId),
+    }
+  : undefined,
+```
+
+Keep `activeCollaboration` unchanged.
+
+- [x] **Step 3: Add guarded AI/content-store invalidation tests**
+
+In `apps/server/src/lib/runtime-with-modules.test.ts`, add tests near the existing `createCollaborationGuardedAiContentStore` coverage:
+
+```typescript
+test("collaboration-guarded AI content store invalidates inactive cache after update and delete", async () => {
+  const invalidated: string[] = [];
+  const store = createCollaborationGuardedAiContentStore(
+    {
+      getById: async () => undefined,
+      create: async (_scope, payload) =>
+        ({
+          documentId: "created",
+          path: payload.path ?? "content/created",
+        }) as never,
+      update: async (_scope, documentId) =>
+        ({ documentId, path: "content/updated" }) as never,
+      softDelete: async (_scope, documentId) =>
+        ({ documentId, path: "content/deleted" }) as never,
+    },
+    undefined,
+    {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  );
+
+  await store.update(
+    { project: "marketing", environment: "draft" },
+    "doc-update",
+    { body: "updated" },
+  );
+  await store.softDelete(
+    { project: "marketing", environment: "draft" },
+    "doc-delete",
+  );
+
+  assert.deepEqual(invalidated, ["doc-update", "doc-delete"]);
+});
+
+test("collaboration-guarded AI content store ignores inactive cache invalidation failure", async () => {
+  const store = createCollaborationGuardedAiContentStore(
+    {
+      getById: async () => undefined,
+      create: async (_scope, payload) =>
+        ({
+          documentId: "created",
+          path: payload.path ?? "content/created",
+        }) as never,
+      update: async (_scope, documentId) =>
+        ({ documentId, path: "content/updated" }) as never,
+      softDelete: async (_scope, documentId) =>
+        ({ documentId, path: "content/deleted" }) as never,
+    },
+    undefined,
+    {
+      invalidateDocument: async () => {
+        throw new Error("redis unavailable");
+      },
+    },
+  );
+
+  const updated = await store.update(
+    { project: "marketing", environment: "draft" },
+    "doc-update",
+    { body: "updated" },
+  );
+
+  assert.equal(updated.documentId, "doc-update");
+});
+```
+
+- [x] **Step 4: Extend the guarded AI/content-store wrapper**
+
+In `apps/server/src/lib/runtime-with-modules.ts`, update `createCollaborationGuardedAiContentStore` to accept a third optional argument:
+
+```typescript
+inactiveCollaborationCache?: {
+  invalidateDocument: (documentId: string) => Promise<void>;
+}
+```
+
+Add a local helper inside the function:
+
+```typescript
+const invalidateInactiveCache = async (documentId: string) => {
+  if (!inactiveCollaborationCache) {
+    return;
+  }
+
+  await inactiveCollaborationCache.invalidateDocument(documentId).catch(() => {
+    // The store mutation is already committed. Inactive Redis cache deletion is
+    // best-effort because future room loads still validate cache metadata
+    // against the PostgreSQL draft head.
+  });
+};
+```
+
+Then in `update`, `softDelete`, and optional `restore`, await invalidation after the underlying store call succeeds:
+
+```typescript
+const document = await store.update(scope, documentId, payload, opts);
+await invalidateInactiveCache(documentId);
+return document;
+```
+
+Use the same pattern for `softDelete` and `restore`.
+
+- [x] **Step 5: Pass the runtime invalidator to the guarded AI/content-store wrapper**
+
+Where `createCollaborationGuardedAiContentStore` is called in `apps/server/src/lib/runtime-with-modules.ts`, pass:
+
+```typescript
+collaborationRedisStore
+  ? {
+      invalidateDocument: (documentId) =>
+        collaborationRedisStore.invalidateInactiveCache(documentId),
+    }
+  : undefined
+```
+
+- [x] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+bun test --cwd apps/server ./src/lib/collaboration/redis-store.test.ts ./src/lib/content-api.test.ts ./src/lib/runtime-with-modules.test.ts
+```
+
+Expected: pass.
+
+- [x] **Step 7: Run workspace gates**
+
+Run:
+
+```bash
+bun run check
+bun run format:check
+git diff --check
+bun run changeset:check
+```
+
+Expected: all pass. This task changes server-only runtime code and a plan file, so a changeset should not be required.
+
+- [ ] **Step 8: Commit the CMS-86 slice**
+
+Run:
+
+```bash
+git add .ai/memory/lessons.md .ai/plans/2026-06-14-cms-86-push-collaboration-cache-invalidation.md apps/server/src/lib/collaboration/redis-store.ts apps/server/src/lib/collaboration/redis-store.test.ts apps/server/src/lib/content-api/types.ts apps/server/src/lib/content-api/routes.ts apps/server/src/lib/content-api-test-support.ts apps/server/src/lib/content-api.test.ts apps/server/src/lib/runtime-with-modules.ts apps/server/src/lib/runtime-with-modules.test.ts
+git commit -m "fix(collaboration): invalidate inactive cache after push writes"
+```
+
+Expected: commit succeeds and the worktree is clean.

--- a/.ai/plans/2026-06-15-cms-155-studio-editor-collaboration.md
+++ b/.ai/plans/2026-06-15-cms-155-studio-editor-collaboration.md
@@ -1,0 +1,46 @@
+# CMS-155 Studio Editor Collaboration Wiring
+
+## Scope
+
+Wire the Studio content editor into the existing collaboration document room so body edits flow through the Hocuspocus/Yjs socket, active-room saves flush the collaboration room, and presence chips include the current session while cursor overlays remain remote-only.
+
+## Spec Delta
+
+- No new product contract is required. The behavior is already specified by:
+  - `docs/specs/SPEC-006-studio-runtime-and-ui.md`: active editor route uses `WS /api/v1/collaboration`, avoids HTTP `PUT` body saves while the collaboration room is active, and Save Draft flushes the room.
+  - `docs/specs/SPEC-007-editor-mdx-and-collaboration.md`: document-room Yjs field names, session-cookie auth, room flush control messages, and presence rendering rules.
+- Affected behavior:
+  - Studio content document editor body binding.
+  - Studio Save Draft/autosave behavior while a document room is active.
+  - Presence chips and remote cursor filtering.
+- Acceptance coverage:
+  - CMS-53: Studio joins and syncs the Hocuspocus/Yjs document room.
+  - CMS-54: Save/autosave flushes collaboration state instead of HTTP-writing active rooms.
+  - CMS-55: Presence chips render current and remote collaborators; cursor overlays exclude the current session.
+
+## Implementation Plan
+
+1. Add failing coverage.
+   - Update presence tests so the current session appears in `users` and is absent from `remoteCursors`.
+   - Add pure Studio helper tests for document-room URL construction and Hocuspocus-compatible sync message framing.
+   - Add server transport coverage for string JSON flush control messages routed outside binary Hocuspocus sync frames.
+
+2. Add Studio document collaboration primitives.
+   - Create `collaboration-document` helpers with document-room URL construction, document-name generation, sync/auth message encoding, incoming message application, and flush request parsing.
+   - Add a React hook that owns a Y.Doc, opens the document-room socket, sends auth + sync step 1, applies incoming sync updates, sends local Yjs updates, and exposes `flush()`.
+
+3. Bind TipTap to Yjs.
+   - Add a collaboration prop to `TipTapEditor`.
+   - Inject a small TipTap extension backed by `y-prosemirror` `ySyncPlugin` for the existing `default` Y.XmlFragment.
+   - Keep existing markdown emission so page state and preview can follow the collaborative document without performing HTTP draft writes.
+
+4. Wire Studio page behavior.
+   - Enable document collaboration only for authenticated cookie sessions, writable latest drafts, and valid project/environment routing.
+   - Pass the Y.XmlFragment into `TipTapEditor`.
+   - Route Save Draft and autosave through `flush()` while collaboration is active; leave the existing guarded HTTP path for non-collaborative/read-only cases.
+   - Include the current session in presence chips and filter it only from cursor overlays.
+
+5. Verify.
+   - Run focused Studio and server tests.
+   - Run formatting/check gates.
+   - Use the existing dev compose stack to verify the server and Studio example still boot and expose the active editor route.

--- a/.changeset/empty-llamas-send.md
+++ b/.changeset/empty-llamas-send.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/studio": patch
+---
+
+Wire Studio editor collaboration document rooms

--- a/.changeset/true-chefs-fly.md
+++ b/.changeset/true-chefs-fly.md
@@ -1,0 +1,5 @@
+---
+"@mdcms/shared": minor
+---
+
+Add collaboration presence contracts

--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -1886,7 +1886,7 @@ testWithDatabase(
         }),
       );
       const loginBody = (await loginResponse.json()) as {
-        data: { session: { email: string } };
+        data: { session: { email: string; name?: string } };
       };
       const setCookie = extractSetCookie(loginResponse);
       const cookie = toCookieHeader(setCookie);
@@ -1894,6 +1894,7 @@ testWithDatabase(
       assert.equal(loginResponse.status, 200);
       assert.equal(setCookie.includes("session_token="), true);
       assert.equal(loginBody.data.session.email, email);
+      assert.equal(loginBody.data.session.name, "Admin User");
 
       const sessionResponse = await handler(
         new Request("http://localhost/api/v1/auth/session", {
@@ -1903,11 +1904,12 @@ testWithDatabase(
         }),
       );
       const sessionBody = (await sessionResponse.json()) as {
-        data: { session: { email: string } };
+        data: { session: { email: string; name?: string } };
       };
 
       assert.equal(sessionResponse.status, 200);
       assert.equal(sessionBody.data.session.email, email);
+      assert.equal(sessionBody.data.session.name, "Admin User");
     } finally {
       await dbConnection.close();
     }

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -99,6 +99,7 @@ export type StudioSession = {
   id: string;
   userId: string;
   email: string;
+  name?: string;
   issuedAt: string;
   expiresAt: string;
 };
@@ -359,6 +360,7 @@ type BetterAuthLikeSession = {
   user?: {
     id?: unknown;
     email?: unknown;
+    name?: unknown;
   };
 };
 
@@ -1222,6 +1224,7 @@ function toStudioSession(payload: BetterAuthLikeSession): StudioSession {
   const sessionId = assertNonEmptyString(payload.session?.id, "session.id");
   const userId = assertNonEmptyString(payload.user?.id, "user.id");
   const email = assertNonEmptyString(payload.user?.email, "user.email");
+  const name = normalizeOptionalOidcClaimString(payload.user?.name);
   const issuedAt = toIsoString(payload.session?.createdAt);
   const expiresAt = toIsoString(payload.session?.expiresAt);
 
@@ -1229,6 +1232,7 @@ function toStudioSession(payload: BetterAuthLikeSession): StudioSession {
     id: sessionId,
     userId,
     email,
+    ...(name ? { name } : {}),
     issuedAt,
     expiresAt,
   };

--- a/apps/server/src/lib/collaboration-auth.test.ts
+++ b/apps/server/src/lib/collaboration-auth.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "bun:test";
 
 import {
+  type CollaborationPresenceUpdate,
+  type CollaborationPresenceUser,
   RuntimeError,
   createEmptyCurrentPrincipalCapabilities,
 } from "@mdcms/shared";
@@ -21,6 +23,17 @@ import type {
 import { createServerRequestHandler } from "./server.js";
 
 const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
+const UNREADABLE_DOCUMENT_ID = "22222222-2222-4222-8222-222222222222";
+
+function createCollaborationRequest(pathAndQuery: string, init?: RequestInit) {
+  return new Request(`http://localhost${pathAndQuery}`, {
+    ...init,
+    headers: {
+      origin: "http://localhost:4173",
+      ...init?.headers,
+    },
+  });
+}
 
 function createSession(userId = "user-1"): StudioSession {
   return {
@@ -29,6 +42,44 @@ function createSession(userId = "user-1"): StudioSession {
     email: `${userId}@mdcms.local`,
     issuedAt: new Date().toISOString(),
     expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+function createPresenceContext() {
+  return {
+    userId: "editor-1",
+    sessionId: "session-1",
+    project: "marketing",
+    environment: "staging",
+    role: "editor",
+    label: "editor-1",
+    color: "#2563eb",
+  };
+}
+
+function createPresenceUpdate(
+  overrides: Partial<CollaborationPresenceUpdate> = {},
+): CollaborationPresenceUpdate {
+  return {
+    type: "presence.update",
+    documentId: DOCUMENT_ID,
+    mode: "view",
+    ...overrides,
+  };
+}
+
+function createPresenceUser(
+  overrides: Partial<CollaborationPresenceUser> = {},
+): CollaborationPresenceUser {
+  return {
+    userId: "editor-1",
+    sessionId: "session-1",
+    label: "editor-1",
+    color: "#2563eb",
+    documentId: DOCUMENT_ID,
+    mode: "view",
+    updatedAt: "2026-06-14T10:00:00.000Z",
+    ...overrides,
   };
 }
 
@@ -244,6 +295,344 @@ test("collaboration handshake rejects API key auth with 4403", async () => {
   }
 
   assert.equal(result.closeCode, 4403);
+});
+
+test("collaboration handshake rejects missing documentId with 4403", async () => {
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({}),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizeHandshake(
+    createCollaborationRequest(
+      "/api/v1/collaboration?project=marketing&environment=staging",
+    ),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4403);
+});
+
+test("presence handshake accepts target-only query and returns label and color", async () => {
+  const session = createSession("editor-1");
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session,
+            role: "editor",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceHandshake(
+    createCollaborationRequest(
+      "/api/v1/collaboration/presence?project=marketing&environment=staging",
+    ),
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assert.equal(result.context.userId, "editor-1");
+  assert.equal(result.context.sessionId, "session-1");
+  assert.equal(result.context.project, "marketing");
+  assert.equal(result.context.environment, "staging");
+  assert.equal(result.context.role, "editor");
+  assert.equal(result.context.label, "editor-1");
+  assert.match(result.context.color, /^#[0-9a-f]{6}$/);
+  assert.deepEqual(requiredScopes, [
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
+    },
+  ]);
+});
+
+test("presence handshake rejects URL documentId with 4403", async () => {
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({}),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceHandshake(
+    createCollaborationRequest(
+      `/api/v1/collaboration/presence?project=marketing&environment=staging&documentId=${DOCUMENT_ID}`,
+    ),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4403);
+});
+
+test("presence handshake rejects API key auth with 4403", async () => {
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({}),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceHandshake(
+    createCollaborationRequest(
+      "/api/v1/collaboration/presence?project=marketing&environment=staging",
+      {
+        headers: {
+          authorization: "Bearer mdcms_key_test",
+        },
+      },
+    ),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4403);
+});
+
+test("presence edit update checks draft-read and write permissions with document path", async () => {
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session: createSession("editor-1"),
+            role: "editor",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceUpdate(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    createPresenceUpdate({
+      mode: "edit",
+    }),
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(requiredScopes, [
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
+      documentPath: "blog/post-1",
+    },
+    {
+      requiredScope: "content:write",
+      project: "marketing",
+      environment: "staging",
+      documentPath: "blog/post-1",
+    },
+  ]);
+});
+
+test("presence view update only checks draft-read permission with document path", async () => {
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session: createSession("viewer-1"),
+            role: "viewer",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceUpdate(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    createPresenceUpdate({
+      mode: "view",
+    }),
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(requiredScopes, [
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
+      documentPath: "blog/post-1",
+    },
+  ]);
+});
+
+test("presence update maps authorization failures to 4403", async () => {
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest() {
+        throw new RuntimeError({
+          code: "FORBIDDEN",
+          message: "Denied",
+          statusCode: 403,
+        });
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceUpdate(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    createPresenceUpdate({
+      mode: "edit",
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4403);
+});
+
+test("presence update maps unauthorized revalidation failures to 4401", async () => {
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest() {
+        throw new RuntimeError({
+          code: "UNAUTHORIZED",
+          message: "Session expired",
+          statusCode: 401,
+        });
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceUpdate(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    createPresenceUpdate({
+      mode: "edit",
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4401);
+});
+
+test("presence snapshot filtering removes unreadable documents and keeps target-level users", async () => {
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        if (requirement.documentPath === "secret/post-2") {
+          throw new RuntimeError({
+            code: "FORBIDDEN",
+            message: "Denied",
+            statusCode: 403,
+          });
+        }
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session: createSession("viewer-1"),
+            role: "viewer",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async ({ documentId }) => {
+      if (documentId === DOCUMENT_ID) {
+        return { path: "blog/post-1" };
+      }
+      if (documentId === UNREADABLE_DOCUMENT_ID) {
+        return { path: "secret/post-2" };
+      }
+      return undefined;
+    },
+  });
+
+  const users = [
+    createPresenceUser({
+      sessionId: "online",
+      documentId: null,
+    }),
+    createPresenceUser({
+      sessionId: "readable",
+      documentId: DOCUMENT_ID,
+    }),
+    createPresenceUser({
+      sessionId: "unreadable",
+      documentId: UNREADABLE_DOCUMENT_ID,
+    }),
+  ];
+
+  const filtered = await guard.filterPresenceSnapshot(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    users,
+  );
+
+  assert.deepEqual(
+    filtered.map((user) => user.sessionId),
+    ["online", "readable"],
+  );
+  assert.deepEqual(requiredScopes, [
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
+      documentPath: "blog/post-1",
+    },
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
+      documentPath: "secret/post-2",
+    },
+  ]);
 });
 
 test("collaboration handshake maps unauthorized session failures to 4401", async () => {
@@ -502,4 +891,68 @@ test("collaboration route returns 426 after successful handshake authorization",
   );
 
   assert.equal(response.status, 426);
+});
+
+test("collaboration presence route returns 426 after successful handshake authorization", async () => {
+  const handler = createServerRequestHandler({
+    env: {
+      NODE_ENV: "test",
+      LOG_LEVEL: "debug",
+      APP_VERSION: "0.0.0",
+      PORT: "4000",
+      SERVICE_NAME: "mdcms-server",
+      MDCMS_COLLAB_ALLOWED_ORIGINS: "http://localhost:4173",
+    },
+    configureApp(app) {
+      mountCollaborationRoutes(app, {
+        authService: createAuthServiceStub({}),
+        resolveDocument: async () => ({ path: "blog/post-1" }),
+        env: {
+          MDCMS_COLLAB_ALLOWED_ORIGINS: "http://localhost:4173",
+        },
+      });
+    },
+  });
+
+  const response = await handler(
+    new Request(
+      "http://localhost/api/v1/collaboration/presence?project=marketing&environment=staging",
+      {
+        headers: {
+          origin: "http://localhost:4173",
+        },
+      },
+    ),
+  );
+  const body = (await response.json()) as {
+    data?: {
+      status?: string;
+      closeCodeOnSessionInvalid?: number;
+      closeCodeOnForbidden?: number;
+      context?: {
+        userId?: string;
+        sessionId?: string;
+        project?: string;
+        environment?: string;
+        role?: string;
+        label?: string;
+        color?: string;
+      };
+    };
+  };
+
+  assert.equal(response.status, 426);
+  assert.equal(body.data?.status, "presence_handshake_authorized");
+  assert.equal(body.data?.closeCodeOnSessionInvalid, 4401);
+  assert.equal(body.data?.closeCodeOnForbidden, 4403);
+  assert.deepEqual(body.data?.context, {
+    userId: "user-1",
+    sessionId: "session-1",
+    project: "marketing",
+    environment: "staging",
+    role: "editor",
+    label: "user-1",
+    color: body.data?.context?.color,
+  });
+  assert.match(body.data?.context?.color ?? "", /^#[0-9a-f]{6}$/);
 });

--- a/apps/server/src/lib/collaboration-auth.test.ts
+++ b/apps/server/src/lib/collaboration-auth.test.ts
@@ -366,6 +366,79 @@ test("presence handshake accepts target-only query and returns label and color",
   ]);
 });
 
+test("presence handshake uses the session display name instead of deriving a label from email", async () => {
+  const session = {
+    ...createSession("user-1"),
+    email: "test@blazity.com",
+    name: "Blazity Test User",
+  };
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest() {
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session,
+            role: "editor",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceHandshake(
+    createCollaborationRequest(
+      "/api/v1/collaboration/presence?project=marketing&environment=staging",
+    ),
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assert.equal(result.context.label, "Blazity Test User");
+});
+
+test("presence handshake falls back to user id without exposing email local-part", async () => {
+  const session = {
+    ...createSession("user-1"),
+    email: "private-label@blazity.com",
+  };
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest() {
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session,
+            role: "editor",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceHandshake(
+    createCollaborationRequest(
+      "/api/v1/collaboration/presence?project=marketing&environment=staging",
+    ),
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assert.equal(result.context.label, "user-1");
+});
+
 test("presence handshake rejects URL documentId with 4403", async () => {
   const guard = createCollaborationAuthGuard({
     authService: createAuthServiceStub({}),

--- a/apps/server/src/lib/collaboration-auth.test.ts
+++ b/apps/server/src/lib/collaboration-auth.test.ts
@@ -570,6 +570,44 @@ test("presence view update only checks draft-read permission with document path"
   ]);
 });
 
+test("presence edit update without a document is rejected before draft-read authorization", async () => {
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        return {
+          mode: "session",
+          principal: {
+            type: "session",
+            session: createSession("editor-1"),
+            role: "editor",
+          },
+        };
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => ({ path: "blog/post-1" }),
+  });
+
+  const result = await guard.authorizePresenceUpdate(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    createPresenceUpdate({
+      documentId: null,
+      mode: "edit",
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    return;
+  }
+
+  assert.equal(result.closeCode, 4403);
+  assert.deepEqual(requiredScopes, []);
+});
+
 test("presence update maps authorization failures to 4403", async () => {
   const guard = createCollaborationAuthGuard({
     authService: createAuthServiceStub({
@@ -697,6 +735,11 @@ test("presence snapshot filtering removes unreadable documents and keeps target-
       requiredScope: "content:read:draft",
       project: "marketing",
       environment: "staging",
+    },
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
       documentPath: "blog/post-1",
     },
     {
@@ -704,6 +747,50 @@ test("presence snapshot filtering removes unreadable documents and keeps target-
       project: "marketing",
       environment: "staging",
       documentPath: "secret/post-2",
+    },
+  ]);
+});
+
+test("presence snapshot filtering returns no users when target draft-read revalidation fails", async () => {
+  const requiredScopes: AuthorizationRequirement[] = [];
+  const guard = createCollaborationAuthGuard({
+    authService: createAuthServiceStub({
+      async authorizeRequest(_request, requirement) {
+        requiredScopes.push(requirement);
+        throw new RuntimeError({
+          code: "FORBIDDEN",
+          message: "Denied",
+          statusCode: 403,
+        });
+      },
+    }),
+    allowedOrigins: ["http://localhost:4173"],
+    resolveDocument: async () => {
+      throw new Error("document paths should not resolve after target deny");
+    },
+  });
+
+  const filtered = await guard.filterPresenceSnapshot(
+    createCollaborationRequest("/api/v1/collaboration/presence"),
+    createPresenceContext(),
+    [
+      createPresenceUser({
+        sessionId: "online",
+        documentId: null,
+      }),
+      createPresenceUser({
+        sessionId: "readable",
+        documentId: DOCUMENT_ID,
+      }),
+    ],
+  );
+
+  assert.deepEqual(filtered, []);
+  assert.deepEqual(requiredScopes, [
+    {
+      requiredScope: "content:read:draft",
+      project: "marketing",
+      environment: "staging",
     },
   ]);
 });

--- a/apps/server/src/lib/collaboration-auth.ts
+++ b/apps/server/src/lib/collaboration-auth.ts
@@ -451,6 +451,13 @@ export function createCollaborationAuthGuard(
       const documentId = update.documentId ?? null;
 
       if (!documentId) {
+        if (update.mode === "edit") {
+          return {
+            ok: false,
+            closeCode: 4403,
+          };
+        }
+
         const authorized = await authorizeDraftRead({
           request,
           project: context.project,
@@ -518,6 +525,24 @@ export function createCollaborationAuthGuard(
     context: CollaborationPresenceContext,
     users: CollaborationPresenceUser[],
   ): Promise<CollaborationPresenceUser[]> {
+    try {
+      const authorized = await authorizeDraftRead({
+        request,
+        project: context.project,
+        environment: context.environment,
+      });
+
+      if (authorized.mode !== "session") {
+        return [];
+      }
+    } catch (error) {
+      if (error instanceof RuntimeError) {
+        return [];
+      }
+
+      throw error;
+    }
+
     const filtered: CollaborationPresenceUser[] = [];
 
     for (const user of users) {

--- a/apps/server/src/lib/collaboration-auth.ts
+++ b/apps/server/src/lib/collaboration-auth.ts
@@ -1,16 +1,29 @@
+import { createHash } from "node:crypto";
+
 import { RuntimeError } from "@mdcms/shared";
+import type {
+  CollaborationPresenceUpdate,
+  CollaborationPresenceUser,
+} from "@mdcms/shared";
 import { z } from "zod";
 
 import type {
   AuthService,
+  AuthorizationRequirement,
   AuthorizedRequest,
   SessionPrincipal,
+  StudioSession,
 } from "./auth.js";
 
 const CollaborationQuerySchema = z.object({
   project: z.string().trim().min(1),
   environment: z.string().trim().min(1),
   documentId: z.string().uuid(),
+});
+
+const CollaborationPresenceQuerySchema = z.object({
+  project: z.string().trim().min(1),
+  environment: z.string().trim().min(1),
 });
 
 export type CollaborationCloseCode = 4401 | 4403;
@@ -25,10 +38,31 @@ export type CollaborationSessionContext = {
   role: string;
 };
 
+export type CollaborationPresenceContext = {
+  userId: string;
+  sessionId: string;
+  project: string;
+  environment: string;
+  role: string;
+  label: string;
+  color: string;
+};
+
 export type CollaborationHandshakeResult =
   | {
       ok: true;
       context: CollaborationSessionContext;
+    }
+  | {
+      ok: false;
+      closeCode: CollaborationCloseCode;
+      message: string;
+    };
+
+export type CollaborationPresenceHandshakeResult =
+  | {
+      ok: true;
+      context: CollaborationPresenceContext;
     }
   | {
       ok: false;
@@ -102,6 +136,23 @@ function parseCollaborationQuery(request: Request): {
   return parsed.data;
 }
 
+function parseCollaborationPresenceQuery(request: Request): {
+  project: string;
+  environment: string;
+} | null {
+  const url = new URL(request.url);
+  const parsed = CollaborationPresenceQuerySchema.safeParse({
+    project: url.searchParams.get("project"),
+    environment: url.searchParams.get("environment"),
+  });
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
 function originIsAllowed(
   request: Request,
   allowedOrigins: ReadonlySet<string>,
@@ -113,6 +164,17 @@ function originIsAllowed(
   }
 
   return allowedOrigins.has(origin);
+}
+
+function derivePresenceLabel(session: StudioSession): string {
+  const [localPart] = session.email.split("@", 1);
+  const label = localPart?.trim();
+
+  return label && label.length > 0 ? label : session.userId;
+}
+
+function derivePresenceColor(userId: string): string {
+  return `#${createHash("sha256").update(userId).digest("hex").slice(0, 6)}`;
 }
 
 /**
@@ -158,6 +220,19 @@ export function createCollaborationAuthGuard(
   authorizeHandshake: (
     request: Request,
   ) => Promise<CollaborationHandshakeResult>;
+  authorizePresenceHandshake: (
+    request: Request,
+  ) => Promise<CollaborationPresenceHandshakeResult>;
+  authorizePresenceUpdate: (
+    request: Request,
+    context: CollaborationPresenceContext,
+    update: CollaborationPresenceUpdate,
+  ) => Promise<{ ok: true } | { ok: false; closeCode: CollaborationCloseCode }>;
+  filterPresenceSnapshot: (
+    request: Request,
+    context: CollaborationPresenceContext,
+    users: CollaborationPresenceUser[],
+  ) => Promise<CollaborationPresenceUser[]>;
   revalidateWrite: (
     request: Request,
     context: CollaborationSessionContext,
@@ -165,21 +240,32 @@ export function createCollaborationAuthGuard(
 } {
   const allowedOrigins = new Set(options.allowedOrigins);
 
+  async function authorizeDraftRead(input: {
+    request: Request;
+    project: string;
+    environment: string;
+    documentPath?: string;
+  }): Promise<AuthorizedRequest> {
+    const requirement: AuthorizationRequirement = {
+      requiredScope: "content:read:draft",
+      project: input.project,
+      environment: input.environment,
+    };
+
+    if (input.documentPath !== undefined) {
+      requirement.documentPath = input.documentPath;
+    }
+
+    return options.authService.authorizeRequest(input.request, requirement);
+  }
+
   async function authorizeDraftReadAndWrite(input: {
     request: Request;
     project: string;
     environment: string;
     documentPath: string;
   }): Promise<AuthorizedRequest> {
-    const readAuthorized = await options.authService.authorizeRequest(
-      input.request,
-      {
-        requiredScope: "content:read:draft",
-        project: input.project,
-        environment: input.environment,
-        documentPath: input.documentPath,
-      },
-    );
+    const readAuthorized = await authorizeDraftRead(input);
 
     await options.authService.authorizeRequest(input.request, {
       requiredScope: "content:write",
@@ -271,6 +357,207 @@ export function createCollaborationAuthGuard(
     }
   }
 
+  async function authorizePresenceHandshake(
+    request: Request,
+  ): Promise<CollaborationPresenceHandshakeResult> {
+    if (!originIsAllowed(request, allowedOrigins)) {
+      return {
+        ok: false,
+        closeCode: 4403,
+        message: "Origin is not allowed for collaboration.",
+      };
+    }
+
+    if (hasApiKeyBearerToken(request.headers.get("authorization"))) {
+      return {
+        ok: false,
+        closeCode: 4403,
+        message: "API keys are not accepted for collaboration endpoints.",
+      };
+    }
+
+    const url = new URL(request.url);
+    if (url.searchParams.has("documentId")) {
+      return {
+        ok: false,
+        closeCode: 4403,
+        message:
+          "Presence connections are target-scoped and must not include documentId.",
+      };
+    }
+
+    const query = parseCollaborationPresenceQuery(request);
+    if (!query) {
+      return {
+        ok: false,
+        closeCode: 4403,
+        message:
+          "Presence collaboration requires valid project and environment query parameters.",
+      };
+    }
+
+    try {
+      const authorized = await authorizeDraftRead({
+        request,
+        project: query.project,
+        environment: query.environment,
+      });
+
+      if (authorized.mode !== "session") {
+        return {
+          ok: false,
+          closeCode: 4403,
+          message: "Only Studio sessions can access collaboration endpoints.",
+        };
+      }
+
+      const principal = authorized.principal as SessionPrincipal;
+
+      return {
+        ok: true,
+        context: {
+          userId: principal.session.userId,
+          sessionId: principal.session.id,
+          project: query.project,
+          environment: query.environment,
+          role: principal.role ?? "viewer",
+          label: derivePresenceLabel(principal.session),
+          color: derivePresenceColor(principal.session.userId),
+        },
+      };
+    } catch (error) {
+      const failure = mapAuthErrorToHandshakeFailure(error);
+      return {
+        ok: false,
+        closeCode: failure.closeCode,
+        message: failure.message,
+      };
+    }
+  }
+
+  async function authorizePresenceUpdate(
+    request: Request,
+    context: CollaborationPresenceContext,
+    update: CollaborationPresenceUpdate,
+  ): Promise<{ ok: true } | { ok: false; closeCode: CollaborationCloseCode }> {
+    try {
+      const session = await options.authService.getSession(request);
+      if (!session) {
+        return {
+          ok: false,
+          closeCode: 4401,
+        };
+      }
+
+      const documentId = update.documentId ?? null;
+
+      if (!documentId) {
+        const authorized = await authorizeDraftRead({
+          request,
+          project: context.project,
+          environment: context.environment,
+        });
+
+        if (authorized.mode !== "session") {
+          return {
+            ok: false,
+            closeCode: 4403,
+          };
+        }
+
+        return { ok: true };
+      }
+
+      const document = await options.resolveDocument({
+        project: context.project,
+        environment: context.environment,
+        documentId,
+      });
+
+      if (!document) {
+        return {
+          ok: false,
+          closeCode: 4403,
+        };
+      }
+
+      const authorized = await authorizeDraftRead({
+        request,
+        project: context.project,
+        environment: context.environment,
+        documentPath: document.path,
+      });
+
+      if (authorized.mode !== "session") {
+        return {
+          ok: false,
+          closeCode: 4403,
+        };
+      }
+
+      if (update.mode === "edit") {
+        await options.authService.authorizeRequest(request, {
+          requiredScope: "content:write",
+          project: context.project,
+          environment: context.environment,
+          documentPath: document.path,
+        });
+      }
+
+      return { ok: true };
+    } catch (error) {
+      const failure = mapAuthErrorToHandshakeFailure(error);
+      return {
+        ok: false,
+        closeCode: failure.closeCode,
+      };
+    }
+  }
+
+  async function filterPresenceSnapshot(
+    request: Request,
+    context: CollaborationPresenceContext,
+    users: CollaborationPresenceUser[],
+  ): Promise<CollaborationPresenceUser[]> {
+    const filtered: CollaborationPresenceUser[] = [];
+
+    for (const user of users) {
+      if (user.documentId === null) {
+        filtered.push(user);
+        continue;
+      }
+
+      const document = await options.resolveDocument({
+        project: context.project,
+        environment: context.environment,
+        documentId: user.documentId,
+      });
+
+      if (!document) {
+        continue;
+      }
+
+      try {
+        const authorized = await authorizeDraftRead({
+          request,
+          project: context.project,
+          environment: context.environment,
+          documentPath: document.path,
+        });
+
+        if (authorized.mode === "session") {
+          filtered.push(user);
+        }
+      } catch (error) {
+        if (!(error instanceof RuntimeError)) {
+          throw error;
+        }
+      }
+    }
+
+    return filtered;
+  }
+
   async function revalidateWrite(
     request: Request,
     context: CollaborationSessionContext,
@@ -303,6 +590,9 @@ export function createCollaborationAuthGuard(
 
   return {
     authorizeHandshake,
+    authorizePresenceHandshake,
+    authorizePresenceUpdate,
+    filterPresenceSnapshot,
     revalidateWrite,
   };
 }
@@ -368,4 +658,43 @@ export function mountCollaborationRoutes(
       },
     );
   });
+
+  collabApp.get?.(
+    "/api/v1/collaboration/presence",
+    async ({ request }: any) => {
+      const result = await guard.authorizePresenceHandshake(request);
+
+      if (!result.ok) {
+        const status = result.closeCode === 4401 ? 401 : 403;
+        throw new RuntimeError({
+          code:
+            result.closeCode === 4401
+              ? "UNAUTHORIZED"
+              : "COLLABORATION_FORBIDDEN",
+          message: result.message,
+          statusCode: status,
+          details: {
+            closeCode: result.closeCode,
+          },
+        });
+      }
+
+      return new Response(
+        JSON.stringify({
+          data: {
+            status: "presence_handshake_authorized",
+            closeCodeOnSessionInvalid: 4401,
+            closeCodeOnForbidden: 4403,
+            context: result.context,
+          },
+        }),
+        {
+          status: 426,
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+        },
+      );
+    },
+  );
 }

--- a/apps/server/src/lib/collaboration-auth.ts
+++ b/apps/server/src/lib/collaboration-auth.ts
@@ -167,8 +167,7 @@ function originIsAllowed(
 }
 
 function derivePresenceLabel(session: StudioSession): string {
-  const [localPart] = session.email.split("@", 1);
-  const label = localPart?.trim();
+  const label = session.name?.trim();
 
   return label && label.length > 0 ? label : session.userId;
 }

--- a/apps/server/src/lib/collaboration/load-soak-test-support.ts
+++ b/apps/server/src/lib/collaboration/load-soak-test-support.ts
@@ -1,0 +1,1066 @@
+import { performance } from "node:perf_hooks";
+import { isDeepStrictEqual } from "node:util";
+
+import type {
+  CollaborationPresenceSnapshot,
+  CollaborationPresenceUpdate,
+  CollaborationPresenceUser,
+} from "@mdcms/shared";
+import * as Y from "yjs";
+
+import type {
+  CollaborationHandshakeResult,
+  CollaborationPresenceContext,
+  CollaborationPresenceHandshakeResult,
+} from "../collaboration-auth.js";
+import type {
+  ContentDocument,
+  ContentLifecycleEventSink,
+  ContentScope,
+} from "../content-api/types.js";
+
+import type { CollaborationYjsMetadata } from "./redis-store.js";
+import {
+  COLLABORATION_YJS_FIELD_NAME,
+  computeCollaborationBodyHash,
+  createCollaborationDocumentName,
+  createCollaborationRuntimeHooks,
+  yDocToFrontmatter,
+  yDocToMarkdown,
+  yjsUpdateToYDoc,
+  type CollaborationRuntimeAuthGuard,
+  type CollaborationRuntimeContentStore,
+  type CollaborationRuntimeContext,
+  type CollaborationRuntimeRedisStore,
+} from "./runtime.js";
+import {
+  createCollaborationWebSocketTransport,
+  type CollaborationAuthHandshakeGuard,
+} from "./transport.js";
+
+export const COLLABORATION_BASELINE_PROFILE = {
+  roomCount: 4,
+  sessionsPerRoom: 3,
+  mutationsPerSession: 25,
+  timeoutMs: 30_000,
+} as const;
+
+export type CollaborationBaselineRoomResult = {
+  documentId: string;
+  sessionCount: number;
+  mutationCount: number;
+  draftRevisionBefore: number;
+  draftRevisionAfter: number;
+  expectedMarkdown: string;
+  finalMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+  finalFrontmatter: Record<string, unknown>;
+  convergedClientMarkdown: string[];
+  redisFreshBeforeCleanup: boolean;
+  activeLockPresentBeforeCleanup: boolean;
+  activeLockPresentAfterCleanup: boolean;
+  finalizedAfterCleanup: boolean;
+  updateCount: number;
+  lifecycleEventCount: number;
+  versionRowsCreated: number;
+  expectedPresenceDuring: CollaborationPresenceUser[];
+  presenceDuring: CollaborationPresenceUser[];
+  presenceAfter: CollaborationPresenceUser[];
+};
+
+export type CollaborationRedisLossRecoveryResult = {
+  documentId: string;
+  expectedMarkdown: string;
+  recoveredMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+  recoveredFrontmatter: Record<string, unknown>;
+  rebuiltFromPostgres: boolean;
+  redisFreshAfterReopen: boolean;
+};
+
+export type CollaborationBaselineResult = {
+  elapsedMs: number;
+  rooms: CollaborationBaselineRoomResult[];
+  redisLossRecovery: CollaborationRedisLossRecoveryResult;
+  activeLockCountBeforeCleanup: number;
+  targetPresenceDuring: CollaborationPresenceUser[];
+  targetPresenceAfter: CollaborationPresenceUser[];
+  totals: {
+    roomCount: number;
+    sessionCount: number;
+    mutationCount: number;
+    contentUpdatedEvents: number;
+    versionRowsCreated: number;
+  };
+};
+
+const PROJECT = "marketing";
+const ENVIRONMENT = "draft";
+const BASELINE_UPDATED_AT = "2026-06-14T12:00:00.000Z";
+
+type BaselineRoomState = {
+  roomIndex: number;
+  seedDocument: ContentDocument;
+  documentName: string;
+  sessions: CollaborationRuntimeContext[];
+  draftRevisionBefore: number;
+  initialBody: string;
+  mutations: string[];
+  roomDocument: Y.Doc;
+  clientDocuments: Y.Doc[];
+  presencePeers: BaselinePresencePeer[];
+};
+
+type BaselineStoredRoom = {
+  state: BaselineRoomState;
+  expectedMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+  redisFreshBeforeCleanup: boolean;
+  activeLockPresentBeforeCleanup: boolean;
+  presenceDuring: CollaborationPresenceUser[];
+};
+
+function cloneJsonObject(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function cloneDocument(document: ContentDocument): ContentDocument {
+  return {
+    ...document,
+    frontmatter: cloneJsonObject(document.frontmatter),
+  };
+}
+
+function recordsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  return isDeepStrictEqual(left, right);
+}
+
+function createBaselineDocument(roomIndex: number): ContentDocument {
+  return {
+    documentId: `00000000-0000-4000-8000-${roomIndex
+      .toString()
+      .padStart(12, "0")}`,
+    translationGroupId: `10000000-0000-4000-8000-${roomIndex
+      .toString()
+      .padStart(12, "0")}`,
+    project: PROJECT,
+    environment: ENVIRONMENT,
+    path: `campaigns/baseline-room-${roomIndex}`,
+    type: "Page",
+    locale: "__mdcms_default__",
+    format: "mdx",
+    isDeleted: false,
+    hasUnpublishedChanges: true,
+    version: 0,
+    publishedVersion: null,
+    draftRevision: roomIndex,
+    frontmatter: {
+      title: `Baseline room ${roomIndex}`,
+    },
+    body: `# Baseline room ${roomIndex}\n\nInitial draft body for room ${roomIndex}.`,
+    createdBy: "baseline-fixture",
+    createdAt: BASELINE_UPDATED_AT,
+    updatedBy: "baseline-fixture",
+    updatedAt: BASELINE_UPDATED_AT,
+  };
+}
+
+class BaselineContentStore implements CollaborationRuntimeContentStore {
+  readonly documents = new Map<string, ContentDocument>();
+  readonly updateCounts = new Map<string, number>();
+  readonly versionRowsCreated = new Map<string, number>();
+
+  constructor(documents: ContentDocument[]) {
+    for (const document of documents) {
+      this.documents.set(document.documentId, cloneDocument(document));
+      this.updateCounts.set(document.documentId, 0);
+      this.versionRowsCreated.set(document.documentId, 0);
+    }
+  }
+
+  async getById(
+    scope: ContentScope,
+    documentId: string,
+    options?: { draft?: boolean },
+  ): Promise<ContentDocument | undefined> {
+    if (
+      scope.project !== PROJECT ||
+      scope.environment !== ENVIRONMENT ||
+      options?.draft !== true
+    ) {
+      return undefined;
+    }
+
+    const document = this.documents.get(documentId);
+    return document ? cloneDocument(document) : undefined;
+  }
+
+  async update(
+    scope: ContentScope,
+    documentId: string,
+    payload: {
+      body: string;
+      frontmatter: Record<string, unknown>;
+      updatedBy: string;
+    },
+    options?: { expectedDraftRevision?: number },
+  ): Promise<ContentDocument> {
+    const current = this.documents.get(documentId);
+
+    if (!current) {
+      throw new Error(`Unknown baseline document ${documentId}`);
+    }
+
+    if (scope.project !== PROJECT || scope.environment !== ENVIRONMENT) {
+      throw new Error(
+        `Unexpected baseline scope ${scope.project}/${scope.environment}`,
+      );
+    }
+
+    if (
+      options?.expectedDraftRevision !== undefined &&
+      options.expectedDraftRevision !== current.draftRevision
+    ) {
+      throw new Error(
+        `Expected draft revision ${options.expectedDraftRevision}, got ${current.draftRevision}`,
+      );
+    }
+
+    const updated: ContentDocument = {
+      ...current,
+      body: payload.body,
+      frontmatter: cloneJsonObject(payload.frontmatter),
+      draftRevision: current.draftRevision + 1,
+      updatedBy: payload.updatedBy,
+      updatedAt: BASELINE_UPDATED_AT,
+    };
+
+    this.documents.set(documentId, updated);
+    this.updateCounts.set(
+      documentId,
+      (this.updateCounts.get(documentId) ?? 0) + 1,
+    );
+
+    return cloneDocument(updated);
+  }
+
+  requireDocument(documentId: string): ContentDocument {
+    const document = this.documents.get(documentId);
+
+    if (!document) {
+      throw new Error(`Unknown baseline document ${documentId}`);
+    }
+
+    return cloneDocument(document);
+  }
+
+  updateCount(documentId: string): number {
+    return this.updateCounts.get(documentId) ?? 0;
+  }
+
+  versionRowCount(documentId: string): number {
+    return this.versionRowsCreated.get(documentId) ?? 0;
+  }
+}
+
+class BaselineRedisStore implements CollaborationRuntimeRedisStore {
+  readonly activeLocks = new Map<string, string>();
+  readonly finalizedDocumentIds = new Set<string>();
+  readonly presenceRecords = new Map<
+    string,
+    CollaborationPresenceUser & { project: string; environment: string }
+  >();
+
+  private readonly states = new Map<string, Uint8Array>();
+  private readonly metadata = new Map<string, CollaborationYjsMetadata>();
+
+  async getFreshYjsState(
+    documentId: string,
+    draftHead: { draftRevision: number; bodyHash: string },
+  ) {
+    const state = this.states.get(documentId);
+    const metadata = this.metadata.get(documentId);
+
+    if (
+      state &&
+      metadata?.draftRevision === draftHead.draftRevision &&
+      metadata.bodyHash === draftHead.bodyHash
+    ) {
+      return {
+        state: new Uint8Array(state),
+        metadata,
+      };
+    }
+
+    return null;
+  }
+
+  async setYjsState(documentId: string, state: Uint8Array): Promise<void> {
+    this.states.set(documentId, new Uint8Array(state));
+  }
+
+  async setYjsMetadata(
+    documentId: string,
+    metadata: CollaborationYjsMetadata,
+  ): Promise<void> {
+    this.metadata.set(documentId, metadata);
+  }
+
+  async clearInactiveCacheTtl(documentId: string): Promise<void> {
+    this.finalizedDocumentIds.delete(documentId);
+  }
+
+  async acquireActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.has(documentId)) {
+      return false;
+    }
+
+    this.activeLocks.set(documentId, leaseValue);
+    return true;
+  }
+
+  async heartbeatActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    return this.activeLocks.get(documentId) === leaseValue;
+  }
+
+  async releaseActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.get(documentId) !== leaseValue) {
+      return false;
+    }
+
+    this.activeLocks.delete(documentId);
+    return true;
+  }
+
+  async finalizeInactiveRoom(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.get(documentId) !== leaseValue) {
+      return false;
+    }
+
+    this.activeLocks.delete(documentId);
+    this.finalizedDocumentIds.add(documentId);
+    return true;
+  }
+
+  async setPresence(
+    record: CollaborationPresenceUser & {
+      project: string;
+      environment: string;
+    },
+  ): Promise<void> {
+    this.presenceRecords.set(record.sessionId, record);
+  }
+
+  async deletePresence(input: {
+    project: string;
+    environment: string;
+    sessionId: string;
+  }): Promise<void> {
+    const record = this.presenceRecords.get(input.sessionId);
+
+    if (
+      record?.project === input.project &&
+      record.environment === input.environment
+    ) {
+      this.presenceRecords.delete(input.sessionId);
+    }
+  }
+
+  async listPresence(input: {
+    project: string;
+    environment: string;
+  }): Promise<CollaborationPresenceUser[]> {
+    return Array.from(this.presenceRecords.values())
+      .filter(
+        (record) =>
+          record.project === input.project &&
+          record.environment === input.environment,
+      )
+      .map(({ project: _project, environment: _environment, ...user }) => ({
+        ...user,
+      }));
+  }
+
+  flushVolatileCollaborationState(): void {
+    this.states.clear();
+    this.metadata.clear();
+    this.activeLocks.clear();
+    this.finalizedDocumentIds.clear();
+  }
+}
+
+class BaselineLifecycleEvents implements ContentLifecycleEventSink {
+  readonly events: Parameters<
+    ContentLifecycleEventSink["emitContentEvent"]
+  >[0][] = [];
+
+  async emitContentEvent(
+    event: Parameters<ContentLifecycleEventSink["emitContentEvent"]>[0],
+  ): Promise<void> {
+    this.events.push(event);
+  }
+
+  contentUpdatedCount(documentId: string): number {
+    return this.events.filter(
+      (event) =>
+        event.event === "content.updated" &&
+        event.document.documentId === documentId,
+    ).length;
+  }
+}
+
+class BaselineAuthGuard implements CollaborationRuntimeAuthGuard {
+  async revalidateWrite(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+}
+
+class BaselinePresenceAuthGuard implements CollaborationAuthHandshakeGuard {
+  async authorizeHandshake(): Promise<CollaborationHandshakeResult> {
+    return {
+      ok: false,
+      closeCode: 4403,
+      message:
+        "Document sockets are not used by the baseline presence harness.",
+    };
+  }
+
+  async authorizePresenceHandshake(): Promise<CollaborationPresenceHandshakeResult> {
+    return {
+      ok: false,
+      closeCode: 4403,
+      message: "Presence handshakes are bypassed by test peers.",
+    };
+  }
+
+  async authorizePresenceUpdate(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+
+  async filterPresenceSnapshot(
+    _request: Request,
+    _context: CollaborationPresenceContext,
+    users: CollaborationPresenceUser[],
+  ): Promise<CollaborationPresenceUser[]> {
+    return users;
+  }
+}
+
+class BaselinePresencePeer {
+  readonly data: {
+    request: Request;
+    context: {
+      kind: "presence";
+      presence: CollaborationPresenceContext;
+    };
+    namespace: string;
+    peer?: unknown;
+  };
+  readonly remoteAddress = "127.0.0.1";
+  readonly snapshots: CollaborationPresenceSnapshot[] = [];
+  readonly closeEvents: { code?: number; reason?: string }[] = [];
+  readyState = 1;
+
+  constructor(context: CollaborationPresenceContext) {
+    this.data = {
+      request: new Request(
+        `http://127.0.0.1/api/v1/collaboration/presence?project=${PROJECT}&environment=${ENVIRONMENT}`,
+      ),
+      context: {
+        kind: "presence",
+        presence: context,
+      },
+      namespace: "baseline-presence",
+    };
+  }
+
+  send(data: unknown): void {
+    if (typeof data !== "string") {
+      return;
+    }
+
+    const parsed = JSON.parse(data) as CollaborationPresenceSnapshot;
+
+    if (parsed.type === "presence.snapshot") {
+      this.snapshots.push(parsed);
+    }
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.closeEvents.push({ code, reason });
+  }
+
+  publish(): void {
+    return;
+  }
+
+  subscribe(): void {
+    return;
+  }
+
+  unsubscribe(): void {
+    return;
+  }
+
+  terminate(): void {
+    this.close();
+  }
+}
+
+function createSessionContext(input: {
+  document: ContentDocument;
+  roomIndex: number;
+  sessionIndex: number;
+}): CollaborationRuntimeContext {
+  return {
+    userId: `baseline-user-${input.roomIndex}-${input.sessionIndex}`,
+    userEmail: `baseline-user-${input.roomIndex}-${input.sessionIndex}@mdcms.test`,
+    sessionId: `baseline-session-${input.roomIndex}-${input.sessionIndex}`,
+    project: PROJECT,
+    environment: ENVIRONMENT,
+    documentId: input.document.documentId,
+    documentPath: input.document.path,
+    role: "editor",
+  };
+}
+
+function createPresenceLabel(sessionIndex: number): string {
+  return `Baseline editor ${sessionIndex}`;
+}
+
+function createPresenceColor(sessionIndex: number): string {
+  return `#${sessionIndex.toString().padStart(6, "0")}`;
+}
+
+function createPresenceContext(
+  context: CollaborationRuntimeContext,
+  sessionIndex: number,
+): CollaborationPresenceContext {
+  return {
+    userId: context.userId,
+    sessionId: context.sessionId,
+    label: createPresenceLabel(sessionIndex),
+    color: createPresenceColor(sessionIndex),
+    project: context.project,
+    environment: context.environment,
+    role: context.role,
+  };
+}
+
+function createExpectedPresenceUsers(input: {
+  sessions: CollaborationRuntimeContext[];
+  mutationCount: number;
+}): CollaborationPresenceUser[] {
+  return input.sessions.map((context, index) => {
+    const sessionIndex = index + 1;
+
+    return {
+      userId: context.userId,
+      sessionId: context.sessionId,
+      label: createPresenceLabel(sessionIndex),
+      color: createPresenceColor(sessionIndex),
+      documentId: context.documentId,
+      mode: "edit",
+      cursor: {
+        anchor: sessionIndex,
+        head: sessionIndex + input.mutationCount,
+      },
+      updatedAt: BASELINE_UPDATED_AT,
+    };
+  });
+}
+
+function buildExpectedRoomMarkdown(input: {
+  roomIndex: number;
+  initialBody: string;
+  mutations: string[];
+}): string {
+  return [
+    `# Baseline room ${input.roomIndex}`,
+    "",
+    input.initialBody,
+    ...input.mutations.flatMap((mutation) => ["", mutation]),
+  ].join("\n");
+}
+
+function createMutationLabel(input: {
+  roomIndex: number;
+  sessionIndex: number;
+  mutationIndex: number;
+}): string {
+  return `room ${input.roomIndex} session ${input.sessionIndex} mutation ${input.mutationIndex}`;
+}
+
+function appendMutationParagraph(
+  document: Y.Doc,
+  mutation: string,
+): Uint8Array {
+  const stateVector = Y.encodeStateVector(document);
+  const fragment = document.getXmlFragment(COLLABORATION_YJS_FIELD_NAME);
+  const paragraph = new Y.XmlElement("paragraph");
+  const text = new Y.XmlText();
+
+  text.insert(0, mutation);
+  paragraph.insert(0, [text]);
+  fragment.insert(fragment.length, [paragraph]);
+
+  return Y.encodeStateAsUpdate(document, stateVector);
+}
+
+function createPresenceUpdateMessage(input: {
+  documentId: string;
+  sessionIndex: number;
+  mutationCount: number;
+}): string {
+  const update: CollaborationPresenceUpdate = {
+    type: "presence.update",
+    documentId: input.documentId,
+    mode: "edit",
+    cursor: {
+      anchor: input.sessionIndex,
+      head: input.sessionIndex + input.mutationCount,
+    },
+  };
+
+  return JSON.stringify(update);
+}
+
+async function flushPresenceTasks(): Promise<void> {
+  for (let taskIndex = 0; taskIndex < 8; taskIndex++) {
+    await Promise.resolve();
+  }
+}
+
+function latestPresenceSnapshotForDocument(
+  peers: BaselinePresencePeer[],
+  documentId: string,
+): CollaborationPresenceUser[] {
+  const latestSnapshot = peers
+    .flatMap((peer) => peer.snapshots)
+    .filter((snapshot) => snapshot.project === PROJECT)
+    .filter((snapshot) => snapshot.environment === ENVIRONMENT)
+    .at(-1);
+
+  return (
+    latestSnapshot?.users.filter((user) => user.documentId === documentId) ?? []
+  );
+}
+
+async function isFreshRedisState(input: {
+  redisStore: BaselineRedisStore;
+  document: ContentDocument;
+  expectedMarkdown: string;
+  expectedFrontmatter: Record<string, unknown>;
+}): Promise<boolean> {
+  const fresh = await input.redisStore.getFreshYjsState(
+    input.document.documentId,
+    {
+      draftRevision: input.document.draftRevision,
+      bodyHash: computeCollaborationBodyHash(input.document.body),
+    },
+  );
+
+  if (!fresh) {
+    return false;
+  }
+
+  const freshDocument = yjsUpdateToYDoc(fresh.state);
+
+  return (
+    yDocToMarkdown(freshDocument) === input.expectedMarkdown &&
+    recordsEqual(yDocToFrontmatter(freshDocument), input.expectedFrontmatter)
+  );
+}
+
+export async function runCollaborationBaselineScenario(): Promise<CollaborationBaselineResult> {
+  const startedAt = performance.now();
+  const seedDocuments = Array.from(
+    { length: COLLABORATION_BASELINE_PROFILE.roomCount },
+    (_, index) => createBaselineDocument(index + 1),
+  );
+  const contentStore = new BaselineContentStore(seedDocuments);
+  const redisStore = new BaselineRedisStore();
+  const lifecycleEvents = new BaselineLifecycleEvents();
+  const hooks = createCollaborationRuntimeHooks({
+    contentStore,
+    redisStore,
+    authGuard: new BaselineAuthGuard(),
+    lifecycleEvents,
+    createRoomLeaseValue: (() => {
+      let leaseIndex = 0;
+      return () => `baseline-lease-${++leaseIndex}`;
+    })(),
+    setActiveLockHeartbeat: () => Symbol("heartbeat"),
+    clearActiveLockHeartbeat: () => undefined,
+    setFinalizedRoomLeaseTimeout: () => Symbol("finalized-room"),
+    clearFinalizedRoomLeaseTimeout: () => undefined,
+  });
+  const presenceTransport = createCollaborationWebSocketTransport({
+    authGuard: new BaselinePresenceAuthGuard(),
+    presenceStore: redisStore,
+    now: () => new Date(BASELINE_UPDATED_AT),
+  });
+
+  const roomStates: BaselineRoomState[] = [];
+
+  for (const [documentIndex, seedDocument] of seedDocuments.entries()) {
+    const roomIndex = documentIndex + 1;
+    const documentName = createCollaborationDocumentName({
+      project: PROJECT,
+      environment: ENVIRONMENT,
+      documentId: seedDocument.documentId,
+    });
+    const sessions = Array.from(
+      { length: COLLABORATION_BASELINE_PROFILE.sessionsPerRoom },
+      (_, sessionIndex) =>
+        createSessionContext({
+          document: seedDocument,
+          roomIndex,
+          sessionIndex: sessionIndex + 1,
+        }),
+    );
+    const draftRevisionBefore = seedDocument.draftRevision;
+    const initialBody = `Initial draft body for room ${roomIndex}.`;
+    const mutations: string[] = [];
+    const loaded = await hooks.onLoadDocument({
+      context: sessions[0],
+      documentName,
+    });
+    const roomDocument = yjsUpdateToYDoc(loaded);
+    const clientDocuments = sessions.map(() => yjsUpdateToYDoc(loaded));
+    const presencePeers = sessions.map(
+      (context, sessionIndex) =>
+        new BaselinePresencePeer(
+          createPresenceContext(context, sessionIndex + 1),
+        ),
+    );
+
+    roomStates.push({
+      roomIndex,
+      seedDocument,
+      documentName,
+      sessions,
+      draftRevisionBefore,
+      initialBody,
+      mutations,
+      roomDocument,
+      clientDocuments,
+      presencePeers,
+    });
+  }
+
+  for (const roomState of roomStates) {
+    for (const peer of roomState.presencePeers) {
+      presenceTransport.websocket.open?.(peer as never);
+    }
+  }
+
+  await flushPresenceTasks();
+
+  for (const roomState of roomStates) {
+    for (const [sessionIndex, peer] of roomState.presencePeers.entries()) {
+      presenceTransport.websocket.message?.(
+        peer as never,
+        createPresenceUpdateMessage({
+          documentId: roomState.seedDocument.documentId,
+          sessionIndex: sessionIndex + 1,
+          mutationCount: 0,
+        }) as never,
+      );
+    }
+  }
+
+  await flushPresenceTasks();
+
+  for (
+    let mutationIndex = 1;
+    mutationIndex <= COLLABORATION_BASELINE_PROFILE.mutationsPerSession;
+    mutationIndex++
+  ) {
+    for (
+      let sessionIndex = 0;
+      sessionIndex < COLLABORATION_BASELINE_PROFILE.sessionsPerRoom;
+      sessionIndex++
+    ) {
+      for (const roomState of roomStates) {
+        const context = roomState.sessions[sessionIndex];
+        await hooks.beforeHandleMessage({
+          context,
+          documentName: roomState.documentName,
+          document: roomState.roomDocument,
+        });
+        const mutation = createMutationLabel({
+          roomIndex: roomState.roomIndex,
+          sessionIndex: sessionIndex + 1,
+          mutationIndex,
+        });
+        roomState.mutations.push(mutation);
+        const update = appendMutationParagraph(
+          roomState.clientDocuments[sessionIndex],
+          mutation,
+        );
+
+        for (const [
+          clientIndex,
+          clientDocument,
+        ] of roomState.clientDocuments.entries()) {
+          if (clientIndex !== sessionIndex) {
+            Y.applyUpdate(clientDocument, update);
+          }
+        }
+
+        Y.applyUpdate(roomState.roomDocument, update);
+        await hooks.onChange({
+          context,
+          documentName: roomState.documentName,
+          document: roomState.roomDocument,
+        });
+      }
+    }
+  }
+
+  for (const roomState of roomStates) {
+    for (const [sessionIndex, peer] of roomState.presencePeers.entries()) {
+      presenceTransport.websocket.message?.(
+        peer as never,
+        createPresenceUpdateMessage({
+          documentId: roomState.seedDocument.documentId,
+          sessionIndex: sessionIndex + 1,
+          mutationCount: COLLABORATION_BASELINE_PROFILE.mutationsPerSession,
+        }) as never,
+      );
+    }
+  }
+
+  await flushPresenceTasks();
+
+  const storedRooms: BaselineStoredRoom[] = [];
+
+  for (const roomState of roomStates) {
+    const expectedMarkdown = buildExpectedRoomMarkdown({
+      roomIndex: roomState.roomIndex,
+      initialBody: roomState.initialBody,
+      mutations: roomState.mutations,
+    });
+    const expectedFrontmatter = cloneJsonObject(
+      roomState.seedDocument.frontmatter,
+    );
+    const lastContext = roomState.sessions[roomState.sessions.length - 1];
+
+    await hooks.onStoreDocument({
+      lastContext,
+      documentName: roomState.documentName,
+      document: roomState.roomDocument,
+    });
+
+    const persistedBeforeCleanup = contentStore.requireDocument(
+      roomState.seedDocument.documentId,
+    );
+    const redisFreshBeforeCleanup = await isFreshRedisState({
+      redisStore,
+      document: persistedBeforeCleanup,
+      expectedMarkdown,
+      expectedFrontmatter,
+    });
+    const activeLockPresentBeforeCleanup = redisStore.activeLocks.has(
+      roomState.seedDocument.documentId,
+    );
+    const presenceDuring = latestPresenceSnapshotForDocument(
+      roomState.presencePeers,
+      roomState.seedDocument.documentId,
+    );
+
+    storedRooms.push({
+      state: roomState,
+      expectedMarkdown,
+      expectedFrontmatter,
+      redisFreshBeforeCleanup,
+      activeLockPresentBeforeCleanup,
+      presenceDuring,
+    });
+  }
+
+  const activeLockCountBeforeCleanup = roomStates.filter((roomState) =>
+    redisStore.activeLocks.has(roomState.seedDocument.documentId),
+  ).length;
+  const targetPresenceDuring = await redisStore.listPresence({
+    project: PROJECT,
+    environment: ENVIRONMENT,
+  });
+
+  for (const storedRoom of storedRooms) {
+    const lastContext =
+      storedRoom.state.sessions[storedRoom.state.sessions.length - 1];
+
+    await hooks.onDisconnect({
+      context: lastContext,
+      documentName: storedRoom.state.documentName,
+      document: storedRoom.state.roomDocument,
+      clientsCount: 0,
+    });
+  }
+
+  for (const roomState of roomStates) {
+    for (const peer of roomState.presencePeers) {
+      presenceTransport.websocket.close?.(
+        peer as never,
+        1000 as never,
+        "baseline room complete" as never,
+      );
+    }
+  }
+
+  await flushPresenceTasks();
+
+  const targetPresenceAfter = await redisStore.listPresence({
+    project: PROJECT,
+    environment: ENVIRONMENT,
+  });
+  const rooms: CollaborationBaselineRoomResult[] = storedRooms.map(
+    (storedRoom) => {
+      const { state } = storedRoom;
+      const persistedAfterCleanup = contentStore.requireDocument(
+        state.seedDocument.documentId,
+      );
+      const presenceAfter = targetPresenceAfter.filter(
+        (user) => user.documentId === state.seedDocument.documentId,
+      );
+      const convergedClientMarkdown = state.clientDocuments.map(
+        (clientDocument) => yDocToMarkdown(clientDocument),
+      );
+
+      return {
+        documentId: state.seedDocument.documentId,
+        sessionCount: state.sessions.length,
+        mutationCount: state.mutations.length,
+        draftRevisionBefore: state.draftRevisionBefore,
+        draftRevisionAfter: persistedAfterCleanup.draftRevision,
+        expectedMarkdown: storedRoom.expectedMarkdown,
+        finalMarkdown: persistedAfterCleanup.body,
+        expectedFrontmatter: storedRoom.expectedFrontmatter,
+        finalFrontmatter: persistedAfterCleanup.frontmatter,
+        convergedClientMarkdown,
+        redisFreshBeforeCleanup: storedRoom.redisFreshBeforeCleanup,
+        activeLockPresentBeforeCleanup:
+          storedRoom.activeLockPresentBeforeCleanup,
+        activeLockPresentAfterCleanup: redisStore.activeLocks.has(
+          state.seedDocument.documentId,
+        ),
+        finalizedAfterCleanup: redisStore.finalizedDocumentIds.has(
+          state.seedDocument.documentId,
+        ),
+        updateCount: contentStore.updateCount(state.seedDocument.documentId),
+        lifecycleEventCount: lifecycleEvents.contentUpdatedCount(
+          state.seedDocument.documentId,
+        ),
+        versionRowsCreated: contentStore.versionRowCount(
+          state.seedDocument.documentId,
+        ),
+        expectedPresenceDuring: createExpectedPresenceUsers({
+          sessions: state.sessions,
+          mutationCount: COLLABORATION_BASELINE_PROFILE.mutationsPerSession,
+        }),
+        presenceDuring: storedRoom.presenceDuring,
+        presenceAfter,
+      };
+    },
+  );
+
+  const recoveryRoom = rooms[0];
+  const recoveryDocument = contentStore.requireDocument(
+    recoveryRoom.documentId,
+  );
+  redisStore.flushVolatileCollaborationState();
+
+  const recoveryContext = createSessionContext({
+    document: recoveryDocument,
+    roomIndex: 1,
+    sessionIndex: 99,
+  });
+  const recoveryDocumentName = createCollaborationDocumentName({
+    project: PROJECT,
+    environment: ENVIRONMENT,
+    documentId: recoveryDocument.documentId,
+  });
+  const recoveredState = await hooks.onLoadDocument({
+    context: recoveryContext,
+    documentName: recoveryDocumentName,
+  });
+  const recoveredDocument = yjsUpdateToYDoc(recoveredState);
+  const recoveredMarkdown = yDocToMarkdown(recoveredDocument);
+  const recoveredFrontmatter = yDocToFrontmatter(recoveredDocument);
+  const redisFreshAfterReopen = await isFreshRedisState({
+    redisStore,
+    document: recoveryDocument,
+    expectedMarkdown: recoveryRoom.expectedMarkdown,
+    expectedFrontmatter: recoveryRoom.expectedFrontmatter,
+  });
+
+  await hooks.onDisconnect({
+    context: recoveryContext,
+    documentName: recoveryDocumentName,
+    document: recoveredDocument,
+    clientsCount: 0,
+  });
+  await presenceTransport.shutdown();
+
+  const redisLossRecovery: CollaborationRedisLossRecoveryResult = {
+    documentId: recoveryDocument.documentId,
+    expectedMarkdown: recoveryRoom.expectedMarkdown,
+    recoveredMarkdown,
+    expectedFrontmatter: recoveryRoom.expectedFrontmatter,
+    recoveredFrontmatter,
+    rebuiltFromPostgres:
+      recoveredMarkdown === recoveryDocument.body &&
+      recordsEqual(recoveredFrontmatter, recoveryDocument.frontmatter),
+    redisFreshAfterReopen,
+  };
+
+  const elapsedMs = performance.now() - startedAt;
+  const totals = rooms.reduce(
+    (accumulator, room) => ({
+      roomCount: accumulator.roomCount + 1,
+      sessionCount: accumulator.sessionCount + room.sessionCount,
+      mutationCount: accumulator.mutationCount + room.mutationCount,
+      contentUpdatedEvents:
+        accumulator.contentUpdatedEvents + room.lifecycleEventCount,
+      versionRowsCreated:
+        accumulator.versionRowsCreated + room.versionRowsCreated,
+    }),
+    {
+      roomCount: 0,
+      sessionCount: 0,
+      mutationCount: 0,
+      contentUpdatedEvents: 0,
+      versionRowsCreated: 0,
+    },
+  );
+
+  return {
+    elapsedMs,
+    rooms,
+    redisLossRecovery,
+    activeLockCountBeforeCleanup,
+    targetPresenceDuring,
+    targetPresenceAfter,
+    totals,
+  };
+}

--- a/apps/server/src/lib/collaboration/load-soak-test-support.ts
+++ b/apps/server/src/lib/collaboration/load-soak-test-support.ts
@@ -21,6 +21,7 @@ import type {
 
 import type { CollaborationYjsMetadata } from "./redis-store.js";
 import {
+  COLLABORATION_FRONTMATTER_FIELD_NAME,
   COLLABORATION_YJS_FIELD_NAME,
   computeCollaborationBodyHash,
   createCollaborationDocumentName,
@@ -47,6 +48,7 @@ export const COLLABORATION_BASELINE_PROFILE = {
 
 export type CollaborationBaselineRoomResult = {
   documentId: string;
+  type: string;
   sessionCount: number;
   mutationCount: number;
   draftRevisionBefore: number;
@@ -98,6 +100,50 @@ const PROJECT = "marketing";
 const ENVIRONMENT = "draft";
 const BASELINE_UPDATED_AT = "2026-06-14T12:00:00.000Z";
 
+type BaselineContentTypeFixture = {
+  type: string;
+  directory: string;
+  locale?: string;
+  frontmatter: (roomIndex: number) => Record<string, unknown>;
+};
+
+const BASELINE_CONTENT_TYPE_FIXTURES: readonly BaselineContentTypeFixture[] = [
+  {
+    type: "post",
+    directory: "content/posts",
+    frontmatter: (roomIndex: number) => ({
+      title: `Baseline post ${roomIndex}`,
+      slug: `baseline-post-${roomIndex}`,
+      featured: false,
+      abTestVariant: "control",
+    }),
+  },
+  {
+    type: "author",
+    directory: "content/authors",
+    frontmatter: (roomIndex: number) => ({
+      name: `Baseline author ${roomIndex}`,
+    }),
+  },
+  {
+    type: "page",
+    directory: "content/pages",
+    frontmatter: (roomIndex: number) => ({
+      title: `Baseline page ${roomIndex}`,
+    }),
+  },
+  {
+    type: "campaign",
+    directory: "content/campaigns",
+    locale: "en",
+    frontmatter: (roomIndex: number) => ({
+      title: `Baseline campaign ${roomIndex}`,
+      slug: `baseline-campaign-${roomIndex}`,
+      summary: `Initial campaign summary ${roomIndex}`,
+    }),
+  },
+];
+
 type BaselineRoomState = {
   roomIndex: number;
   seedDocument: ContentDocument;
@@ -141,6 +187,11 @@ function recordsEqual(
 }
 
 function createBaselineDocument(roomIndex: number): ContentDocument {
+  const fixture =
+    BASELINE_CONTENT_TYPE_FIXTURES[
+      (roomIndex - 1) % BASELINE_CONTENT_TYPE_FIXTURES.length
+    ];
+
   return {
     documentId: `00000000-0000-4000-8000-${roomIndex
       .toString()
@@ -150,18 +201,16 @@ function createBaselineDocument(roomIndex: number): ContentDocument {
       .padStart(12, "0")}`,
     project: PROJECT,
     environment: ENVIRONMENT,
-    path: `campaigns/baseline-room-${roomIndex}`,
-    type: "Page",
-    locale: "__mdcms_default__",
+    path: `${fixture.directory}/baseline-room-${roomIndex}`,
+    type: fixture.type,
+    locale: fixture.locale ?? "__mdcms_default__",
     format: "mdx",
     isDeleted: false,
     hasUnpublishedChanges: true,
     version: 0,
     publishedVersion: null,
     draftRevision: roomIndex,
-    frontmatter: {
-      title: `Baseline room ${roomIndex}`,
-    },
+    frontmatter: fixture.frontmatter(roomIndex),
     body: `# Baseline room ${roomIndex}\n\nInitial draft body for room ${roomIndex}.`,
     createdBy: "baseline-fixture",
     createdAt: BASELINE_UPDATED_AT,
@@ -625,6 +674,60 @@ function appendMutationParagraph(
   return Y.encodeStateAsUpdate(document, stateVector);
 }
 
+function writeCollaborationFrontmatterMutation(input: {
+  document: Y.Doc;
+  frontmatter: Record<string, unknown>;
+}): void {
+  const frontmatter = input.document.getMap<unknown>(
+    COLLABORATION_FRONTMATTER_FIELD_NAME,
+  );
+
+  frontmatter.clear();
+
+  for (const [fieldName, value] of Object.entries(input.frontmatter)) {
+    frontmatter.set(fieldName, value);
+  }
+}
+
+function buildExpectedCollaborationFrontmatter(input: {
+  seedDocument: ContentDocument;
+  mutationCount: number;
+  sessionId: string;
+}): Record<string, unknown> {
+  const frontmatter = cloneJsonObject(input.seedDocument.frontmatter);
+
+  if (input.seedDocument.type === "post") {
+    return {
+      ...frontmatter,
+      abTestVariant: input.sessionId,
+      featured: true,
+    };
+  }
+
+  if (input.seedDocument.type === "author") {
+    return {
+      ...frontmatter,
+      name: `${String(frontmatter.name)} (${input.mutationCount})`,
+    };
+  }
+
+  if (input.seedDocument.type === "page") {
+    return {
+      ...frontmatter,
+      title: `${String(frontmatter.title)} (${input.mutationCount})`,
+    };
+  }
+
+  if (input.seedDocument.type === "campaign") {
+    return {
+      ...frontmatter,
+      summary: `Updated by ${input.sessionId} after ${input.mutationCount} mutations`,
+    };
+  }
+
+  throw new Error(`Unsupported baseline type ${input.seedDocument.type}`);
+}
+
 function createPresenceUpdateMessage(input: {
   documentId: string;
   sessionIndex: number;
@@ -860,10 +963,18 @@ export async function runCollaborationBaselineScenario(): Promise<CollaborationB
       initialBody: roomState.initialBody,
       mutations: roomState.mutations,
     });
-    const expectedFrontmatter = cloneJsonObject(
-      roomState.seedDocument.frontmatter,
-    );
     const lastContext = roomState.sessions[roomState.sessions.length - 1];
+
+    const expectedFrontmatter = buildExpectedCollaborationFrontmatter({
+      seedDocument: roomState.seedDocument,
+      mutationCount: roomState.mutations.length,
+      sessionId: lastContext.sessionId,
+    });
+
+    writeCollaborationFrontmatterMutation({
+      document: roomState.roomDocument,
+      frontmatter: expectedFrontmatter,
+    });
 
     await hooks.onStoreDocument({
       lastContext,
@@ -949,6 +1060,7 @@ export async function runCollaborationBaselineScenario(): Promise<CollaborationB
 
       return {
         documentId: state.seedDocument.documentId,
+        type: state.seedDocument.type,
         sessionCount: state.sessions.length,
         mutationCount: state.mutations.length,
         draftRevisionBefore: state.draftRevisionBefore,

--- a/apps/server/src/lib/collaboration/load-soak-test-support.ts
+++ b/apps/server/src/lib/collaboration/load-soak-test-support.ts
@@ -510,6 +510,10 @@ class BaselinePresenceAuthGuard implements CollaborationAuthHandshakeGuard {
   ): Promise<CollaborationPresenceUser[]> {
     return users;
   }
+
+  async revalidateWrite(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
 }
 
 class BaselinePresencePeer {

--- a/apps/server/src/lib/collaboration/load-soak.test.ts
+++ b/apps/server/src/lib/collaboration/load-soak.test.ts
@@ -15,6 +15,12 @@ test("collaboration baseline load/soak scenario satisfies SPEC-007", async () =>
   assert.equal(COLLABORATION_BASELINE_PROFILE.mutationsPerSession, 25);
   assert.equal(COLLABORATION_BASELINE_PROFILE.timeoutMs, 30_000);
   assert.equal(result.rooms.length, COLLABORATION_BASELINE_PROFILE.roomCount);
+  assert.deepEqual(result.rooms.map((room) => room.type).sort(), [
+    "author",
+    "campaign",
+    "page",
+    "post",
+  ]);
   assert.equal(result.totals.sessionCount, 12);
   assert.equal(result.totals.mutationCount, 300);
   assert.equal(result.totals.contentUpdatedEvents, 4);

--- a/apps/server/src/lib/collaboration/load-soak.test.ts
+++ b/apps/server/src/lib/collaboration/load-soak.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+
+import {
+  COLLABORATION_BASELINE_PROFILE,
+  runCollaborationBaselineScenario,
+} from "./load-soak-test-support.js";
+
+test("collaboration baseline load/soak scenario satisfies SPEC-007", async () => {
+  const result = await runCollaborationBaselineScenario();
+
+  assert.equal(COLLABORATION_BASELINE_PROFILE.roomCount, 4);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.sessionsPerRoom, 3);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.mutationsPerSession, 25);
+  assert.equal(COLLABORATION_BASELINE_PROFILE.timeoutMs, 30_000);
+  assert.equal(result.rooms.length, COLLABORATION_BASELINE_PROFILE.roomCount);
+  assert.equal(result.totals.sessionCount, 12);
+  assert.equal(result.totals.mutationCount, 300);
+  assert.equal(result.totals.contentUpdatedEvents, 4);
+  assert.equal(result.totals.versionRowsCreated, 0);
+  assert.equal(
+    result.activeLockCountBeforeCleanup,
+    COLLABORATION_BASELINE_PROFILE.roomCount,
+  );
+  assert.deepEqual(
+    result.targetPresenceDuring,
+    result.rooms.flatMap((room) => room.expectedPresenceDuring),
+  );
+  assert.deepEqual(result.targetPresenceAfter, []);
+  assert.ok(
+    result.elapsedMs < COLLABORATION_BASELINE_PROFILE.timeoutMs,
+    `baseline took ${result.elapsedMs}ms`,
+  );
+  assert.equal(result.redisLossRecovery.rebuiltFromPostgres, true);
+  assert.equal(
+    result.redisLossRecovery.recoveredMarkdown,
+    result.redisLossRecovery.expectedMarkdown,
+  );
+  assert.deepEqual(
+    result.redisLossRecovery.recoveredFrontmatter,
+    result.redisLossRecovery.expectedFrontmatter,
+  );
+  assert.equal(result.redisLossRecovery.redisFreshAfterReopen, true);
+
+  for (const room of result.rooms) {
+    assert.equal(room.sessionCount, 3);
+    assert.equal(room.mutationCount, 75);
+    assert.equal(room.updateCount, 1);
+    assert.equal(room.draftRevisionAfter, room.draftRevisionBefore + 1);
+    assert.equal(room.finalMarkdown, room.expectedMarkdown);
+    assert.deepEqual(room.finalFrontmatter, room.expectedFrontmatter);
+    assert.deepEqual(
+      room.convergedClientMarkdown,
+      Array.from({ length: room.sessionCount }, () => room.expectedMarkdown),
+    );
+    assert.equal(room.redisFreshBeforeCleanup, true);
+    assert.equal(room.activeLockPresentBeforeCleanup, true);
+    assert.equal(room.activeLockPresentAfterCleanup, false);
+    assert.equal(room.finalizedAfterCleanup, true);
+    assert.equal(room.lifecycleEventCount, 1);
+    assert.equal(room.versionRowsCreated, 0);
+    assert.deepEqual(room.presenceDuring, room.expectedPresenceDuring);
+    assert.deepEqual(room.presenceAfter, []);
+  }
+});

--- a/apps/server/src/lib/collaboration/recovery.integration.test.ts
+++ b/apps/server/src/lib/collaboration/recovery.integration.test.ts
@@ -1,0 +1,399 @@
+import assert from "node:assert/strict";
+
+import { and, eq } from "drizzle-orm";
+
+import { createDatabaseContentStore } from "../content-api.js";
+import {
+  DEFAULT_ACTOR,
+  type ContentLifecycleEventSink,
+} from "../content-api/types.js";
+import {
+  createContentDocument,
+  createDatabaseTestContext,
+  resetDatabaseTestScope,
+  seedSchemaRegistryScope,
+  stableFixtureName,
+  stableFixturePath,
+  testWithDatabase,
+} from "../content-api-test-support.js";
+import { documentVersions, documents } from "../db/schema.js";
+
+import type { CollaborationYjsMetadata } from "./redis-store.js";
+import {
+  computeCollaborationBodyHash,
+  createCollaborationDocumentName,
+  createCollaborationRuntimeHooks,
+  markdownToYDoc,
+  yDocToFrontmatter,
+  yDocToMarkdown,
+  yjsUpdateToYDoc,
+  type CollaborationRuntimeAuthGuard,
+  type CollaborationRuntimeContext,
+  type CollaborationRuntimeRedisStore,
+} from "./runtime.js";
+
+type CreatedDocument = {
+  documentId: string;
+  draftRevision: number;
+  path: string;
+};
+
+class DatabaseRecoveryRedisStore implements CollaborationRuntimeRedisStore {
+  readonly activeLocks = new Map<string, string>();
+  readonly calls: Array<{
+    method: "getFreshYjsState";
+    documentId: string;
+    hit: boolean;
+  }> = [];
+
+  private readonly states = new Map<string, Uint8Array>();
+  private readonly metadata = new Map<string, CollaborationYjsMetadata>();
+
+  async getFreshYjsState(
+    documentId: string,
+    draftHead: { draftRevision: number; bodyHash: string },
+  ) {
+    const state = this.states.get(documentId);
+    const metadata = this.metadata.get(documentId);
+    const hit =
+      state !== undefined &&
+      metadata?.draftRevision === draftHead.draftRevision &&
+      metadata.bodyHash === draftHead.bodyHash;
+
+    this.calls.push({ method: "getFreshYjsState", documentId, hit });
+
+    if (!hit) {
+      return null;
+    }
+
+    return {
+      state: new Uint8Array(state),
+      metadata,
+    };
+  }
+
+  async setYjsState(documentId: string, state: Uint8Array): Promise<void> {
+    this.states.set(documentId, new Uint8Array(state));
+  }
+
+  async setYjsMetadata(
+    documentId: string,
+    metadata: CollaborationYjsMetadata,
+  ): Promise<void> {
+    this.metadata.set(documentId, metadata);
+  }
+
+  async clearInactiveCacheTtl(_documentId: string): Promise<void> {
+    return;
+  }
+
+  async acquireActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.has(documentId)) {
+      return false;
+    }
+
+    this.activeLocks.set(documentId, leaseValue);
+    return true;
+  }
+
+  async heartbeatActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    return this.activeLocks.get(documentId) === leaseValue;
+  }
+
+  async releaseActiveLock(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.get(documentId) !== leaseValue) {
+      return false;
+    }
+
+    this.activeLocks.delete(documentId);
+    return true;
+  }
+
+  async finalizeInactiveRoom(
+    documentId: string,
+    leaseValue: string,
+  ): Promise<boolean> {
+    if (this.activeLocks.get(documentId) !== leaseValue) {
+      return false;
+    }
+
+    this.activeLocks.delete(documentId);
+    return true;
+  }
+
+  flushVolatileCollaborationState(): void {
+    this.states.clear();
+    this.metadata.clear();
+    this.activeLocks.clear();
+  }
+}
+
+class DatabaseRecoveryLifecycleEvents implements ContentLifecycleEventSink {
+  readonly events: Parameters<
+    ContentLifecycleEventSink["emitContentEvent"]
+  >[0][] = [];
+
+  async emitContentEvent(
+    event: Parameters<ContentLifecycleEventSink["emitContentEvent"]>[0],
+  ): Promise<void> {
+    this.events.push(event);
+  }
+}
+
+const databaseRecoveryAuthGuard = {
+  async revalidateWrite(): Promise<{ ok: true }> {
+    return { ok: true };
+  },
+} satisfies CollaborationRuntimeAuthGuard;
+
+function createContext(input: {
+  created: CreatedDocument;
+  project: string;
+  environment: string;
+  sessionId: string;
+  userId: string;
+}): CollaborationRuntimeContext {
+  return {
+    userId: input.userId,
+    userEmail: "collaboration-recovery@mdcms.local",
+    sessionId: input.sessionId,
+    project: input.project,
+    environment: input.environment,
+    documentId: input.created.documentId,
+    documentPath: input.created.path,
+    role: "editor",
+  };
+}
+
+testWithDatabase(
+  "collaboration recovers edited draft content from Postgres after Redis state is lost",
+  async () => {
+    const { handler, dbConnection, csrfHeaders, cookie, userId } =
+      await createDatabaseTestContext(
+        "test:collaboration-db-recovery-after-redis-loss",
+      );
+    const scope = {
+      project: stableFixtureName("collaboration-db-recovery"),
+      environment: "production",
+    };
+    const requestScopeHeaders = {
+      "x-mdcms-project": scope.project,
+      "x-mdcms-environment": scope.environment,
+    };
+
+    try {
+      await resetDatabaseTestScope(dbConnection.db, scope);
+      await seedSchemaRegistryScope(dbConnection.db, {
+        scope,
+        schemaHash: "collaboration-db-recovery-schema",
+        entries: [
+          {
+            type: "page",
+            directory: "content/pages",
+            localized: false,
+            fields: {
+              title: { kind: "string", required: true, nullable: false },
+            },
+          },
+        ],
+      });
+
+      const created = (await createContentDocument(
+        handler,
+        csrfHeaders,
+        requestScopeHeaders,
+        {
+          path: stableFixturePath("pages", "collaboration-db-recovery"),
+          type: "page",
+          locale: "__mdcms_default__",
+          format: "mdx",
+          frontmatter: {
+            title: "Collaboration DB recovery",
+          },
+          body: "# Collaboration DB recovery\n\nInitial persisted body.",
+        },
+      )) as CreatedDocument;
+      const documentName = createCollaborationDocumentName({
+        project: scope.project,
+        environment: scope.environment,
+        documentId: created.documentId,
+      });
+      const redisStore = new DatabaseRecoveryRedisStore();
+      const lifecycleEvents = new DatabaseRecoveryLifecycleEvents();
+      let leaseIndex = 0;
+      const hooks = createCollaborationRuntimeHooks({
+        contentStore: createDatabaseContentStore({ db: dbConnection.db }),
+        redisStore,
+        authGuard: databaseRecoveryAuthGuard,
+        lifecycleEvents,
+        setActiveLockHeartbeat: () => "heartbeat",
+        clearActiveLockHeartbeat: () => undefined,
+        setFinalizedRoomLeaseTimeout: () => "finalized-room",
+        clearFinalizedRoomLeaseTimeout: () => undefined,
+        createRoomLeaseValue: () => `lease-${++leaseIndex}`,
+      });
+      const editContext = createContext({
+        created,
+        project: scope.project,
+        environment: scope.environment,
+        sessionId: "session-db-recovery-edit",
+        userId,
+      });
+
+      await hooks.onLoadDocument({
+        context: editContext,
+        documentName,
+      });
+
+      const expectedFrontmatter = {
+        title: "Recovered collaboration draft",
+      };
+      const editedDocument = markdownToYDoc(
+        "# Recovered collaboration draft\n\nPersisted through Postgres.",
+        expectedFrontmatter,
+      );
+      const expectedMarkdown = yDocToMarkdown(editedDocument);
+
+      await hooks.onChange({
+        context: editContext,
+        documentName,
+        document: editedDocument,
+      });
+      await hooks.onStoreDocument({
+        lastContext: editContext,
+        documentName,
+        document: editedDocument,
+      });
+      await hooks.onDisconnect({
+        context: editContext,
+        documentName,
+        document: editedDocument,
+        clientsCount: 0,
+      });
+
+      const expectedDraftRevision = created.draftRevision + 1;
+      const persisted = await dbConnection.db.query.documents.findFirst({
+        where: eq(documents.documentId, created.documentId),
+      });
+
+      assert.ok(persisted);
+      assert.equal(persisted.body, expectedMarkdown);
+      assert.deepEqual(persisted.frontmatter, expectedFrontmatter);
+      assert.equal(persisted.draftRevision, expectedDraftRevision);
+      assert.equal(persisted.updatedBy, DEFAULT_ACTOR);
+      assert.equal(lifecycleEvents.events.length, 1);
+      assert.equal(lifecycleEvents.events[0]?.actor.id, userId);
+
+      const apiReadResponse = await handler(
+        new Request(
+          `http://localhost/api/v1/content/${created.documentId}?draft=true`,
+          {
+            headers: {
+              ...requestScopeHeaders,
+              cookie,
+            },
+          },
+        ),
+      );
+      const apiReadBody = (await apiReadResponse.json()) as {
+        data: {
+          body: string;
+          draftRevision: number;
+          frontmatter: Record<string, unknown>;
+        };
+      };
+
+      assert.equal(apiReadResponse.status, 200);
+      assert.equal(apiReadBody.data.body, expectedMarkdown);
+      assert.deepEqual(apiReadBody.data.frontmatter, expectedFrontmatter);
+      assert.equal(apiReadBody.data.draftRevision, expectedDraftRevision);
+
+      const versionsBeforeRecovery = await dbConnection.db
+        .select({ id: documentVersions.id })
+        .from(documentVersions)
+        .where(
+          and(
+            eq(documentVersions.documentId, created.documentId),
+            eq(documentVersions.projectId, persisted.projectId),
+            eq(documentVersions.environmentId, persisted.environmentId),
+          ),
+        );
+
+      assert.equal(versionsBeforeRecovery.length, 0);
+
+      redisStore.flushVolatileCollaborationState();
+
+      const recoveryContext = createContext({
+        created,
+        project: scope.project,
+        environment: scope.environment,
+        sessionId: "session-db-recovery-reopen",
+        userId,
+      });
+      const recoveredState = await hooks.onLoadDocument({
+        context: recoveryContext,
+        documentName,
+      });
+      const recoveredDocument = yjsUpdateToYDoc(recoveredState);
+
+      assert.equal(yDocToMarkdown(recoveredDocument), expectedMarkdown);
+      assert.deepEqual(
+        yDocToFrontmatter(recoveredDocument),
+        expectedFrontmatter,
+      );
+      assert.deepEqual(
+        redisStore.calls.map(({ hit }) => hit),
+        [false, false],
+      );
+
+      const rebuiltRedisState = await redisStore.getFreshYjsState(
+        created.documentId,
+        {
+          draftRevision: expectedDraftRevision,
+          bodyHash: computeCollaborationBodyHash(expectedMarkdown),
+        },
+      );
+
+      assert.ok(rebuiltRedisState);
+
+      await hooks.onDisconnect({
+        context: recoveryContext,
+        documentName,
+        document: recoveredDocument,
+        clientsCount: 0,
+      });
+
+      const versionsAfterRecovery = await dbConnection.db
+        .select({ id: documentVersions.id })
+        .from(documentVersions)
+        .where(
+          and(
+            eq(documentVersions.documentId, created.documentId),
+            eq(documentVersions.projectId, persisted.projectId),
+            eq(documentVersions.environmentId, persisted.environmentId),
+          ),
+        );
+      const persistedAfterRecovery =
+        await dbConnection.db.query.documents.findFirst({
+          where: eq(documents.documentId, created.documentId),
+        });
+
+      assert.equal(versionsAfterRecovery.length, 0);
+      assert.equal(
+        persistedAfterRecovery?.draftRevision,
+        expectedDraftRevision,
+      );
+    } finally {
+      await dbConnection.close();
+    }
+  },
+);

--- a/apps/server/src/lib/collaboration/redis-store.test.ts
+++ b/apps/server/src/lib/collaboration/redis-store.test.ts
@@ -2,11 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "bun:test";
 
 import { RuntimeError } from "@mdcms/shared";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
 
 import {
   COLLABORATION_ACTIVE_LOCK_LEASE_SECONDS,
   COLLABORATION_INACTIVE_CACHE_TTL_SECONDS,
+  COLLABORATION_PRESENCE_TTL_SECONDS,
   buildCollaborationActiveKey,
+  buildCollaborationPresenceKey,
   buildCollaborationYjsMetaKey,
   buildCollaborationYjsStateKey,
   createCollaborationRedisStore,
@@ -21,9 +24,12 @@ class FakeRedisClient implements CollaborationRedisClient {
     key?: string;
     keys?: string[];
     seconds?: number;
+    count?: number;
     value?: Buffer | string;
     condition?: "NX";
     args?: string[];
+    cursor?: string;
+    pattern?: string;
   }> = [];
 
   async get(key: string): Promise<string | null> {
@@ -93,6 +99,28 @@ class FakeRedisClient implements CollaborationRedisClient {
   async exists(key: string): Promise<number> {
     this.calls.push({ method: "exists", key });
     return this.values.has(key) ? 1 : 0;
+  }
+
+  async scan(
+    cursor: string,
+    matchKeyword: "MATCH",
+    pattern: string,
+    countKeyword: "COUNT",
+    count: number,
+  ): Promise<[string, string[]]> {
+    this.calls.push({ method: "scan", cursor, pattern, count });
+    assert.equal(cursor, "0");
+    assert.equal(matchKeyword, "MATCH");
+    assert.equal(countKeyword, "COUNT");
+    assert.equal(count > 0, true);
+
+    const expression = new RegExp(
+      `^${pattern
+        .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+        .replaceAll("*", ".*")}$`,
+    );
+
+    return ["0", [...this.values.keys()].filter((key) => expression.test(key))];
   }
 
   async eval(
@@ -166,6 +194,22 @@ function createStore(): {
   };
 }
 
+function createPresenceRecord(
+  overrides: Partial<CollaborationPresenceUser> = {},
+): CollaborationPresenceUser {
+  return {
+    userId: "user-1",
+    sessionId: "session-1",
+    label: "Ada",
+    color: "#2563eb",
+    documentId: "11111111-1111-4111-8111-111111111111",
+    mode: "view",
+    cursor: { anchor: 2, head: 7 },
+    updatedAt: "2026-06-14T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
 test("collaboration Redis key builders match the documented key shape", () => {
   const documentId = "5ad76d8b-4de0-48e7-9370-8f5d2df3b1d1";
 
@@ -181,6 +225,134 @@ test("collaboration Redis key builders match the documented key shape", () => {
     buildCollaborationActiveKey(documentId),
     "mdcms:collaboration:active:5ad76d8b-4de0-48e7-9370-8f5d2df3b1d1",
   );
+  assert.equal(
+    buildCollaborationPresenceKey({
+      project: "marketing",
+      environment: "draft",
+      sessionId: "session-1",
+    }),
+    "mdcms:collaboration:presence:marketing:draft:session-1",
+  );
+});
+
+test("presence writes JSON records with the presence heartbeat TTL", async () => {
+  const { client, store } = createStore();
+  const record = createPresenceRecord();
+  const key = buildCollaborationPresenceKey({
+    project: "marketing",
+    environment: "draft",
+    sessionId: "session-1",
+  });
+
+  await store.setPresence({
+    ...record,
+    project: "marketing",
+    environment: "draft",
+  });
+
+  assert.deepEqual(JSON.parse(String(client.values.get(key))), record);
+  assert.deepEqual(client.calls.at(-1), {
+    method: "set",
+    key,
+    value: JSON.stringify(record),
+    seconds: COLLABORATION_PRESENCE_TTL_SECONDS,
+    condition: undefined,
+  });
+});
+
+test("presence listing returns valid records only for the requested target", async () => {
+  const { client, store } = createStore();
+  const valid = createPresenceRecord({
+    sessionId: "session-1",
+    label: "Ada",
+  });
+  const otherEnvironment = createPresenceRecord({
+    sessionId: "session-2",
+    label: "Grace",
+  });
+  const otherProject = createPresenceRecord({
+    sessionId: "session-3",
+    label: "Linus",
+  });
+
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "marketing",
+      environment: "draft",
+      sessionId: valid.sessionId,
+    }),
+    JSON.stringify(valid),
+  );
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "marketing",
+      environment: "draft",
+      sessionId: "malformed-json",
+    }),
+    "{",
+  );
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "marketing",
+      environment: "draft",
+      sessionId: "invalid-shape",
+    }),
+    JSON.stringify({ ...valid, label: "", sessionId: "invalid-shape" }),
+  );
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "marketing",
+      environment: "prod",
+      sessionId: otherEnvironment.sessionId,
+    }),
+    JSON.stringify(otherEnvironment),
+  );
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "sales",
+      environment: "draft",
+      sessionId: otherProject.sessionId,
+    }),
+    JSON.stringify(otherProject),
+  );
+
+  assert.deepEqual(
+    await store.listPresence({ project: "marketing", environment: "draft" }),
+    [valid],
+  );
+});
+
+test("presence delete removes only the exact session key", async () => {
+  const { client, store } = createStore();
+  const targetKey = buildCollaborationPresenceKey({
+    project: "marketing",
+    environment: "draft",
+    sessionId: "session-1",
+  });
+  const siblingKey = buildCollaborationPresenceKey({
+    project: "marketing",
+    environment: "draft",
+    sessionId: "session-2",
+  });
+
+  client.values.set(targetKey, JSON.stringify(createPresenceRecord()));
+  client.values.set(
+    siblingKey,
+    JSON.stringify(createPresenceRecord({ sessionId: "session-2" })),
+  );
+
+  await store.deletePresence({
+    project: "marketing",
+    environment: "draft",
+    sessionId: "session-1",
+  });
+
+  assert.equal(client.values.has(targetKey), false);
+  assert.equal(client.values.has(siblingKey), true);
+  assert.deepEqual(client.calls.at(-1), {
+    method: "del",
+    keys: [targetKey],
+  });
 });
 
 test("state and metadata round trip through Redis without changing binary bytes", async () => {

--- a/apps/server/src/lib/collaboration/redis-store.test.ts
+++ b/apps/server/src/lib/collaboration/redis-store.test.ts
@@ -134,19 +134,20 @@ class FakeRedisClient implements CollaborationRedisClient {
     const seconds = scriptArgs[1];
     const activeKey = numberOfKeys === 3 ? keys[2] : keys[0];
 
-    if (typeof activeKey !== "string" || typeof leaseValue !== "string") {
+    if (typeof activeKey !== "string") {
       throw new Error("Invalid fake Redis eval invocation.");
     }
 
-    const call: (typeof this.calls)[number] = {
-      method: "eval",
-      args: [leaseValue],
-    };
+    const call: (typeof this.calls)[number] = { method: "eval" };
 
     if (numberOfKeys === 1) {
       call.key = activeKey;
     } else {
       call.keys = keys;
+    }
+
+    if (leaseValue !== undefined) {
+      call.args = [leaseValue];
     }
 
     if (seconds !== undefined) {
@@ -155,6 +156,22 @@ class FakeRedisClient implements CollaborationRedisClient {
 
     this.calls.push(call);
     assert.equal(numberOfKeys === 1 || numberOfKeys === 3, true);
+
+    if (numberOfKeys === 3 && script.includes('"EXISTS", KEYS[3]')) {
+      if (this.values.has(activeKey)) {
+        return 0;
+      }
+
+      const [stateKey, metaKey] = keys;
+      assert.equal(typeof stateKey, "string");
+      assert.equal(typeof metaKey, "string");
+
+      return this.del(stateKey, metaKey);
+    }
+
+    if (typeof leaseValue !== "string") {
+      throw new Error("Invalid fake Redis eval invocation.");
+    }
 
     if (this.values.get(activeKey) !== leaseValue) {
       return 0;
@@ -493,6 +510,71 @@ test("active-room lifecycle clears inactive TTLs then expires cache after final 
         method: "expire",
         key: buildCollaborationYjsMetaKey(documentId),
         seconds: COLLABORATION_INACTIVE_CACHE_TTL_SECONDS,
+      },
+    ],
+  );
+});
+
+test("inactive collaboration cache invalidation deletes Yjs state and metadata", async () => {
+  const documentId = "9c003bee-4f4c-42d4-b445-d393a17067bb";
+  const { client, store } = createStore();
+
+  client.values.set(
+    buildCollaborationYjsStateKey(documentId),
+    Buffer.from("state"),
+  );
+  client.values.set(
+    buildCollaborationYjsMetaKey(documentId),
+    JSON.stringify({ draftRevision: 4, bodyHash: "body-hash" }),
+  );
+
+  await store.invalidateInactiveCache(documentId);
+
+  assert.equal(
+    client.values.has(buildCollaborationYjsStateKey(documentId)),
+    false,
+  );
+  assert.equal(
+    client.values.has(buildCollaborationYjsMetaKey(documentId)),
+    false,
+  );
+  assert.deepEqual(
+    client.calls.filter((call) => call.method === "del"),
+    [
+      {
+        method: "del",
+        keys: [
+          buildCollaborationYjsStateKey(documentId),
+          buildCollaborationYjsMetaKey(documentId),
+        ],
+      },
+    ],
+  );
+});
+
+test("inactive collaboration cache invalidation preserves cache when active lock exists", async () => {
+  const documentId = "54f00952-2fb9-49d4-8510-086850825c86";
+  const { client, store } = createStore();
+  const stateKey = buildCollaborationYjsStateKey(documentId);
+  const metaKey = buildCollaborationYjsMetaKey(documentId);
+
+  client.values.set(stateKey, Buffer.from("state"));
+  client.values.set(
+    metaKey,
+    JSON.stringify({ draftRevision: 4, bodyHash: "body-hash" }),
+  );
+  client.values.set(buildCollaborationActiveKey(documentId), "room-1");
+
+  await store.invalidateInactiveCache(documentId);
+
+  assert.equal(client.values.has(stateKey), true);
+  assert.equal(client.values.has(metaKey), true);
+  assert.deepEqual(
+    client.calls.filter((call) => call.method === "eval"),
+    [
+      {
+        method: "eval",
+        keys: [stateKey, metaKey, buildCollaborationActiveKey(documentId)],
       },
     ],
   );

--- a/apps/server/src/lib/collaboration/redis-store.test.ts
+++ b/apps/server/src/lib/collaboration/redis-store.test.ts
@@ -250,6 +250,14 @@ test("collaboration Redis key builders match the documented key shape", () => {
     }),
     "mdcms:collaboration:presence:marketing:draft:session-1",
   );
+  assert.equal(
+    buildCollaborationPresenceKey({
+      project: "market:ing",
+      environment: "draft:blue",
+      sessionId: "session:1*",
+    }),
+    "mdcms:collaboration:presence:market%3Aing:draft%3Ablue:session%3A1%2A",
+  );
 });
 
 test("presence writes JSON records with the presence heartbeat TTL", async () => {
@@ -336,6 +344,52 @@ test("presence listing returns valid records only for the requested target", asy
   assert.deepEqual(
     await store.listPresence({ project: "marketing", environment: "draft" }),
     [valid],
+  );
+});
+
+test("presence listing scans the encoded target prefix", async () => {
+  const { client, store } = createStore();
+  const valid = createPresenceRecord({
+    sessionId: "session:1",
+    label: "Ada",
+  });
+  const otherTarget = createPresenceRecord({
+    sessionId: "session:2",
+    label: "Grace",
+  });
+
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "market:ing",
+      environment: "draft:blue",
+      sessionId: valid.sessionId,
+    }),
+    JSON.stringify(valid),
+  );
+  client.values.set(
+    buildCollaborationPresenceKey({
+      project: "market",
+      environment: "ing:draft:blue",
+      sessionId: otherTarget.sessionId,
+    }),
+    JSON.stringify(otherTarget),
+  );
+
+  assert.deepEqual(
+    await store.listPresence({
+      project: "market:ing",
+      environment: "draft:blue",
+    }),
+    [valid],
+  );
+  assert.deepEqual(
+    client.calls.find((call) => call.method === "scan"),
+    {
+      method: "scan",
+      cursor: "0",
+      pattern: "mdcms:collaboration:presence:market%3Aing:draft%3Ablue:*",
+      count: 100,
+    },
   );
 });
 

--- a/apps/server/src/lib/collaboration/redis-store.ts
+++ b/apps/server/src/lib/collaboration/redis-store.ts
@@ -224,6 +224,13 @@ end
 return 0
 `;
 
+const INVALIDATE_INACTIVE_CACHE_SCRIPT = `
+if redis.call("EXISTS", KEYS[3]) == 0 then
+  return redis.call("DEL", KEYS[1], KEYS[2])
+end
+return 0
+`;
+
 function redisBooleanResult(result: unknown): boolean {
   return result === 1 || result === "1";
 }
@@ -408,6 +415,18 @@ export function createCollaborationRedisStore(
       await client.expire(
         buildCollaborationYjsMetaKey(documentId),
         inactiveCacheTtlSeconds,
+      );
+    },
+
+    async invalidateInactiveCache(documentId: string): Promise<void> {
+      const client = requireCollaborationRedisClient(dependency);
+
+      await client.eval(
+        INVALIDATE_INACTIVE_CACHE_SCRIPT,
+        3,
+        buildCollaborationYjsStateKey(documentId),
+        buildCollaborationYjsMetaKey(documentId),
+        buildCollaborationActiveKey(documentId),
       );
     },
 

--- a/apps/server/src/lib/collaboration/redis-store.ts
+++ b/apps/server/src/lib/collaboration/redis-store.ts
@@ -104,12 +104,37 @@ export function buildCollaborationActiveKey(documentId: string): string {
   return `mdcms:collaboration:active:${documentId}`;
 }
 
+function encodeCollaborationRedisKeySegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/\*/g, "%2A");
+}
+
 export function buildCollaborationPresenceKey(input: {
   project: string;
   environment: string;
   sessionId: string;
 }): string {
-  return `mdcms:collaboration:presence:${input.project}:${input.environment}:${input.sessionId}`;
+  return [
+    "mdcms",
+    "collaboration",
+    "presence",
+    encodeCollaborationRedisKeySegment(input.project),
+    encodeCollaborationRedisKeySegment(input.environment),
+    encodeCollaborationRedisKeySegment(input.sessionId),
+  ].join(":");
+}
+
+function buildCollaborationPresenceScanPattern(input: {
+  project: string;
+  environment: string;
+}): string {
+  return [
+    "mdcms",
+    "collaboration",
+    "presence",
+    encodeCollaborationRedisKeySegment(input.project),
+    encodeCollaborationRedisKeySegment(input.environment),
+    "*",
+  ].join(":");
 }
 
 export function createUnavailableCollaborationRedisDependency(
@@ -341,10 +366,7 @@ export function createCollaborationRedisStore(
         throw new Error("Collaboration Redis client does not support SCAN.");
       }
 
-      const pattern = buildCollaborationPresenceKey({
-        ...input,
-        sessionId: "*",
-      });
+      const pattern = buildCollaborationPresenceScanPattern(input);
       const records: CollaborationPresenceUser[] = [];
       let cursor = "0";
 

--- a/apps/server/src/lib/collaboration/redis-store.ts
+++ b/apps/server/src/lib/collaboration/redis-store.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
 
+import {
+  CollaborationPresenceUserSchema,
+  type CollaborationPresenceUser,
+} from "@mdcms/shared";
+
 import { createCollaborationUnavailableError } from "./errors.js";
 
 export const COLLABORATION_INACTIVE_CACHE_TTL_SECONDS = 30 * 60;
 export const COLLABORATION_ACTIVE_LOCK_LEASE_SECONDS = 30;
+export const COLLABORATION_PRESENCE_TTL_SECONDS = 30;
+const COLLABORATION_PRESENCE_SCAN_COUNT = 100;
 
 export type CollaborationYjsMetadata = {
   draftRevision: number;
@@ -23,6 +30,11 @@ export type CollaborationDraftHead = {
 export type FreshCollaborationYjsState = {
   state: Uint8Array;
   metadata: CollaborationYjsMetadata;
+};
+
+type CollaborationPresenceRecordInput = CollaborationPresenceUser & {
+  project: string;
+  environment: string;
 };
 
 export type CollaborationRedisClient = {
@@ -51,6 +63,13 @@ export type CollaborationRedisClient = {
     numberOfKeys: number,
     ...args: string[]
   ): Promise<unknown>;
+  scan?(
+    cursor: string,
+    matchKeyword: "MATCH",
+    pattern: string,
+    countKeyword: "COUNT",
+    count: number,
+  ): Promise<[string, string[]]>;
 };
 
 export type CollaborationRedisUnavailableReason =
@@ -83,6 +102,14 @@ export function buildCollaborationYjsMetaKey(documentId: string): string {
 
 export function buildCollaborationActiveKey(documentId: string): string {
   return `mdcms:collaboration:active:${documentId}`;
+}
+
+export function buildCollaborationPresenceKey(input: {
+  project: string;
+  environment: string;
+  sessionId: string;
+}): string {
+  return `mdcms:collaboration:presence:${input.project}:${input.environment}:${input.sessionId}`;
 }
 
 export function createUnavailableCollaborationRedisDependency(
@@ -152,6 +179,25 @@ function parseYjsMetadata(raw: string | null): CollaborationYjsMetadata | null {
   }
 
   const result = CollaborationYjsMetadataSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+function parsePresenceUser(
+  raw: string | null,
+): CollaborationPresenceUser | null {
+  if (raw === null) {
+    return null;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const result = CollaborationPresenceUserSchema.safeParse(parsed);
   return result.success ? result.data : null;
 }
 
@@ -250,6 +296,75 @@ export function createCollaborationRedisStore(
         buildCollaborationYjsStateKey(documentId),
         buildCollaborationYjsMetaKey(documentId),
       );
+    },
+
+    async setPresence(record: CollaborationPresenceRecordInput): Promise<void> {
+      const client = requireCollaborationRedisClient(dependency);
+      const presenceRecord = CollaborationPresenceUserSchema.parse(record);
+
+      await client.set(
+        buildCollaborationPresenceKey({
+          project: record.project,
+          environment: record.environment,
+          sessionId: record.sessionId,
+        }),
+        JSON.stringify(presenceRecord),
+        "EX",
+        COLLABORATION_PRESENCE_TTL_SECONDS,
+      );
+    },
+
+    async deletePresence(input: {
+      project: string;
+      environment: string;
+      sessionId: string;
+    }): Promise<void> {
+      await requireCollaborationRedisClient(dependency).del(
+        buildCollaborationPresenceKey(input),
+      );
+    },
+
+    async listPresence(input: {
+      project: string;
+      environment: string;
+    }): Promise<CollaborationPresenceUser[]> {
+      const client = requireCollaborationRedisClient(dependency);
+
+      if (!client.scan) {
+        throw new Error("Collaboration Redis client does not support SCAN.");
+      }
+
+      const pattern = buildCollaborationPresenceKey({
+        ...input,
+        sessionId: "*",
+      });
+      const records: CollaborationPresenceUser[] = [];
+      let cursor = "0";
+
+      do {
+        const [nextCursor, keys] = await client.scan(
+          cursor,
+          "MATCH",
+          pattern,
+          "COUNT",
+          COLLABORATION_PRESENCE_SCAN_COUNT,
+        );
+        cursor = nextCursor;
+
+        const rawRecords = await Promise.all(
+          keys.map((key) => client.get(key)),
+        );
+
+        for (const rawRecord of rawRecords) {
+          const record = parsePresenceUser(rawRecord);
+
+          if (record !== null) {
+            records.push(record);
+          }
+        }
+      } while (cursor !== "0");
+
+      return records;
     },
 
     async getFreshYjsState(

--- a/apps/server/src/lib/collaboration/runtime.test.ts
+++ b/apps/server/src/lib/collaboration/runtime.test.ts
@@ -13,6 +13,7 @@ import type {
 import { createUnavailableCollaborationRedisDependency } from "./redis-store.js";
 import {
   computeCollaborationBodyHash,
+  createCollaborationDocumentName,
   createCollaborationRuntime,
   createCollaborationRuntimeHooks,
   encodeYDocState,
@@ -578,6 +579,33 @@ test("onLoadDocument rejects documentName mismatches without mutating authentica
   assert.equal(context.project, "marketing");
   assert.equal(context.environment, "draft");
   assert.equal(context.documentId, DOCUMENT_ID);
+});
+
+test("onLoadDocument accepts encoded documentName route segments", async () => {
+  const document = createDocument({
+    project: "marketing:site",
+    environment: "preview/draft",
+  });
+  const { hooks, redisStore } = createHarness(document);
+  const context = createContext({
+    project: document.project,
+    environment: document.environment,
+  });
+  const documentName = createCollaborationDocumentName({
+    project: document.project,
+    environment: document.environment,
+    documentId: document.documentId,
+  });
+
+  await hooks.onLoadDocument({
+    context,
+    documentName,
+  });
+
+  assert.equal(documentName, `marketing%3Asite:preview%2Fdraft:${DOCUMENT_ID}`);
+  assert.equal(context.project, "marketing:site");
+  assert.equal(context.environment, "preview/draft");
+  assert.equal(redisStore.calls[0]?.documentId, DOCUMENT_ID);
 });
 
 test("onLoadDocument returns Redis cached binary when metadata matches", async () => {

--- a/apps/server/src/lib/collaboration/runtime.test.ts
+++ b/apps/server/src/lib/collaboration/runtime.test.ts
@@ -4,10 +4,11 @@ import { test } from "bun:test";
 import { RuntimeError } from "@mdcms/shared";
 
 import type { CollaborationSessionContext } from "../collaboration-auth.js";
-import type {
-  ContentDocument,
-  ContentLifecycleEventSink,
-  ContentScope,
+import {
+  DEFAULT_ACTOR,
+  type ContentDocument,
+  type ContentLifecycleEventSink,
+  type ContentScope,
 } from "../content-api/types.js";
 
 import { createUnavailableCollaborationRedisDependency } from "./redis-store.js";
@@ -805,7 +806,7 @@ test("onStoreDocument autosaves changed body and frontmatter to PostgreSQL", asy
 
   assert.equal(contentStore.updates.length, 1);
   assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 4);
-  assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-1");
+  assert.equal(contentStore.updates[0]?.payload.updatedBy, DEFAULT_ACTOR);
   assert.match(contentStore.updates[0]?.payload.body ?? "", /# Changed/);
   assert.deepEqual(contentStore.updates[0]?.payload.frontmatter, {
     title: "Changed",
@@ -1210,7 +1211,7 @@ test("last disconnect changed body saves once with expected revision, last write
 
   assert.equal(contentStore.updates.length, 1);
   assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 8);
-  assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-2");
+  assert.equal(contentStore.updates[0]?.payload.updatedBy, DEFAULT_ACTOR);
   assert.match(contentStore.updates[0]?.payload.body ?? "", /# Changed/);
   assert.equal(lifecycleEvents.events.length, 1);
   assert.equal(lifecycleEvents.events[0]?.event, "content.updated");
@@ -1308,7 +1309,7 @@ test("last disconnect attributes a pending debounced edit to its writer", async 
   });
 
   assert.equal(contentStore.updates.length, 1);
-  assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-pending");
+  assert.equal(contentStore.updates[0]?.payload.updatedBy, DEFAULT_ACTOR);
 });
 
 test("last disconnect uses neutral lifecycle email when writer email is unavailable", async () => {

--- a/apps/server/src/lib/collaboration/runtime.test.ts
+++ b/apps/server/src/lib/collaboration/runtime.test.ts
@@ -17,7 +17,9 @@ import {
   createCollaborationRuntimeHooks,
   encodeYDocState,
   markdownToYDoc,
+  yDocToFrontmatter,
   yDocToMarkdown,
+  yjsUpdateToYDoc,
   type CollaborationRuntimeAuthGuard,
   type CollaborationRuntimeContentStore,
   type CollaborationRuntimeContext,
@@ -74,7 +76,11 @@ class FakeContentStore implements CollaborationRuntimeContentStore {
   readonly updates: Array<{
     scope: ContentScope;
     documentId: string;
-    payload: { body?: string; updatedBy?: string };
+    payload: {
+      body?: string;
+      frontmatter?: Record<string, unknown>;
+      updatedBy?: string;
+    };
     options?: { expectedDraftRevision?: number };
   }> = [];
 
@@ -99,7 +105,11 @@ class FakeContentStore implements CollaborationRuntimeContentStore {
   async update(
     scope: ContentScope,
     documentId: string,
-    payload: { body?: string; updatedBy?: string },
+    payload: {
+      body?: string;
+      frontmatter?: Record<string, unknown>;
+      updatedBy?: string;
+    },
     options?: { expectedDraftRevision?: number },
   ): Promise<ContentDocument> {
     this.updates.push({ scope, documentId, payload, options });
@@ -127,6 +137,7 @@ class FakeContentStore implements CollaborationRuntimeContentStore {
     this.document = {
       ...this.document,
       body: payload.body ?? this.document.body,
+      frontmatter: payload.frontmatter ?? this.document.frontmatter,
       draftRevision: this.document.draftRevision + 1,
       updatedBy: payload.updatedBy ?? this.document.updatedBy,
       updatedAt: "2026-06-11T10:01:00.000Z",
@@ -406,6 +417,30 @@ test("createCollaborationRuntime fails with collaboration unavailable when Redis
   );
 });
 
+test("markdownToYDoc stores frontmatter in the collaboration Y.Doc", () => {
+  const frontmatter = {
+    title: "Launch",
+    featured: true,
+    order: 3,
+  };
+
+  const ydoc = markdownToYDoc("# Launch\n\nBody.", frontmatter);
+
+  assert.deepEqual(yDocToFrontmatter(ydoc), frontmatter);
+  assert.equal(yDocToMarkdown(ydoc), "# Launch\n\nBody.");
+});
+
+test("frontmatter Y.Doc helpers snapshot nested values", () => {
+  const frontmatter = { seo: { title: "Original" } };
+  const ydoc = markdownToYDoc("# Launch", frontmatter);
+
+  (frontmatter.seo as { title: string }).title = "Mutated after write";
+  const firstRead = yDocToFrontmatter(ydoc) as { seo: { title: string } };
+  firstRead.seo.title = "Mutated after read";
+
+  assert.deepEqual(yDocToFrontmatter(ydoc), { seo: { title: "Original" } });
+});
+
 test("onLoadDocument falls back to PostgreSQL and seeds Redis when cache is missing", async () => {
   const document = createDocument({
     body: "# Fresh draft\n\nSeed this body.",
@@ -570,6 +605,36 @@ test("onLoadDocument returns Redis cached binary when metadata matches", async (
   );
 });
 
+test("onLoadDocument reconciles cached Yjs frontmatter with PostgreSQL draft", async () => {
+  const document = createDocument({
+    body: "# Cached draft",
+    draftRevision: 12,
+    frontmatter: { title: "Current" },
+  });
+  const { hooks, contentStore, redisStore } = createHarness(document);
+  redisStore.state = encodeYDocState(markdownToYDoc(document.body, {}));
+  redisStore.metadata = {
+    draftRevision: 12,
+    bodyHash: computeCollaborationBodyHash(document.body),
+  };
+  const context = createContext();
+
+  const loaded = await hooks.onLoadDocument({
+    context,
+    documentName: DOCUMENT_ID,
+  });
+  const loadedDocument = yjsUpdateToYDoc(loaded);
+
+  await hooks.onStoreDocument({
+    document: loadedDocument,
+    documentName: DOCUMENT_ID,
+    lastContext: context,
+  });
+
+  assert.equal(contentStore.updates.length, 0);
+  assert.deepEqual(yDocToFrontmatter(loadedDocument), { title: "Current" });
+});
+
 test("onLoadDocument active lock conflict does not overwrite Redis cache", async () => {
   const { hooks, redisStore } = createHarness(
     createDocument({ body: "# Conflicting draft", draftRevision: 6 }),
@@ -655,15 +720,17 @@ test("beforeHandleMessage rejects revoked sessions and lost write permission wit
   }
 });
 
-test("onStoreDocument writes Redis state and metadata only", async () => {
-  const document = createDocument({ body: "# Stored", draftRevision: 4 });
-  const { hooks, contentStore, redisStore } = createHarness(document);
-  const context = createContext({
-    loadedDraftRevision: 4,
-    loadedBodyHash: computeCollaborationBodyHash(document.body),
-    roomLeaseValue: "lease-1",
+test("onStoreDocument writes Redis state without PostgreSQL update when unchanged", async () => {
+  const document = createDocument({
+    body: "# Stored\n\nSame body.",
+    draftRevision: 4,
+    frontmatter: { title: "Stored" },
   });
-  const ydoc = markdownToYDoc("# Stored\n\nChanged in Yjs.");
+  const { hooks, contentStore, redisStore } = createHarness(document);
+  const context = createContext();
+  const ydoc = markdownToYDoc(document.body, document.frontmatter);
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
 
   await hooks.onStoreDocument({
     document: ydoc,
@@ -678,6 +745,142 @@ test("onStoreDocument writes Redis state and metadata only", async () => {
     bodyHash: computeCollaborationBodyHash(document.body),
   });
   assert.equal(contentStore.document.body, document.body);
+});
+
+test("onStoreDocument autosaves changed body and frontmatter to PostgreSQL", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 4,
+    frontmatter: { title: "Original", featured: false },
+  });
+  const { hooks, contentStore, lifecycleEvents, redisStore } =
+    createHarness(document);
+  const context = createContext();
+  const ydoc = markdownToYDoc("# Changed\n\nBody.", {
+    title: "Changed",
+    featured: true,
+  });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  await hooks.onStoreDocument({
+    document: ydoc,
+    documentName: DOCUMENT_ID,
+    lastContext: createContext({
+      userId: "writer-1",
+      userEmail: "writer-1@example.com",
+      loadedDraftRevision: context.loadedDraftRevision,
+      loadedBodyHash: context.loadedBodyHash,
+      loadedFrontmatterHash: context.loadedFrontmatterHash,
+      roomLeaseValue: context.roomLeaseValue,
+    }),
+  });
+
+  assert.equal(contentStore.updates.length, 1);
+  assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 4);
+  assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-1");
+  assert.match(contentStore.updates[0]?.payload.body ?? "", /# Changed/);
+  assert.deepEqual(contentStore.updates[0]?.payload.frontmatter, {
+    title: "Changed",
+    featured: true,
+  });
+  assert.equal(contentStore.document.draftRevision, 5);
+  assert.deepEqual(redisStore.metadata, {
+    draftRevision: 5,
+    bodyHash: computeCollaborationBodyHash(contentStore.document.body),
+  });
+  assert.equal(lifecycleEvents.events.length, 1);
+  assert.equal(lifecycleEvents.events[0]?.event, "content.updated");
+  assert.equal(lifecycleEvents.events[0]?.actor.id, "writer-1");
+});
+
+test("active autosave failure does not publish unsaved Yjs state to Redis", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 4,
+    frontmatter: { title: "Original" },
+  });
+  const { hooks, contentStore, redisStore } = createHarness(document);
+  const context = createContext();
+  const changed = markdownToYDoc("# Changed\n\nBody.", { title: "Changed" });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  const cachedState = redisStore.state;
+  const cachedMetadata = redisStore.metadata;
+  assert.ok(cachedState);
+  assert.ok(cachedMetadata);
+  const updateError = new Error("database unavailable");
+  contentStore.updateError = updateError;
+
+  await assert.rejects(
+    hooks.onStoreDocument({
+      document: changed,
+      documentName: DOCUMENT_ID,
+      lastContext: createContext({
+        userId: "writer-failed",
+        loadedDraftRevision: context.loadedDraftRevision,
+        loadedBodyHash: context.loadedBodyHash,
+        loadedFrontmatterHash: context.loadedFrontmatterHash,
+        roomLeaseValue: context.roomLeaseValue,
+      }),
+    }),
+    updateError,
+  );
+
+  assert.deepEqual(redisStore.state, cachedState);
+  assert.deepEqual(redisStore.metadata, cachedMetadata);
+  assert.equal(
+    redisStore.calls.some((call) => call.method === "finalizeInactiveRoom"),
+    false,
+  );
+});
+
+test("active autosave stale draft revision fails closed without overwriting PostgreSQL", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 3,
+  });
+  const { hooks, contentStore, redisStore, closedRooms } =
+    createHarness(document);
+  const context = createContext();
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  contentStore.document = {
+    ...contentStore.document,
+    body: "# External change",
+    draftRevision: 4,
+  };
+
+  await assert.rejects(
+    hooks.onStoreDocument({
+      document: markdownToYDoc("# Collaboration change"),
+      documentName: DOCUMENT_ID,
+      lastContext: createContext({
+        loadedDraftRevision: context.loadedDraftRevision,
+        loadedBodyHash: context.loadedBodyHash,
+        loadedFrontmatterHash: context.loadedFrontmatterHash,
+        roomLeaseValue: context.roomLeaseValue,
+      }),
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeError && error.code === "STALE_DRAFT_REVISION",
+  );
+
+  assert.equal(contentStore.document.body, "# External change");
+  assert.equal(
+    redisStore.calls.some((call) => call.method === "finalizeInactiveRoom"),
+    false,
+  );
+  assert.deepEqual(closedRooms, [DOCUMENT_ID]);
+
+  await assert.rejects(
+    hooks.beforeHandleMessage({
+      context,
+      documentName: DOCUMENT_ID,
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeError &&
+      error.code === "COLLABORATION_ACTIVE_LOCK_LOST",
+  );
 });
 
 test("onStoreDocument fails closed before cache writes when active lock is lost", async () => {
@@ -989,6 +1192,67 @@ test("last disconnect changed body saves once with expected revision, last write
     draftRevision: 9,
     bodyHash: computeCollaborationBodyHash(contentStore.document.body),
   });
+});
+
+test("last disconnect after active autosave does not increment draft revision again", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 8,
+    frontmatter: { title: "Original" },
+  });
+  const { hooks, contentStore, lifecycleEvents } = createHarness(document);
+  const context = createContext();
+  const changed = markdownToYDoc("# Changed\n\nBody.", { title: "Changed" });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  await hooks.onStoreDocument({
+    document: changed,
+    documentName: DOCUMENT_ID,
+    lastContext: createContext({
+      userId: "writer-2",
+      loadedDraftRevision: context.loadedDraftRevision,
+      loadedBodyHash: context.loadedBodyHash,
+      loadedFrontmatterHash: context.loadedFrontmatterHash,
+      roomLeaseValue: context.roomLeaseValue,
+    }),
+  });
+  await hooks.onDisconnect({
+    clientsCount: 0,
+    context,
+    document: changed,
+    documentName: DOCUMENT_ID,
+  });
+
+  assert.equal(contentStore.updates.length, 1);
+  assert.equal(contentStore.document.draftRevision, 9);
+  assert.equal(lifecycleEvents.events.length, 1);
+});
+
+test("last disconnect persists frontmatter-only changes when autosave has not run", async () => {
+  const document = createDocument({
+    body: "# Original\n\nBody.",
+    draftRevision: 9,
+    frontmatter: { title: "Original" },
+  });
+  const { hooks, contentStore, lifecycleEvents } = createHarness(document);
+  const context = createContext();
+  const changed = markdownToYDoc(document.body, { title: "Changed" });
+
+  await hooks.onLoadDocument({ context, documentName: DOCUMENT_ID });
+  await hooks.onDisconnect({
+    clientsCount: 0,
+    context,
+    document: changed,
+    documentName: DOCUMENT_ID,
+  });
+
+  assert.equal(contentStore.updates.length, 1);
+  assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 9);
+  assert.deepEqual(contentStore.updates[0]?.payload.frontmatter, {
+    title: "Changed",
+  });
+  assert.equal(contentStore.document.draftRevision, 10);
+  assert.equal(lifecycleEvents.events.length, 1);
 });
 
 test("last disconnect attributes a pending debounced edit to its writer", async () => {

--- a/apps/server/src/lib/collaboration/runtime.ts
+++ b/apps/server/src/lib/collaboration/runtime.ts
@@ -14,10 +14,11 @@ import type {
   CollaborationCloseCode,
   CollaborationSessionContext,
 } from "../collaboration-auth.js";
-import type {
-  ContentDocument,
-  ContentLifecycleEventSink,
-  ContentScope,
+import {
+  DEFAULT_ACTOR,
+  type ContentDocument,
+  type ContentLifecycleEventSink,
+  type ContentScope,
 } from "../content-api/types.js";
 
 import {
@@ -42,6 +43,8 @@ export const COLLABORATION_FINALIZED_ROOM_LEASE_TTL_MS =
   COLLABORATION_INACTIVE_CACHE_TTL_SECONDS * 1000;
 export const COLLABORATION_YJS_FIELD_NAME = "default";
 export const COLLABORATION_FRONTMATTER_FIELD_NAME = "frontmatter";
+const POSTGRES_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export type CollaborationDocumentFlushResult = {
   status: "saved" | "unchanged";
@@ -646,6 +649,12 @@ function createLifecycleActor(writer: CollaborationRuntimeLastWriter): {
   };
 }
 
+function toContentStoreActorId(userId: string): string {
+  const normalized = userId.trim();
+
+  return POSTGRES_UUID_PATTERN.test(normalized) ? normalized : DEFAULT_ACTOR;
+}
+
 function createActiveLockLostError(documentId: string): RuntimeError {
   return new RuntimeError({
     code: "COLLABORATION_ACTIVE_LOCK_LOST",
@@ -928,7 +937,7 @@ export function createCollaborationRuntimeHooks(
       {
         body: nextBody,
         frontmatter: nextFrontmatter,
-        updatedBy: input.writer.userId,
+        updatedBy: toContentStoreActorId(input.writer.userId),
       },
       { expectedDraftRevision },
     );

--- a/apps/server/src/lib/collaboration/runtime.ts
+++ b/apps/server/src/lib/collaboration/runtime.ts
@@ -41,6 +41,7 @@ export const COLLABORATION_ACTIVE_LOCK_HEARTBEAT_INTERVAL_MS = Math.floor(
 export const COLLABORATION_FINALIZED_ROOM_LEASE_TTL_MS =
   COLLABORATION_INACTIVE_CACHE_TTL_SECONDS * 1000;
 export const COLLABORATION_YJS_FIELD_NAME = "default";
+export const COLLABORATION_FRONTMATTER_FIELD_NAME = "frontmatter";
 
 export type CollaborationRuntimeLastWriter = {
   userId: string;
@@ -52,6 +53,8 @@ export type CollaborationRuntimeContext = CollaborationSessionContext & {
   loadedDraftRevision?: number;
   loadedBodyHash?: string;
   loadedCanonicalBody?: string;
+  loadedFrontmatterHash?: string;
+  loadedCanonicalFrontmatter?: Record<string, unknown>;
   roomLeaseValue?: string;
   lastWriter?: CollaborationRuntimeLastWriter;
   request?: Request;
@@ -73,7 +76,11 @@ export type CollaborationRuntimeContentStore = {
   update: (
     scope: ContentScope,
     documentId: string,
-    payload: { body: string; updatedBy: string },
+    payload: {
+      body: string;
+      frontmatter: Record<string, unknown>;
+      updatedBy: string;
+    },
     options?: { expectedDraftRevision?: number },
   ) => Promise<ContentDocument>;
 };
@@ -113,6 +120,8 @@ type RoomState = {
   loadedDraftRevision: number;
   loadedBodyHash: string;
   loadedCanonicalBody: string;
+  loadedFrontmatterHash: string;
+  loadedCanonicalFrontmatter: Record<string, unknown>;
   roomLeaseValue: string;
   lastWriter?: CollaborationRuntimeLastWriter;
   activeLockHeartbeatInFlight?: boolean;
@@ -145,7 +154,10 @@ export type CreateCollaborationRuntimeHooksOptions = {
   clearFinalizedRoomLeaseTimeout?: (timer: unknown) => void;
   closeRoom?: (documentName: string) => Promise<void> | void;
   createRoomLeaseValue?: () => string;
-  convertMarkdownToYjsUpdate?: (markdown: string) => Uint8Array;
+  convertMarkdownToYjsUpdate?: (
+    markdown: string,
+    frontmatter?: Record<string, unknown>,
+  ) => Uint8Array;
 };
 
 export type CreateCollaborationRuntimeOptions = Omit<
@@ -182,6 +194,30 @@ export function computeCollaborationBodyHash(body: string): string {
   return `sha256:${createHash("sha256").update(body, "utf8").digest("hex")}`;
 }
 
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${stableJson(
+            (value as Record<string, unknown>)[key],
+          )}`,
+      )
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function computeFrontmatterHash(frontmatter: Record<string, unknown>): string {
+  return `sha256:${createHash("sha256").update(stableJson(frontmatter), "utf8").digest("hex")}`;
+}
+
 export function encodeYDocState(document: Y.Doc): Uint8Array {
   return Y.encodeStateAsUpdate(document);
 }
@@ -192,17 +228,54 @@ export function yjsUpdateToYDoc(update: Uint8Array): Y.Doc {
   return document;
 }
 
-export function markdownToYDoc(markdown: string): Y.Doc {
+function cloneJsonObject(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+export function writeFrontmatterToYDoc(
+  document: Y.Doc,
+  frontmatter: Record<string, unknown>,
+): void {
+  const frontmatterSnapshot = cloneJsonObject(frontmatter);
+  const frontmatterMap = document.getMap<unknown>(
+    COLLABORATION_FRONTMATTER_FIELD_NAME,
+  );
+  frontmatterMap.clear();
+
+  for (const [fieldName, value] of Object.entries(frontmatterSnapshot)) {
+    frontmatterMap.set(fieldName, value);
+  }
+}
+
+export function yDocToFrontmatter(document: Y.Doc): Record<string, unknown> {
+  return cloneJsonObject(
+    Object.fromEntries(
+      document.getMap<unknown>(COLLABORATION_FRONTMATTER_FIELD_NAME).entries(),
+    ),
+  );
+}
+
+export function markdownToYDoc(
+  markdown: string,
+  frontmatter: Record<string, unknown> = {},
+): Y.Doc {
   const tiptapDocument = parseMarkdownToDocument(markdown);
-  return TiptapTransformer.toYdoc(
+  const document = TiptapTransformer.toYdoc(
     tiptapDocument,
     COLLABORATION_YJS_FIELD_NAME,
     createEditorCoreExtensions(),
   );
+  writeFrontmatterToYDoc(document, frontmatter);
+  return document;
 }
 
-export function markdownToYjsUpdate(markdown: string): Uint8Array {
-  return encodeYDocState(markdownToYDoc(markdown));
+export function markdownToYjsUpdate(
+  markdown: string,
+  frontmatter: Record<string, unknown> = {},
+): Uint8Array {
+  return encodeYDocState(markdownToYDoc(markdown, frontmatter));
 }
 
 export function yDocToMarkdown(document: Y.Doc): string {
@@ -360,6 +433,10 @@ function assignLoadedRoomState(
   context.loadedDraftRevision = state.loadedDraftRevision;
   context.loadedBodyHash = state.loadedBodyHash;
   context.loadedCanonicalBody = state.loadedCanonicalBody;
+  context.loadedFrontmatterHash = state.loadedFrontmatterHash;
+  context.loadedCanonicalFrontmatter = cloneJsonObject(
+    state.loadedCanonicalFrontmatter,
+  );
   context.roomLeaseValue = state.roomLeaseValue;
   context.lastWriter = state.lastWriter;
 }
@@ -470,31 +547,6 @@ function assertActiveLockHeld(state: RoomState | undefined): void {
   if (state?.activeLockLost) {
     throw createActiveLockLostError(state.documentId);
   }
-}
-
-function metadataFromContextOrState(
-  context: CollaborationRuntimeContext,
-  state?: RoomState,
-): CollaborationYjsMetadata {
-  const draftRevision =
-    state?.loadedDraftRevision ?? context.loadedDraftRevision;
-  const bodyHash = state?.loadedBodyHash ?? context.loadedBodyHash;
-
-  if (typeof draftRevision !== "number" || typeof bodyHash !== "string") {
-    throw new RuntimeError({
-      code: "INVALID_COLLABORATION_CONTEXT",
-      message: "Collaboration room is missing loaded draft metadata.",
-      statusCode: 500,
-      details: {
-        documentId: context.documentId,
-      },
-    });
-  }
-
-  return {
-    draftRevision,
-    bodyHash,
-  };
 }
 
 export function createCollaborationRuntimeHooks(
@@ -679,6 +731,135 @@ export function createCollaborationRuntimeHooks(
     throw createActiveLockLostError(input.documentId);
   }
 
+  async function persistRoomDraft(input: {
+    context: CollaborationRuntimeContext;
+    document: Y.Doc;
+    key: string;
+    state: RoomState | undefined;
+    writer: CollaborationRuntimeLastWriter;
+  }): Promise<CollaborationYjsMetadata> {
+    const nextBody = yDocToMarkdown(input.document);
+    const nextFrontmatter = yDocToFrontmatter(input.document);
+    const loadedCanonicalBody =
+      input.state?.loadedCanonicalBody ?? input.context.loadedCanonicalBody;
+    const loadedFrontmatterHash =
+      input.state?.loadedFrontmatterHash ?? input.context.loadedFrontmatterHash;
+
+    if (typeof loadedCanonicalBody !== "string") {
+      throw new RuntimeError({
+        code: "INVALID_COLLABORATION_CONTEXT",
+        message: "Collaboration room is missing loaded canonical body.",
+        statusCode: 500,
+        details: {
+          documentId: input.context.documentId,
+        },
+      });
+    }
+
+    if (typeof loadedFrontmatterHash !== "string") {
+      throw new RuntimeError({
+        code: "INVALID_COLLABORATION_CONTEXT",
+        message: "Collaboration room is missing loaded frontmatter metadata.",
+        statusCode: 500,
+        details: {
+          documentId: input.context.documentId,
+        },
+      });
+    }
+
+    const nextFrontmatterHash = computeFrontmatterHash(nextFrontmatter);
+    const bodyChanged = nextBody !== loadedCanonicalBody;
+    const frontmatterChanged = nextFrontmatterHash !== loadedFrontmatterHash;
+
+    if (!bodyChanged && !frontmatterChanged) {
+      const loadedDraftRevision =
+        input.state?.loadedDraftRevision ?? input.context.loadedDraftRevision;
+      const loadedBodyHash =
+        input.state?.loadedBodyHash ?? input.context.loadedBodyHash;
+
+      if (
+        typeof loadedDraftRevision !== "number" ||
+        typeof loadedBodyHash !== "string"
+      ) {
+        throw new RuntimeError({
+          code: "INVALID_COLLABORATION_CONTEXT",
+          message: "Collaboration room is missing loaded draft metadata.",
+          statusCode: 500,
+          details: {
+            documentId: input.context.documentId,
+          },
+        });
+      }
+
+      return { draftRevision: loadedDraftRevision, bodyHash: loadedBodyHash };
+    }
+
+    const expectedDraftRevision =
+      input.state?.loadedDraftRevision ?? input.context.loadedDraftRevision;
+
+    if (typeof expectedDraftRevision !== "number") {
+      throw new RuntimeError({
+        code: "INVALID_COLLABORATION_CONTEXT",
+        message: "Collaboration autosave is missing expected draft revision.",
+        statusCode: 500,
+        details: {
+          documentId: input.context.documentId,
+        },
+      });
+    }
+
+    const updated = await options.contentStore.update(
+      scopeFromContext(input.context),
+      input.context.documentId,
+      {
+        body: nextBody,
+        frontmatter: nextFrontmatter,
+        updatedBy: input.writer.userId,
+      },
+      { expectedDraftRevision },
+    );
+
+    const metadata = {
+      draftRevision: updated.draftRevision,
+      bodyHash: computeCollaborationBodyHash(updated.body),
+    };
+    const loadedCanonicalFrontmatter = cloneJsonObject(updated.frontmatter);
+    const updatedFrontmatterHash = computeFrontmatterHash(updated.frontmatter);
+
+    if (input.state) {
+      input.state.loadedDraftRevision = updated.draftRevision;
+      input.state.loadedBodyHash = metadata.bodyHash;
+      input.state.loadedCanonicalBody = nextBody;
+      input.state.loadedFrontmatterHash = updatedFrontmatterHash;
+      input.state.loadedCanonicalFrontmatter = loadedCanonicalFrontmatter;
+      input.state.lastWriter = input.writer;
+    }
+
+    assignLoadedRoomState(
+      input.context,
+      input.state ?? {
+        documentId: input.context.documentId,
+        documentName: input.key,
+        loadedDraftRevision: updated.draftRevision,
+        loadedBodyHash: metadata.bodyHash,
+        loadedCanonicalBody: nextBody,
+        loadedFrontmatterHash: updatedFrontmatterHash,
+        loadedCanonicalFrontmatter,
+        roomLeaseValue: input.context.roomLeaseValue ?? "",
+        lastWriter: input.writer,
+      },
+    );
+
+    await options.lifecycleEvents?.emitContentEvent({
+      event: "content.updated",
+      scope: scopeFromContext(input.context),
+      document: updated,
+      actor: createLifecycleActor(input.writer),
+    });
+
+    return metadata;
+  }
+
   return {
     async onLoadDocument(payload: RuntimeHookPayload): Promise<Uint8Array> {
       const context = requireRuntimeContext(payload);
@@ -693,8 +874,18 @@ export function createCollaborationRuntimeHooks(
         draftHead,
       );
 
-      const state = cached?.state ?? convertMarkdownToYjsUpdate(draft.body);
+      const sourceState =
+        cached?.state ??
+        convertMarkdownToYjsUpdate(draft.body, draft.frontmatter);
+      const sourceDocument = yjsUpdateToYDoc(sourceState);
+      const draftFrontmatterHash = computeFrontmatterHash(draft.frontmatter);
+      const frontmatterReconciled =
+        computeFrontmatterHash(yDocToFrontmatter(sourceDocument)) !==
+        draftFrontmatterHash;
+      writeFrontmatterToYDoc(sourceDocument, draft.frontmatter);
+      const state = encodeYDocState(sourceDocument);
       const loadedCanonicalBody = canonicalizeMarkdownUpdate(state);
+      const loadedCanonicalFrontmatter = cloneJsonObject(draft.frontmatter);
 
       const roomLeaseValue = createRoomLeaseValue();
       const acquired = await options.redisStore.acquireActiveLock(
@@ -712,12 +903,14 @@ export function createCollaborationRuntimeHooks(
         loadedDraftRevision: draftHead.draftRevision,
         loadedBodyHash: draftHead.bodyHash,
         loadedCanonicalBody,
+        loadedFrontmatterHash: draftFrontmatterHash,
+        loadedCanonicalFrontmatter,
         roomLeaseValue,
       };
       const key = roomKey(context);
 
       try {
-        if (!cached) {
+        if (!cached || frontmatterReconciled) {
           await options.redisStore.setYjsState(context.documentId, state);
           await options.redisStore.setYjsMetadata(
             context.documentId,
@@ -829,7 +1022,6 @@ export function createCollaborationRuntimeHooks(
         throw createCloseEvent(result.closeCode);
       }
 
-      const metadata = metadataFromContextOrState(context, state);
       const document = payload.document;
 
       if (!document) {
@@ -853,6 +1045,29 @@ export function createCollaborationRuntimeHooks(
           leaseValue,
           state,
         });
+      }
+
+      const writer = state?.lastWriter ??
+        context.lastWriter ?? {
+          userId: context.userId,
+          ...(context.userEmail ? { email: context.userEmail } : {}),
+        };
+      let metadata: CollaborationYjsMetadata;
+
+      try {
+        metadata = await persistRoomDraft({
+          context,
+          document,
+          key,
+          state,
+          writer,
+        });
+      } catch (error) {
+        if (state) {
+          await markActiveLockLost(key, state);
+        }
+
+        throw error;
       }
 
       await options.redisStore.setYjsState(
@@ -900,20 +1115,6 @@ export function createCollaborationRuntimeHooks(
 
       try {
         const nextState = encodeYDocState(document);
-        const nextBody = yDocToMarkdown(document);
-        const loadedCanonicalBody =
-          state?.loadedCanonicalBody ?? context.loadedCanonicalBody;
-
-        if (typeof loadedCanonicalBody !== "string") {
-          throw new RuntimeError({
-            code: "INVALID_COLLABORATION_CONTEXT",
-            message: "Collaboration room is missing loaded canonical body.",
-            statusCode: 500,
-            details: {
-              documentId: context.documentId,
-            },
-          });
-        }
 
         await verifyActiveLockOwnership({
           documentId: context.documentId,
@@ -923,58 +1124,18 @@ export function createCollaborationRuntimeHooks(
           state,
         });
 
-        const currentDraft = await loadDraftDocument(
-          options.contentStore,
-          context,
-        );
-        let metadata: CollaborationYjsMetadata = {
-          draftRevision: currentDraft.draftRevision,
-          bodyHash: computeCollaborationBodyHash(currentDraft.body),
-        };
-
-        if (nextBody !== loadedCanonicalBody) {
-          const writer = state?.lastWriter ??
-            context.lastWriter ?? {
-              userId: context.userId,
-              ...(context.userEmail ? { email: context.userEmail } : {}),
-            };
-          const expectedDraftRevision =
-            state?.loadedDraftRevision ?? context.loadedDraftRevision;
-
-          if (typeof expectedDraftRevision !== "number") {
-            throw new RuntimeError({
-              code: "INVALID_COLLABORATION_CONTEXT",
-              message:
-                "Collaboration final save is missing expected draft revision.",
-              statusCode: 500,
-              details: {
-                documentId: context.documentId,
-              },
-            });
-          }
-
-          const updated = await options.contentStore.update(
-            scopeFromContext(context),
-            context.documentId,
-            {
-              body: nextBody,
-              updatedBy: writer.userId,
-            },
-            { expectedDraftRevision },
-          );
-
-          metadata = {
-            draftRevision: updated.draftRevision,
-            bodyHash: computeCollaborationBodyHash(updated.body),
+        const writer = state?.lastWriter ??
+          context.lastWriter ?? {
+            userId: context.userId,
+            ...(context.userEmail ? { email: context.userEmail } : {}),
           };
-
-          await options.lifecycleEvents?.emitContentEvent({
-            event: "content.updated",
-            scope: scopeFromContext(context),
-            document: updated,
-            actor: createLifecycleActor(writer),
-          });
-        }
+        const metadata = await persistRoomDraft({
+          context,
+          document,
+          key,
+          state,
+          writer,
+        });
 
         await options.redisStore.setYjsState(context.documentId, nextState);
         await options.redisStore.setYjsMetadata(context.documentId, metadata);

--- a/apps/server/src/lib/collaboration/runtime.ts
+++ b/apps/server/src/lib/collaboration/runtime.ts
@@ -374,7 +374,19 @@ export function createCollaborationDocumentName(input: {
   environment: string;
   documentId: string;
 }): string {
-  return `${input.project}:${input.environment}:${input.documentId}`;
+  return [input.project, input.environment, input.documentId]
+    .map((segment) => encodeURIComponent(segment))
+    .join(":");
+}
+
+function decodeCollaborationDocumentNameSegment(
+  segment: string,
+): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
 }
 
 function parseCollaborationDocumentName(
@@ -384,19 +396,47 @@ function parseCollaborationDocumentName(
 > {
   const colonParts = documentName.split(":");
   if (colonParts.length === 3) {
+    const project = decodeCollaborationDocumentNameSegment(colonParts[0] ?? "");
+    const environment = decodeCollaborationDocumentNameSegment(
+      colonParts[1] ?? "",
+    );
+    const documentId = decodeCollaborationDocumentNameSegment(
+      colonParts[2] ?? "",
+    );
+
+    if (!project || !environment || !documentId) {
+      return {
+        documentId: documentName,
+      };
+    }
+
     return {
-      project: colonParts[0],
-      environment: colonParts[1],
-      documentId: colonParts[2],
+      project,
+      environment,
+      documentId,
     };
   }
 
   const slashParts = documentName.split("/");
   if (slashParts.length === 3) {
+    const project = decodeCollaborationDocumentNameSegment(slashParts[0] ?? "");
+    const environment = decodeCollaborationDocumentNameSegment(
+      slashParts[1] ?? "",
+    );
+    const documentId = decodeCollaborationDocumentNameSegment(
+      slashParts[2] ?? "",
+    );
+
+    if (!project || !environment || !documentId) {
+      return {
+        documentId: documentName,
+      };
+    }
+
     return {
-      project: slashParts[0],
-      environment: slashParts[1],
-      documentId: slashParts[2],
+      project,
+      environment,
+      documentId,
     };
   }
 

--- a/apps/server/src/lib/collaboration/runtime.ts
+++ b/apps/server/src/lib/collaboration/runtime.ts
@@ -43,6 +43,11 @@ export const COLLABORATION_FINALIZED_ROOM_LEASE_TTL_MS =
 export const COLLABORATION_YJS_FIELD_NAME = "default";
 export const COLLABORATION_FRONTMATTER_FIELD_NAME = "frontmatter";
 
+export type CollaborationDocumentFlushResult = {
+  status: "saved" | "unchanged";
+  draftRevision: number;
+};
+
 export type CollaborationRuntimeLastWriter = {
   userId: string;
   email?: string;
@@ -175,7 +180,11 @@ export type CollaborationRuntimeHooks = ReturnType<
 export type CollaborationRuntime = {
   config: Partial<Configuration<CollaborationRuntimeContext>>;
   hooks: CollaborationRuntimeHooks;
-  server: Hocuspocus<CollaborationRuntimeContext>;
+  server: Hocuspocus<CollaborationRuntimeContext> & {
+    flushDocument?: (
+      documentName: string,
+    ) => Promise<CollaborationDocumentFlushResult>;
+  };
 };
 
 type RuntimeHookPayload = {
@@ -189,6 +198,71 @@ type RuntimeHookPayload = {
   requestParameters?: URLSearchParams;
   lastContext?: CollaborationRuntimeContext;
 };
+
+type CollaborationStoreDebouncer = {
+  isDebounced?: (id: string) => boolean;
+  isCurrentlyExecuting?: (id: string) => boolean;
+  executeNow?: (id: string) => Promise<unknown> | unknown;
+};
+
+type FlushableHocuspocusServer = Hocuspocus<CollaborationRuntimeContext> & {
+  debouncer?: CollaborationStoreDebouncer;
+  flushDocument?: (
+    documentName: string,
+  ) => Promise<CollaborationDocumentFlushResult>;
+};
+
+const COLLABORATION_FLUSH_POLL_INTERVAL_MS = 10;
+const COLLABORATION_FLUSH_SETTLE_TIMEOUT_MS = 2000;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForStoreDebounceToSettle(
+  debouncer: CollaborationStoreDebouncer | undefined,
+  debounceId: string,
+): Promise<void> {
+  if (!debouncer) {
+    return;
+  }
+
+  const startedAt = Date.now();
+
+  while (
+    debouncer.isDebounced?.(debounceId) ||
+    debouncer.isCurrentlyExecuting?.(debounceId)
+  ) {
+    if (Date.now() - startedAt > COLLABORATION_FLUSH_SETTLE_TIMEOUT_MS) {
+      throw new RuntimeError({
+        code: "COLLABORATION_FLUSH_TIMEOUT",
+        message: "Timed out waiting for collaboration flush to finish.",
+        statusCode: 503,
+      });
+    }
+
+    await sleep(COLLABORATION_FLUSH_POLL_INTERVAL_MS);
+  }
+}
+
+async function flushPendingStoreForDocument(
+  server: FlushableHocuspocusServer,
+  documentName: string,
+): Promise<void> {
+  const debounceId = `onStoreDocument-${documentName}`;
+  const debouncer = server.debouncer;
+
+  // Hocuspocus exposes flushPendingStores(), but that public method does not
+  // return the async store-hook promise. The debouncer is used here only to
+  // await the specific document flush that Hocuspocus already schedules.
+  if (debouncer?.isDebounced?.(debounceId)) {
+    await debouncer.executeNow?.(debounceId);
+  } else {
+    server.flushPendingStores();
+  }
+
+  await waitForStoreDebounceToSettle(debouncer, debounceId);
+}
 
 export function computeCollaborationBodyHash(body: string): string {
   return `sha256:${createHash("sha256").update(body, "utf8").digest("hex")}`;
@@ -861,6 +935,25 @@ export function createCollaborationRuntimeHooks(
   }
 
   return {
+    getDocumentFlushState(documentName: string): { draftRevision: number } {
+      const state = roomStates.get(documentName);
+
+      if (!state) {
+        throw new RuntimeError({
+          code: "COLLABORATION_ROOM_NOT_LOADED",
+          message: "Collaboration room is not loaded.",
+          statusCode: 409,
+          details: { documentName },
+        });
+      }
+
+      assertActiveLockHeld(state);
+
+      return {
+        draftRevision: state.loadedDraftRevision,
+      };
+    },
+
     async onLoadDocument(payload: RuntimeHookPayload): Promise<Uint8Array> {
       const context = requireRuntimeContext(payload);
       const draft = await loadDraftDocument(options.contentStore, context);
@@ -1173,7 +1266,7 @@ export function createCollaborationRuntime(
   options: CreateCollaborationRuntimeOptions,
 ): CollaborationRuntime {
   const redisStore = resolveRedisStore(options);
-  let server: Hocuspocus<CollaborationRuntimeContext> | undefined;
+  let server: FlushableHocuspocusServer | undefined;
   const hooks = createCollaborationRuntimeHooks({
     ...options,
     redisStore,
@@ -1196,10 +1289,27 @@ export function createCollaborationRuntime(
     onStoreDocument: hooks.onStoreDocument,
     onDisconnect: hooks.onDisconnect,
   };
+  const hocuspocusServer = new Hocuspocus<CollaborationRuntimeContext>(
+    config,
+  ) as FlushableHocuspocusServer;
+
+  hocuspocusServer.flushDocument = async (documentName) => {
+    const before = hooks.getDocumentFlushState(documentName).draftRevision;
+
+    await flushPendingStoreForDocument(hocuspocusServer, documentName);
+
+    const after = hooks.getDocumentFlushState(documentName).draftRevision;
+
+    return {
+      status: after > before ? "saved" : "unchanged",
+      draftRevision: after,
+    };
+  };
+  server = hocuspocusServer;
 
   return {
     config,
     hooks,
-    server: (server = new Hocuspocus<CollaborationRuntimeContext>(config)),
+    server,
   };
 }

--- a/apps/server/src/lib/collaboration/transport.integration.test.ts
+++ b/apps/server/src/lib/collaboration/transport.integration.test.ts
@@ -16,7 +16,11 @@ import type {
   CollaborationPresenceContext,
   CollaborationSessionContext,
 } from "../collaboration-auth.js";
-import type { ContentDocument, ContentScope } from "../content-api/types.js";
+import {
+  DEFAULT_ACTOR,
+  type ContentDocument,
+  type ContentScope,
+} from "../content-api/types.js";
 
 import {
   COLLABORATION_INACTIVE_CACHE_TTL_SECONDS,
@@ -610,7 +614,7 @@ test("Bun collaboration sockets sync Yjs updates and finalize the document room 
     );
 
     assert.match(contentStore.updates[0]?.payload.body ?? "", /Updated from A/);
-    assert.equal(contentStore.updates[0]?.payload.updatedBy, "writer-1");
+    assert.equal(contentStore.updates[0]?.payload.updatedBy, DEFAULT_ACTOR);
     assert.equal(contentStore.updates[0]?.options?.expectedDraftRevision, 5);
     assert.deepEqual(redisStore.metadata, {
       draftRevision: 6,

--- a/apps/server/src/lib/collaboration/transport.integration.test.ts
+++ b/apps/server/src/lib/collaboration/transport.integration.test.ts
@@ -9,9 +9,13 @@ import {
   MessageType,
   OutgoingMessage,
 } from "@hocuspocus/server";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
 import * as Y from "yjs";
 
-import type { CollaborationSessionContext } from "../collaboration-auth.js";
+import type {
+  CollaborationPresenceContext,
+  CollaborationSessionContext,
+} from "../collaboration-auth.js";
 import type { ContentDocument, ContentScope } from "../content-api/types.js";
 
 import {
@@ -60,7 +64,7 @@ type TestWebSocket = {
     event: "open" | "message" | "close" | "error",
     listener: (event: any) => void,
   ) => void;
-  send: (data: Uint8Array) => void;
+  send: (data: string | Uint8Array) => void;
   close: () => void;
 };
 
@@ -117,6 +121,20 @@ function createSessionContext(
   };
 }
 
+function createPresenceContext(
+  overrides: Partial<CollaborationPresenceContext> = {},
+): CollaborationPresenceContext {
+  return {
+    userId: overrides.userId ?? "user-1",
+    sessionId: overrides.sessionId ?? "session-1",
+    project: overrides.project ?? "marketing",
+    environment: overrides.environment ?? "draft",
+    role: overrides.role ?? "editor",
+    label: overrides.label ?? overrides.userId ?? "user-1",
+    color: overrides.color ?? "#2563eb",
+  };
+}
+
 class IntegrationContentStore implements CollaborationRuntimeContentStore {
   document: ContentDocument;
   readonly updates: Array<{
@@ -167,6 +185,10 @@ class IntegrationRedisStore implements CollaborationRuntimeRedisStore {
   metadata: CollaborationYjsMetadata | null = null;
   activeLeaseValue: string | null = null;
   readonly expirations = new Map<string, number>();
+  readonly presenceRecords = new Map<
+    string,
+    CollaborationPresenceUser & { project: string; environment: string }
+  >();
 
   async getFreshYjsState(
     _documentId: string,
@@ -244,6 +266,43 @@ class IntegrationRedisStore implements CollaborationRuntimeRedisStore {
     this.activeLeaseValue = null;
     return true;
   }
+
+  async setPresence(
+    record: CollaborationPresenceUser & {
+      project: string;
+      environment: string;
+    },
+  ): Promise<void> {
+    this.presenceRecords.set(record.sessionId, record);
+  }
+
+  async deletePresence(input: {
+    project: string;
+    environment: string;
+    sessionId: string;
+  }): Promise<void> {
+    const record = this.presenceRecords.get(input.sessionId);
+
+    if (
+      record?.project === input.project &&
+      record.environment === input.environment
+    ) {
+      this.presenceRecords.delete(input.sessionId);
+    }
+  }
+
+  async listPresence(input: {
+    project: string;
+    environment: string;
+  }): Promise<CollaborationPresenceUser[]> {
+    return Array.from(this.presenceRecords.values())
+      .filter(
+        (record) =>
+          record.project === input.project &&
+          record.environment === input.environment,
+      )
+      .map(({ project: _project, environment: _environment, ...user }) => user);
+  }
 }
 
 function createAuthMessage(documentName: string): Uint8Array {
@@ -257,14 +316,14 @@ function createAuthMessage(documentName: string): Uint8Array {
 
 async function waitFor(
   predicate: () => boolean,
-  message: string,
+  message: string | (() => string),
   timeoutMs = 8_000,
 ): Promise<void> {
   const startedAt = Date.now();
 
   while (!predicate()) {
     if (Date.now() - startedAt > timeoutMs) {
-      throw new Error(message);
+      throw new Error(typeof message === "function" ? message() : message);
     }
 
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -400,6 +459,80 @@ class RawHocuspocusSocket {
   }
 }
 
+class PresenceSocket {
+  readonly socket: TestWebSocket;
+  readonly snapshots: Array<{
+    type: "presence.snapshot";
+    project: string;
+    environment: string;
+    users: CollaborationPresenceUser[];
+  }> = [];
+  closeEvent: { code: number; reason: string } | undefined;
+
+  constructor(url: string) {
+    this.socket = new WebSocketRuntime(url);
+    this.socket.addEventListener("message", (event) => {
+      void this.handleMessage(event.data);
+    });
+    this.socket.addEventListener("close", (event) => {
+      this.closeEvent = {
+        code: event.code,
+        reason: event.reason,
+      };
+    });
+  }
+
+  async open(): Promise<void> {
+    await waitFor(
+      () => this.socket.readyState === WebSocketRuntime.OPEN,
+      "Timed out opening presence WebSocket.",
+    );
+  }
+
+  sendUpdate(update: unknown): void {
+    this.socket.send(JSON.stringify(update));
+  }
+
+  latestSnapshot() {
+    return this.snapshots.at(-1);
+  }
+
+  close(): void {
+    if (
+      this.socket.readyState !== WebSocketRuntime.CLOSED &&
+      this.socket.readyState !== WebSocketRuntime.CLOSING
+    ) {
+      this.socket.close();
+    }
+  }
+
+  private async handleMessage(rawData: unknown): Promise<void> {
+    const text =
+      typeof rawData === "string"
+        ? rawData
+        : rawData instanceof ArrayBuffer
+          ? new TextDecoder().decode(rawData)
+          : rawData instanceof Uint8Array
+            ? new TextDecoder().decode(rawData)
+            : await (rawData as Blob).text();
+    const payload = JSON.parse(text) as {
+      type?: string;
+      project?: string;
+      environment?: string;
+      users?: CollaborationPresenceUser[];
+    };
+
+    if (payload.type === "presence.snapshot") {
+      this.snapshots.push({
+        type: "presence.snapshot",
+        project: payload.project ?? "",
+        environment: payload.environment ?? "",
+        users: payload.users ?? [],
+      });
+    }
+  }
+}
+
 test("Bun collaboration sockets sync Yjs updates and finalize the document room on last disconnect", async () => {
   const contentStore = new IntegrationContentStore(
     createDocument({ body: "# Shared\n\nInitial body.", draftRevision: 5 }),
@@ -425,6 +558,12 @@ test("Bun collaboration sockets sync Yjs updates and finalize the document room 
           }),
         };
       },
+      authorizePresenceHandshake: async () => ({
+        ok: true,
+        context: createPresenceContext(),
+      }),
+      authorizePresenceUpdate: async () => ({ ok: true }),
+      filterPresenceSnapshot: async (_request, _context, users) => users,
     },
     runtime,
   });
@@ -489,6 +628,113 @@ test("Bun collaboration sockets sync Yjs updates and finalize the document room 
   }
 });
 
+test("Bun presence sockets exchange JSON snapshots and clean up on disconnect", async () => {
+  const redisStore = new IntegrationRedisStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: {
+      authorizeHandshake: async () => ({
+        ok: true,
+        context: createSessionContext(),
+      }),
+      authorizePresenceHandshake: async (request) => {
+        const url = new URL(request.url);
+        const sessionId = url.searchParams.get("sessionId") ?? "session-1";
+        const userId = url.searchParams.get("userId") ?? sessionId;
+
+        return {
+          ok: true,
+          context: createPresenceContext({
+            userId,
+            sessionId,
+            label: userId,
+          }),
+        };
+      },
+      authorizePresenceUpdate: async () => ({ ok: true }),
+      filterPresenceSnapshot: async (_request, _context, users) => users,
+    },
+    presenceStore: redisStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+  const port = await getAvailablePort();
+  const server = BunRuntime.serve({
+    port,
+    websocket: transport.websocket,
+    fetch: (request, bunServer) =>
+      transport.handleFetchUpgrade(request, bunServer as never) ??
+      new Response("ok"),
+  });
+  const baseUrl = `ws://127.0.0.1:${server.port}/api/v1/collaboration/presence?project=marketing&environment=draft`;
+  const clientA = new PresenceSocket(
+    `${baseUrl}&userId=ada&sessionId=session-a`,
+  );
+  let clientB: PresenceSocket | undefined;
+
+  try {
+    await clientA.open();
+    await waitFor(
+      () => clientA.latestSnapshot()?.users.length === 1,
+      "Timed out waiting for initial presence snapshot.",
+      1_000,
+    );
+
+    clientB = new PresenceSocket(`${baseUrl}&userId=grace&sessionId=session-b`);
+    const connectedClientB = clientB;
+
+    await connectedClientB.open();
+    await waitFor(
+      () =>
+        clientA
+          .latestSnapshot()
+          ?.users.some((user) => user.sessionId === "session-b") === true &&
+        connectedClientB.latestSnapshot()?.users.length === 2,
+      "Timed out waiting for joined presence snapshot.",
+      1_000,
+    );
+
+    clientA.sendUpdate({
+      type: "presence.update",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+      cursor: { anchor: 3, head: 9 },
+    });
+
+    await waitFor(
+      () =>
+        connectedClientB
+          .latestSnapshot()
+          ?.users.some(
+            (user) =>
+              user.sessionId === "session-a" &&
+              user.documentId === DOCUMENT_ID &&
+              user.mode === "edit" &&
+              user.cursor?.anchor === 3 &&
+              user.cursor.head === 9,
+          ) === true,
+      "Timed out waiting for edited presence snapshot.",
+      1_000,
+    );
+
+    clientA.close();
+
+    await waitFor(
+      () =>
+        connectedClientB
+          .latestSnapshot()
+          ?.users.every((user) => user.sessionId !== "session-a") === true,
+      "Timed out waiting for disconnect presence cleanup.",
+      1_000,
+    );
+
+    assert.equal(redisStore.presenceRecords.has("session-a"), false);
+    assert.equal(redisStore.presenceRecords.has("session-b"), true);
+  } finally {
+    clientA.close();
+    clientB?.close();
+    server.stop(true);
+  }
+});
+
 test("Bun collaboration socket receives a forbidden close message when write revalidation fails after upgrade", async () => {
   const contentStore = new IntegrationContentStore(
     createDocument({ body: "# Shared\n\nInitial body.", draftRevision: 5 }),
@@ -508,6 +754,12 @@ test("Bun collaboration socket receives a forbidden close message when write rev
         ok: true,
         context: createSessionContext({ userId: "writer-1" }),
       }),
+      authorizePresenceHandshake: async () => ({
+        ok: true,
+        context: createPresenceContext(),
+      }),
+      authorizePresenceUpdate: async () => ({ ok: true }),
+      filterPresenceSnapshot: async (_request, _context, users) => users,
     },
     runtime,
   });

--- a/apps/server/src/lib/collaboration/transport.integration.test.ts
+++ b/apps/server/src/lib/collaboration/transport.integration.test.ts
@@ -568,6 +568,7 @@ test("Bun collaboration sockets sync Yjs updates and finalize the document room 
       }),
       authorizePresenceUpdate: async () => ({ ok: true }),
       filterPresenceSnapshot: async (_request, _context, users) => users,
+      revalidateWrite: async () => ({ ok: true }),
     },
     runtime,
   });
@@ -656,6 +657,7 @@ test("Bun presence sockets exchange JSON snapshots and clean up on disconnect", 
       },
       authorizePresenceUpdate: async () => ({ ok: true }),
       filterPresenceSnapshot: async (_request, _context, users) => users,
+      revalidateWrite: async () => ({ ok: true }),
     },
     presenceStore: redisStore,
     now: () => new Date("2026-06-14T10:00:00.000Z"),
@@ -764,6 +766,7 @@ test("Bun collaboration socket receives a forbidden close message when write rev
       }),
       authorizePresenceUpdate: async () => ({ ok: true }),
       filterPresenceSnapshot: async (_request, _context, users) => users,
+      revalidateWrite: async () => ({ ok: true }),
     },
     runtime,
   });

--- a/apps/server/src/lib/collaboration/transport.test.ts
+++ b/apps/server/src/lib/collaboration/transport.test.ts
@@ -532,6 +532,9 @@ test("collaboration transport upgrades and delegates open, message, and close to
             handleMessage(message: Uint8Array) {
               delegated.push(`message:${Array.from(message).join(",")}`);
             },
+            async waitForPendingMessages() {
+              delegated.push("wait");
+            },
             handleClose(event?: { code?: number; reason?: string }) {
               delegated.push(`close:${event?.code}:${event?.reason}`);
             },
@@ -583,6 +586,9 @@ test("collaboration transport handles document-room flush control messages outsi
             handleMessage(message: Uint8Array) {
               delegated.push(`message:${Array.from(message).join(",")}`);
             },
+            async waitForPendingMessages() {
+              delegated.push("wait");
+            },
             handleClose(event?: { code?: number; reason?: string }) {
               delegated.push(`close:${event?.code}:${event?.reason}`);
             },
@@ -618,7 +624,10 @@ test("collaboration transport handles document-room flush control messages outsi
   await waitFor(() => sent.length === 1, "Timed out waiting for flush result.");
 
   assert.deepEqual(flushed, [`marketing:staging:${DOCUMENT_ID}`]);
-  assert.deepEqual(delegated, [`open:editor-1:${calls[0]!.request.url}`]);
+  assert.deepEqual(delegated, [
+    `open:editor-1:${calls[0]!.request.url}`,
+    "wait",
+  ]);
   assert.deepEqual(JSON.parse(sent[0] as string), {
     type: "mdcms.collaboration.flush.result",
     requestId: "flush-1",

--- a/apps/server/src/lib/collaboration/transport.test.ts
+++ b/apps/server/src/lib/collaboration/transport.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
 import type { WebSocketLike } from "@hocuspocus/server";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
 
-import type { CollaborationSessionContext } from "../collaboration-auth.js";
+import type {
+  CollaborationPresenceContext,
+  CollaborationSessionContext,
+} from "../collaboration-auth.js";
 import {
   createCollaborationWebSocketTransport,
   isCollaborationWebSocketUpgradeRequest,
@@ -27,6 +31,21 @@ function createContext(
   };
 }
 
+function createPresenceContext(
+  overrides: Partial<CollaborationPresenceContext> = {},
+): CollaborationPresenceContext {
+  return {
+    userId: "user-1",
+    sessionId: "session-1",
+    project: "marketing",
+    environment: "staging",
+    role: "editor",
+    label: "Ada",
+    color: "#2563eb",
+    ...overrides,
+  };
+}
+
 function createUpgradeRequest(headers: HeadersInit = {}): Request {
   return new Request(
     `http://localhost/api/v1/collaboration?project=marketing&environment=staging&documentId=${DOCUMENT_ID}`,
@@ -41,6 +60,35 @@ function createUpgradeRequest(headers: HeadersInit = {}): Request {
   );
 }
 
+function createPresenceUpgradeRequest(
+  overrides: {
+    sessionId?: string;
+    userId?: string;
+    headers?: HeadersInit;
+  } = {},
+): Request {
+  const url = new URL("http://localhost/api/v1/collaboration/presence");
+  url.searchParams.set("project", "marketing");
+  url.searchParams.set("environment", "staging");
+
+  if (overrides.sessionId) {
+    url.searchParams.set("sessionId", overrides.sessionId);
+  }
+
+  if (overrides.userId) {
+    url.searchParams.set("userId", overrides.userId);
+  }
+
+  return new Request(url, {
+    headers: {
+      connection: "Upgrade",
+      upgrade: "websocket",
+      origin: "http://localhost:4173",
+      ...overrides.headers,
+    },
+  });
+}
+
 function createAuthGuard(
   result:
     | { ok: true; context: CollaborationSessionContext }
@@ -49,6 +97,102 @@ function createAuthGuard(
   return {
     async authorizeHandshake() {
       return result;
+    },
+    async authorizePresenceHandshake() {
+      return { ok: true, context: createPresenceContext() };
+    },
+    async authorizePresenceUpdate() {
+      return { ok: true };
+    },
+    async filterPresenceSnapshot(_request, _context, users) {
+      return users;
+    },
+  };
+}
+
+function createPresenceAuthGuard(overrides: {
+  authorizePresenceHandshake?: CollaborationAuthHandshakeGuard["authorizePresenceHandshake"];
+  authorizePresenceUpdate?: CollaborationAuthHandshakeGuard["authorizePresenceUpdate"];
+  filterPresenceSnapshot?: CollaborationAuthHandshakeGuard["filterPresenceSnapshot"];
+}): CollaborationAuthHandshakeGuard {
+  return {
+    async authorizeHandshake() {
+      return { ok: true, context: createContext() };
+    },
+    authorizePresenceHandshake:
+      overrides.authorizePresenceHandshake ??
+      (async (request) => {
+        const url = new URL(request.url);
+        const sessionId = url.searchParams.get("sessionId") ?? "session-1";
+        const userId = url.searchParams.get("userId") ?? sessionId;
+
+        return {
+          ok: true,
+          context: createPresenceContext({
+            userId,
+            sessionId,
+            label: userId,
+          }),
+        };
+      }),
+    authorizePresenceUpdate:
+      overrides.authorizePresenceUpdate ?? (async () => ({ ok: true })),
+    filterPresenceSnapshot:
+      overrides.filterPresenceSnapshot ??
+      (async (_request, _context, users) => users),
+  };
+}
+
+function createPresenceStore(initialUsers: CollaborationPresenceUser[] = []) {
+  type PresenceRecord = CollaborationPresenceUser & {
+    project: string;
+    environment: string;
+  };
+  const records = new Map<string, PresenceRecord>();
+  const setCalls: PresenceRecord[] = [];
+  const deleteCalls: Array<{
+    project: string;
+    environment: string;
+    sessionId: string;
+  }> = [];
+
+  for (const user of initialUsers) {
+    records.set(`${user.sessionId}`, {
+      ...user,
+      project: "marketing",
+      environment: "staging",
+    });
+  }
+
+  return {
+    records,
+    setCalls,
+    deleteCalls,
+    async setPresence(record: PresenceRecord) {
+      setCalls.push(record);
+      records.set(record.sessionId, record);
+    },
+    async deletePresence(input: {
+      project: string;
+      environment: string;
+      sessionId: string;
+    }) {
+      deleteCalls.push(input);
+      records.delete(input.sessionId);
+    },
+    async listPresence(input: {
+      project: string;
+      environment: string;
+    }): Promise<CollaborationPresenceUser[]> {
+      return Array.from(records.values())
+        .filter(
+          (record) =>
+            record.project === input.project &&
+            record.environment === input.environment,
+        )
+        .map(
+          ({ project: _project, environment: _environment, ...user }) => user,
+        );
     },
   };
 }
@@ -69,13 +213,16 @@ function createBunServerStub() {
 
 function createBunSocketStub(data: Record<string, unknown>) {
   const events: string[] = [];
+  const sent: unknown[] = [];
 
   return {
     events,
+    sent,
     socket: {
       data,
       remoteAddress: "127.0.0.1",
       send(payload: unknown) {
+        sent.push(payload);
         events.push(`send:${payload instanceof Uint8Array ? "bytes" : "text"}`);
         return 1;
       },
@@ -98,6 +245,41 @@ function createBunSocketStub(data: Record<string, unknown>) {
   };
 }
 
+function parseSnapshotMessages(sent: unknown[]) {
+  return sent
+    .filter((payload): payload is string => typeof payload === "string")
+    .map((payload) => JSON.parse(payload) as unknown)
+    .filter(
+      (
+        payload,
+      ): payload is {
+        type: "presence.snapshot";
+        project: string;
+        environment: string;
+        users: CollaborationPresenceUser[];
+      } =>
+        typeof payload === "object" &&
+        payload !== null &&
+        (payload as { type?: unknown }).type === "presence.snapshot",
+    );
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 test("collaboration transport detects only websocket upgrades for the collaboration endpoint", () => {
   assert.equal(
     isCollaborationWebSocketUpgradeRequest(createUpgradeRequest()),
@@ -109,6 +291,10 @@ test("collaboration transport detects only websocket upgrades for the collaborat
         headers: { upgrade: "websocket" },
       }),
     ),
+    true,
+  );
+  assert.equal(
+    isCollaborationWebSocketUpgradeRequest(createPresenceUpgradeRequest()),
     true,
   );
   assert.equal(
@@ -139,6 +325,31 @@ test("collaboration transport returns 503 before upgrade when runtime is unavail
   assert.deepEqual(calls, []);
 });
 
+test("presence transport returns 503 before upgrade when presence storage is unavailable", async () => {
+  const { calls, server } = createBunServerStub();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    runtime: {
+      server: {
+        handleConnection() {
+          throw new Error("presence should not start hocuspocus connection");
+        },
+      },
+    },
+    unavailableDetails: { reason: "missing_redis_url" },
+  });
+
+  const response = await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest(),
+    server as never,
+  );
+  const body = (await response?.json()) as { code: string; details?: unknown };
+
+  assert.equal(response?.status, 503);
+  assert.equal(body.code, "COLLABORATION_UNAVAILABLE");
+  assert.deepEqual(calls, []);
+});
+
 test("collaboration transport falls through for non-collaboration requests", async () => {
   const { calls, server } = createBunServerStub();
   let authorized = false;
@@ -147,6 +358,15 @@ test("collaboration transport falls through for non-collaboration requests", asy
       async authorizeHandshake() {
         authorized = true;
         return { ok: true, context: createContext() };
+      },
+      async authorizePresenceHandshake() {
+        throw new Error("should not authorize presence request");
+      },
+      async authorizePresenceUpdate() {
+        throw new Error("should not authorize presence update");
+      },
+      async filterPresenceSnapshot() {
+        throw new Error("should not filter presence snapshot");
       },
     },
     runtime: {
@@ -168,6 +388,62 @@ test("collaboration transport falls through for non-collaboration requests", asy
   assert.equal(response, undefined);
   assert.equal(authorized, false);
   assert.deepEqual(calls, []);
+});
+
+test("presence transport maps handshake failures to collaboration HTTP errors", async () => {
+  const { calls: unauthorizedCalls, server: unauthorizedServer } =
+    createBunServerStub();
+  const unauthorizedTransport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      authorizePresenceHandshake: async () => ({
+        ok: false,
+        closeCode: 4401,
+        message: "No session",
+      }),
+    }),
+    presenceStore: createPresenceStore(),
+  });
+
+  const unauthorizedResponse = await unauthorizedTransport.handleFetchUpgrade(
+    createPresenceUpgradeRequest(),
+    unauthorizedServer as never,
+  );
+  const unauthorizedBody = (await unauthorizedResponse?.json()) as {
+    code: string;
+    details?: { closeCode?: number };
+  };
+
+  assert.equal(unauthorizedResponse?.status, 401);
+  assert.equal(unauthorizedBody.code, "UNAUTHORIZED");
+  assert.equal(unauthorizedBody.details?.closeCode, 4401);
+  assert.deepEqual(unauthorizedCalls, []);
+
+  const { calls: forbiddenCalls, server: forbiddenServer } =
+    createBunServerStub();
+  const forbiddenTransport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      authorizePresenceHandshake: async () => ({
+        ok: false,
+        closeCode: 4403,
+        message: "Forbidden",
+      }),
+    }),
+    presenceStore: createPresenceStore(),
+  });
+
+  const forbiddenResponse = await forbiddenTransport.handleFetchUpgrade(
+    createPresenceUpgradeRequest(),
+    forbiddenServer as never,
+  );
+  const forbiddenBody = (await forbiddenResponse?.json()) as {
+    code: string;
+    details?: { closeCode?: number };
+  };
+
+  assert.equal(forbiddenResponse?.status, 403);
+  assert.equal(forbiddenBody.code, "COLLABORATION_FORBIDDEN");
+  assert.equal(forbiddenBody.details?.closeCode, 4403);
+  assert.deepEqual(forbiddenCalls, []);
 });
 
 test("collaboration transport maps unauthorized handshakes to 401 with close details", async () => {
@@ -286,6 +562,610 @@ test("collaboration transport upgrades and delegates open, message, and close to
   ]);
 });
 
+test("presence transport stores online record and sends initial filtered snapshot on open", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  const response = await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+
+  assert.equal(response, undefined);
+  assert.equal(calls.length, 1);
+
+  const { socket, sent } = createBunSocketStub(calls[0]!.options.data);
+
+  transport.websocket.open(socket as never);
+
+  await waitFor(
+    () => parseSnapshotMessages(sent).length === 1,
+    "Timed out waiting for initial presence snapshot.",
+  );
+
+  assert.deepEqual(presenceStore.setCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      userId: "ada",
+      sessionId: "session-1",
+      label: "ada",
+      color: "#2563eb",
+      documentId: null,
+      mode: "view",
+      updatedAt: "2026-06-14T10:00:00.000Z",
+    },
+  ]);
+  assert.deepEqual(parseSnapshotMessages(sent), [
+    {
+      type: "presence.snapshot",
+      project: "marketing",
+      environment: "staging",
+      users: [
+        {
+          userId: "ada",
+          sessionId: "session-1",
+          label: "ada",
+          color: "#2563eb",
+          documentId: null,
+          mode: "view",
+          updatedAt: "2026-06-14T10:00:00.000Z",
+        },
+      ],
+    },
+  ]);
+});
+
+test("presence transport rolls back peer lifecycle when open storage fails", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore: {
+      ...presenceStore,
+      async setPresence() {
+        throw new Error("redis unavailable");
+      },
+    },
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+
+  const peer = createBunSocketStub(calls[0]!.options.data);
+
+  transport.websocket.open(peer.socket as never);
+
+  await waitFor(
+    () =>
+      peer.events.some(
+        (event) => event === "close:1011:Presence storage failed.",
+      ),
+    "Timed out waiting for failed presence open cleanup.",
+  );
+
+  peer.events.length = 0;
+  transport.websocket.close(peer.socket as never, 1000, "after failed open");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.deepEqual(presenceStore.deleteCalls, []);
+  assert.deepEqual(peer.events, []);
+});
+
+test("presence transport stores authorized updates and broadcasts filtered snapshots", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const filterCalls: string[] = [];
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      filterPresenceSnapshot: async (_request, context, users) => {
+        filterCalls.push(context.sessionId);
+        return context.sessionId === "session-2"
+          ? users.filter((user) => user.sessionId === "session-2")
+          : users;
+      },
+    }),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const peerA = createBunSocketStub(calls[0]!.options.data);
+  const peerB = createBunSocketStub(calls[1]!.options.data);
+
+  transport.websocket.open(peerA.socket as never);
+  transport.websocket.open(peerB.socket as never);
+  await waitFor(
+    () =>
+      parseSnapshotMessages(peerA.sent).length > 0 &&
+      parseSnapshotMessages(peerB.sent).length > 0,
+    "Timed out waiting for initial presence snapshots.",
+  );
+  peerA.sent.length = 0;
+  peerB.sent.length = 0;
+  filterCalls.length = 0;
+
+  transport.websocket.message(
+    peerA.socket as never,
+    JSON.stringify({
+      type: "presence.update",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+      cursor: { anchor: 2, head: 7 },
+    }) as never,
+  );
+
+  await waitFor(
+    () =>
+      filterCalls.length === 2 &&
+      parseSnapshotMessages(peerA.sent).length > 0 &&
+      parseSnapshotMessages(peerB.sent).length > 0,
+    "Timed out waiting for update broadcast.",
+  );
+
+  assert.deepEqual(presenceStore.records.get("session-1"), {
+    project: "marketing",
+    environment: "staging",
+    userId: "ada",
+    sessionId: "session-1",
+    label: "ada",
+    color: "#2563eb",
+    documentId: DOCUMENT_ID,
+    mode: "edit",
+    cursor: { anchor: 2, head: 7 },
+    updatedAt: "2026-06-14T10:00:00.000Z",
+  });
+  assert.deepEqual(filterCalls, ["session-1", "session-2"]);
+  assert.deepEqual(
+    parseSnapshotMessages(peerA.sent)
+      .at(-1)
+      ?.users.map((user) => user.sessionId),
+    ["session-1", "session-2"],
+  );
+  assert.deepEqual(parseSnapshotMessages(peerB.sent).at(-1)?.users, [
+    {
+      userId: "grace",
+      sessionId: "session-2",
+      label: "grace",
+      color: "#2563eb",
+      documentId: null,
+      mode: "view",
+      updatedAt: "2026-06-14T10:00:00.000Z",
+    },
+  ]);
+});
+
+test("presence transport fails closed and cleans up when update storage fails", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  let failNextSet = false;
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore: {
+      ...presenceStore,
+      async setPresence(record) {
+        if (failNextSet) {
+          throw new Error("redis unavailable");
+        }
+
+        await presenceStore.setPresence(record);
+      },
+    },
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const peerA = createBunSocketStub(calls[0]!.options.data);
+  const observer = createBunSocketStub(calls[1]!.options.data);
+
+  transport.websocket.open(peerA.socket as never);
+  transport.websocket.open(observer.socket as never);
+  await waitFor(
+    () =>
+      presenceStore.records.has("session-1") &&
+      presenceStore.records.has("session-2") &&
+      parseSnapshotMessages(observer.sent).length > 0,
+    "Timed out waiting for initial presence records.",
+  );
+
+  failNextSet = true;
+  observer.sent.length = 0;
+  peerA.events.length = 0;
+  transport.websocket.message(
+    peerA.socket as never,
+    JSON.stringify({
+      type: "presence.update",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+    }) as never,
+  );
+
+  await waitFor(
+    () =>
+      peerA.events.some(
+        (event) => event === "close:1011:Presence update failed.",
+      ) &&
+      presenceStore.deleteCalls.length === 1 &&
+      parseSnapshotMessages(observer.sent).at(-1)?.users.length === 1,
+    "Timed out waiting for failed update cleanup.",
+  );
+
+  assert.deepEqual(presenceStore.deleteCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    },
+  ]);
+  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.deepEqual(
+    parseSnapshotMessages(observer.sent)
+      .at(-1)
+      ?.users.map((user) => user.sessionId),
+    ["session-2"],
+  );
+});
+
+test("presence transport fails closed and cleans up when update authorization throws", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      authorizePresenceUpdate: async () => {
+        throw new Error("auth backend unavailable");
+      },
+    }),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const peerA = createBunSocketStub(calls[0]!.options.data);
+  const observer = createBunSocketStub(calls[1]!.options.data);
+
+  transport.websocket.open(peerA.socket as never);
+  transport.websocket.open(observer.socket as never);
+  await waitFor(
+    () =>
+      presenceStore.records.has("session-1") &&
+      presenceStore.records.has("session-2") &&
+      parseSnapshotMessages(observer.sent).length > 0,
+    "Timed out waiting for initial presence records.",
+  );
+
+  observer.sent.length = 0;
+  peerA.events.length = 0;
+  transport.websocket.message(
+    peerA.socket as never,
+    JSON.stringify({
+      type: "presence.update",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+    }) as never,
+  );
+
+  await waitFor(
+    () =>
+      peerA.events.some(
+        (event) => event === "close:1011:Presence update failed.",
+      ) &&
+      presenceStore.deleteCalls.length === 1 &&
+      parseSnapshotMessages(observer.sent).at(-1)?.users.length === 1,
+    "Timed out waiting for thrown update authorization cleanup.",
+  );
+
+  assert.deepEqual(presenceStore.deleteCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    },
+  ]);
+  assert.equal(presenceStore.records.has("session-1"), false);
+});
+
+test("presence transport cleans up peers when snapshot filtering fails", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      filterPresenceSnapshot: async (_request, context, users) => {
+        if (context.sessionId === "session-1") {
+          throw new Error("authorization backend unavailable");
+        }
+
+        return users;
+      },
+    }),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const peerA = createBunSocketStub(calls[0]!.options.data);
+  const observer = createBunSocketStub(calls[1]!.options.data);
+
+  transport.websocket.open(peerA.socket as never);
+  transport.websocket.open(observer.socket as never);
+
+  await waitFor(
+    () =>
+      peerA.events.some(
+        (event) => event === "close:1011:Presence snapshot failed.",
+      ) &&
+      presenceStore.deleteCalls.length === 1 &&
+      parseSnapshotMessages(observer.sent).at(-1)?.users.length === 1,
+    "Timed out waiting for failed snapshot cleanup.",
+  );
+
+  assert.deepEqual(presenceStore.deleteCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    },
+  ]);
+  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.deepEqual(
+    parseSnapshotMessages(observer.sent)
+      .at(-1)
+      ?.users.map((user) => user.sessionId),
+    ["session-2"],
+  );
+});
+
+test("presence transport omits cursor from target-level updates", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+
+  const peer = createBunSocketStub(calls[0]!.options.data);
+  transport.websocket.open(peer.socket as never);
+  await waitFor(
+    () => parseSnapshotMessages(peer.sent).length > 0,
+    "Timed out waiting for initial presence snapshot.",
+  );
+  transport.websocket.message(
+    peer.socket as never,
+    JSON.stringify({
+      type: "presence.update",
+      documentId: null,
+      mode: "view",
+      cursor: { anchor: 2, head: 7 },
+    }) as never,
+  );
+  await waitFor(
+    () => presenceStore.setCalls.length === 2,
+    "Timed out waiting for target-level presence update.",
+  );
+
+  assert.equal(presenceStore.records.get("session-1")?.documentId, null);
+  assert.equal(presenceStore.records.get("session-1")?.cursor, undefined);
+});
+
+test("presence transport closes with 4403 for invalid JSON and invalid update payloads", async () => {
+  const { calls, server } = createBunServerStub();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore: createPresenceStore(),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const invalidJsonPeer = createBunSocketStub(calls[0]!.options.data);
+  const invalidSchemaPeer = createBunSocketStub(calls[1]!.options.data);
+
+  transport.websocket.open(invalidJsonPeer.socket as never);
+  transport.websocket.open(invalidSchemaPeer.socket as never);
+  await waitFor(
+    () =>
+      parseSnapshotMessages(invalidJsonPeer.sent).length > 0 &&
+      parseSnapshotMessages(invalidSchemaPeer.sent).length > 0,
+    "Timed out waiting for initial presence snapshots.",
+  );
+  invalidJsonPeer.events.length = 0;
+  invalidSchemaPeer.events.length = 0;
+
+  transport.websocket.message(
+    invalidJsonPeer.socket as never,
+    "not-json" as never,
+  );
+  transport.websocket.message(
+    invalidSchemaPeer.socket as never,
+    JSON.stringify({ type: "presence.update", mode: "publish" }) as never,
+  );
+
+  await waitFor(
+    () =>
+      invalidJsonPeer.events.some((event) =>
+        event.startsWith("close:4403:Invalid presence update"),
+      ) &&
+      invalidSchemaPeer.events.some((event) =>
+        event.startsWith("close:4403:Invalid presence update"),
+      ),
+    "Timed out waiting for invalid presence update closes.",
+  );
+
+  assert.match(
+    invalidJsonPeer.events.find((event) => event.startsWith("close:4403")) ??
+      "",
+    /^close:4403:Invalid presence update/,
+  );
+  assert.match(
+    invalidSchemaPeer.events.find((event) => event.startsWith("close:4403")) ??
+      "",
+    /^close:4403:Invalid presence update/,
+  );
+});
+
+test("presence transport closes with update authorization close codes", async () => {
+  const { calls, server } = createBunServerStub();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({
+      authorizePresenceUpdate: async () => ({ ok: false, closeCode: 4401 }),
+    }),
+    presenceStore: createPresenceStore(),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest(),
+    server as never,
+  );
+
+  const peer = createBunSocketStub(calls[0]!.options.data);
+
+  transport.websocket.open(peer.socket as never);
+  await waitFor(
+    () => parseSnapshotMessages(peer.sent).length > 0,
+    "Timed out waiting for initial presence snapshot.",
+  );
+  peer.events.length = 0;
+  transport.websocket.message(
+    peer.socket as never,
+    JSON.stringify({
+      type: "presence.update",
+      documentId: DOCUMENT_ID,
+      mode: "view",
+    }) as never,
+  );
+  await waitFor(
+    () =>
+      peer.events.some(
+        (event) =>
+          event === "close:4401:Presence update is no longer authorized.",
+      ),
+    "Timed out waiting for unauthorized presence update close.",
+  );
+
+  assert.deepEqual(
+    peer.events.at(-1),
+    "close:4401:Presence update is no longer authorized.",
+  );
+});
+
+test("presence transport deletes presence only after the last local socket for a session closes", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore,
+    now: () => new Date("2026-06-14T10:00:00.000Z"),
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "grace", sessionId: "session-2" }),
+    server as never,
+  );
+
+  const firstTab = createBunSocketStub(calls[0]!.options.data);
+  const secondTab = createBunSocketStub(calls[1]!.options.data);
+  const observer = createBunSocketStub(calls[2]!.options.data);
+
+  transport.websocket.open(firstTab.socket as never);
+  transport.websocket.open(secondTab.socket as never);
+  transport.websocket.open(observer.socket as never);
+  await waitFor(
+    () => parseSnapshotMessages(observer.sent).length > 0,
+    "Timed out waiting for observer presence snapshot.",
+  );
+  observer.sent.length = 0;
+
+  transport.websocket.close(firstTab.socket as never, 1000, "tab closed");
+  await waitFor(
+    () => parseSnapshotMessages(observer.sent).length > 0,
+    "Timed out waiting for first close broadcast.",
+  );
+
+  assert.deepEqual(presenceStore.deleteCalls, []);
+  assert.equal(presenceStore.records.has("session-1"), true);
+
+  transport.websocket.close(secondTab.socket as never, 1000, "tab closed");
+  await waitFor(
+    () =>
+      presenceStore.deleteCalls.length === 1 &&
+      parseSnapshotMessages(observer.sent).at(-1)?.users.length === 1,
+    "Timed out waiting for last close cleanup.",
+  );
+
+  assert.deepEqual(presenceStore.deleteCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    },
+  ]);
+  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.deepEqual(
+    parseSnapshotMessages(observer.sent)
+      .at(-1)
+      ?.users.map((user) => user.sessionId),
+    ["session-2"],
+  );
+});
+
 test("collaboration transport shutdown closes peers and waits for documents to unload", async () => {
   const context = createContext({ userId: "editor-1" });
   const { calls, server } = createBunServerStub();
@@ -343,6 +1223,67 @@ test("collaboration transport shutdown closes peers and waits for documents to u
     "getDocumentsCount:1",
     "unloaded",
     "getDocumentsCount:0",
+  ]);
+  assert.deepEqual(socketEvents, ["close:1001:Server shutting down."]);
+});
+
+test("collaboration transport shutdown awaits deterministic presence cleanup", async () => {
+  const { calls, server } = createBunServerStub();
+  const presenceStore = createPresenceStore();
+  let releasePresenceCleanup: (() => void) | undefined;
+  let cleanupCompleted = false;
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createPresenceAuthGuard({}),
+    presenceStore: {
+      ...presenceStore,
+      async deletePresence(input) {
+        await new Promise<void>((resolve) => {
+          releasePresenceCleanup = resolve;
+        });
+        cleanupCompleted = true;
+        await presenceStore.deletePresence(input);
+      },
+    },
+  });
+
+  await transport.handleFetchUpgrade(
+    createPresenceUpgradeRequest({ userId: "ada", sessionId: "session-1" }),
+    server as never,
+  );
+
+  const { socket, events: socketEvents } = createBunSocketStub(
+    calls[0]!.options.data,
+  );
+
+  transport.websocket.open(socket as never);
+  await waitFor(
+    () => presenceStore.records.has("session-1"),
+    "Timed out waiting for initial presence record.",
+  );
+
+  let shutdownFinished = false;
+  const shutdown = transport.shutdown().then(() => {
+    shutdownFinished = true;
+  });
+
+  await waitFor(
+    () => releasePresenceCleanup !== undefined,
+    "Timed out waiting for shutdown presence cleanup to start.",
+  );
+
+  assert.equal(shutdownFinished, false);
+  assert.equal(cleanupCompleted, false);
+  releasePresenceCleanup?.();
+  await shutdown;
+
+  assert.equal(cleanupCompleted, true);
+  assert.equal(shutdownFinished, true);
+  assert.deepEqual(presenceStore.deleteCalls, [
+    {
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    },
   ]);
   assert.deepEqual(socketEvents, ["close:1001:Server shutting down."]);
 });

--- a/apps/server/src/lib/collaboration/transport.test.ts
+++ b/apps/server/src/lib/collaboration/transport.test.ts
@@ -562,6 +562,71 @@ test("collaboration transport upgrades and delegates open, message, and close to
   ]);
 });
 
+test("collaboration transport handles document-room flush control messages outside Hocuspocus sync", async () => {
+  const context = createContext({ userId: "editor-1" });
+  const { calls, server } = createBunServerStub();
+  const delegated: string[] = [];
+  const flushed: string[] = [];
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: createAuthGuard({ ok: true, context }),
+    runtime: {
+      server: {
+        handleConnection(
+          websocket: WebSocketLike,
+          request: Request,
+          defaultContext: CollaborationRuntimeContext,
+        ) {
+          delegated.push(`open:${defaultContext.userId}:${request.url}`);
+          assert.equal(typeof websocket.send, "function");
+
+          return {
+            handleMessage(message: Uint8Array) {
+              delegated.push(`message:${Array.from(message).join(",")}`);
+            },
+            handleClose(event?: { code?: number; reason?: string }) {
+              delegated.push(`close:${event?.code}:${event?.reason}`);
+            },
+          };
+        },
+        async flushDocument(documentName: string) {
+          flushed.push(documentName);
+          return { status: "saved" as const, draftRevision: 12 };
+        },
+      },
+    },
+  });
+
+  const response = await transport.handleFetchUpgrade(
+    createUpgradeRequest(),
+    server as never,
+  );
+
+  assert.equal(response, undefined);
+  assert.equal(calls.length, 1);
+
+  const { socket, sent } = createBunSocketStub(calls[0]!.options.data);
+
+  transport.websocket.open(socket as never);
+  transport.websocket.message(
+    socket as never,
+    JSON.stringify({
+      type: "mdcms.collaboration.flush",
+      requestId: "flush-1",
+    }),
+  );
+
+  await waitFor(() => sent.length === 1, "Timed out waiting for flush result.");
+
+  assert.deepEqual(flushed, [`marketing:staging:${DOCUMENT_ID}`]);
+  assert.deepEqual(delegated, [`open:editor-1:${calls[0]!.request.url}`]);
+  assert.deepEqual(JSON.parse(sent[0] as string), {
+    type: "mdcms.collaboration.flush.result",
+    requestId: "flush-1",
+    status: "saved",
+    draftRevision: 12,
+  });
+});
+
 test("presence transport stores online record and sends initial filtered snapshot on open", async () => {
   const { calls, server } = createBunServerStub();
   const presenceStore = createPresenceStore();

--- a/apps/server/src/lib/collaboration/transport.test.ts
+++ b/apps/server/src/lib/collaboration/transport.test.ts
@@ -107,6 +107,9 @@ function createAuthGuard(
     async filterPresenceSnapshot(_request, _context, users) {
       return users;
     },
+    async revalidateWrite() {
+      return result.ok ? { ok: true } : result;
+    },
   };
 }
 
@@ -114,6 +117,7 @@ function createPresenceAuthGuard(overrides: {
   authorizePresenceHandshake?: CollaborationAuthHandshakeGuard["authorizePresenceHandshake"];
   authorizePresenceUpdate?: CollaborationAuthHandshakeGuard["authorizePresenceUpdate"];
   filterPresenceSnapshot?: CollaborationAuthHandshakeGuard["filterPresenceSnapshot"];
+  revalidateWrite?: CollaborationAuthHandshakeGuard["revalidateWrite"];
 }): CollaborationAuthHandshakeGuard {
   return {
     async authorizeHandshake() {
@@ -140,6 +144,7 @@ function createPresenceAuthGuard(overrides: {
     filterPresenceSnapshot:
       overrides.filterPresenceSnapshot ??
       (async (_request, _context, users) => users),
+    revalidateWrite: overrides.revalidateWrite ?? (async () => ({ ok: true })),
   };
 }
 
@@ -155,22 +160,32 @@ function createPresenceStore(initialUsers: CollaborationPresenceUser[] = []) {
     environment: string;
     sessionId: string;
   }> = [];
+  const key = (input: {
+    project: string;
+    environment: string;
+    sessionId: string;
+  }) =>
+    [input.project, input.environment, input.sessionId]
+      .map((segment) => encodeURIComponent(segment))
+      .join(":");
 
   for (const user of initialUsers) {
-    records.set(`${user.sessionId}`, {
+    const record = {
       ...user,
       project: "marketing",
       environment: "staging",
-    });
+    };
+    records.set(key(record), record);
   }
 
   return {
     records,
+    key,
     setCalls,
     deleteCalls,
     async setPresence(record: PresenceRecord) {
       setCalls.push(record);
-      records.set(record.sessionId, record);
+      records.set(key(record), record);
     },
     async deletePresence(input: {
       project: string;
@@ -178,7 +193,7 @@ function createPresenceStore(initialUsers: CollaborationPresenceUser[] = []) {
       sessionId: string;
     }) {
       deleteCalls.push(input);
-      records.delete(input.sessionId);
+      records.delete(key(input));
     },
     async listPresence(input: {
       project: string;
@@ -367,6 +382,9 @@ test("collaboration transport falls through for non-collaboration requests", asy
       },
       async filterPresenceSnapshot() {
         throw new Error("should not filter presence snapshot");
+      },
+      async revalidateWrite() {
+        throw new Error("should not revalidate writes");
       },
     },
     runtime: {
@@ -570,8 +588,15 @@ test("collaboration transport handles document-room flush control messages outsi
   const { calls, server } = createBunServerStub();
   const delegated: string[] = [];
   const flushed: string[] = [];
+  const securityEvents: string[] = [];
   const transport = createCollaborationWebSocketTransport({
-    authGuard: createAuthGuard({ ok: true, context }),
+    authGuard: {
+      ...createAuthGuard({ ok: true, context }),
+      async revalidateWrite(_request, revalidatedContext) {
+        securityEvents.push(`revalidate:${revalidatedContext.documentId}`);
+        return { ok: true as const };
+      },
+    },
     runtime: {
       server: {
         handleConnection(
@@ -595,6 +620,7 @@ test("collaboration transport handles document-room flush control messages outsi
           };
         },
         async flushDocument(documentName: string) {
+          securityEvents.push(`flush:${documentName}`);
           flushed.push(documentName);
           return { status: "saved" as const, draftRevision: 12 };
         },
@@ -624,6 +650,10 @@ test("collaboration transport handles document-room flush control messages outsi
   await waitFor(() => sent.length === 1, "Timed out waiting for flush result.");
 
   assert.deepEqual(flushed, [`marketing:staging:${DOCUMENT_ID}`]);
+  assert.deepEqual(securityEvents, [
+    `revalidate:${DOCUMENT_ID}`,
+    `flush:marketing:staging:${DOCUMENT_ID}`,
+  ]);
   assert.deepEqual(delegated, [
     `open:editor-1:${calls[0]!.request.url}`,
     "wait",
@@ -633,6 +663,61 @@ test("collaboration transport handles document-room flush control messages outsi
     requestId: "flush-1",
     status: "saved",
     draftRevision: 12,
+  });
+});
+
+test("collaboration transport rejects flush control messages after write access is revoked", async () => {
+  const context = createContext({ userId: "editor-1" });
+  const { calls, server } = createBunServerStub();
+  const flushed: string[] = [];
+  const transport = createCollaborationWebSocketTransport({
+    authGuard: {
+      ...createAuthGuard({ ok: true, context }),
+      async revalidateWrite() {
+        return { ok: false as const, closeCode: 4403 as const };
+      },
+    },
+    runtime: {
+      server: {
+        handleConnection() {
+          return {
+            handleMessage() {
+              throw new Error("flush control messages should not delegate");
+            },
+            async waitForPendingMessages() {},
+            handleClose() {},
+          };
+        },
+        async flushDocument(documentName: string) {
+          flushed.push(documentName);
+          return { status: "saved" as const, draftRevision: 12 };
+        },
+      },
+    },
+  });
+
+  await transport.handleFetchUpgrade(createUpgradeRequest(), server as never);
+
+  const { socket, sent } = createBunSocketStub(calls[0]!.options.data);
+
+  transport.websocket.open(socket as never);
+  transport.websocket.message(
+    socket as never,
+    JSON.stringify({
+      type: "mdcms.collaboration.flush",
+      requestId: "flush-1",
+    }),
+  );
+
+  await waitFor(() => sent.length === 1, "Timed out waiting for flush error.");
+
+  assert.deepEqual(flushed, []);
+  assert.deepEqual(JSON.parse(sent[0] as string), {
+    type: "mdcms.collaboration.flush.result",
+    requestId: "flush-1",
+    status: "error",
+    code: "FORBIDDEN",
+    message: "Collaboration write access is no longer allowed.",
   });
 });
 
@@ -792,18 +877,27 @@ test("presence transport stores authorized updates and broadcasts filtered snaps
     "Timed out waiting for update broadcast.",
   );
 
-  assert.deepEqual(presenceStore.records.get("session-1"), {
-    project: "marketing",
-    environment: "staging",
-    userId: "ada",
-    sessionId: "session-1",
-    label: "ada",
-    color: "#2563eb",
-    documentId: DOCUMENT_ID,
-    mode: "edit",
-    cursor: { anchor: 2, head: 7 },
-    updatedAt: "2026-06-14T10:00:00.000Z",
-  });
+  assert.deepEqual(
+    presenceStore.records.get(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    {
+      project: "marketing",
+      environment: "staging",
+      userId: "ada",
+      sessionId: "session-1",
+      label: "ada",
+      color: "#2563eb",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+      cursor: { anchor: 2, head: 7 },
+      updatedAt: "2026-06-14T10:00:00.000Z",
+    },
+  );
   assert.deepEqual(filterCalls, ["session-1", "session-2"]);
   assert.deepEqual(
     parseSnapshotMessages(peerA.sent)
@@ -859,8 +953,20 @@ test("presence transport fails closed and cleans up when update storage fails", 
   transport.websocket.open(observer.socket as never);
   await waitFor(
     () =>
-      presenceStore.records.has("session-1") &&
-      presenceStore.records.has("session-2") &&
+      presenceStore.records.has(
+        presenceStore.key({
+          project: "marketing",
+          environment: "staging",
+          sessionId: "session-1",
+        }),
+      ) &&
+      presenceStore.records.has(
+        presenceStore.key({
+          project: "marketing",
+          environment: "staging",
+          sessionId: "session-2",
+        }),
+      ) &&
       parseSnapshotMessages(observer.sent).length > 0,
     "Timed out waiting for initial presence records.",
   );
@@ -894,7 +1000,16 @@ test("presence transport fails closed and cleans up when update storage fails", 
       sessionId: "session-1",
     },
   ]);
-  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.equal(
+    presenceStore.records.has(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    false,
+  );
   assert.deepEqual(
     parseSnapshotMessages(observer.sent)
       .at(-1)
@@ -932,8 +1047,20 @@ test("presence transport fails closed and cleans up when update authorization th
   transport.websocket.open(observer.socket as never);
   await waitFor(
     () =>
-      presenceStore.records.has("session-1") &&
-      presenceStore.records.has("session-2") &&
+      presenceStore.records.has(
+        presenceStore.key({
+          project: "marketing",
+          environment: "staging",
+          sessionId: "session-1",
+        }),
+      ) &&
+      presenceStore.records.has(
+        presenceStore.key({
+          project: "marketing",
+          environment: "staging",
+          sessionId: "session-2",
+        }),
+      ) &&
       parseSnapshotMessages(observer.sent).length > 0,
     "Timed out waiting for initial presence records.",
   );
@@ -966,7 +1093,16 @@ test("presence transport fails closed and cleans up when update authorization th
       sessionId: "session-1",
     },
   ]);
-  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.equal(
+    presenceStore.records.has(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    false,
+  );
 });
 
 test("presence transport cleans up peers when snapshot filtering fails", async () => {
@@ -1018,7 +1154,16 @@ test("presence transport cleans up peers when snapshot filtering fails", async (
       sessionId: "session-1",
     },
   ]);
-  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.equal(
+    presenceStore.records.has(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    false,
+  );
   assert.deepEqual(
     parseSnapshotMessages(observer.sent)
       .at(-1)
@@ -1061,8 +1206,15 @@ test("presence transport omits cursor from target-level updates", async () => {
     "Timed out waiting for target-level presence update.",
   );
 
-  assert.equal(presenceStore.records.get("session-1")?.documentId, null);
-  assert.equal(presenceStore.records.get("session-1")?.cursor, undefined);
+  const storedTargetLevelUser = presenceStore.records.get(
+    presenceStore.key({
+      project: "marketing",
+      environment: "staging",
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(storedTargetLevelUser?.documentId, null);
+  assert.equal(storedTargetLevelUser?.cursor, undefined);
 });
 
 test("presence transport closes with 4403 for invalid JSON and invalid update payloads", async () => {
@@ -1214,7 +1366,16 @@ test("presence transport deletes presence only after the last local socket for a
   );
 
   assert.deepEqual(presenceStore.deleteCalls, []);
-  assert.equal(presenceStore.records.has("session-1"), true);
+  assert.equal(
+    presenceStore.records.has(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    true,
+  );
 
   transport.websocket.close(secondTab.socket as never, 1000, "tab closed");
   await waitFor(
@@ -1231,7 +1392,16 @@ test("presence transport deletes presence only after the last local socket for a
       sessionId: "session-1",
     },
   ]);
-  assert.equal(presenceStore.records.has("session-1"), false);
+  assert.equal(
+    presenceStore.records.has(
+      presenceStore.key({
+        project: "marketing",
+        environment: "staging",
+        sessionId: "session-1",
+      }),
+    ),
+    false,
+  );
   assert.deepEqual(
     parseSnapshotMessages(observer.sent)
       .at(-1)
@@ -1331,7 +1501,14 @@ test("collaboration transport shutdown awaits deterministic presence cleanup", a
 
   transport.websocket.open(socket as never);
   await waitFor(
-    () => presenceStore.records.has("session-1"),
+    () =>
+      presenceStore.records.has(
+        presenceStore.key({
+          project: "marketing",
+          environment: "staging",
+          sessionId: "session-1",
+        }),
+      ),
     "Timed out waiting for initial presence record.",
   );
 

--- a/apps/server/src/lib/collaboration/transport.ts
+++ b/apps/server/src/lib/collaboration/transport.ts
@@ -5,11 +5,18 @@ import {
   MessageType,
   type WebSocketLike,
 } from "@hocuspocus/server";
-import { RuntimeError } from "@mdcms/shared";
+import {
+  CollaborationPresenceUpdateSchema,
+  RuntimeError,
+  type CollaborationPresenceUpdate,
+  type CollaborationPresenceUser,
+} from "@mdcms/shared";
 
 import type {
   CollaborationCloseCode,
   CollaborationHandshakeResult,
+  CollaborationPresenceContext,
+  CollaborationPresenceHandshakeResult,
   CollaborationSessionContext,
 } from "../collaboration-auth.js";
 import { toServerErrorResponse } from "../errors.js";
@@ -40,12 +47,45 @@ export type CollaborationAuthHandshakeGuard = {
   authorizeHandshake: (
     request: Request,
   ) => Promise<CollaborationHandshakeResult>;
+  authorizePresenceHandshake: (
+    request: Request,
+  ) => Promise<CollaborationPresenceHandshakeResult>;
+  authorizePresenceUpdate: (
+    request: Request,
+    context: CollaborationPresenceContext,
+    update: CollaborationPresenceUpdate,
+  ) => Promise<{ ok: true } | { ok: false; closeCode: CollaborationCloseCode }>;
+  filterPresenceSnapshot: (
+    request: Request,
+    context: CollaborationPresenceContext,
+    users: CollaborationPresenceUser[],
+  ) => Promise<CollaborationPresenceUser[]>;
+};
+
+export type CollaborationPresenceStore = {
+  setPresence: (
+    record: CollaborationPresenceUser & {
+      project: string;
+      environment: string;
+    },
+  ) => Promise<void>;
+  deletePresence: (input: {
+    project: string;
+    environment: string;
+    sessionId: string;
+  }) => Promise<void>;
+  listPresence: (input: {
+    project: string;
+    environment: string;
+  }) => Promise<CollaborationPresenceUser[]>;
 };
 
 export type CreateCollaborationWebSocketTransportOptions = {
   authGuard: CollaborationAuthHandshakeGuard;
   runtime?: { server: HocuspocusConnectionServer };
+  presenceStore?: CollaborationPresenceStore;
   unavailableDetails?: Record<string, unknown>;
+  now?: () => Date;
 };
 
 export type CollaborationWebSocketTransport = {
@@ -58,21 +98,68 @@ export type CollaborationWebSocketTransport = {
 };
 
 const COLLABORATION_PATHNAME = "/api/v1/collaboration";
+const COLLABORATION_PRESENCE_PATHNAME = "/api/v1/collaboration/presence";
 const COLLABORATION_SESSION_INVALID_REASON =
   "Collaboration session is no longer valid.";
 const COLLABORATION_WRITE_FORBIDDEN_REASON =
   "Collaboration write access is no longer allowed.";
+const COLLABORATION_PRESENCE_INVALID_UPDATE_REASON = "Invalid presence update.";
+const COLLABORATION_PRESENCE_UNAUTHORIZED_UPDATE_REASON =
+  "Presence update is no longer authorized.";
 const COLLABORATION_SHUTDOWN_CLOSE_CODE = 1001;
 const COLLABORATION_SHUTDOWN_CLOSE_REASON = "Server shutting down.";
 const COLLABORATION_DRAIN_POLL_INTERVAL_MS = 10;
 const COLLABORATION_DRAIN_TIMEOUT_MS = 10_000;
+
+type CollaborationRouteKind = "document" | "presence";
+
+type CollaborationPeerContext =
+  | {
+      kind: "document";
+      collaboration: CollaborationSessionContext;
+    }
+  | {
+      kind: "presence";
+      presence: CollaborationPresenceContext;
+    };
+
+type PresencePeerLifecycle = {
+  peer: Peer;
+  context: CollaborationPresenceContext;
+  stored: boolean;
+  counted: boolean;
+  closing: boolean;
+  openTask?: Promise<void>;
+  closeTask?: Promise<void>;
+};
+
+type PresenceCloseOptions = {
+  broadcast: boolean;
+  waitForOpen: boolean;
+};
+
+function resolveCollaborationRouteKind(
+  request: Request,
+): CollaborationRouteKind | undefined {
+  const pathname = resolvePathname(request);
+
+  if (pathname === COLLABORATION_PATHNAME) {
+    return "document";
+  }
+
+  if (pathname === COLLABORATION_PRESENCE_PATHNAME) {
+    return "presence";
+  }
+
+  return undefined;
+}
 
 export function isCollaborationWebSocketUpgradeRequest(
   request: Request,
 ): boolean {
   return (
     request.method.toUpperCase() === "GET" &&
-    resolvePathname(request) === COLLABORATION_PATHNAME &&
+    resolveCollaborationRouteKind(request) !== undefined &&
     request.headers.get("upgrade")?.toLowerCase() === "websocket"
   );
 }
@@ -111,11 +198,19 @@ function createHandshakeError(
 function collaborationContextFromPeer(
   peer: Peer,
 ): CollaborationSessionContext | undefined {
-  const context = peer.context as PeerContext & {
-    collaboration?: CollaborationSessionContext;
-  };
+  const context = peer.context as PeerContext &
+    Partial<CollaborationPeerContext>;
 
-  return context.collaboration;
+  return context.kind === "document" ? context.collaboration : undefined;
+}
+
+function presenceContextFromPeer(
+  peer: Peer,
+): CollaborationPresenceContext | undefined {
+  const context = peer.context as PeerContext &
+    Partial<CollaborationPeerContext>;
+
+  return context.kind === "presence" ? context.presence : undefined;
 }
 
 function createRuntimeContext(
@@ -179,14 +274,375 @@ async function waitForCollaborationDocumentsToUnload(
   }
 }
 
+function presenceConnectionKey(context: CollaborationPresenceContext): string {
+  return `${context.project}\0${context.environment}\0${context.sessionId}`;
+}
+
+function presenceTargetMatches(
+  context: CollaborationPresenceContext,
+  target: { project: string; environment: string },
+): boolean {
+  return (
+    context.project === target.project &&
+    context.environment === target.environment
+  );
+}
+
+function createPresenceRecord(input: {
+  context: CollaborationPresenceContext;
+  update?: CollaborationPresenceUpdate;
+  now: () => Date;
+}): CollaborationPresenceUser & { project: string; environment: string } {
+  const documentId = input.update?.documentId ?? null;
+  const cursor =
+    documentId !== null && input.update?.cursor
+      ? { cursor: input.update.cursor }
+      : {};
+
+  return {
+    project: input.context.project,
+    environment: input.context.environment,
+    userId: input.context.userId,
+    sessionId: input.context.sessionId,
+    label: input.context.label,
+    color: input.context.color,
+    documentId,
+    mode: input.update?.mode ?? "view",
+    ...cursor,
+    updatedAt: input.now().toISOString(),
+  };
+}
+
+function parsePresenceUpdate(message: Message): CollaborationPresenceUpdate {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(message.uint8Array()));
+  } catch {
+    throw new RuntimeError({
+      code: "COLLABORATION_FORBIDDEN",
+      message: COLLABORATION_PRESENCE_INVALID_UPDATE_REASON,
+      statusCode: 403,
+    });
+  }
+
+  const result = CollaborationPresenceUpdateSchema.safeParse(parsed);
+
+  if (!result.success) {
+    throw new RuntimeError({
+      code: "COLLABORATION_FORBIDDEN",
+      message: COLLABORATION_PRESENCE_INVALID_UPDATE_REASON,
+      statusCode: 403,
+    });
+  }
+
+  return result.data;
+}
+
 export function createCollaborationWebSocketTransport(
   options: CreateCollaborationWebSocketTransportOptions,
 ): CollaborationWebSocketTransport {
   const peerConnections = new WeakMap<Peer, HocuspocusClientConnection>();
   const openPeers = new Set<Peer>();
+  const presenceConnectionCounts = new Map<string, number>();
+  const presencePeerLifecycles = new Map<Peer, PresencePeerLifecycle>();
+  const pendingPresenceTasks = new Set<Promise<void>>();
+  const now = options.now ?? (() => new Date());
+
+  function trackPresenceTask(task: Promise<void>): void {
+    const trackedTask = task
+      .catch(() => {
+        // The caller owns the visible close/cleanup behavior. This catch keeps
+        // fire-and-forget adapter hooks from surfacing unhandled rejections.
+      })
+      .finally(() => {
+        pendingPresenceTasks.delete(trackedTask);
+      });
+
+    pendingPresenceTasks.add(trackedTask);
+  }
+
+  function incrementPresenceConnectionCount(
+    context: CollaborationPresenceContext,
+  ): void {
+    const connectionKey = presenceConnectionKey(context);
+    presenceConnectionCounts.set(
+      connectionKey,
+      (presenceConnectionCounts.get(connectionKey) ?? 0) + 1,
+    );
+  }
+
+  async function deletePresenceIfNoOtherLocalConnection(
+    context: CollaborationPresenceContext,
+  ): Promise<void> {
+    if (!options.presenceStore) {
+      return;
+    }
+
+    if (
+      (presenceConnectionCounts.get(presenceConnectionKey(context)) ?? 0) > 0
+    ) {
+      return;
+    }
+
+    await options.presenceStore.deletePresence({
+      project: context.project,
+      environment: context.environment,
+      sessionId: context.sessionId,
+    });
+  }
+
+  async function releaseCountedPresence(
+    context: CollaborationPresenceContext,
+  ): Promise<void> {
+    if (!options.presenceStore) {
+      return;
+    }
+
+    const connectionKey = presenceConnectionKey(context);
+    const remaining = (presenceConnectionCounts.get(connectionKey) ?? 1) - 1;
+
+    if (remaining > 0) {
+      presenceConnectionCounts.set(connectionKey, remaining);
+      return;
+    }
+
+    presenceConnectionCounts.delete(connectionKey);
+    await options.presenceStore.deletePresence({
+      project: context.project,
+      environment: context.environment,
+      sessionId: context.sessionId,
+    });
+  }
+
+  async function broadcastPresenceSnapshot(target: {
+    project: string;
+    environment: string;
+  }): Promise<void> {
+    if (!options.presenceStore) {
+      return;
+    }
+
+    const users = await options.presenceStore.listPresence(target);
+
+    await Promise.all(
+      Array.from(openPeers).map(async (peer) => {
+        const lifecycle = presencePeerLifecycles.get(peer);
+        const context = lifecycle?.context;
+
+        if (!context || !presenceTargetMatches(context, target)) {
+          return;
+        }
+
+        try {
+          const filteredUsers = await options.authGuard.filterPresenceSnapshot(
+            peer.request,
+            context,
+            users,
+          );
+
+          peer.send(
+            JSON.stringify({
+              type: "presence.snapshot",
+              project: target.project,
+              environment: target.environment,
+              users: filteredUsers,
+            }),
+          );
+        } catch {
+          lifecycle.closing = true;
+          peer.close(1011, "Presence snapshot failed.");
+          await handlePresenceClose(lifecycle, {
+            broadcast: true,
+            waitForOpen: false,
+          });
+        }
+      }),
+    );
+  }
+
+  async function cleanupPresenceLifecycle(
+    lifecycle: PresencePeerLifecycle,
+    optionsOverride: { broadcast: boolean } = { broadcast: true },
+  ): Promise<void> {
+    if (lifecycle.counted) {
+      lifecycle.counted = false;
+      lifecycle.stored = false;
+      await releaseCountedPresence(lifecycle.context);
+    } else if (lifecycle.stored) {
+      lifecycle.stored = false;
+      await deletePresenceIfNoOtherLocalConnection(lifecycle.context);
+    }
+
+    presencePeerLifecycles.delete(lifecycle.peer);
+
+    if (optionsOverride.broadcast) {
+      await broadcastPresenceSnapshot({
+        project: lifecycle.context.project,
+        environment: lifecycle.context.environment,
+      });
+    }
+  }
+
+  async function handlePresenceOpen(
+    lifecycle: PresencePeerLifecycle,
+  ): Promise<void> {
+    if (!options.presenceStore) {
+      openPeers.delete(lifecycle.peer);
+      presencePeerLifecycles.delete(lifecycle.peer);
+      lifecycle.peer.close(1011, "Presence storage is unavailable.");
+      return;
+    }
+
+    try {
+      if (lifecycle.closing) {
+        return;
+      }
+
+      await options.presenceStore.setPresence(
+        createPresenceRecord({ context: lifecycle.context, now }),
+      );
+      lifecycle.stored = true;
+
+      if (lifecycle.closing) {
+        await cleanupPresenceLifecycle(lifecycle);
+        return;
+      }
+
+      incrementPresenceConnectionCount(lifecycle.context);
+      lifecycle.counted = true;
+
+      await broadcastPresenceSnapshot({
+        project: lifecycle.context.project,
+        environment: lifecycle.context.environment,
+      });
+    } catch {
+      lifecycle.closing = true;
+      openPeers.delete(lifecycle.peer);
+      try {
+        await cleanupPresenceLifecycle(lifecycle, { broadcast: false });
+      } catch {
+        presencePeerLifecycles.delete(lifecycle.peer);
+      }
+      lifecycle.peer.close(1011, "Presence storage failed.");
+    }
+  }
+
+  async function handlePresenceMessage(
+    lifecycle: PresencePeerLifecycle,
+    message: Message,
+  ): Promise<void> {
+    const { context, peer } = lifecycle;
+
+    if (lifecycle.closing) {
+      return;
+    }
+
+    if (!options.presenceStore) {
+      peer.close(1011, "Presence storage is unavailable.");
+      return;
+    }
+
+    let update: CollaborationPresenceUpdate;
+
+    try {
+      update = parsePresenceUpdate(message);
+    } catch {
+      peer.close(4403, COLLABORATION_PRESENCE_INVALID_UPDATE_REASON);
+      return;
+    }
+
+    try {
+      const authorization = await options.authGuard.authorizePresenceUpdate(
+        peer.request,
+        context,
+        update,
+      );
+
+      if (!authorization.ok) {
+        peer.close(
+          authorization.closeCode,
+          COLLABORATION_PRESENCE_UNAUTHORIZED_UPDATE_REASON,
+        );
+        return;
+      }
+
+      await options.presenceStore.setPresence(
+        createPresenceRecord({ context, update, now }),
+      );
+      lifecycle.stored = true;
+      await broadcastPresenceSnapshot({
+        project: context.project,
+        environment: context.environment,
+      });
+    } catch {
+      lifecycle.closing = true;
+      peer.close(1011, "Presence update failed.");
+      await handlePresenceClose(lifecycle);
+    }
+  }
+
+  async function handlePresenceClose(
+    lifecycle: PresencePeerLifecycle,
+    optionsOverride: PresenceCloseOptions = {
+      broadcast: true,
+      waitForOpen: true,
+    },
+  ): Promise<void> {
+    if (lifecycle.closeTask) {
+      await lifecycle.closeTask;
+      return;
+    }
+
+    lifecycle.closing = true;
+    openPeers.delete(lifecycle.peer);
+
+    lifecycle.closeTask = (async () => {
+      if (optionsOverride.waitForOpen) {
+        await lifecycle.openTask;
+      }
+      await cleanupPresenceLifecycle(lifecycle, optionsOverride);
+    })();
+
+    await lifecycle.closeTask;
+  }
+
   const adapter = bunAdapter({
     hooks: {
       upgrade: async (request) => {
+        const routeKind = resolveCollaborationRouteKind(request);
+
+        if (routeKind === "presence") {
+          if (!options.presenceStore) {
+            return createErrorResponse(
+              createCollaborationUnavailableError(
+                options.unavailableDetails ?? { reason: "runtime_unavailable" },
+              ),
+              request,
+            );
+          }
+
+          const authorization =
+            await options.authGuard.authorizePresenceHandshake(request);
+
+          if (!authorization.ok) {
+            return createErrorResponse(
+              createHandshakeError(
+                authorization.closeCode,
+                authorization.message,
+              ),
+              request,
+            );
+          }
+
+          return {
+            context: {
+              kind: "presence",
+              presence: authorization.context,
+            },
+          };
+        }
+
         if (!options.runtime) {
           return createErrorResponse(
             createCollaborationUnavailableError(
@@ -211,12 +667,29 @@ export function createCollaborationWebSocketTransport(
 
         return {
           context: {
+            kind: "document",
             collaboration: authorization.context,
           },
         };
       },
       open: (peer) => {
         openPeers.add(peer);
+        const presenceContext = presenceContextFromPeer(peer);
+
+        if (presenceContext) {
+          const lifecycle: PresencePeerLifecycle = {
+            peer,
+            context: presenceContext,
+            stored: false,
+            counted: false,
+            closing: false,
+          };
+          presencePeerLifecycles.set(peer, lifecycle);
+          lifecycle.openTask = handlePresenceOpen(lifecycle);
+          trackPresenceTask(lifecycle.openTask);
+          return;
+        }
+
         const context = collaborationContextFromPeer(peer);
 
         if (!context || !options.runtime) {
@@ -249,9 +722,23 @@ export function createCollaborationWebSocketTransport(
         peerConnections.set(peer, connection);
       },
       message: (peer: Peer, message: Message) => {
+        const presenceLifecycle = presencePeerLifecycles.get(peer);
+
+        if (presenceLifecycle) {
+          trackPresenceTask(handlePresenceMessage(presenceLifecycle, message));
+          return;
+        }
+
         peerConnections.get(peer)?.handleMessage(message.uint8Array());
       },
       close: (peer, event) => {
+        const presenceLifecycle = presencePeerLifecycles.get(peer);
+
+        if (presenceLifecycle) {
+          trackPresenceTask(handlePresenceClose(presenceLifecycle));
+          return;
+        }
+
         const connection = peerConnections.get(peer);
         peerConnections.delete(peer);
         openPeers.delete(peer);
@@ -288,9 +775,19 @@ export function createCollaborationWebSocketTransport(
         );
       }
 
+      await Promise.all(
+        Array.from(presencePeerLifecycles.values()).map((lifecycle) =>
+          handlePresenceClose(lifecycle, {
+            broadcast: false,
+            waitForOpen: true,
+          }),
+        ),
+      );
+      await Promise.all(Array.from(pendingPresenceTasks));
       server?.flushPendingStores?.();
       await waitForCollaborationDocumentsToUnload(server);
       openPeers.clear();
+      presenceConnectionCounts.clear();
     },
   };
 }

--- a/apps/server/src/lib/collaboration/transport.ts
+++ b/apps/server/src/lib/collaboration/transport.ts
@@ -34,6 +34,7 @@ export type CollaborationWebSocketHandler = BunAdapter["websocket"];
 type HocuspocusClientConnection = {
   handleMessage: (message: Uint8Array) => void;
   handleClose: (event?: { code: number; reason: string }) => void;
+  waitForPendingMessages?: () => Promise<void>;
 };
 
 type HocuspocusConnectionServer = {
@@ -467,6 +468,7 @@ export function createCollaborationWebSocketTransport(
   async function handleDocumentFlushMessage(
     peer: Peer,
     context: CollaborationSessionContext,
+    connection: HocuspocusClientConnection | undefined,
     request: CollaborationFlushRequest,
   ): Promise<void> {
     const server = options.runtime?.server;
@@ -480,6 +482,8 @@ export function createCollaborationWebSocketTransport(
           statusCode: 503,
         });
       }
+
+      await connection?.waitForPendingMessages?.();
 
       const result = await server.flushDocument(
         createDocumentNameFromContext(context),
@@ -882,7 +886,12 @@ export function createCollaborationWebSocketTransport(
 
         if (context && flushRequest) {
           trackDocumentTask(
-            handleDocumentFlushMessage(peer, context, flushRequest),
+            handleDocumentFlushMessage(
+              peer,
+              context,
+              peerConnections.get(peer),
+              flushRequest,
+            ),
           );
           return;
         }

--- a/apps/server/src/lib/collaboration/transport.ts
+++ b/apps/server/src/lib/collaboration/transport.ts
@@ -68,6 +68,10 @@ export type CollaborationAuthHandshakeGuard = {
     context: CollaborationPresenceContext,
     users: CollaborationPresenceUser[],
   ) => Promise<CollaborationPresenceUser[]>;
+  revalidateWrite: (
+    request: Request,
+    context: CollaborationSessionContext,
+  ) => Promise<{ ok: true } | { ok: false; closeCode: CollaborationCloseCode }>;
 };
 
 export type CollaborationPresenceStore = {
@@ -484,6 +488,22 @@ export function createCollaborationWebSocketTransport(
       }
 
       await connection?.waitForPendingMessages?.();
+
+      const authorization = await options.authGuard.revalidateWrite(
+        peer.request,
+        context,
+      );
+
+      if (!authorization.ok) {
+        throw new RuntimeError({
+          code: authorization.closeCode === 4401 ? "UNAUTHORIZED" : "FORBIDDEN",
+          message:
+            authorization.closeCode === 4401
+              ? COLLABORATION_SESSION_INVALID_REASON
+              : COLLABORATION_WRITE_FORBIDDEN_REASON,
+          statusCode: authorization.closeCode === 4401 ? 401 : 403,
+        });
+      }
 
       const result = await server.flushDocument(
         createDocumentNameFromContext(context),

--- a/apps/server/src/lib/collaboration/transport.ts
+++ b/apps/server/src/lib/collaboration/transport.ts
@@ -22,7 +22,11 @@ import type {
 import { toServerErrorResponse } from "../errors.js";
 import { createJsonResponse, resolvePathname } from "../http-utils.js";
 import { createCollaborationUnavailableError } from "./errors.js";
-import type { CollaborationRuntimeContext } from "./runtime.js";
+import {
+  createCollaborationDocumentName,
+  type CollaborationDocumentFlushResult,
+  type CollaborationRuntimeContext,
+} from "./runtime.js";
 
 export type BunUpgradeServer = Parameters<BunAdapter["handleUpgrade"]>[1];
 export type CollaborationWebSocketHandler = BunAdapter["websocket"];
@@ -40,6 +44,9 @@ type HocuspocusConnectionServer = {
   ) => HocuspocusClientConnection;
   closeConnections?: (documentName?: string) => void;
   flushPendingStores?: () => void;
+  flushDocument?: (
+    documentName: string,
+  ) => Promise<CollaborationDocumentFlushResult>;
   getDocumentsCount?: () => number;
 };
 
@@ -112,6 +119,26 @@ const COLLABORATION_DRAIN_POLL_INTERVAL_MS = 10;
 const COLLABORATION_DRAIN_TIMEOUT_MS = 10_000;
 
 type CollaborationRouteKind = "document" | "presence";
+
+type CollaborationFlushRequest = {
+  type: "mdcms.collaboration.flush";
+  requestId: string;
+};
+
+type CollaborationFlushResultPayload =
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "saved" | "unchanged";
+      draftRevision: number;
+    }
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "error";
+      code: string;
+      message: string;
+    };
 
 type CollaborationPeerContext =
   | {
@@ -211,6 +238,67 @@ function presenceContextFromPeer(
     Partial<CollaborationPeerContext>;
 
   return context.kind === "presence" ? context.presence : undefined;
+}
+
+function createDocumentNameFromContext(
+  context: CollaborationSessionContext,
+): string {
+  return createCollaborationDocumentName({
+    project: context.project,
+    environment: context.environment,
+    documentId: context.documentId,
+  });
+}
+
+function readStringMessage(message: Message): string | null {
+  const rawData = (message as { rawData?: unknown }).rawData;
+
+  if (typeof rawData === "string") {
+    return rawData;
+  }
+
+  if (rawData !== undefined) {
+    return null;
+  }
+
+  if (typeof message === "string") {
+    return message;
+  }
+
+  try {
+    return (message as { text?: () => string }).text?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseCollaborationFlushRequest(
+  message: Message,
+): CollaborationFlushRequest | null {
+  const text = readStringMessage(message);
+
+  if (!text) {
+    return null;
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    (payload as { type?: unknown }).type !== "mdcms.collaboration.flush" ||
+    typeof (payload as { requestId?: unknown }).requestId !== "string"
+  ) {
+    return null;
+  }
+
+  return payload as CollaborationFlushRequest;
 }
 
 function createRuntimeContext(
@@ -347,6 +435,7 @@ export function createCollaborationWebSocketTransport(
   const presenceConnectionCounts = new Map<string, number>();
   const presencePeerLifecycles = new Map<Peer, PresencePeerLifecycle>();
   const pendingPresenceTasks = new Set<Promise<void>>();
+  const pendingDocumentTasks = new Set<Promise<void>>();
   const now = options.now ?? (() => new Date());
 
   function trackPresenceTask(task: Promise<void>): void {
@@ -360,6 +449,65 @@ export function createCollaborationWebSocketTransport(
       });
 
     pendingPresenceTasks.add(trackedTask);
+  }
+
+  function trackDocumentTask(task: Promise<void>): void {
+    const trackedTask = task
+      .catch(() => {
+        // The task sends its own error payload. This prevents unhandled
+        // rejections from fire-and-forget websocket adapter hooks.
+      })
+      .finally(() => {
+        pendingDocumentTasks.delete(trackedTask);
+      });
+
+    pendingDocumentTasks.add(trackedTask);
+  }
+
+  async function handleDocumentFlushMessage(
+    peer: Peer,
+    context: CollaborationSessionContext,
+    request: CollaborationFlushRequest,
+  ): Promise<void> {
+    const server = options.runtime?.server;
+    let payload: CollaborationFlushResultPayload;
+
+    try {
+      if (!server?.flushDocument) {
+        throw new RuntimeError({
+          code: "COLLABORATION_FLUSH_UNAVAILABLE",
+          message: "Collaboration flush is unavailable.",
+          statusCode: 503,
+        });
+      }
+
+      const result = await server.flushDocument(
+        createDocumentNameFromContext(context),
+      );
+
+      payload = {
+        type: "mdcms.collaboration.flush.result",
+        requestId: request.requestId,
+        status: result.status,
+        draftRevision: result.draftRevision,
+      };
+    } catch (error) {
+      payload = {
+        type: "mdcms.collaboration.flush.result",
+        requestId: request.requestId,
+        status: "error",
+        code:
+          error instanceof RuntimeError
+            ? error.code
+            : "COLLABORATION_FLUSH_FAILED",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Collaboration flush failed.",
+      };
+    }
+
+    peer.send(JSON.stringify(payload));
   }
 
   function incrementPresenceConnectionCount(
@@ -729,6 +877,16 @@ export function createCollaborationWebSocketTransport(
           return;
         }
 
+        const context = collaborationContextFromPeer(peer);
+        const flushRequest = parseCollaborationFlushRequest(message);
+
+        if (context && flushRequest) {
+          trackDocumentTask(
+            handleDocumentFlushMessage(peer, context, flushRequest),
+          );
+          return;
+        }
+
         peerConnections.get(peer)?.handleMessage(message.uint8Array());
       },
       close: (peer, event) => {
@@ -784,6 +942,7 @@ export function createCollaborationWebSocketTransport(
         ),
       );
       await Promise.all(Array.from(pendingPresenceTasks));
+      await Promise.all(Array.from(pendingDocumentTasks));
       server?.flushPendingStores?.();
       await waitForCollaborationDocumentsToUnload(server);
       openPeers.clear();

--- a/apps/server/src/lib/content-api-test-support.ts
+++ b/apps/server/src/lib/content-api-test-support.ts
@@ -41,7 +41,7 @@ export const baseEnv = {
 
 export const dbEnv = {
   ...baseEnv,
-  DATABASE_URL: "postgres://mdcms:mdcms@localhost:5432/mdcms",
+  DATABASE_URL: "postgres://mdcms:mdcms@127.0.0.1:5432/mdcms",
 } as NodeJS.ProcessEnv;
 
 export const logger = createConsoleLogger({
@@ -242,6 +242,7 @@ export function createHandler(
   options: {
     lookupMediaAsset?: ContentMediaAssetLookup;
     activeCollaboration?: MountContentApiRoutesOptions["activeCollaboration"];
+    inactiveCollaborationCache?: MountContentApiRoutesOptions["inactiveCollaborationCache"];
   } = {},
 ) {
   const store = createInMemoryContentStore({
@@ -266,6 +267,7 @@ export function createHandler(
         }),
         lookupMediaAsset: options.lookupMediaAsset,
         activeCollaboration: options.activeCollaboration,
+        inactiveCollaborationCache: options.inactiveCollaborationCache,
       });
     },
     now: () => new Date("2026-03-02T10:00:00.000Z"),

--- a/apps/server/src/lib/content-api.test.ts
+++ b/apps/server/src/lib/content-api.test.ts
@@ -1774,6 +1774,190 @@ test("content API update rejects an active collaboration document", async () => 
   assert.equal(draft.data.body, "before");
 });
 
+test("content API update invalidates inactive collaboration cache after successful commit", async () => {
+  const invalidated: Array<{ documentId: string; body: string }> = [];
+  let handler: ReturnType<typeof createHandler>;
+  handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        const draftResponse = await handler(
+          new Request(
+            `http://localhost/api/v1/content/${documentId}?draft=true`,
+            { headers: scopeHeaders },
+          ),
+        );
+        const draft = (await draftResponse.json()) as {
+          data: { body: string };
+        };
+
+        invalidated.push({ documentId, body: draft.data.body });
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidate-after-update",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidate-after-update" },
+      body: "before",
+    },
+  );
+  const documentId = String(created.documentId);
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "invalidate-after-update" },
+        body: "after",
+        draftRevision: created.draftRevision,
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [{ documentId, body: "after" }]);
+});
+
+test("content API delete invalidates inactive collaboration cache after successful commit", async () => {
+  const invalidated: string[] = [];
+  const handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidate-after-delete",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidate-after-delete" },
+      body: "delete me",
+    },
+  );
+  const documentId = String(created.documentId);
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${documentId}`, {
+      method: "DELETE",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [documentId]);
+});
+
+test("content API does not invalidate inactive collaboration cache when active collaboration blocks update", async () => {
+  const invalidated: string[] = [];
+  const activeDocumentIds = new Set<string>();
+  const handler = createHandler({
+    activeCollaboration: {
+      isDocumentActive: async (documentId) => activeDocumentIds.has(documentId),
+    },
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/no-invalidate-when-active",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "no-invalidate-when-active" },
+      body: "before",
+    },
+  );
+  const documentId = String(created.documentId);
+
+  activeDocumentIds.add(documentId);
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "no-invalidate-when-active" },
+        body: "after",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(invalidated, []);
+});
+
+test("content API update remains successful when inactive collaboration cache invalidation fails", async () => {
+  const attempted: string[] = [];
+  const handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        attempted.push(documentId);
+        throw new Error("redis unavailable");
+      },
+    },
+  });
+  const created = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/invalidation-failure-still-updates",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "invalidation-failure-still-updates" },
+      body: "before",
+    },
+  );
+  const documentId = String(created.documentId);
+
+  const response = await handler(
+    new Request(`http://localhost/api/v1/content/${documentId}`, {
+      method: "PUT",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        frontmatter: { slug: "invalidation-failure-still-updates" },
+        body: "after",
+        draftRevision: created.draftRevision,
+      }),
+    }),
+  );
+  const body = (await response.json()) as { data: { body: string } };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.data.body, "after");
+  assert.deepEqual(attempted, [documentId]);
+
+  const draftResponse = await handler(
+    new Request(`http://localhost/api/v1/content/${documentId}?draft=true`, {
+      headers: scopeHeaders,
+    }),
+  );
+  const draft = (await draftResponse.json()) as { data: { body: string } };
+
+  assert.equal(draftResponse.status, 200);
+  assert.equal(draft.data.body, "after");
+});
+
 test("content API create remains allowed while another document is active", async () => {
   const handler = createHandler({
     activeCollaboration: {
@@ -1880,6 +2064,65 @@ test("content API bulk delete reports active collaboration per document and cont
   assert.equal(body.data.results[1]?.documentId, unlocked.documentId);
   assert.equal(body.data.results[1]?.status, "succeeded");
   assert.equal(body.data.results[1]?.document?.isDeleted, true);
+});
+
+test("content API bulk delete invalidates inactive collaboration cache for successful documents only", async () => {
+  const invalidated: string[] = [];
+  const activeDocumentIds = new Set<string>();
+  const handler = createHandler({
+    activeCollaboration: {
+      isDocumentActive: async (documentId) => activeDocumentIds.has(documentId),
+    },
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  });
+  const locked = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/bulk-invalidate-delete-locked",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "bulk-invalidate-delete-locked" },
+      body: "locked",
+    },
+  );
+  const unlocked = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/bulk-invalidate-delete-unlocked",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "bulk-invalidate-delete-unlocked" },
+      body: "unlocked",
+    },
+  );
+  const lockedDocumentId = String(locked.documentId);
+  const unlockedDocumentId = String(unlocked.documentId);
+
+  activeDocumentIds.add(lockedDocumentId);
+
+  const response = await handler(
+    new Request("http://localhost/api/v1/content/bulk", {
+      method: "POST",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "delete",
+        documentIds: [lockedDocumentId, unlockedDocumentId],
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [unlockedDocumentId]);
 });
 
 test("content API restore rejects an active collaboration document", async () => {
@@ -2041,6 +2284,61 @@ test("content API bulk move constructs archive slug paths and updates drafts", a
   assert.equal(draftResponse.status, 200);
   assert.equal(draft.data.path, "archive/bulk-move-slug");
   assert.equal(draft.data.draftRevision, 2);
+});
+
+test("content API bulk move invalidates inactive collaboration cache after successful commit", async () => {
+  const invalidated: Array<{ documentId: string; path: string }> = [];
+  let handler: ReturnType<typeof createHandler>;
+  handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        const draftResponse = await handler(
+          new Request(
+            `http://localhost/api/v1/content/${documentId}?draft=true`,
+            { headers: scopeHeaders },
+          ),
+        );
+        const draft = (await draftResponse.json()) as {
+          data: { path: string };
+        };
+
+        invalidated.push({ documentId, path: draft.data.path });
+      },
+    },
+  });
+  const document = await createContentDocument(
+    handler,
+    (headers = {}) => headers,
+    scopeHeaders,
+    {
+      path: "blog/bulk-invalidate-move",
+      type: "BlogPost",
+      locale: "en",
+      format: "md",
+      frontmatter: { slug: "bulk-invalidate-move" },
+      body: "move me",
+    },
+  );
+  const documentId = String(document.documentId);
+
+  const response = await handler(
+    new Request("http://localhost/api/v1/content/bulk", {
+      method: "POST",
+      headers: { ...scopeHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "move",
+        documentIds: [documentId],
+        move: {
+          targetDirectory: "archive",
+        },
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(invalidated, [
+    { documentId, path: "archive/bulk-invalidate-move" },
+  ]);
 });
 
 test("content API bulk move requires schema hash when write schema state exists", async () => {
@@ -4995,6 +5293,106 @@ test("content API restores a historical version to draft state by default", asyn
   assert.equal(versionsBody.data.length, 2);
   assert.equal(versionsBody.data[0]?.version, 2);
   assert.equal(versionsBody.data[1]?.version, 1);
+});
+
+test("content API version restore invalidates inactive collaboration cache after commit and ignores failure", async () => {
+  const invalidated: Array<{ documentId: string; body: string }> = [];
+  let handler: ReturnType<typeof createHandler>;
+  handler = createHandler({
+    inactiveCollaborationCache: {
+      invalidateDocument: async (documentId) => {
+        const draftResponse = await handler(
+          new Request(
+            `http://localhost/api/v1/content/${documentId}?draft=true`,
+            { headers: scopeHeaders },
+          ),
+        );
+        const draft = (await draftResponse.json()) as {
+          data: { body: string };
+        };
+
+        invalidated.push({ documentId, body: draft.data.body });
+        throw new Error("redis unavailable");
+      },
+    },
+  });
+
+  const createResponse = await handler(
+    new Request("http://localhost/api/v1/content", {
+      method: "POST",
+      headers: {
+        ...scopeHeaders,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        path: "blog/restore-version-invalidate",
+        type: "BlogPost",
+        locale: "en",
+        format: "md",
+        frontmatter: {
+          slug: "restore-version-invalidate",
+          title: "Version One",
+        },
+        body: "version one body",
+      }),
+    }),
+  );
+  const created = (await createResponse.json()) as {
+    data: { documentId: string };
+  };
+
+  assert.equal(createResponse.status, 200);
+
+  const firstPublishResponse = await handler(
+    new Request(
+      `http://localhost/api/v1/content/${created.data.documentId}/publish`,
+      {
+        method: "POST",
+        headers: scopeHeaders,
+      },
+    ),
+  );
+
+  assert.equal(firstPublishResponse.status, 200);
+
+  const updateResponse = await handler(
+    new Request(`http://localhost/api/v1/content/${created.data.documentId}`, {
+      method: "PUT",
+      headers: {
+        ...scopeHeaders,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        frontmatter: {
+          slug: "restore-version-invalidate",
+          title: "Version Two",
+        },
+        body: "version two body",
+      }),
+    }),
+  );
+
+  assert.equal(updateResponse.status, 200);
+  invalidated.length = 0;
+
+  const restoreResponse = await handler(
+    new Request(
+      `http://localhost/api/v1/content/${created.data.documentId}/versions/1/restore`,
+      {
+        method: "POST",
+        headers: scopeHeaders,
+      },
+    ),
+  );
+  const restoreBody = (await restoreResponse.json()) as {
+    data: { body: string };
+  };
+
+  assert.equal(restoreResponse.status, 200);
+  assert.equal(restoreBody.data.body, "version one body");
+  assert.deepEqual(invalidated, [
+    { documentId: created.data.documentId, body: "version one body" },
+  ]);
 });
 
 test("content API restores a historical version to published state when requested", async () => {

--- a/apps/server/src/lib/content-api.ts
+++ b/apps/server/src/lib/content-api.ts
@@ -6,6 +6,7 @@ export type {
   InMemoryContentSchemaScope,
   MountContentApiRoutesOptions,
   ContentActiveCollaborationChecker,
+  ContentInactiveCollaborationCacheInvalidator,
 } from "./content-api/types.js";
 export { createDatabaseContentStore } from "./content-api/database-store.js";
 export { createInMemoryContentStore } from "./content-api/in-memory-store.js";

--- a/apps/server/src/lib/content-api/routes.ts
+++ b/apps/server/src/lib/content-api/routes.ts
@@ -536,6 +536,22 @@ async function assertNoActiveCollaboration(
   throw createDocumentCollaborationActiveError(documentId);
 }
 
+async function invalidateInactiveCollaborationCache(
+  inactiveCollaborationCache: MountContentApiRoutesOptions["inactiveCollaborationCache"],
+  documentId: string,
+): Promise<void> {
+  if (!inactiveCollaborationCache) {
+    return;
+  }
+
+  try {
+    await inactiveCollaborationCache.invalidateDocument(documentId);
+  } catch {
+    // The content mutation is already committed. Stale inactive Redis cache is
+    // rejected by draft-revision/body-hash metadata on the next room load.
+  }
+}
+
 const BULK_REQUEST_LEVEL_ERROR_CODES = new Set([
   "UNAUTHORIZED",
   "MISSING_TARGET_ROUTING",
@@ -1284,6 +1300,13 @@ export function mountContentApiRoutes(
             );
           }
 
+          if (payload.action === "delete" || payload.action === "move") {
+            await invalidateInactiveCollaborationCache(
+              options.inactiveCollaborationCache,
+              documentId,
+            );
+          }
+
           results.push({
             documentId,
             status: "succeeded",
@@ -1413,6 +1436,11 @@ export function mountContentApiRoutes(
               expectedSchemaHash: schemaHash,
               expectedDraftRevision,
             }),
+        );
+
+        await invalidateInactiveCollaborationCache(
+          options.inactiveCollaborationCache,
+          params.documentId,
         );
 
         return {
@@ -1584,6 +1612,11 @@ export function mountContentApiRoutes(
               changeSummary,
               actorId,
             }),
+        );
+
+        await invalidateInactiveCollaborationCache(
+          options.inactiveCollaborationCache,
+          params.documentId,
         );
 
         return {
@@ -1920,6 +1953,11 @@ export function mountContentApiRoutes(
           scope,
           authorization,
           () => options.store.softDelete(scope, params.documentId),
+        );
+
+        await invalidateInactiveCollaborationCache(
+          options.inactiveCollaborationCache,
+          params.documentId,
         );
 
         return {

--- a/apps/server/src/lib/content-api/types.ts
+++ b/apps/server/src/lib/content-api/types.ts
@@ -289,6 +289,10 @@ export type ContentActiveCollaborationChecker = {
   isDocumentActive: (documentId: string) => Promise<boolean>;
 };
 
+export type ContentInactiveCollaborationCacheInvalidator = {
+  invalidateDocument: (documentId: string) => Promise<void>;
+};
+
 export const CONTENT_LIFECYCLE_EVENTS = [
   "content.created",
   "content.updated",
@@ -320,6 +324,7 @@ export type MountContentApiRoutesOptions = {
   resolveUsers?: ContentUserSummaryLookup;
   lifecycleEvents?: ContentLifecycleEventSink;
   activeCollaboration?: ContentActiveCollaborationChecker;
+  inactiveCollaborationCache?: ContentInactiveCollaborationCacheInvalidator;
   previewTokenSecret?: string;
   previewTokenTtlSeconds?: number;
 };

--- a/apps/server/src/lib/runtime-with-modules.test.ts
+++ b/apps/server/src/lib/runtime-with-modules.test.ts
@@ -88,6 +88,34 @@ function createServerModule(
   };
 }
 
+function createAiStoreDocument(
+  documentId: string,
+  overrides: Partial<ContentDocumentResponse> = {},
+): ContentDocumentResponse {
+  return {
+    documentId,
+    translationGroupId: `${documentId}-translation-group`,
+    project: "marketing",
+    environment: "draft",
+    path: `content/${documentId}`,
+    type: "BlogPost",
+    locale: "en",
+    format: "md",
+    frontmatter: {},
+    body: "body",
+    version: 0,
+    publishedVersion: null,
+    hasUnpublishedChanges: true,
+    isDeleted: false,
+    createdAt: "2026-06-11T00:00:00.000Z",
+    createdBy: "user-1",
+    updatedAt: "2026-06-11T00:00:00.000Z",
+    updatedBy: "user-1",
+    draftRevision: 1,
+    ...overrides,
+  };
+}
+
 test("createServerRequestHandlerWithModules surfaces module actions in /api/v1/actions", async () => {
   const { handler, moduleLoadReport, dbConnection } =
     createServerRequestHandlerWithModules({
@@ -235,6 +263,11 @@ test("createCollaborationGuardedAiContentStore blocks existing-document writes w
     {
       isDocumentActive: async (documentId) => documentId === "active-document",
     },
+    {
+      invalidateDocument: async () => {
+        calls.push("invalidate");
+      },
+    },
   );
 
   await assert.rejects(
@@ -285,6 +318,118 @@ test("createCollaborationGuardedAiContentStore blocks existing-document writes w
   );
 
   assert.deepEqual(calls, ["getById", "create"]);
+});
+
+test("createCollaborationGuardedAiContentStore invalidates inactive cache after update and delete", async () => {
+  const invalidated: string[] = [];
+  const store = createCollaborationGuardedAiContentStore(
+    {
+      async getById() {
+        return undefined;
+      },
+      async update(_scope, documentId) {
+        return createAiStoreDocument(documentId, { path: "content/updated" });
+      },
+      async create(_scope, payload) {
+        return createAiStoreDocument("created", { path: payload.path });
+      },
+      async softDelete(_scope, documentId) {
+        return createAiStoreDocument(documentId, {
+          path: "content/deleted",
+          isDeleted: true,
+        });
+      },
+    },
+    undefined,
+    {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  );
+
+  await store.update(
+    { project: "marketing", environment: "draft" },
+    "doc-update",
+    { body: "updated" },
+    { expectedSchemaHash: "schema-hash" },
+  );
+  await store.softDelete(
+    { project: "marketing", environment: "draft" },
+    "doc-delete",
+  );
+
+  assert.deepEqual(invalidated, ["doc-update", "doc-delete"]);
+});
+
+test("createCollaborationGuardedAiContentStore invalidates inactive cache after restore", async () => {
+  const invalidated: string[] = [];
+  const store = createCollaborationGuardedAiContentStore(
+    {
+      async getById() {
+        return undefined;
+      },
+      async update(_scope, documentId) {
+        return createAiStoreDocument(documentId);
+      },
+      async create(_scope, payload) {
+        return createAiStoreDocument("created", { path: payload.path });
+      },
+      async softDelete(_scope, documentId) {
+        return createAiStoreDocument(documentId, { isDeleted: true });
+      },
+      async restore(_scope, documentId) {
+        return createAiStoreDocument(documentId);
+      },
+    },
+    undefined,
+    {
+      invalidateDocument: async (documentId) => {
+        invalidated.push(documentId);
+      },
+    },
+  );
+
+  const restore = store.restore;
+  assert.ok(restore);
+
+  await restore({ project: "marketing", environment: "draft" }, "doc-restore");
+
+  assert.deepEqual(invalidated, ["doc-restore"]);
+});
+
+test("createCollaborationGuardedAiContentStore ignores inactive cache invalidation failure after update", async () => {
+  const store = createCollaborationGuardedAiContentStore(
+    {
+      async getById() {
+        return undefined;
+      },
+      async update(_scope, documentId) {
+        return createAiStoreDocument(documentId, { path: "content/updated" });
+      },
+      async create(_scope, payload) {
+        return createAiStoreDocument("created", { path: payload.path });
+      },
+      async softDelete(_scope, documentId) {
+        return createAiStoreDocument(documentId, { isDeleted: true });
+      },
+    },
+    undefined,
+    {
+      invalidateDocument: async () => {
+        throw new Error("redis unavailable");
+      },
+    },
+  );
+
+  const updated = await store.update(
+    { project: "marketing", environment: "draft" },
+    "doc-update",
+    { body: "updated" },
+    { expectedSchemaHash: "schema-hash" },
+  );
+
+  assert.equal(updated.documentId, "doc-update");
 });
 
 test("createServerRequestHandlerWithModules loads bundled modules when APP_VERSION is unset", async () => {

--- a/apps/server/src/lib/runtime-with-modules.ts
+++ b/apps/server/src/lib/runtime-with-modules.ts
@@ -32,6 +32,7 @@ import {
   isCollaborationWebSocketUpgradeRequest,
   type BunUpgradeServer,
   type CollaborationWebSocketHandler,
+  type CollaborationPresenceStore,
   type CollaborationWebSocketTransport,
 } from "./collaboration/transport.js";
 import {
@@ -106,7 +107,7 @@ export type CreateServerRequestHandlerWithModulesOptions = {
 
 type RuntimeCollaborationRedisStore = CollaborationRuntimeRedisStore & {
   isActive: (documentId: string) => Promise<boolean>;
-};
+} & CollaborationPresenceStore;
 
 export type PrepareServerRequestHandlerWithModulesOptions =
   CreateServerRequestHandlerWithModulesOptions & {
@@ -338,6 +339,7 @@ export function createServerRequestHandlerWithModules(
     {
       authGuard: collaborationAuthGuard,
       runtime: collaborationRuntime,
+      presenceStore: collaborationRedisStore,
       unavailableDetails: options.collaborationUnavailableDetails,
     },
   );

--- a/apps/server/src/lib/runtime-with-modules.ts
+++ b/apps/server/src/lib/runtime-with-modules.ts
@@ -19,6 +19,7 @@ import {
   createDatabaseContentStore,
   mountContentApiRoutes,
   type ContentActiveCollaborationChecker,
+  type ContentInactiveCollaborationCacheInvalidator,
 } from "./content-api.js";
 import { createCollaborationRedisDependency } from "./collaboration/redis-client.js";
 import { createDocumentCollaborationActiveError } from "./collaboration/errors.js";
@@ -107,6 +108,7 @@ export type CreateServerRequestHandlerWithModulesOptions = {
 
 type RuntimeCollaborationRedisStore = CollaborationRuntimeRedisStore & {
   isActive: (documentId: string) => Promise<boolean>;
+  invalidateInactiveCache: (documentId: string) => Promise<void>;
 } & CollaborationPresenceStore;
 
 export type PrepareServerRequestHandlerWithModulesOptions =
@@ -174,8 +176,21 @@ async function assertNoActiveCollaboration(
 export function createCollaborationGuardedAiContentStore(
   store: AiContentStore,
   activeCollaboration: ContentActiveCollaborationChecker | undefined,
+  inactiveCollaborationCache?: ContentInactiveCollaborationCacheInvalidator,
 ): AiContentStore {
   const restore = store.restore;
+  const invalidateInactiveCache = async (documentId: string) => {
+    if (!inactiveCollaborationCache) {
+      return;
+    }
+
+    await inactiveCollaborationCache
+      .invalidateDocument(documentId)
+      .catch(() => {
+        // The mutation is already committed. Inactive Redis cache deletion is
+        // best-effort; future room loads still validate metadata against the DB.
+      });
+  };
 
   return {
     getById: (scope, documentId, opts) =>
@@ -183,16 +198,22 @@ export function createCollaborationGuardedAiContentStore(
     create: (scope, payload, opts) => store.create(scope, payload, opts),
     update: async (scope, documentId, payload, opts) => {
       await assertNoActiveCollaboration(activeCollaboration, documentId);
-      return store.update(scope, documentId, payload, opts);
+      const document = await store.update(scope, documentId, payload, opts);
+      await invalidateInactiveCache(documentId);
+      return document;
     },
     softDelete: async (scope, documentId) => {
       await assertNoActiveCollaboration(activeCollaboration, documentId);
-      return store.softDelete(scope, documentId);
+      const document = await store.softDelete(scope, documentId);
+      await invalidateInactiveCache(documentId);
+      return document;
     },
     restore: restore
       ? async (scope, documentId) => {
           await assertNoActiveCollaboration(activeCollaboration, documentId);
-          return restore(scope, documentId);
+          const document = await restore(scope, documentId);
+          await invalidateInactiveCache(documentId);
+          return document;
         }
       : undefined,
   };
@@ -303,6 +324,12 @@ export function createServerRequestHandlerWithModules(
             collaborationRedisStore.isActive(documentId),
         }
       : undefined);
+  const inactiveCollaborationCache = collaborationRedisStore
+    ? {
+        invalidateDocument: (documentId: string) =>
+          collaborationRedisStore.invalidateInactiveCache(documentId),
+      }
+    : undefined;
   const resolveCollaborationDocument: CollaborationDocumentLocator = async ({
     project,
     environment,
@@ -583,6 +610,7 @@ export function createServerRequestHandlerWithModules(
         restore: (scope, documentId) => contentStore.restore(scope, documentId),
       },
       activeCollaboration,
+      inactiveCollaborationCache,
     ),
     contextResolver: {
       loadDraftContext: async ({
@@ -718,6 +746,7 @@ export function createServerRequestHandlerWithModules(
         },
         lifecycleEvents: webhookRuntime.dispatcher,
         activeCollaboration,
+        inactiveCollaborationCache,
         previewTokenSecret: env.MDCMS_PREVIEW_TOKEN_SECRET,
       });
       mountSchemaApiRoutes(app, {

--- a/apps/studio-example/app/admin/[[...path]]/page.test.tsx
+++ b/apps/studio-example/app/admin/[[...path]]/page.test.tsx
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { resolve } from "node:path";
 
 import { AdminStudioClient } from "../admin-studio-client";
+import { resetPreparedAdminStudioConfigCacheForTests } from "../prepared-studio-config-cache";
 import { resolveStudioExampleAppRoot } from "../resolve-studio-example-app-root";
 import AdminCatchAllPage from "./page";
 
@@ -21,6 +22,7 @@ test("resolveStudioExampleAppRoot does not duplicate the app path", () => {
 });
 
 test("admin catch-all page prepares studio config with local MDX metadata", async () => {
+  resetPreparedAdminStudioConfigCacheForTests();
   const element = await AdminCatchAllPage();
 
   assert.equal(element.type, AdminStudioClient);

--- a/apps/studio-example/app/admin/[[...path]]/page.tsx
+++ b/apps/studio-example/app/admin/[[...path]]/page.tsx
@@ -1,18 +1,9 @@
-import { resolve } from "node:path";
-
-import { prepareStudioConfig } from "@mdcms/studio/runtime";
-
-import config from "../../../mdcms.config";
 import { AdminStudioClient } from "../admin-studio-client";
-import { resolveStudioExampleAppRoot } from "../resolve-studio-example-app-root";
+import { getPreparedAdminStudioConfig } from "../prepared-studio-config-cache";
 import { extractPreparedStudioComponentMetadata } from "../studio-config";
 
 export default async function AdminCatchAllPage() {
-  const appRoot = resolveStudioExampleAppRoot();
-  const preparedConfig = await prepareStudioConfig(config, {
-    cwd: appRoot,
-    tsconfigPath: resolve(appRoot, "tsconfig.json"),
-  });
+  const preparedConfig = await getPreparedAdminStudioConfig();
 
   return (
     <AdminStudioClient

--- a/apps/studio-example/app/admin/prepared-studio-config-cache.test.ts
+++ b/apps/studio-example/app/admin/prepared-studio-config-cache.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import type { MdcmsConfig } from "@mdcms/studio";
+
+import {
+  createPreparedStudioConfigSignature,
+  loadCachedPreparedStudioConfig,
+  type PreparedStudioConfigCacheState,
+} from "./prepared-studio-config-cache";
+
+test("loadCachedPreparedStudioConfig reuses prepared config for the same signature", async () => {
+  const cache: PreparedStudioConfigCacheState<{ value: number }> = {};
+  let prepareCount = 0;
+  const prepare = async () => ({ value: ++prepareCount });
+
+  const first = await loadCachedPreparedStudioConfig({
+    cache,
+    signature: "same",
+    prepare,
+  });
+  const second = await loadCachedPreparedStudioConfig({
+    cache,
+    signature: "same",
+    prepare,
+  });
+
+  assert.equal(prepareCount, 1);
+  assert.equal(first, second);
+});
+
+test("loadCachedPreparedStudioConfig shares a pending preparation for the same signature", async () => {
+  const cache: PreparedStudioConfigCacheState<{ value: number }> = {};
+  let prepareCount = 0;
+  let resolvePrepared: (value: { value: number }) => void = () => {};
+  const prepare = () => {
+    prepareCount += 1;
+
+    return new Promise<{ value: number }>((resolve) => {
+      resolvePrepared = resolve;
+    });
+  };
+
+  const first = loadCachedPreparedStudioConfig({
+    cache,
+    signature: "same",
+    prepare,
+  });
+  const second = loadCachedPreparedStudioConfig({
+    cache,
+    signature: "same",
+    prepare,
+  });
+  assert.equal(prepareCount, 1);
+
+  resolvePrepared({ value: 1 });
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+
+  assert.equal(firstResult, secondResult);
+});
+
+test("loadCachedPreparedStudioConfig refreshes prepared config when the signature changes", async () => {
+  const cache: PreparedStudioConfigCacheState<{ value: number }> = {};
+  let prepareCount = 0;
+  const prepare = async () => ({ value: ++prepareCount });
+
+  const first = await loadCachedPreparedStudioConfig({
+    cache,
+    signature: "before",
+    prepare,
+  });
+  const second = await loadCachedPreparedStudioConfig({
+    cache,
+    signature: "after",
+    prepare,
+  });
+
+  assert.equal(prepareCount, 2);
+  assert.notEqual(first, second);
+  assert.deepEqual(second, { value: 2 });
+});
+
+test("loadCachedPreparedStudioConfig clears failed preparations before retrying", async () => {
+  const cache: PreparedStudioConfigCacheState<{ value: number }> = {};
+  let prepareCount = 0;
+  const prepare = async () => {
+    prepareCount += 1;
+
+    if (prepareCount === 1) {
+      throw new Error("prepare failed");
+    }
+
+    return { value: prepareCount };
+  };
+
+  await assert.rejects(
+    () =>
+      loadCachedPreparedStudioConfig({
+        cache,
+        signature: "same",
+        prepare,
+      }),
+    /prepare failed/,
+  );
+  const retry = await loadCachedPreparedStudioConfig({
+    cache,
+    signature: "same",
+    prepare,
+  });
+
+  assert.equal(prepareCount, 2);
+  assert.deepEqual(retry, { value: 2 });
+});
+
+test("createPreparedStudioConfigSignature changes when a configured component file changes", () => {
+  const root = mkdtempSync(join(tmpdir(), "mdcms-studio-config-cache-"));
+  const componentPath = join(root, "Chart.tsx");
+  const tsconfigPath = join(root, "tsconfig.json");
+  writeFileSync(join(root, "mdcms.config.ts"), "export default {};\n");
+  writeFileSync(tsconfigPath, "{}\n");
+  writeFileSync(componentPath, "export function Chart() { return null; }\n");
+  const config = {
+    project: "marketing-site",
+    environment: "staging",
+    serverUrl: "http://localhost:4000",
+    components: [
+      {
+        name: "Chart",
+        importPath: "./Chart",
+        load: async () => null,
+      },
+    ],
+  } satisfies MdcmsConfig;
+
+  const before = createPreparedStudioConfigSignature({
+    config,
+    cwd: root,
+    tsconfigPath,
+  });
+  writeFileSync(componentPath, "export function Chart() { return 'new'; }\n");
+  const after = createPreparedStudioConfigSignature({
+    config,
+    cwd: root,
+    tsconfigPath,
+  });
+
+  assert.notEqual(before, after);
+});
+
+test("createPreparedStudioConfigSignature changes when an explicit dependency file changes", () => {
+  const root = mkdtempSync(join(tmpdir(), "mdcms-studio-config-cache-"));
+  const dependencyPath = join(root, "registry.ts");
+  writeFileSync(join(root, "mdcms.config.ts"), "export default {};\n");
+  writeFileSync(dependencyPath, "export const value = 'before';\n");
+  const config = {
+    project: "marketing-site",
+    environment: "staging",
+    serverUrl: "http://localhost:4000",
+  } satisfies MdcmsConfig;
+
+  const before = createPreparedStudioConfigSignature({
+    config,
+    cwd: root,
+    dependencyPaths: ["registry.ts"],
+  });
+  writeFileSync(dependencyPath, "export const value = 'after';\n");
+  const after = createPreparedStudioConfigSignature({
+    config,
+    cwd: root,
+    dependencyPaths: ["registry.ts"],
+  });
+
+  assert.notEqual(before, after);
+});

--- a/apps/studio-example/app/admin/prepared-studio-config-cache.test.ts
+++ b/apps/studio-example/app/admin/prepared-studio-config-cache.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { test } from "node:test";
+import { test } from "bun:test";
 
 import type { MdcmsConfig } from "@mdcms/studio";
 

--- a/apps/studio-example/app/admin/prepared-studio-config-cache.ts
+++ b/apps/studio-example/app/admin/prepared-studio-config-cache.ts
@@ -1,0 +1,140 @@
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+import type { MdcmsConfig } from "@mdcms/studio";
+import { prepareStudioConfig } from "@mdcms/studio/runtime";
+
+import config from "../../mdcms.config";
+import { resolveStudioExampleAppRoot } from "./resolve-studio-example-app-root";
+
+type PreparedStudioConfig = Awaited<ReturnType<typeof prepareStudioConfig>>;
+
+export type PreparedStudioConfigCacheState<TConfig> = {
+  signature?: string;
+  value?: Promise<TConfig>;
+};
+
+const adminStudioConfigCache: PreparedStudioConfigCacheState<PreparedStudioConfig> =
+  {};
+
+function readFileSignature(filePath: string): string {
+  try {
+    const stat = statSync(filePath);
+
+    return `${filePath}:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return `${filePath}:missing`;
+  }
+}
+
+function resolveComponentSourceFileForSignature(
+  component: NonNullable<MdcmsConfig["components"]>[number],
+  cwd: string,
+): string {
+  const normalizedImportPath = isAbsolute(component.importPath)
+    ? component.importPath
+    : resolve(cwd, component.importPath);
+  const candidates = [
+    normalizedImportPath,
+    `${normalizedImportPath}.tsx`,
+    `${normalizedImportPath}.ts`,
+    `${normalizedImportPath}.jsx`,
+    `${normalizedImportPath}.js`,
+    resolve(normalizedImportPath, "index.tsx"),
+    resolve(normalizedImportPath, "index.ts"),
+    resolve(normalizedImportPath, "index.jsx"),
+    resolve(normalizedImportPath, "index.js"),
+  ];
+
+  return (
+    candidates.find((candidate) => {
+      try {
+        return statSync(candidate).isFile();
+      } catch {
+        return false;
+      }
+    }) ?? normalizedImportPath
+  );
+}
+
+export function createPreparedStudioConfigSignature(input: {
+  config: MdcmsConfig;
+  cwd: string;
+  dependencyPaths?: string[];
+  tsconfigPath?: string;
+}): string {
+  const sourceFiles = new Set<string>([
+    resolve(input.cwd, "mdcms.config.ts"),
+    ...(input.tsconfigPath ? [input.tsconfigPath] : []),
+    ...(input.dependencyPaths ?? []).map((dependencyPath) =>
+      isAbsolute(dependencyPath)
+        ? dependencyPath
+        : resolve(input.cwd, dependencyPath),
+    ),
+  ]);
+
+  for (const component of input.config.components ?? []) {
+    sourceFiles.add(
+      resolveComponentSourceFileForSignature(component, input.cwd),
+    );
+  }
+
+  return Array.from(sourceFiles)
+    .sort((left, right) => left.localeCompare(right))
+    .map(readFileSignature)
+    .join("|");
+}
+
+export async function loadCachedPreparedStudioConfig<TConfig>(input: {
+  cache: PreparedStudioConfigCacheState<TConfig>;
+  signature: string;
+  prepare: () => Promise<TConfig>;
+}): Promise<TConfig> {
+  if (input.cache.signature === input.signature && input.cache.value) {
+    return input.cache.value;
+  }
+
+  const pending = input.prepare();
+  input.cache.signature = input.signature;
+  input.cache.value = pending;
+
+  try {
+    return await pending;
+  } catch (error) {
+    if (input.cache.value === pending) {
+      input.cache.signature = undefined;
+      input.cache.value = undefined;
+    }
+
+    throw error;
+  }
+}
+
+export async function getPreparedAdminStudioConfig(): Promise<PreparedStudioConfig> {
+  const appRoot = resolveStudioExampleAppRoot();
+  const tsconfigPath = resolve(appRoot, "tsconfig.json");
+  const signature = createPreparedStudioConfigSignature({
+    config,
+    cwd: appRoot,
+    dependencyPaths: [
+      "lib/preview-routing.ts",
+      "lib/studio-example-studio-config.ts",
+    ],
+    tsconfigPath,
+  });
+
+  return loadCachedPreparedStudioConfig({
+    cache: adminStudioConfigCache,
+    signature,
+    prepare: () =>
+      prepareStudioConfig(config, {
+        cwd: appRoot,
+        tsconfigPath,
+      }),
+  });
+}
+
+export function resetPreparedAdminStudioConfigCacheForTests(): void {
+  adminStudioConfigCache.signature = undefined;
+  adminStudioConfigCache.value = undefined;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/cli": {
       "name": "@mdcms/cli",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "bin": {
         "mdcms": "./dist/bin/mdcms.js",
       },
@@ -86,7 +86,7 @@
       "name": "@mdcms/editor-core",
       "version": "0.1.0",
       "dependencies": {
-        "@mdcms/shared": "^0.4.0",
+        "@mdcms/shared": "^0.5.0",
         "@tiptap/core": "^3.7.0",
         "@tiptap/extension-code-block-lowlight": "^3.7.0",
         "@tiptap/extension-highlight": "^3.7.0",
@@ -121,7 +121,7 @@
     },
     "packages/react-primitives": {
       "name": "@mdcms/react-primitives",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@mdcms/shared": "workspace:*",
         "tslib": "^2.3.0",
@@ -138,7 +138,7 @@
     },
     "packages/sdk": {
       "name": "@mdcms/sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@mdcms/shared": "^0.3.0",
         "@mdx-js/mdx": "^3.1.1",
@@ -159,7 +159,7 @@
     },
     "packages/shared": {
       "name": "@mdcms/shared",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "elysia": "^1.4.25",
         "tslib": "^2.3.0",
@@ -169,7 +169,7 @@
     },
     "packages/studio": {
       "name": "@mdcms/studio",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@elysiajs/eden": "^1.4.8",
         "@floating-ui/react-dom": "^2.1.8",
@@ -177,7 +177,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/space-grotesk": "^5.2.10",
         "@mdcms/editor-core": "^0.1.0",
-        "@mdcms/shared": "^0.4.0",
+        "@mdcms/shared": "^0.5.0",
         "@radix-ui/react-avatar": "1.1.11",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-dropdown-menu": "2.1.16",
@@ -205,6 +205,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "elysia": "^1.4.25",
+        "lib0": "^0.2.117",
         "lowlight": "^3.3.0",
         "lucide-react": "^1.7.0",
         "mdast-util-from-markdown": "^2.0.3",
@@ -216,6 +217,9 @@
         "tailwindcss": "^4.2.0",
         "tslib": "^2.3.0",
         "tw-animate-css": "1.3.3",
+        "y-prosemirror": "^1.3.7",
+        "y-protocols": "^1.0.7",
+        "yjs": "^13.6.31",
       },
       "devDependencies": {
         "@types/react": "^19.0.12",

--- a/docs/specs/SPEC-001-platform-overview-and-scope.md
+++ b/docs/specs/SPEC-001-platform-overview-and-scope.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-001 Platform Overview and Scope
@@ -28,7 +28,9 @@ This section keeps only the product-scope split for the live product definition.
 ### MVP
 
 - Schema-based content modeling with explicit schema sync.
-- TipTap-based Markdown/MDX editing with an active collaboration socket/cache runtime for document rooms.
+- TipTap-based Markdown/MDX editing with an active collaboration socket/cache
+  runtime for document rooms, server-owned collaboration autosave, and baseline
+  presence indicators.
 - REST API with explicit project/environment routing, draft writes, and publish-as-version semantics.
 - SDK, CLI, and Studio as the primary operator surfaces.
 - Draft/publish workflow, version history, permissions, and authentication.
@@ -41,6 +43,6 @@ This section keeps only the product-scope split for the live product definition.
 
 - AI integration (`High`) and AI-assisted CMS migration (`High`).
 - SEO analysis (`Medium`), scheduled publishing (`Medium`), and comprehensive audit log (`Medium`).
-- Advanced media organization, image transformations, CDN controls, asset governance, presence awareness (`Medium`), advanced multi-user collaboration UI (`Medium`), webhooks (`Medium`), full-text search (`Medium`), and advanced bulk operation workflows (`Medium`).
+- Advanced media organization, image transformations, CDN controls, asset governance, advanced multi-user collaboration controls beyond baseline presence (`Medium`), webhooks (`Medium`), full-text search (`Medium`), and advanced bulk operation workflows (`Medium`).
 - Schema-aware API filtering (`Low`), third-party plugin sandboxing (`Low`), cursor-based pagination (`Low`), and side-by-side translation view (`Low`).
 - Organizations (`Deferred`), multi-tenant SaaS (`Deferred`), and white-label branding (`Deferred`).

--- a/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
+++ b/docs/specs/SPEC-003-content-storage-versioning-and-migrations.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-003 Content Storage, Versioning, and Migrations
@@ -146,8 +146,8 @@ flowchart LR
 Studio draft persistence depends on the active editor mode:
 
 - **Single-user draft auto-save** serializes the current editor state to markdown/MDX and persists it to the `documents` row (for example, after the last change or on editor blur).
-- **Collaborative editing** stores active Yjs state in Redis and persists to PostgreSQL only on the last-disconnect final save. Periodic/debounced PostgreSQL autosave from active collaboration rooms is deferred.
-- Single-user HTTP draft auto-save and collaboration final-save DB writes are silent draft `UPDATE`s — they never create version rows and never pollute history.
+- **Collaborative editing** stores active Yjs state in Redis and persists durable draft state to PostgreSQL through server-owned active collaboration autosave and last-disconnect final save. Active collaboration autosave serializes the current Y.Doc to markdown/MDX, combines it with the room's current frontmatter draft state, updates the `documents` row, increments `draft_revision`, and emits `content.updated` only when the draft head changes.
+- Single-user HTTP draft auto-save, collaboration autosave, and collaboration final-save DB writes are silent draft `UPDATE`s — they never create version rows and never pollute history.
 - If Redis is lost (crash, flush), the last saved draft in PostgreSQL is the recovery point.
 
 ### Soft Delete
@@ -654,7 +654,7 @@ The deterministic error contract for a blocked existing-document mutation is:
 - Code: `DOCUMENT_COLLABORATION_ACTIVE`
 - Details: `{ documentId }`
 
-The active collaboration lock is separate from the inactive Yjs cache. A Yjs state cache may remain in Redis for 30 minutes after the last collaborator disconnects, but that inactive cache must not block content mutations.
+The active collaboration lock is separate from the inactive Yjs cache. A Yjs state cache may remain in Redis for 30 minutes after the last collaborator disconnects, but that inactive cache must not block content mutations. Any successful existing-document content mutation that changes or deletes the draft head while no active collaboration lock exists must invalidate the inactive Yjs state and metadata for that document after the database transaction succeeds. This includes CLI-driven `cms push` updates/deletes and equivalent server content-store writes. If Redis invalidation fails after the database commit, the mutation remains successful; the next collaboration room load must still reject stale cache through draft-revision/body-hash metadata checks and rebuild from PostgreSQL.
 
 ### CMS ↔ CLI (Draft-Revision Optimistic Concurrency)
 

--- a/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
+++ b/docs/specs/SPEC-005-auth-authorization-and-request-routing.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-005 Auth, Authorization, and Request Routing
@@ -409,17 +409,17 @@ MDCMS rejects sign-in with `AUTH_SAML_REQUIRED_ATTRIBUTE_MISSING` (`401`) when:
 
 #### Collaboration Socket Authentication
 
-Collaboration sockets are authenticated with the same Studio session cookie as the Studio runtime. API keys are rejected for this endpoint even when a key has content scopes:
+Collaboration sockets are authenticated with the same Studio session cookie as the Studio runtime. API keys are rejected for collaboration endpoints even when a key has content scopes:
 
-- Connect URL: `/api/v1/collaboration?project=...&environment=...&documentId=...`
+- Document-room URL: `/api/v1/collaboration?project=...&environment=...&documentId=...`
+- Presence-stream URL: `/api/v1/collaboration/presence?project=...&environment=...`
 - `Origin` must match the configured Studio allowlist.
 - Session cookie is validated through better-auth during the WebSocket handshake.
-- `project`, `environment`, and `documentId` are required query parameters.
-- Target document must belong to the requested `(project, environment)` scope.
-- Folder/path RBAC (`documents.path`) is evaluated before subscribing the socket to the document room.
+- `project` and `environment` are required for every collaboration socket.
+- `documentId` is required for document-room sockets and forbidden on the presence stream.
+- For document-room sockets, the target document must belong to the requested `(project, environment)` scope.
+- Folder/path RBAC (`documents.path`) is evaluated before subscribing the socket to the document room. Presence-stream snapshots are filtered to documents the subscriber can read in the routed target.
 - Revoked/expired sessions are disconnected immediately with `4401`; authorization failures return `4403`.
-
-Presence indicators and periodic/debounced PostgreSQL autosave from active collaboration rooms are not part of this authentication contract.
 
 ### API Authentication
 

--- a/docs/specs/SPEC-006-studio-runtime-and-ui.md
+++ b/docs/specs/SPEC-006-studio-runtime-and-ui.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-006 Studio Runtime and UI
@@ -520,6 +520,14 @@ Normative behavior:
     locale variant is unpublished or has unpublished changes
   - `Published` only when every existing locale variant in the group has a
     published version and none have unpublished changes
+- The content list subscribes to the target-scoped collaboration presence stream
+  when the current session can read content in the active target. Visible rows
+  show compact user-identifiable presence indicators for users currently viewing
+  or editing that document. Editing indicators take precedence over viewing
+  indicators when the same document has both.
+- Presence labels and colors come from the collaboration presence contract owned
+  by SPEC-007. The list must not render presence for documents omitted by the
+  backend presence filter or for rows outside the current visible result set.
 
 Deterministic states:
 
@@ -601,10 +609,9 @@ Normative behavior:
   collaboration socket/Yjs path owned by SPEC-007. The active collaboration
   lock blocks normal existing-document HTTP mutations for that document, so
   Studio must not perform HTTP `PUT` auto-save for the active room. PostgreSQL
-  draft persistence for the active collaboration runtime happens through the
-  collaboration final save after the last collaborator disconnects.
-  Periodic/debounced PostgreSQL autosave from active collaboration rooms
-  remains deferred.
+  draft persistence for the active collaboration runtime happens through
+  server-owned collaboration autosave and the collaboration final save after the
+  last collaborator disconnects.
 - The primary canvas edits the document `body` through the editor engine owned
   by SPEC-007.
 - The editor supports media insertion from four inputs: the toolbar image
@@ -698,11 +705,11 @@ Normative behavior:
   reloads the iframe after persistence succeeds. In an active collaboration
   document room, manual preview refresh must not force an HTTP draft save or
   bypass the active collaboration lock; it refreshes against the latest
-  persisted state, and unsaved Yjs changes become visible to backend-backed
-  preview only after the collaboration save contract persists them. Route
-  resolution uses the latest persisted draft snapshot; local unsaved
-  frontmatter changes must not navigate the iframe before the canonical draft
-  row is updated.
+  persisted state, and unsaved Yjs/frontmatter changes become visible to
+  backend-backed preview only after the collaboration autosave/final-save
+  contract persists them. Route resolution uses the latest persisted draft
+  snapshot; local unsaved frontmatter changes must not navigate the iframe
+  before the canonical draft row is updated.
 - When route resolution returns a URL, Studio requests a signed preview token
   from `POST /api/v1/content/:documentId/preview-token` before loading the
   iframe. Studio sends the resolved URL as `previewUrl` when available, appends
@@ -738,16 +745,17 @@ Normative behavior:
   editor mode. In non-collaborative operation, this is the same HTTP draft
   write routine that the auto-save debounce uses. In an active collaboration
   document room, it must not issue normal HTTP `PUT` while the active
-  collaboration lock exists; collaboration final save owns PostgreSQL draft
-  persistence for the active runtime slice. `Save draft` is enabled only while
+  collaboration lock exists; it requests an immediate collaboration autosave
+  flush through the collaboration runtime and reflects `Saving...` until the
+  server acknowledges persisted draft state. `Save draft` is enabled only while
   the draft is in `unsaved` state and a publish is not in flight; it is hidden
-  when the active target denies writes. It must not introduce a separate write
-  path or bypass the same guard checks that auto-save respects (RBAC, schema
-  mismatch, viewing a prior version, active collaboration lock).
+  when the active target denies writes. It must not introduce a separate content
+  write path or bypass the same guard checks that auto-save respects (RBAC,
+  schema mismatch, viewing a prior version, active collaboration lock).
 - In non-collaborative operation, the auto-save debounce continues to run
   independently of `Save draft`; removing the manual button must never disable
-  auto-save. Periodic/debounced PostgreSQL autosave from active collaboration
-  rooms is deferred and must not be represented as independent HTTP `PUT`
+  auto-save. Active collaboration autosave continues to run through the
+  collaboration runtime and must not be represented as independent HTTP `PUT`
   auto-save while the active collaboration lock exists.
 - `Publish` opens the publish dialog and is disabled until the draft is
   saved, has unpublished changes, a publish is not already running, and the
@@ -859,7 +867,9 @@ Normative behavior:
   as body edits. Changing only a property field is sufficient to mark the draft
   unsaved and trigger the active draft persistence path. When a collaboration
   document room is active, Studio must not bypass the active collaboration lock
-  with a separate HTTP `PUT` for frontmatter-only edits.
+  with a separate HTTP `PUT` for frontmatter-only edits; frontmatter changes must
+  be included in the collaboration room draft state so collaboration autosave and
+  final save persist body and frontmatter together.
 - Existing write-blocking states continue to apply to both body and property
   editing. When Studio is read-only because of RBAC, schema mismatch, or
   other guarded write conditions, the `Properties` schema form is disabled

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -58,6 +58,11 @@ Active collaboration transport contract:
     presence heartbeat for one Studio session
 - The active-room key is a heartbeat lease held only while collaborators are connected. It is distinct from the inactive Yjs cache, which may remain for 30 minutes after the last disconnect.
 - If Redis is unavailable, collaboration upgrade requests fail before upgrade with `503` and error code `COLLABORATION_UNAVAILABLE`; the rest of the HTTP API can still boot and serve non-collaboration traffic.
+- Studio clients treat transient document-room and target-presence WebSocket
+  closes as recoverable and reconnect with bounded backoff. Authorization
+  failures (`4401`/`4403`) fail closed. During document-room reconnect, Studio
+  visibly reports the degraded connection state and keeps the editor read-only
+  until the room is synchronized again.
 
 #### Collaboration Authorization Flow
 

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -128,7 +128,10 @@ environment)` target.
 - Editor presence shows collaborators in the current room with labels/colors.
   Live cursor/selection overlays are shown only while the caller is editing the
   latest draft. Users without write access do not join the editing room and
-  must not appear as active editors.
+  must not appear as active editors. Clients must clear cursor/selection
+  coordinates when that user's focus leaves the editable document surface; the
+  user remains present, but other clients must not render a stale caret for that
+  session.
 - Presence heartbeats expire stale records within 30 seconds. Normal socket close
   removes the session's presence record immediately.
 

--- a/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
+++ b/docs/specs/SPEC-007-editor-mdx-and-collaboration.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-007 Editor, MDX, and Collaboration
@@ -13,7 +13,7 @@ This is the live canonical document under `docs/`.
 
 ### Editor Engine
 
-The content editor is built on **TipTap**. MDCMS supports Markdown/MDX serialization, explicit publish/version-history flows, and a Hocuspocus-backed collaboration runtime for active Studio document rooms. Presence indicators and periodic/debounced PostgreSQL autosave from active collaboration rooms remain deferred.
+The content editor is built on **TipTap**. MDCMS supports Markdown/MDX serialization, explicit publish/version-history flows, a Hocuspocus-backed collaboration runtime for active Studio document rooms, presence indicators, and server-owned active collaboration autosave.
 
 > **TipTap & ProseMirror:** TipTap is a framework built on top of ProseMirror (the low-level editing engine by Marijn Haverbeke). TipTap provides the extension system, React integration, NodeViews, and developer-friendly APIs — but under the hood, every TipTap document is a ProseMirror document. When this spec refers to "ProseMirror document model," "node types," or "schema," it means TipTap's internal data structures inherited from ProseMirror. You interact with them through TipTap's API; direct ProseMirror imports are only needed for advanced custom extensions.
 
@@ -38,8 +38,8 @@ If the parser implementation changes again, it must be swapped behind the same a
 flowchart LR
   EA["Editor A"] -->|"WebSocket + session cookie"| API["API Server (Elysia HTTP + Hocuspocus via crossws bridge)"]
   EB["Editor B"] -->|"WebSocket + session cookie"| API
-  API --> REDIS["Redis (Yjs state)"]
-  API -->|"Last-disconnect final save / publish"| PG["PostgreSQL (mutable heads + version rows)"]
+  API --> REDIS["Redis (Yjs state + presence heartbeats)"]
+  API -->|"Active autosave / final save / publish"| PG["PostgreSQL (mutable heads + version rows)"]
 ```
 
 Active collaboration transport contract:
@@ -49,10 +49,13 @@ Active collaboration transport contract:
 - Collaboration runs in the same Bun process as the API server via Hocuspocus through a Bun-compatible `crossws` bridge.
 - Connection target is explicit via query params: `project`, `environment`, and `documentId`. All three are required.
 - API keys are rejected for collaboration sockets; the endpoint accepts session-cookie auth only.
-- Redis stores active Yjs state and room metadata under namespaced keys:
+- Redis stores active Yjs state, room metadata, and presence heartbeats under
+  namespaced keys:
   - `mdcms:collaboration:yjs:{documentId}` — binary Yjs state
   - `mdcms:collaboration:yjs-meta:{documentId}` — source draft metadata, including the source `draftRevision` and body hash
   - `mdcms:collaboration:active:{documentId}` — active-room heartbeat lease
+  - `mdcms:collaboration:presence:{project}:{environment}:{sessionId}` — online
+    presence heartbeat for one Studio session
 - The active-room key is a heartbeat lease held only while collaborators are connected. It is distinct from the inactive Yjs cache, which may remain for 30 minutes after the last disconnect.
 - If Redis is unavailable, collaboration upgrade requests fail before upgrade with `503` and error code `COLLABORATION_UNAVAILABLE`; the rest of the HTTP API can still boot and serve non-collaboration traffic.
 
@@ -70,7 +73,7 @@ WebSocket connect (`/api/v1/collaboration?project=...&environment=...&documentId
 
 ### State Management
 
-**Source of truth hierarchy:** PostgreSQL `body` (markdown/MDX) is the canonical durable source of truth. During an active document room, Redis holds ephemeral Yjs state for real-time editing and PostgreSQL is updated only by the final save after the last collaborator disconnects. Publish flows read from PostgreSQL and remain blocked while the active collaboration lock exists.
+**Source of truth hierarchy:** PostgreSQL `body` (markdown/MDX) and `frontmatter` are the canonical durable draft source of truth. During an active document room, Redis holds ephemeral Yjs state for real-time editing and presence heartbeats for online indicators. PostgreSQL is updated by server-owned active collaboration autosave and by the final save after the last collaborator disconnects. Publish flows read from PostgreSQL and remain blocked while the active collaboration lock exists.
 
 **Single-user document load/save cycle:**
 
@@ -84,27 +87,54 @@ WebSocket connect (`/api/v1/collaboration?project=...&environment=...&documentId
 **Collaboration cache design:** Redis-backed Yjs state is ephemeral and PostgreSQL remains canonical. The Yjs binary is never stored in PostgreSQL.
 
 - `onLoadDocument` may use Redis Yjs state only when `mdcms:collaboration:yjs-meta:{documentId}` matches the current PostgreSQL draft head. Metadata must match the current draft revision and body hash. If metadata is missing or stale, the room is rebuilt from PostgreSQL markdown/MDX and Redis state/metadata are replaced.
-- `onStoreDocument` persists only binary Yjs state and matching metadata to Redis. It must never persist Yjs binary to PostgreSQL.
+- The room Y.Doc contains both the ProseMirror document state and a top-level
+  shared map named `frontmatter`. Studio property controls update that shared
+  map while the active collaboration lock exists. The server reads body and
+  frontmatter from the same Y.Doc snapshot when autosaving or final-saving.
+- `onStoreDocument` persists only binary Yjs state and matching metadata to Redis. It must never persist Yjs binary to PostgreSQL. It also schedules active collaboration autosave when the serialized document differs from the last PostgreSQL draft head known to the room.
 - While a room is active, the server clears inactive-cache TTLs on the Yjs state/meta keys and maintains `mdcms:collaboration:active:{documentId}` as a heartbeat lease.
-- After the last collaborator disconnects, the server serializes the current Y.Doc to markdown/MDX and performs a final draft save only when the serialized body differs from the current PostgreSQL draft body. A no-op final save must not increment `draft_revision`.
-- Final saves are attributed to the last actual writer in the room, not merely the last disconnecting user.
-- Final saves use the expected draft revision from room load/save metadata and fail closed on stale revision instead of overwriting newer PostgreSQL content.
-- If a final save updates the database, it emits the existing `content.updated` lifecycle event.
+- Active collaboration autosave is server-owned. Studio clients must not issue normal HTTP `PUT /api/v1/content/:documentId` while the active collaboration lock exists. The server debounces PostgreSQL autosaves for active rooms for approximately 2 seconds after the latest Yjs mutation and must flush at least every 10 seconds under sustained edits.
+- Each active collaboration autosave serializes the current Y.Doc to the ProseMirror JSON shape used by the editor, serializes that document model to Markdown/MDX, combines it with the room's current frontmatter draft state, and updates the `documents` head row only when the body or frontmatter differs from the current PostgreSQL draft head.
+- Active collaboration autosaves are silent draft `UPDATE`s: they increment `draft_revision`, set `has_unpublished_changes = TRUE`, never create `document_versions` rows, and emit the existing `content.updated` lifecycle event when the database changes.
+- Active collaboration autosaves and final saves are attributed to the last actual writer in the room, not merely the last disconnecting user.
+- Active collaboration autosaves use the expected draft revision from room load/save metadata and refresh that expected revision after each successful database write. A stale revision fails closed instead of overwriting newer PostgreSQL content, closes the room to further writes, and requires clients to reconnect so the next room load rebuilds from the canonical draft head.
+- After the last collaborator disconnects, the server flushes any pending active autosave, serializes the current Y.Doc to markdown/MDX, and performs a final draft save only when the serialized body or frontmatter differs from the current PostgreSQL draft head. A no-op final save must not increment `draft_revision`.
 - After last-disconnect cleanup, the server sets a 30-minute TTL on `mdcms:collaboration:yjs:{documentId}` and `mdcms:collaboration:yjs-meta:{documentId}`, then removes `mdcms:collaboration:active:{documentId}`.
+- If Redis is lost or flushed, the last successfully saved PostgreSQL draft head is the recovery point. A later room load with missing or stale Yjs state must rebuild from PostgreSQL, replace Redis Yjs state/metadata, and never resurrect stale Redis content over a newer draft head.
 
 #### Active Collaboration Lock
 
 Existing-document mutations must fail while `mdcms:collaboration:active:{documentId}` exists. The lock applies to update, move, restore, restore-version, publish, unpublish, delete, bulk equivalents, and server content-store writes from AI or module surfaces. Reads and new document creation remain allowed. The content API error contract is defined in SPEC-003.
 
-### Presence Awareness (Post-MVP)
+### Presence Awareness
 
-Presence awareness is deferred. When implemented, the server will track:
+Presence awareness is part of the collaboration contract. Presence is ephemeral
+runtime state, not durable content, and must never create document versions.
 
-- Which users are online
-- Which document each user is currently viewing or editing
-- Cursor positions and selections within collaborative editing sessions
+- The server tracks which Studio sessions are online in each `(project,
+environment)` target.
+- Each online presence record includes the user id, session id, display label,
+  deterministic user color, current document id when the user is viewing or
+  editing a document, mode (`view` or `edit`), cursor/selection positions when
+  reported by the editor, and `updatedAt`.
+- Baseline editor presence reports cursor positions and selections through the
+  target-scoped presence stream. Cursor/selection data is scoped to the target
+  document and is sent only to callers authorized to read that document. A
+  future document-room Yjs awareness provider may mirror the same data on the
+  document collaboration socket, but the presence stream remains the
+  Studio-facing snapshot source for list and editor indicators.
+- Content-list presence exposes aggregate online/editing indicators per visible
+  row. It must filter out presence records for documents the caller cannot read.
+- Editor presence shows collaborators in the current room with labels/colors.
+  Live cursor/selection overlays are shown only while the caller is editing the
+  latest draft. Users without write access do not join the editing room and
+  must not appear as active editors.
+- Presence heartbeats expire stale records within 30 seconds. Normal socket close
+  removes the session's presence record immediately.
 
-Presence indicators belong in the content list and editor only after the presence contract exists.
+Presence labels prefer the authenticated user's display name. If no display name
+is available, Studio uses a stable fallback derived from the user id without
+exposing additional private account fields.
 
 ### Saving
 
@@ -121,9 +151,10 @@ There are two distinct save operations:
 - Frontmatter-only edits and body-only edits use the same draft-save pipeline
   and the same unsaved/saving/saved state machine.
 
-Active collaboration document rooms use the collaboration final-save behavior
-documented above. Periodic/debounced PostgreSQL autosave from active
-collaboration rooms remains deferred.
+Active collaboration document rooms use the server-owned active collaboration
+autosave and final-save behavior documented above. Studio must route body and
+frontmatter draft changes through the collaboration runtime while the active
+collaboration lock exists, never through a normal HTTP draft `PUT`.
 
 **Publish (versioned):**
 
@@ -794,8 +825,8 @@ Draft propagation to the real-app preview is staged:
 - In single-user HTTP editing, Studio may persist the current body/frontmatter
   through the normal draft update path before refreshing the iframe. In an
   active collaboration document room, preview refresh uses collaboration-backed
-  persisted state according to the collaboration save contract and must not
-  bypass the active collaboration lock.
+  persisted state according to the collaboration autosave/final-save contract
+  and must not bypass the active collaboration lock.
 - Lower-latency live injection may be added later through a host-adapter
   `postMessage` protocol, but it must preserve the same serialization contract
   and must never write published content.
@@ -836,6 +867,50 @@ controls derived from `catalog.components[*].extractedProps`.
 
 ---
 
+## Collaboration Regression Coverage
+
+The CI suite must include deterministic collaboration coverage for the
+collaboration runtime, persistence path, and Studio-facing presence behavior.
+
+Round-trip fidelity coverage must exercise every configured content type shape
+that the editor can produce. For each fixture, `serialize(parse(markdown)) ===
+markdown` must hold byte-for-byte. Fixtures must cover Markdown and MDX bodies,
+frontmatter fields supported by the Studio properties panel, MDX component nodes
+with props, nested component children, native image/link serialization, and
+collapsed MDX component UI state proving it does not affect serialization.
+
+The baseline concurrency profile is:
+
+1. Four document rooms in one `(project, environment)` target.
+2. Three authenticated Studio sessions per room.
+3. Twenty-five body mutations per session, applied through Yjs.
+4. One active autosave flush after all mutations in each room.
+5. Last-disconnect cleanup for every room.
+
+The baseline passes only when all of the following are true within a 30-second CI
+timeout:
+
+- every client in a room observes converged Yjs state;
+- Redis contains fresh Yjs state and metadata before disconnect cleanup;
+- PostgreSQL contains the expected Markdown/MDX and frontmatter after the active
+  autosave flush;
+- each changed document's `draft_revision` increments exactly once for the
+  forced autosave flush, and the later no-op final save does not increment it;
+- no `document_versions` rows are created;
+- `content.updated` is emitted for every document whose autosave changed the
+  database;
+- active locks are present while rooms have clients and are removed after final
+  cleanup;
+- presence snapshots show the expected online/editing users while clients are
+  connected and remove those users after disconnect.
+
+Redis-loss validation must be deterministic. The test harness must persist at
+least one active autosave to PostgreSQL, flush or restart Redis, open a new room
+for the same document, and prove the new Yjs state is rebuilt from the
+PostgreSQL draft head rather than from stale/missing Redis state.
+
+---
+
 ## Collaboration Endpoints
 
 The collaboration transport is a WebSocket upgrade route mounted under the versioned API prefix. It is session-cookie only and rejects API-key authentication.
@@ -843,6 +918,7 @@ The collaboration transport is a WebSocket upgrade route mounted under the versi
 | Method | Endpoint                                                           | Description                                                                                                      |
 | ------ | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | `WS`   | `/api/v1/collaboration?project=...&environment=...&documentId=...` | Open real-time collaboration socket (Session cookie required, API keys rejected, explicit document room target). |
+| `WS`   | `/api/v1/collaboration/presence?project=...&environment=...`       | Subscribe to target-scoped presence snapshots for the Studio content list and shell.                             |
 
 Endpoint contract:
 
@@ -864,3 +940,83 @@ Endpoint contract:
 - A plain non-upgrade `GET` may return `426 Upgrade Required` only after
   collaboration availability, authentication, routing, document existence, and
   authorization checks pass.
+
+Document-room control messages:
+
+- Yjs sync/update and awareness messages use the Hocuspocus protocol.
+- Studio may send an application JSON flush message on the same document-room
+  socket after ensuring pending local Yjs updates have been applied:
+
+```typescript
+type CollaborationFlushRequest = {
+  type: "mdcms.collaboration.flush";
+  requestId: string;
+};
+
+type CollaborationFlushResult =
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "saved" | "unchanged";
+      draftRevision: number;
+    }
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "error";
+      code: string;
+      message: string;
+    };
+```
+
+- A successful flush performs the same authorization revalidation and
+  optimistic draft-revision checks as active collaboration autosave. `saved`
+  means PostgreSQL changed and `draft_revision` advanced; `unchanged` means the
+  room snapshot already matched the PostgreSQL draft head.
+
+Presence stream contract:
+
+- `project` and `environment` are required query parameters. `documentId` is not
+  accepted on the presence stream URL. Document-specific state is reported in
+  JSON messages after the target-scoped socket is established.
+- Authentication, origin, API-key rejection, target routing, Redis availability,
+  and `426 Upgrade Required` behavior match the document collaboration socket.
+- Clients send JSON updates with shape:
+
+```typescript
+type CollaborationPresenceUpdate = {
+  type: "presence.update";
+  documentId?: string | null;
+  mode: "view" | "edit";
+  cursor?: { anchor: number; head: number } | null;
+};
+```
+
+- A `presence.update` with no `documentId` records target-level online presence.
+  A `view` update with a `documentId` requires draft read access for that
+  document. An `edit` update requires draft read and content write access for
+  that document. Failed update authorization closes the socket with the same
+  `4401` or `4403` close codes as document-room write revalidation.
+- The server sends JSON snapshots with shape:
+
+```typescript
+type CollaborationPresenceSnapshot = {
+  type: "presence.snapshot";
+  project: string;
+  environment: string;
+  users: Array<{
+    userId: string;
+    sessionId: string;
+    label: string;
+    color: string;
+    documentId: string | null;
+    mode: "view" | "edit";
+    cursor?: { anchor: number; head: number };
+    updatedAt: string;
+  }>;
+};
+```
+
+- Presence snapshots must include only documents visible to the authenticated
+  subscriber in the routed target. Cursor details are omitted unless the
+  subscriber can read the target document draft.

--- a/docs/specs/SPEC-008-cli-and-sdk.md
+++ b/docs/specs/SPEC-008-cli-and-sdk.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-008 CLI and SDK
@@ -383,6 +383,7 @@ The manifest is flushed atomically (via `writeScopedManifestAtomic`) after each 
 - **Schema mismatch handling:** With preflight active, the per-doc `SCHEMA_HASH_MISMATCH` (`409`) path covers race conditions only — a concurrent sync changed the server hash between preflight and content writes. Failed documents are reported with reason code `schema_hash_mismatch`; the exit summary directs the developer to re-run `cms push` rather than `cms schema sync`, since the local state may already be fresh. Other documents in the same push run continue (partial success).
 - **Path conflict handling:** If the server returns `CONTENT_PATH_CONFLICT` (`409`) for a document (update, create, or new-file), that document is reported as failed with reason code `content_path_conflict`. The exit summary directs the developer to run `cms pull` to re-sync the manifest.
 - **Active collaboration handling:** If the server returns `DOCUMENT_COLLABORATION_ACTIVE` (`409`) for a known document, that document is reported as failed with reason code `collaboration_active`. Other documents in the same push run continue. The exit summary tells the developer to wait for the active Studio collaboration session to close before retrying the locked document.
+- **Inactive collaboration cache invalidation:** When a pushed update or delete succeeds and no active collaboration session exists for that document, the server invalidates inactive Redis Yjs state and metadata for that document after committing the database change. The CLI does not call Redis directly and does not expose a separate cache flag. A successful push means the next Studio collaboration room for that document must load from the newly persisted PostgreSQL draft head, not from the previous inactive Yjs cache.
 - **Draft optimistic concurrency:** If the server's current `draft_revision` differs from the base draft revision in the manifest, the push is **rejected** for that document with reason code `stale_draft_revision`. The developer must `cms pull` first, then re-apply their changes.
 - On success, the server updates `documents`, increments `draft_revision`, and does not create new `document_versions` rows.
 - Optional `--validate` flag runs schema validation locally before pushing. Validation covers both changed and selected new documents. Because preflight has already normalized local vs server schema state (or aborted), the old "local schema differs from last synced" warning inside `--validate` is no longer needed.

--- a/docs/specs/SPEC-010-media-webhooks-search-and-integrations.md
+++ b/docs/specs/SPEC-010-media-webhooks-search-and-integrations.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-10
+last_updated: 2026-06-14
 ---
 
 # SPEC-010 Media, Webhooks, Search, and Integrations
@@ -224,15 +224,15 @@ Validation rules:
 
 ### Events
 
-| Event                 | Trigger                                                                                                                                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `content.created`     | A new document is created                                                                                                                                                                                    |
-| `content.updated`     | Draft content persisted (includes editor auto-save ticks and explicit draft writes). Intended for staging/preview cache invalidation — production consumers should subscribe to `content.published` instead. |
-| `content.published`   | A document is published                                                                                                                                                                                      |
-| `content.unpublished` | A document is unpublished (`published_version` cleared)                                                                                                                                                      |
-| `content.deleted`     | A document is soft-deleted                                                                                                                                                                                   |
-| `content.restored`    | A deleted document is restored                                                                                                                                                                               |
-| `media.uploaded`      | A media file is uploaded                                                                                                                                                                                     |
+| Event                 | Trigger                                                                                                                                                                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content.created`     | A new document is created                                                                                                                                                                                                                                             |
+| `content.updated`     | Draft content persisted (includes single-user editor auto-save ticks, active collaboration autosaves/final saves, and explicit draft writes). Intended for staging/preview cache invalidation — production consumers should subscribe to `content.published` instead. |
+| `content.published`   | A document is published                                                                                                                                                                                                                                               |
+| `content.unpublished` | A document is unpublished (`published_version` cleared)                                                                                                                                                                                                               |
+| `content.deleted`     | A document is soft-deleted                                                                                                                                                                                                                                            |
+| `content.restored`    | A deleted document is restored                                                                                                                                                                                                                                        |
+| `media.uploaded`      | A media file is uploaded                                                                                                                                                                                                                                              |
 
 ### Payload Format
 

--- a/docs/specs/SPEC-011-local-development-and-operations.md
+++ b/docs/specs/SPEC-011-local-development-and-operations.md
@@ -2,7 +2,7 @@
 status: live
 canonical: true
 created: 2026-03-11
-last_updated: 2026-06-11
+last_updated: 2026-06-14
 ---
 
 # SPEC-011 Local Development and Operations
@@ -201,12 +201,33 @@ This seed key is intended for local demo UX only and does not replace normal CLI
 
 The collaboration runtime requires `REDIS_URL`. If Redis is not configured or cannot initialize, the server can still boot for non-collaboration HTTP traffic, but collaboration upgrade requests fail with `COLLABORATION_UNAVAILABLE`.
 
-Collaboration uses three namespaced Redis keys per document:
+Collaboration uses namespaced Redis keys for document state and target-scoped
+presence:
 
 - `mdcms:collaboration:yjs:{documentId}` stores the binary Yjs state.
 - `mdcms:collaboration:yjs-meta:{documentId}` stores cache metadata for the PostgreSQL draft head used to build or last save the Yjs state.
 - `mdcms:collaboration:active:{documentId}` stores the active-room heartbeat lease while collaborators are connected.
+- `mdcms:collaboration:presence:{project}:{environment}:{sessionId}` stores one
+  Studio session's ephemeral presence heartbeat.
 
 The active-room lock is distinct from the inactive Yjs cache. The active lock exists only while a document room has connected collaborators and blocks existing-document mutations. The Yjs state and metadata keys may remain after disconnect so a recently closed room can reopen quickly; after the last collaborator disconnects, both inactive cache keys receive a 30-minute TTL and the active-room lock is removed.
+
+Redis is not the durable collaboration source of truth. If Redis is flushed,
+restarted, or restored from an older snapshot, the durable recovery point is the
+last successfully saved PostgreSQL draft head. Operators should expect connected
+collaboration rooms and presence streams to reconnect or fail closed while Redis
+is unavailable; no published versions are created by recovery.
+
+Redis-loss recovery drill:
+
+1. Open a document in Studio collaboration mode and make a body or frontmatter
+   change.
+2. Wait for the active collaboration autosave indicator to return to `Saved`.
+3. Flush or restart Redis in the local environment.
+4. Reopen the same document room.
+5. Verify the editor loads the last PostgreSQL draft head, not a stale Redis Yjs
+   cache, and that `document_versions` did not receive a new row.
+6. Verify content list/editor presence repopulates after reconnect and stale
+   presence indicators disappear within 30 seconds.
 
 ---

--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -195,7 +195,12 @@ AI output is always mediated through proposals:
    apply may proceed when the operation's `originalText` still appears exactly
    once in the current draft body. Proposal kinds without an exact source-text
    replacement anchor continue to require the live draft revision to match the
-   proposal's base revision.
+   proposal's base revision. When the accepted proposal targets the same
+   document as an open Studio collaboration room and the proposal kind is
+   `replace_selection`, `insert_block`, or `update_frontmatter`, Studio applies
+   the proposal into the active collaboration document instead of calling the
+   normal apply endpoint. Persistence then follows the collaboration autosave
+   contract defined in the editor and collaboration spec.
 6. Studio reconciles local editor state from the accepted draft response.
 
 Rejecting a proposal has no content side effects. Proposals expire after a short
@@ -617,6 +622,25 @@ All AI write application paths must:
 - produce an audit event that identifies the human actor, target document,
   proposal kind, accepted/rejected outcome, model/provider metadata, and
   validation result
+
+Active collaboration exception:
+
+- For current-document body/frontmatter proposals accepted while a Studio
+  collaboration room is open, Studio applies the proposal through the active
+  editor/Yjs collaboration state. It must use the same operation semantics as
+  server apply: `replace_selection` requires a unique live source-text match,
+  `insert_block` appends with markdown block separation, and
+  `update_frontmatter` shallow-merges the patch.
+- The active collaboration path must not call the normal apply endpoint or any
+  normal content update endpoint for the active document while the collaboration
+  lock exists.
+- The short post-accept undo window for these collaboration-applied proposals
+  replays the captured prior draft snapshot through the active collaboration
+  state while the room remains connected. If the room is no longer connected,
+  undo fails loud in the proposal card.
+- Creating documents, deleting documents, and proposals targeting any document
+  other than the current active collaboration document continue to use the
+  server apply endpoint.
 
 ## Endpoint Contracts
 

--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -694,8 +694,10 @@ reads `AI_PROVIDER` and normalizes it case-insensitively:
 absent, the direct Anthropic provider defaults to `claude-sonnet-4-6`, and the
 Groq provider uses its server-defined default. Provider-specific base URL
 overrides are server-only operator settings: `GROQ_BASE_URL` for Groq and
-`ANTHROPIC_BASE_URL` for Anthropic. Missing or blank required provider
-credentials must fail deterministically as `AI_PROVIDER_UNAVAILABLE`.
+`ANTHROPIC_BASE_URL` for Anthropic. Missing or blank base URL overrides are
+treated as absent and use the provider's default API endpoint. Missing or blank
+required provider credentials must fail deterministically as
+`AI_PROVIDER_UNAVAILABLE`.
 
 The orchestration layer must support task-specific prompt templates or
 equivalent workflow definitions for at least:

--- a/packages/modules/core.ai/src/server/providers/anthropic.ts
+++ b/packages/modules/core.ai/src/server/providers/anthropic.ts
@@ -5,6 +5,8 @@ import type { AiProvider } from "../provider.js";
 
 export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
 export const ANTHROPIC_PROVIDER_DEFAULT_MODEL = "claude-sonnet-4-6" as const;
+export const ANTHROPIC_PROVIDER_DEFAULT_BASE_URL =
+  "https://api.anthropic.com/v1" as const;
 
 export type AnthropicProviderOptions = {
   apiKey: string;
@@ -33,7 +35,7 @@ export function createAnthropicAiProvider(
 
   const anthropic = createAnthropic({
     apiKey: trimmedKey,
-    ...(options.baseURL ? { baseURL: options.baseURL } : {}),
+    baseURL: options.baseURL?.trim() || ANTHROPIC_PROVIDER_DEFAULT_BASE_URL,
   });
   const modelId = options.model?.trim() || ANTHROPIC_PROVIDER_DEFAULT_MODEL;
 

--- a/packages/modules/core.ai/src/server/providers/factory.test.ts
+++ b/packages/modules/core.ai/src/server/providers/factory.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "bun:test";
 
 import { RuntimeError } from "@mdcms/shared";
 
+import { createAnthropicAiProvider } from "./anthropic.js";
 import { ECHO_PROVIDER_ID } from "./echo.js";
 import {
   AI_MODEL_ENV_KEY,
@@ -13,6 +14,40 @@ import {
 } from "./factory.js";
 import { GROQ_PROVIDER_DEFAULT_MODEL, GROQ_PROVIDER_ID } from "./groq.js";
 import { NULL_PROVIDER_ID } from "./null.js";
+
+function withTemporaryEnvVar<T>(
+  key: string,
+  value: string | undefined,
+  callback: () => T,
+): T {
+  const previous = process.env[key];
+
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+
+  try {
+    return callback();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+}
+
+function readProviderBaseUrl(
+  provider: ReturnType<typeof createAnthropicAiProvider>,
+) {
+  const languageModel = provider.languageModel as {
+    config?: { baseURL?: unknown };
+  } | null;
+
+  return languageModel?.config?.baseURL;
+}
 
 describe("resolveAiProvider", () => {
   test("returns null provider when env var is missing", () => {
@@ -73,6 +108,19 @@ describe("resolveAiProvider", () => {
       },
     });
     assert.equal(provider.languageModel?.modelId, "claude-opus-4-6");
+  });
+
+  test("anthropic ignores blank SDK base URL env from compose defaults", () => {
+    withTemporaryEnvVar("ANTHROPIC_BASE_URL", "", () => {
+      const provider = createAnthropicAiProvider({
+        apiKey: "sk-ant-test-key",
+      });
+
+      assert.equal(
+        readProviderBaseUrl(provider),
+        "https://api.anthropic.com/v1",
+      );
+    });
   });
 
   test("anthropic without ANTHROPIC_API_KEY raises AI_PROVIDER_UNAVAILABLE", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./lib/runtime/index.js";
 export * from "./lib/contracts/action-catalog.js";
 export * from "./lib/contracts/ai.js";
+export * from "./lib/contracts/collaboration.js";
 export * from "./lib/contracts/config.js";
 export * from "./lib/contracts/content-api.js";
 export * from "./lib/contracts/current-principal-capabilities.js";

--- a/packages/shared/src/lib/contracts/collaboration.test.ts
+++ b/packages/shared/src/lib/contracts/collaboration.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import {
+  CollaborationPresenceCursorSchema,
+  CollaborationPresenceSnapshotSchema,
+  CollaborationPresenceUpdateSchema,
+} from "./collaboration.js";
+
+test("collaboration presence schemas parse updates and snapshots", () => {
+  const update = CollaborationPresenceUpdateSchema.parse({
+    type: "presence.update",
+    documentId: "11111111-1111-4111-8111-111111111111",
+    mode: "edit",
+    cursor: { anchor: 2, head: 7 },
+  });
+  assert.equal(update.mode, "edit");
+
+  const snapshot = CollaborationPresenceSnapshotSchema.parse({
+    type: "presence.snapshot",
+    project: "marketing",
+    environment: "draft",
+    users: [
+      {
+        userId: "user-1",
+        sessionId: "session-1",
+        label: "Ada",
+        color: "#2563eb",
+        documentId: "11111111-1111-4111-8111-111111111111",
+        mode: "view",
+        cursor: { anchor: 1, head: 1 },
+        updatedAt: "2026-06-14T10:00:00.000Z",
+      },
+    ],
+  });
+  assert.equal(snapshot.users[0]?.label, "Ada");
+});
+
+test("collaboration presence schemas reject invalid modes and cursors", () => {
+  assert.equal(
+    CollaborationPresenceUpdateSchema.safeParse({
+      type: "presence.update",
+      mode: "publish",
+    }).success,
+    false,
+  );
+  assert.equal(
+    CollaborationPresenceCursorSchema.safeParse({ anchor: -1, head: 1 })
+      .success,
+    false,
+  );
+});

--- a/packages/shared/src/lib/contracts/collaboration.ts
+++ b/packages/shared/src/lib/contracts/collaboration.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const CollaborationPresenceModeSchema = z.enum(["view", "edit"]);
+
+export type CollaborationPresenceMode = z.infer<
+  typeof CollaborationPresenceModeSchema
+>;
+
+export const CollaborationPresenceCursorSchema = z.object({
+  anchor: z.number().int().nonnegative(),
+  head: z.number().int().nonnegative(),
+});
+
+export type CollaborationPresenceCursor = z.infer<
+  typeof CollaborationPresenceCursorSchema
+>;
+
+export const CollaborationPresenceUpdateSchema = z.object({
+  type: z.literal("presence.update"),
+  documentId: z.string().uuid().nullable().optional(),
+  mode: CollaborationPresenceModeSchema,
+  cursor: CollaborationPresenceCursorSchema.nullable().optional(),
+});
+
+export type CollaborationPresenceUpdate = z.infer<
+  typeof CollaborationPresenceUpdateSchema
+>;
+
+export const CollaborationPresenceUserSchema = z.object({
+  userId: z.string().min(1),
+  sessionId: z.string().min(1),
+  label: z.string().min(1),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  documentId: z.string().uuid().nullable(),
+  mode: CollaborationPresenceModeSchema,
+  cursor: CollaborationPresenceCursorSchema.optional(),
+  updatedAt: z.string().datetime(),
+});
+
+export type CollaborationPresenceUser = z.infer<
+  typeof CollaborationPresenceUserSchema
+>;
+
+export const CollaborationPresenceSnapshotSchema = z.object({
+  type: z.literal("presence.snapshot"),
+  project: z.string().min(1),
+  environment: z.string().min(1),
+  users: z.array(CollaborationPresenceUserSchema),
+});
+
+export type CollaborationPresenceSnapshot = z.infer<
+  typeof CollaborationPresenceSnapshotSchema
+>;

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -117,6 +117,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "elysia": "^1.4.25",
+    "lib0": "^0.2.117",
     "lowlight": "^3.3.0",
     "lucide-react": "^1.7.0",
     "mdast-util-from-markdown": "^2.0.3",
@@ -127,7 +128,10 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.2.0",
     "tslib": "^2.3.0",
-    "tw-animate-css": "1.3.3"
+    "tw-animate-css": "1.3.3",
+    "y-prosemirror": "^1.3.7",
+    "y-protocols": "^1.0.7",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@types/react": "^19.0.12",

--- a/packages/studio/src/lib/build-runtime.test.ts
+++ b/packages/studio/src/lib/build-runtime.test.ts
@@ -281,11 +281,11 @@ test("buildStudioRuntimeArtifacts inlines production runtime environment", async
 // Budget for the studio-runtime first-load bundle. Raised from 2.0 MB
 // to 2.5 MB when the assistant chat picked up `streamdown` for proper
 // markdown rendering (Sonia bullet — chat needs headings, lists, code
-// blocks, GFM). Streamdown pulls in shiki + mermaid transitively for
-// syntax highlighting and diagrams; both are deliberate features. A
-// future optimisation can split these out via dynamic import — track
-// in the assistant performance work.
-const STUDIO_RUNTIME_SIZE_BUDGET_BYTES = 2_500_000;
+// blocks, GFM). Raised to 2.65 MB when real-time collaboration moved
+// Yjs and y-protocols into the default document editor runtime. The
+// build currently emits one browser module; future runtime splitting
+// can move assistant/collaboration surfaces behind dynamic imports.
+const STUDIO_RUNTIME_SIZE_BUDGET_BYTES = 2_650_000;
 
 test("buildStudioRuntimeArtifacts keeps the default browser runtime below the first-load size target", async () => {
   await withTempDir("studio-runtime-real-", async (directory) => {

--- a/packages/studio/src/lib/build-runtime.ts
+++ b/packages/studio/src/lib/build-runtime.ts
@@ -180,7 +180,8 @@ function createWorkspaceSourceAliasPlugin(input: {
   projectRoot: string;
 }): BunBuildPlugin {
   const sharedPackageRoot = resolve(input.projectRoot, "../shared");
-  const sharedSourceExports = new Map([
+  const editorCorePackageRoot = resolve(input.projectRoot, "../editor-core");
+  const firstPartySourceExports = new Map([
     ["@mdcms/shared", join(sharedPackageRoot, "src/index.ts")],
     ["@mdcms/shared/mdx", join(sharedPackageRoot, "src/lib/mdx/index.ts")],
     [
@@ -195,20 +196,24 @@ function createWorkspaceSourceAliasPlugin(input: {
       "@mdcms/shared/server",
       join(sharedPackageRoot, "src/lib/contracts/schema-hash.ts"),
     ],
+    ["@mdcms/editor-core", join(editorCorePackageRoot, "src/index.ts")],
   ]);
 
   return {
     name: "mdcms-workspace-source-aliases",
     setup(build) {
-      build.onResolve({ filter: /^@mdcms\/shared(?:\/.*)?$/ }, (args) => {
-        const sourcePath = sharedSourceExports.get(args.path);
+      build.onResolve(
+        { filter: /^@mdcms\/(?:shared|editor-core)(?:\/.*)?$/ },
+        (args) => {
+          const sourcePath = firstPartySourceExports.get(args.path);
 
-        if (!sourcePath || !existsSync(sourcePath)) {
-          return undefined;
-        }
+          if (!sourcePath || !existsSync(sourcePath)) {
+            return undefined;
+          }
 
-        return { path: sourcePath };
-      });
+          return { path: sourcePath };
+        },
+      );
     },
   };
 }

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.test.tsx
@@ -1,14 +1,18 @@
 import assert from "node:assert/strict";
 
 import { test } from "bun:test";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
+  ContentTypeDocumentsTable,
   getContentTypeTableColumns,
   TranslationCoverageSummary,
 } from "./page.js";
 import * as pageModule from "./page.js";
+
+const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
 
 test("TranslationCoverageSummary renders nothing for the idle state", () => {
   const markup = renderToStaticMarkup(
@@ -107,4 +111,77 @@ test("content type table keeps the original columns for non-localized lists", ()
     getContentTypeTableColumns(false).map((column) => column.label),
     ["", "Title / Path", "Status", "Updated", "Author", ""],
   );
+});
+
+test("content type table renders row presence indicators without adding columns", () => {
+  const columns = getContentTypeTableColumns(false);
+  const rowPresence: CollaborationPresenceUser[] = [
+    {
+      userId: "user-ada",
+      sessionId: "session-ada",
+      label: "Ada Lovelace",
+      color: "#2563eb",
+      documentId: DOCUMENT_ID,
+      mode: "edit",
+      updatedAt: "2026-06-14T10:01:00.000Z",
+    },
+  ];
+  const markup = renderToStaticMarkup(
+    createElement(ContentTypeDocumentsTable, {
+      documents: [
+        {
+          documentId: DOCUMENT_ID,
+          translationGroupId: "translation-group-1",
+          title: "Launch plan",
+          path: "content/launch-plan.mdx",
+          locale: "en-US",
+          status: "changed",
+          updatedAt: "2026-06-14T10:00:00.000Z",
+          createdBy: "user-author",
+          updatedBy: "user-author",
+        },
+      ],
+      users: {
+        "user-author": { email: "author@example.com", name: "Author" },
+      },
+      capabilities: {
+        canPublishContent: true,
+        canUnpublishContent: true,
+        canCreateContent: true,
+        canDeleteContent: true,
+      },
+      pendingRowAction: false,
+      selectedDocumentIds: new Set<string>(),
+      allRenderedSelected: false,
+      someRenderedSelected: false,
+      selectionDisabled: false,
+      showTranslationCoverage: false,
+      translationCoverageStatus: "idle",
+      translationCoverageByGroup: {},
+      tableColumns: columns,
+      presenceByDocumentId: new Map<string, CollaborationPresenceUser[]>([
+        [DOCUMENT_ID, rowPresence],
+      ]),
+      onToggleDocumentSelected: () => {},
+      onToggleRenderedSelection: () => {},
+      onRowClick: () => {},
+      rowActionHandlers: {
+        onEdit: () => {},
+        onPublish: () => {},
+        onUnpublish: () => {},
+        onDuplicate: () => {},
+        onDelete: () => {},
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    columns.map((column) => column.label),
+    ["", "Title / Path", "Status", "Updated", "Author", ""],
+  );
+  assert.equal(markup.match(/<th[\s>]/g)?.length, columns.length);
+  assert.match(markup, /Launch plan/);
+  assert.match(markup, /data-mdcms-presence-indicators="true"/);
+  assert.match(markup, /data-mdcms-presence-mode="edit"/);
+  assert.match(markup, /Ada Lovelace editing/);
 });

--- a/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
+++ b/packages/studio/src/lib/runtime-ui/app/admin/content/[type]/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import type { ContentBulkAction } from "@mdcms/shared";
+import type {
+  CollaborationPresenceUser,
+  ContentBulkAction,
+} from "@mdcms/shared";
 import { useParams, useRouter } from "../../../../adapters/next-navigation.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -62,6 +65,7 @@ import {
 } from "../../../../components/ui/dialog.js";
 import { PageHeader } from "../../../../components/layout/page-header.js";
 import { Skeleton } from "../../../../components/ui/skeleton.js";
+import { PresenceIndicators } from "../../../../components/presence/presence-indicators.js";
 
 import { useAdminCapabilities } from "../../capabilities-context.js";
 import { useStudioMountInfo } from "../../mount-info-context.js";
@@ -74,10 +78,12 @@ import {
   type ContentTypeListFilters,
 } from "../../../../hooks/use-content-type-list.js";
 import { useCreateDocument } from "../../../../hooks/use-create-document.js";
+import { useCollaborationPresence } from "../../../../hooks/use-collaboration-presence.js";
 import { CreateDocumentDialog } from "../../../../components/create-document-dialog.js";
 import { createStudioContentListApi } from "../../../../../content-list-api.js";
 import { createStudioSchemaRouteApi } from "../../../../../schema-route-api.js";
 import { createStudioDocumentRouteApi } from "../../../../../document-route-api.js";
+import { groupPresenceByDocument } from "../../../../lib/collaboration-presence.js";
 import { useToast } from "../../../../components/toast.js";
 import {
   formatContentTranslationCoverageLabel,
@@ -526,7 +532,7 @@ function RowActions({
   );
 }
 
-function ContentTypeDocumentsTable({
+export function ContentTypeDocumentsTable({
   documents,
   users,
   capabilities,
@@ -539,6 +545,7 @@ function ContentTypeDocumentsTable({
   translationCoverageStatus,
   translationCoverageByGroup,
   tableColumns,
+  presenceByDocumentId,
   onToggleDocumentSelected,
   onToggleRenderedSelection,
   onRowClick,
@@ -565,6 +572,7 @@ function ContentTypeDocumentsTable({
     typeof useContentTypeList
   >["translationCoverageByGroup"];
   tableColumns: ReturnType<typeof getContentTypeTableColumns>;
+  presenceByDocumentId?: ReadonlyMap<string, CollaborationPresenceUser[]>;
   onToggleDocumentSelected: (documentId: string, checked: boolean) => void;
   onToggleRenderedSelection: (checked: boolean) => void;
   onRowClick: (documentId: string) => void;
@@ -650,9 +658,15 @@ function ContentTypeDocumentsTable({
               </TableCell>
               <TableCell className="px-4 py-3">
                 <div className="max-w-[480px]">
-                  <p className="truncate text-[13px] font-semibold text-foreground">
-                    {doc.title}
-                  </p>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <p className="min-w-0 truncate text-[13px] font-semibold text-foreground">
+                      {doc.title}
+                    </p>
+                    <PresenceIndicators
+                      className="shrink-0"
+                      users={presenceByDocumentId?.get(doc.documentId) ?? []}
+                    />
+                  </div>
                   <p className="truncate font-mono text-[11px] text-foreground-muted">
                     {doc.path}
                   </p>
@@ -926,6 +940,15 @@ function useContentTypePageController() {
     [list.documents],
   );
   const renderedDocumentIdsKey = renderedDocumentIds.join("\u0000");
+  const presence = useCollaborationPresence({ mode: "view" });
+  const presenceByDocumentId = useMemo(
+    () =>
+      groupPresenceByDocument(presence.snapshot?.users ?? [], {
+        visibleDocumentIds: renderedDocumentIds,
+        currentSessionId: presence.currentSessionId,
+      }),
+    [presence.currentSessionId, presence.snapshot?.users, renderedDocumentIds],
+  );
   const selectedDocuments = useMemo(
     () => getSelectedDocuments(list.documents, selectedDocumentIds),
     [list.documents, selectedDocumentIds],
@@ -1244,6 +1267,7 @@ function useContentTypePageController() {
     moveTargetDirectory,
     moveTargetDirectoryError,
     openBulkAction,
+    presenceByDocumentId,
     rowActionError,
     rowActionHandlers,
     schemaEntry,
@@ -1285,6 +1309,7 @@ function ContentTypePageView({
   moveTargetDirectoryError,
   openBulkAction,
   rowActionError,
+  presenceByDocumentId,
   rowActionHandlers,
   schemaEntry,
   searchInput,
@@ -1511,6 +1536,7 @@ function ContentTypePageView({
                 translationCoverageStatus={list.translationCoverageStatus}
                 translationCoverageByGroup={list.translationCoverageByGroup}
                 tableColumns={tableColumns}
+                presenceByDocumentId={presenceByDocumentId}
                 onToggleDocumentSelected={toggleDocumentSelection}
                 onToggleRenderedSelection={toggleRenderedSelection}
                 onRowClick={(documentId) =>

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.test.ts
@@ -105,6 +105,20 @@ test("applyAssistantCollaborationProposalDraft rejects ambiguous replace_selecti
   );
 });
 
+test("applyAssistantCollaborationProposalDraft rejects proposal kind and operation mismatches", () => {
+  assert.throws(
+    () =>
+      applyAssistantCollaborationProposalDraft({
+        proposal: buildProposal({ kind: "insert_block" }),
+        documentId: "doc_1",
+        body: "The old intro is here.",
+        frontmatter: {},
+      }),
+    (error) =>
+      error instanceof RuntimeError && error.code === "AI_OUTPUT_INVALID",
+  );
+});
+
 test("applyAssistantCollaborationProposalDraft appends insert blocks and merges frontmatter patches", () => {
   const insert = applyAssistantCollaborationProposalDraft({
     proposal: buildProposal({

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+
+import { RuntimeError, type AiProposal } from "@mdcms/shared";
+import { test } from "bun:test";
+
+import {
+  applyAssistantCollaborationProposalDraft,
+  isAssistantCollaborationProposalApplicable,
+} from "./assistant-collaboration-apply.js";
+
+function buildProposal(overrides: Partial<AiProposal> = {}): AiProposal {
+  return {
+    proposalId: "proposal_1",
+    kind: "replace_selection",
+    project: "demo",
+    environment: "staging",
+    documentId: "doc_1",
+    baseDraftRevision: 4,
+    type: "page",
+    locale: "en",
+    summary: "Rewrite intro",
+    operations: [
+      {
+        op: "replace_selection",
+        selectionId: "sel_1",
+        originalText: "old intro",
+        replacementText: "new intro",
+      },
+    ],
+    validation: { status: "valid" },
+    expiresAt: "2026-06-15T10:05:00.000Z",
+    provider: {
+      providerId: "echo",
+      model: "echo-1",
+      promptTemplateId: "current_document_edit.v1",
+    },
+    ...overrides,
+  };
+}
+
+test("isAssistantCollaborationProposalApplicable only accepts current-document edit proposals", () => {
+  assert.equal(
+    isAssistantCollaborationProposalApplicable({
+      proposal: buildProposal(),
+      documentId: "doc_1",
+    }),
+    true,
+  );
+  assert.equal(
+    isAssistantCollaborationProposalApplicable({
+      proposal: buildProposal({ documentId: "doc_2" }),
+      documentId: "doc_1",
+    }),
+    false,
+  );
+  assert.equal(
+    isAssistantCollaborationProposalApplicable({
+      proposal: buildProposal({
+        kind: "create_document",
+        documentId: undefined,
+        baseDraftRevision: undefined,
+        operations: [
+          {
+            op: "create_document",
+            path: "pages/new",
+            format: "mdx",
+            frontmatter: {},
+            body: "",
+          },
+        ],
+      }),
+      documentId: "doc_1",
+    }),
+    false,
+  );
+});
+
+test("applyAssistantCollaborationProposalDraft replaces a unique live selection and returns prior draft", () => {
+  const result = applyAssistantCollaborationProposalDraft({
+    proposal: buildProposal(),
+    documentId: "doc_1",
+    body: "The old intro is here.",
+    frontmatter: { title: "About" },
+  });
+
+  assert.equal(result.body, "The new intro is here.");
+  assert.deepEqual(result.frontmatter, { title: "About" });
+  assert.deepEqual(result.priorDraft, {
+    body: "The old intro is here.",
+    frontmatter: { title: "About" },
+  });
+});
+
+test("applyAssistantCollaborationProposalDraft rejects ambiguous replace_selection proposals", () => {
+  assert.throws(
+    () =>
+      applyAssistantCollaborationProposalDraft({
+        proposal: buildProposal(),
+        documentId: "doc_1",
+        body: "old intro\n\nold intro",
+        frontmatter: {},
+      }),
+    (error) =>
+      error instanceof RuntimeError && error.code === "AI_PROPOSAL_CONFLICT",
+  );
+});
+
+test("applyAssistantCollaborationProposalDraft appends insert blocks and merges frontmatter patches", () => {
+  const insert = applyAssistantCollaborationProposalDraft({
+    proposal: buildProposal({
+      kind: "insert_block",
+      operations: [{ op: "insert_block", bodyMdx: "<Hero />" }],
+    }),
+    documentId: "doc_1",
+    body: "Existing body.",
+    frontmatter: { title: "About" },
+  });
+
+  assert.equal(insert.body, "Existing body.\n\n<Hero />");
+  assert.deepEqual(insert.frontmatter, { title: "About" });
+
+  const frontmatter = applyAssistantCollaborationProposalDraft({
+    proposal: buildProposal({
+      kind: "update_frontmatter",
+      operations: [
+        { op: "update_frontmatter", patch: { title: "Updated", draft: true } },
+      ],
+    }),
+    documentId: "doc_1",
+    body: "Existing body.",
+    frontmatter: { title: "About", untouched: "yes" },
+  });
+
+  assert.equal(frontmatter.body, "Existing body.");
+  assert.deepEqual(frontmatter.frontmatter, {
+    title: "Updated",
+    draft: true,
+    untouched: "yes",
+  });
+});

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.ts
@@ -1,0 +1,195 @@
+import {
+  RuntimeError,
+  type AiProposal,
+  type AiProposalOperation,
+} from "@mdcms/shared";
+
+export type AssistantCollaborationPriorDraft = {
+  body: string;
+  frontmatter: Record<string, unknown>;
+};
+
+export type AssistantCollaborationProposalDraftResult = {
+  body: string;
+  frontmatter: Record<string, unknown>;
+  priorDraft: AssistantCollaborationPriorDraft;
+};
+
+type ExistingDocumentAiProposal = AiProposal & { documentId: string };
+
+type ReplaceSelectionOperation = Extract<
+  AiProposalOperation,
+  { op: "replace_selection" }
+>;
+
+function aiProposalConflict(
+  message: string,
+  details: Record<string, unknown>,
+): RuntimeError {
+  return new RuntimeError({
+    code: "AI_PROPOSAL_CONFLICT",
+    message,
+    statusCode: 409,
+    details,
+  });
+}
+
+function aiOutputInvalid(
+  message: string,
+  details: Record<string, unknown>,
+): RuntimeError {
+  return new RuntimeError({
+    code: "AI_OUTPUT_INVALID",
+    message,
+    statusCode: 422,
+    details,
+  });
+}
+
+function getSingleOperation(proposal: AiProposal): AiProposalOperation {
+  const [operation] = proposal.operations;
+
+  if (!operation) {
+    throw aiOutputInvalid("Proposal has no operations to apply.", {
+      proposalId: proposal.proposalId,
+    });
+  }
+
+  if (proposal.operations.length > 1) {
+    throw aiOutputInvalid("Proposal must contain exactly one operation.", {
+      proposalId: proposal.proposalId,
+      operationCount: proposal.operations.length,
+    });
+  }
+
+  return operation;
+}
+
+function findReplaceSelectionMatch(
+  body: string,
+  operation: ReplaceSelectionOperation,
+): number {
+  const original = operation.originalText;
+  const index = body.indexOf(original);
+
+  if (index < 0) {
+    throw aiProposalConflict(
+      "Original selection text was not found in the current draft body.",
+      { selectionId: operation.selectionId },
+    );
+  }
+
+  const last = body.lastIndexOf(original);
+  if (index !== last) {
+    throw aiProposalConflict(
+      "Original selection text appears more than once in the current draft body; refusing to apply ambiguously.",
+      { selectionId: operation.selectionId },
+    );
+  }
+
+  return index;
+}
+
+function applyReplaceSelection(
+  body: string,
+  operation: ReplaceSelectionOperation,
+): string {
+  const index = findReplaceSelectionMatch(body, operation);
+
+  return (
+    body.slice(0, index) +
+    operation.replacementText +
+    body.slice(index + operation.originalText.length)
+  );
+}
+
+function applyInsertBlock(
+  body: string,
+  operation: Extract<AiProposalOperation, { op: "insert_block" }>,
+): string {
+  if (body.length === 0) {
+    return operation.bodyMdx;
+  }
+
+  const separator = body.endsWith("\n") ? "\n" : "\n\n";
+  return `${body}${separator}${operation.bodyMdx}`;
+}
+
+function mergeFrontmatter(
+  current: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...current, ...patch };
+}
+
+function isExistingDocumentEditProposal(
+  proposal: AiProposal,
+): proposal is ExistingDocumentAiProposal {
+  return (
+    Boolean(proposal.documentId) &&
+    (proposal.kind === "replace_selection" ||
+      proposal.kind === "insert_block" ||
+      proposal.kind === "update_frontmatter")
+  );
+}
+
+export function isAssistantCollaborationProposalApplicable({
+  proposal,
+  documentId,
+}: {
+  proposal: AiProposal;
+  documentId: string;
+}): boolean {
+  return (
+    isExistingDocumentEditProposal(proposal) &&
+    proposal.documentId === documentId
+  );
+}
+
+export function applyAssistantCollaborationProposalDraft({
+  proposal,
+  documentId,
+  body,
+  frontmatter,
+}: {
+  proposal: AiProposal;
+  documentId: string;
+  body: string;
+  frontmatter: Record<string, unknown>;
+}): AssistantCollaborationProposalDraftResult {
+  if (
+    !isAssistantCollaborationProposalApplicable({
+      proposal,
+      documentId,
+    })
+  ) {
+    throw aiOutputInvalid(
+      "Proposal cannot be applied through the active collaboration document.",
+      { proposalId: proposal.proposalId, documentId: proposal.documentId },
+    );
+  }
+
+  const operation = getSingleOperation(proposal);
+  const priorDraft = { body, frontmatter: { ...frontmatter } };
+  let nextBody = body;
+  let nextFrontmatter = frontmatter;
+
+  if (operation.op === "replace_selection") {
+    nextBody = applyReplaceSelection(body, operation);
+  } else if (operation.op === "insert_block") {
+    nextBody = applyInsertBlock(body, operation);
+  } else if (operation.op === "update_frontmatter") {
+    nextFrontmatter = mergeFrontmatter(frontmatter, operation.patch);
+  } else {
+    throw aiOutputInvalid(
+      `Unsupported operation kind "${operation.op}" for active collaboration apply.`,
+      { proposalId: proposal.proposalId },
+    );
+  }
+
+  return {
+    body: nextBody,
+    frontmatter: nextFrontmatter,
+    priorDraft,
+  };
+}

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.ts
@@ -170,6 +170,13 @@ export function applyAssistantCollaborationProposalDraft({
   }
 
   const operation = getSingleOperation(proposal);
+  if (operation.op !== proposal.kind) {
+    throw aiOutputInvalid(
+      `Proposal kind "${proposal.kind}" does not match operation kind "${operation.op}".`,
+      { proposalId: proposal.proposalId },
+    );
+  }
+
   const priorDraft = { body, frontmatter: { ...frontmatter } };
   let nextBody = body;
   let nextFrontmatter = frontmatter;

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
@@ -16,6 +16,10 @@ import type {
   StudioAiRouteApi,
 } from "../../../ai-route-api.js";
 import type {
+  AssistantCollaborationPriorDraft,
+  AssistantCollaborationProposalDraftResult,
+} from "./assistant-collaboration-apply.js";
+import type {
   AssistantContextDoc,
   AssistantMessage,
   AssistantMessageContextSnapshot,
@@ -141,6 +145,11 @@ type AssistantAction =
       priorDraft?: { body: string; frontmatter: Record<string, unknown> };
       /** Draft revision the apply call produced. */
       postApplyDraftRevision?: number;
+      /**
+       * Proposal landed through the active collaboration room instead of
+       * the server apply endpoint.
+       */
+      acceptedViaCollaboration?: boolean;
     }
   | {
       /**
@@ -502,6 +511,13 @@ export type AssistantActiveDocument = {
     /** AI-facing selected span; complete block selections preserve markdown markers. */
     text: string;
   };
+  applyCollaborationProposal?: (input: {
+    proposal: StudioAiProposal;
+  }) => Promise<AssistantCollaborationProposalDraftResult | null>;
+  undoCollaborationProposal?: (input: {
+    proposal: StudioAiProposal;
+    priorDraft: AssistantCollaborationPriorDraft;
+  }) => Promise<void>;
 };
 
 function addDocumentPath(
@@ -1094,6 +1110,9 @@ function reducer(
                 : {}),
               ...(action.postApplyDraftRevision !== undefined
                 ? { postApplyDraftRevision: action.postApplyDraftRevision }
+                : {}),
+              ...(action.acceptedViaCollaboration !== undefined
+                ? { acceptedViaCollaboration: action.acceptedViaCollaboration }
                 : {}),
             },
           }
@@ -1862,12 +1881,50 @@ function useAssistantProviderModel({
       acceptProposal: (proposal) => {
         void (async () => {
           const liveApi = apiRef.current;
+          const liveDoc = activeDocumentRef.current;
+          const wireProposal = state.store.wireProposals[
+            proposal.proposalId
+          ] as StudioAiProposal | undefined;
           const placeholderUser: AssistantMessage = {
             id: `m-accept-${Date.now().toString(36)}`,
             role: "user",
             at: new Date().toISOString(),
             text: `Accept ${proposal.proposalId}`,
           };
+          try {
+            const collaborationApplyResult =
+              wireProposal && liveDoc?.applyCollaborationProposal
+                ? await liveDoc.applyCollaborationProposal({
+                    proposal: wireProposal,
+                  })
+                : null;
+
+            if (collaborationApplyResult && liveDoc) {
+              const acceptedAt = new Date().toISOString();
+              const hiddenMessage: AssistantMessage = {
+                id: `m-accept-signal-${Date.now().toString(36)}`,
+                role: "user",
+                at: acceptedAt,
+                text: describeAcceptanceForAgent(proposal),
+                hidden: true,
+              };
+              dispatch({
+                type: "mark-proposal-accepted",
+                threadId: state.activeThreadId,
+                proposalId: proposal.proposalId,
+                acceptedAt,
+                hiddenMessage,
+                acceptedDocumentId: liveDoc.documentId,
+                priorDraft: collaborationApplyResult.priorDraft,
+                acceptedViaCollaboration: true,
+              });
+              return;
+            }
+          } catch (error) {
+            appendErrorTurn(placeholderUser, error);
+            return;
+          }
+
           if (!liveApi) {
             appendErrorTurn(
               placeholderUser,
@@ -1898,12 +1955,6 @@ function useAssistantProviderModel({
             );
             return;
           }
-          // Send the wire-shape proposal body so the server doesn't
-          // need to look it up in its in-memory store — chat proposals
-          // live entirely client-side.
-          const wireProposal = state.store.wireProposals[
-            proposal.proposalId
-          ] as StudioAiProposal | undefined;
           try {
             const applyResult = await liveApi.applyProposal({
               proposalId: proposal.proposalId,
@@ -1969,12 +2020,51 @@ function useAssistantProviderModel({
         // can stay mounted and render an inline error — SPEC-014
         // says undo errors do NOT become chat error turns.
         const liveApi = apiRef.current;
+        const liveDoc = activeDocumentRef.current;
         if (!proposal.acceptedAt || !proposal.acceptedDocumentId) {
           throw new RuntimeError({
             code: "AI_UNDO_UNAVAILABLE",
             message: "Undo is not available for this proposal.",
             statusCode: 400,
           });
+        }
+        const wireProposal = state.store.wireProposals[proposal.proposalId] as
+          | StudioAiProposal
+          | undefined;
+        if (proposal.acceptedViaCollaboration) {
+          if (
+            !wireProposal ||
+            !proposal.priorDraft ||
+            !liveDoc?.undoCollaborationProposal
+          ) {
+            throw new RuntimeError({
+              code: "AI_UNDO_UNAVAILABLE",
+              message:
+                "Undo is only available while the active collaboration room is connected.",
+              statusCode: 409,
+            });
+          }
+
+          await liveDoc.undoCollaborationProposal({
+            proposal: wireProposal,
+            priorDraft: proposal.priorDraft,
+          });
+          const undoneAt = new Date().toISOString();
+          const hiddenMessage: AssistantMessage = {
+            id: `m-undo-signal-${Date.now().toString(36)}`,
+            role: "user",
+            at: undoneAt,
+            text: describeUndoForAgent(proposal),
+            hidden: true,
+          };
+          dispatch({
+            type: "mark-proposal-undone",
+            threadId: state.activeThreadId,
+            proposalId: proposal.proposalId,
+            undoneAt,
+            hiddenMessage,
+          });
+          return;
         }
         if (!liveApi) {
           throw new RuntimeError({
@@ -1993,9 +2083,6 @@ function useAssistantProviderModel({
             statusCode: 503,
           });
         }
-        const wireProposal = state.store.wireProposals[proposal.proposalId] as
-          | StudioAiProposal
-          | undefined;
         if (!wireProposal) {
           throw new RuntimeError({
             code: "AI_UNDO_UNAVAILABLE",

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
@@ -115,6 +115,12 @@ type ProposalCommonFields = {
    * to clobber them.
    */
   postApplyDraftRevision?: number;
+  /**
+   * True when the proposal was applied into an active collaboration room
+   * instead of through the server apply endpoint. Undo must use the same
+   * active room while the short undo window is open.
+   */
+  acceptedViaCollaboration?: boolean;
 };
 
 export type AssistantProposalEdit = ProposalCommonFields & {

--- a/packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  createEmptyCurrentPrincipalCapabilities,
+  type SchemaRegistryFieldSnapshot,
+} from "@mdcms/shared";
+
+import { createDocumentEditor } from "../../../document-editor.js";
+import {
+  extractMarkdownFromEditor,
+  roundTripMarkdown,
+} from "../../../markdown-pipeline.js";
+import {
+  areJsonValuesEqual,
+  cloneFrontmatter,
+  getPropertyDescriptors,
+  type ContentDocumentPageReadyState,
+} from "../../pages/content-document-page-state.js";
+import { MdxComponentCollapseProvider } from "./mdx-component-collapse.js";
+import { MdxComponentNodeView } from "./mdx-component-node-view.js";
+import {
+  nextMdxComponentCollapseSnapshot,
+  toggleMdxComponentCollapseSnapshot,
+  type MdxComponentCollapseSnapshot,
+} from "./mdx-component-collapse-state.js";
+import { TipTapEditor } from "./tiptap-editor.js";
+
+type CollaborationRoundTripFixture = {
+  type: string;
+  body: string;
+};
+
+const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
+  {
+    type: "Article",
+    body: [
+      "# Product Update",
+      "",
+      "Intro with [docs](https://docs.example.com).",
+      "",
+      "![Hero image](https://cdn.example.com/hero.png)",
+      "",
+      "- [ ] Draft",
+      "- [x] Published",
+      "",
+      "```ts",
+      "const value = 42;",
+      "```",
+    ].join("\n"),
+  },
+  {
+    type: "MarketingPage",
+    body: [
+      '<Hero title="Launch" image={{"src":"https://cdn.example.com/hero.png"}} />',
+      "",
+      '<Callout type="warning">',
+      "This is **important** content.",
+      "",
+      '<Button href="/start">',
+      "Start",
+      "</Button>",
+      "</Callout>",
+    ].join("\n"),
+  },
+  {
+    type: "LandingPage",
+    body: [
+      '<section style={{"backgroundColor":"#fff"}}>',
+      "<h2>",
+      'Title with <span style={{"color":"#2563eb"}}>accent</span>',
+      "</h2>",
+      "</section>",
+    ].join("\n"),
+  },
+];
+
+type FrontmatterFixture = {
+  type: string;
+  frontmatter: Record<string, unknown>;
+  fields: Record<string, SchemaRegistryFieldSnapshot>;
+  editableFields: string[];
+  unsupportedFields: string[];
+};
+
+const FRONTMATTER_FIXTURES: FrontmatterFixture[] = [
+  {
+    type: "Article",
+    frontmatter: {
+      title: "Product Update",
+      priority: 3,
+      featured: true,
+      heroImage: "media_hero",
+      status: "published",
+    },
+    fields: {
+      title: { kind: "string", required: true, nullable: false },
+      priority: { kind: "number", required: false, nullable: true },
+      featured: { kind: "boolean", required: false, nullable: false },
+      heroImage: {
+        kind: "file",
+        required: false,
+        nullable: true,
+        file: {
+          preset: "image",
+          accept: ["image/png", "image/jpeg"],
+          emptyStringAsUnset: true,
+        },
+      },
+      status: {
+        kind: "string",
+        required: false,
+        nullable: true,
+        options: ["draft", "review", "published"],
+      },
+    },
+    editableFields: ["title", "priority", "featured", "heroImage", "status"],
+    unsupportedFields: [],
+  },
+  {
+    type: "LandingPage",
+    frontmatter: {
+      seo: { title: "Launch", description: "Ship the new page." },
+      tags: ["launch", "product"],
+    },
+    fields: {
+      seo: {
+        kind: "object",
+        required: false,
+        nullable: false,
+        fields: {
+          title: { kind: "string", required: true, nullable: false },
+          description: { kind: "string", required: false, nullable: true },
+        },
+      },
+      tags: {
+        kind: "array",
+        required: false,
+        nullable: false,
+        item: { kind: "string", required: true, nullable: false },
+      },
+    },
+    editableFields: [],
+    unsupportedFields: ["seo", "tags"],
+  },
+];
+
+function createFixtureReadyState(
+  fixture: FrontmatterFixture,
+): ContentDocumentPageReadyState {
+  return {
+    status: "ready",
+    typeId: fixture.type,
+    typeLabel: fixture.type,
+    documentId: "11111111-1111-4111-8111-111111111111",
+    locale: "en",
+    route: {
+      project: "marketing",
+      initialEnvironment: "draft",
+      write: { canWrite: true, schemaHash: "schema-hash" },
+    },
+    schemaState: {
+      status: "ready",
+      project: "marketing",
+      environment: "draft",
+      localSchemaHash: "schema-hash",
+      serverSchemaHash: "schema-hash",
+      isMismatch: false,
+      hasLocalSyncPayload: true,
+      canSync: true,
+      capabilities: {
+        ...createEmptyCurrentPrincipalCapabilities(),
+        content: {
+          read: true,
+          readDraft: true,
+          write: true,
+          publish: true,
+          unpublish: true,
+          delete: true,
+        },
+        schema: { read: true, write: true },
+        media: { read: true, upload: true, delete: true },
+        ai: { use: true },
+      },
+      entries: [
+        {
+          type: fixture.type,
+          directory: "content",
+          localized: false,
+          schemaHash: "schema-hash",
+          syncedAt: "2026-06-14T10:00:00.000Z",
+          resolvedSchema: {
+            type: fixture.type,
+            directory: "content",
+            localized: false,
+            fields: fixture.fields,
+          },
+        },
+      ],
+      reload: async () => {
+        throw new Error("not used");
+      },
+      sync: async () => {
+        throw new Error("not used");
+      },
+    },
+    document: {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      type: fixture.type,
+      locale: "en",
+      path: "content/example",
+      format: "mdx",
+      frontmatter: fixture.frontmatter,
+      body: "",
+      publishedVersion: null,
+      hasUnpublishedChanges: true,
+      draftRevision: 1,
+      updatedAt: "2026-06-14T10:00:00.000Z",
+    },
+    draftBody: "",
+    draftFrontmatter: cloneFrontmatter(fixture.frontmatter),
+    saveState: "saved",
+    canWrite: true,
+    canAi: true,
+    canReadMedia: true,
+    canUploadMedia: true,
+    publishDialogOpen: false,
+    publishChangeSummary: "",
+    publishState: "idle",
+    restoreVersionState: "idle",
+    versionHistory: { status: "ready", versions: [] },
+    selectedComparison: {},
+    versionDiff: { status: "idle" },
+    translationVariants: [],
+    localized: false,
+    variantsFetchFailed: false,
+  };
+}
+
+function extractMarkdownFromSaveEditor(body: string): string {
+  const editor = createDocumentEditor({ content: body });
+
+  try {
+    return extractMarkdownFromEditor(editor);
+  } finally {
+    editor.destroy();
+  }
+}
+
+function renderMdxNodeViewSavePathUnderCollapse(props: {
+  body: string;
+  snapshot: MdxComponentCollapseSnapshot;
+}): {
+  state: MdxComponentCollapseSnapshot["globalState"];
+  markup: string;
+  markdown: string;
+} {
+  const editor = createDocumentEditor({ content: props.body });
+
+  try {
+    const CalloutPreview = (previewProps: { children?: ReactNode }) =>
+      createElement("aside", null, previewProps.children);
+    const markup = renderToStaticMarkup(
+      createElement(
+        MdxComponentCollapseProvider,
+        { snapshot: props.snapshot },
+        createElement(MdxComponentNodeView, {
+          node: {
+            attrs: {
+              componentName: "Callout",
+              isVoid: false,
+              props: { type: "warning" },
+            },
+          },
+          selected: false,
+          readOnly: false,
+          forbidden: false,
+          context: {
+            hostBridge: {
+              resolveComponent: () => CalloutPreview,
+              renderMdxPreview: () => () => {},
+            },
+            mdx: {
+              catalog: { components: [] },
+            },
+          },
+          editor,
+          getPos: () => 1,
+          deleteNode: () => {},
+        } as never),
+      ),
+    );
+
+    return {
+      state: props.snapshot.globalState,
+      markup,
+      markdown: extractMarkdownFromEditor(editor),
+    };
+  } finally {
+    editor.destroy();
+  }
+}
+
+function getCollapseToolbarButtonMarkup(markup: string): string {
+  const match = markup.match(
+    /<button(?=[^>]*title="Collapse all components")[\s\S]*?<\/button>/,
+  );
+
+  assert.ok(match?.[0], "expected the Collapse all toolbar button to render");
+
+  return match[0];
+}
+
+test("collaboration body fixtures round-trip byte-for-byte", () => {
+  for (const fixture of BODY_FIXTURES) {
+    assert.equal(
+      roundTripMarkdown(fixture.body).markdown,
+      fixture.body,
+      `${fixture.type} body must not produce a phantom collaboration diff`,
+    );
+    assert.equal(
+      extractMarkdownFromSaveEditor(fixture.body),
+      fixture.body,
+      `${fixture.type} editor save path must not produce a phantom collaboration diff`,
+    );
+  }
+});
+
+test("collaboration frontmatter fixtures preserve supported values", () => {
+  for (const fixture of FRONTMATTER_FIXTURES) {
+    const cloned = cloneFrontmatter(fixture.frontmatter);
+    assert.notEqual(cloned, fixture.frontmatter);
+    assert.equal(
+      areJsonValuesEqual(cloned, fixture.frontmatter),
+      true,
+      `${fixture.type} frontmatter clone must preserve JSON values`,
+    );
+
+    const descriptors = getPropertyDescriptors(
+      createFixtureReadyState(fixture),
+    );
+    const editable = descriptors
+      .filter((descriptor) => descriptor.status === "editable")
+      .map((descriptor) => descriptor.fieldName)
+      .sort();
+    const unsupported = descriptors
+      .filter((descriptor) => descriptor.status === "unsupported")
+      .map((descriptor) => descriptor.fieldName)
+      .sort();
+
+    assert.deepEqual(editable, fixture.editableFields.sort());
+    assert.deepEqual(unsupported, fixture.unsupportedFields.sort());
+  }
+});
+
+test("collapsed MDX component UI state does not affect serialization", () => {
+  const body = [
+    '<Callout type="warning">',
+    "Keep this **body** stable.",
+    "",
+    '<Button href="/start">',
+    "Start",
+    "</Button>",
+    "</Callout>",
+  ].join("\n");
+  const initial: MdxComponentCollapseSnapshot = {
+    globalState: null,
+    generation: 0,
+  };
+  const collapsed = toggleMdxComponentCollapseSnapshot(initial);
+  const expanded = nextMdxComponentCollapseSnapshot(collapsed, "expanded");
+
+  assert.equal(collapsed.globalState, "collapsed");
+  assert.equal(expanded.globalState, "expanded");
+
+  const collapsedResult = renderMdxNodeViewSavePathUnderCollapse({
+    body,
+    snapshot: collapsed,
+  });
+  const expandedResult = renderMdxNodeViewSavePathUnderCollapse({
+    body,
+    snapshot: expanded,
+  });
+
+  assert.deepEqual(
+    [
+      { state: collapsedResult.state, markdown: collapsedResult.markdown },
+      { state: expandedResult.state, markdown: expandedResult.markdown },
+    ],
+    [
+      { state: "collapsed", markdown: body },
+      { state: "expanded", markdown: body },
+    ],
+  );
+  assert.match(
+    collapsedResult.markup,
+    /data-mdcms-mdx-component-collapsed="true"/,
+  );
+  assert.match(
+    collapsedResult.markup,
+    /<div(?=[^>]*data-node-view-content)(?=[^>]*data-mdcms-mdx-editable-slot="Callout")[^>]*>/,
+  );
+  assert.match(
+    expandedResult.markup,
+    /data-mdcms-mdx-component-collapsed="false"/,
+  );
+  assert.match(
+    expandedResult.markup,
+    /<div(?=[^>]*data-node-view-content)(?=[^>]*data-mdcms-mdx-editable-slot="Callout")[^>]*>/,
+  );
+});
+
+test("collapse all remains available in read-only and forbidden modes", () => {
+  const initialContent = [
+    '<Callout type="warning">',
+    "Read-only reviewers can still collapse this block.",
+    "</Callout>",
+  ].join("\n");
+  const readOnlyButton = getCollapseToolbarButtonMarkup(
+    renderToStaticMarkup(
+      createElement(TipTapEditor, {
+        initialContent,
+        readOnly: true,
+      }),
+    ),
+  );
+  const forbiddenButton = getCollapseToolbarButtonMarkup(
+    renderToStaticMarkup(
+      createElement(TipTapEditor, {
+        initialContent,
+        forbidden: true,
+      }),
+    ),
+  );
+
+  assert.doesNotMatch(readOnlyButton, /\sdisabled(?:=""|\s|>)/);
+  assert.doesNotMatch(forbiddenButton, /\sdisabled(?:=""|\s|>)/);
+});

--- a/packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/collaboration-round-trip-fidelity.test.ts
@@ -36,7 +36,7 @@ type CollaborationRoundTripFixture = {
 
 const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
   {
-    type: "Article",
+    type: "post",
     body: [
       "# Product Update",
       "",
@@ -53,7 +53,7 @@ const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
     ].join("\n"),
   },
   {
-    type: "MarketingPage",
+    type: "page",
     body: [
       '<Hero title="Launch" image={{"src":"https://cdn.example.com/hero.png"}} />',
       "",
@@ -67,7 +67,7 @@ const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
     ].join("\n"),
   },
   {
-    type: "LandingPage",
+    type: "campaign",
     body: [
       '<section style={{"backgroundColor":"#fff"}}>',
       "<h2>",
@@ -75,6 +75,10 @@ const BODY_FIXTURES: CollaborationRoundTripFixture[] = [
       "</h2>",
       "</section>",
     ].join("\n"),
+  },
+  {
+    type: "author",
+    body: ["# Ada Lovelace", "", "Author profile copy."].join("\n"),
   },
 ];
 
@@ -88,63 +92,81 @@ type FrontmatterFixture = {
 
 const FRONTMATTER_FIXTURES: FrontmatterFixture[] = [
   {
-    type: "Article",
+    type: "post",
     frontmatter: {
       title: "Product Update",
-      priority: 3,
+      slug: "product-update",
       featured: true,
-      heroImage: "media_hero",
-      status: "published",
+      abTestVariant: "control",
+      author: "11111111-1111-4111-8111-111111111111",
     },
     fields: {
       title: { kind: "string", required: true, nullable: false },
-      priority: { kind: "number", required: false, nullable: true },
+      slug: { kind: "string", required: true, nullable: false },
       featured: { kind: "boolean", required: false, nullable: false },
-      heroImage: {
-        kind: "file",
-        required: false,
-        nullable: true,
-        file: {
-          preset: "image",
-          accept: ["image/png", "image/jpeg"],
-          emptyStringAsUnset: true,
-        },
-      },
-      status: {
+      abTestVariant: {
         kind: "string",
         required: false,
         nullable: true,
-        options: ["draft", "review", "published"],
+      },
+      author: {
+        kind: "string",
+        required: false,
+        nullable: true,
+        reference: { targetType: "author" },
       },
     },
-    editableFields: ["title", "priority", "featured", "heroImage", "status"],
+    editableFields: ["abTestVariant", "author", "featured", "slug", "title"],
     unsupportedFields: [],
   },
   {
-    type: "LandingPage",
+    type: "author",
     frontmatter: {
-      seo: { title: "Launch", description: "Ship the new page." },
-      tags: ["launch", "product"],
+      name: "Ada Lovelace",
     },
     fields: {
-      seo: {
-        kind: "object",
-        required: false,
+      name: { kind: "string", required: true, nullable: false },
+    },
+    editableFields: ["name"],
+    unsupportedFields: [],
+  },
+  {
+    type: "page",
+    frontmatter: {
+      title: "Launch",
+    },
+    fields: {
+      title: { kind: "string", required: true, nullable: false },
+    },
+    editableFields: ["title"],
+    unsupportedFields: [],
+  },
+  {
+    type: "campaign",
+    frontmatter: {
+      title: "Summer Campaign",
+      slug: "summer-campaign",
+      summary: "Localized launch copy.",
+    },
+    fields: {
+      title: {
+        kind: "string",
+        required: true,
         nullable: false,
-        fields: {
-          title: { kind: "string", required: true, nullable: false },
-          description: { kind: "string", required: false, nullable: true },
-        },
       },
-      tags: {
-        kind: "array",
-        required: false,
+      slug: {
+        kind: "string",
+        required: true,
         nullable: false,
-        item: { kind: "string", required: true, nullable: false },
+      },
+      summary: {
+        kind: "string",
+        required: true,
+        nullable: false,
       },
     },
-    editableFields: [],
-    unsupportedFields: ["seo", "tags"],
+    editableFields: ["slug", "summary", "title"],
+    unsupportedFields: [],
   },
 ];
 
@@ -315,6 +337,13 @@ function getCollapseToolbarButtonMarkup(markup: string): string {
 }
 
 test("collaboration body fixtures round-trip byte-for-byte", () => {
+  assert.deepEqual(BODY_FIXTURES.map((fixture) => fixture.type).sort(), [
+    "author",
+    "campaign",
+    "page",
+    "post",
+  ]);
+
   for (const fixture of BODY_FIXTURES) {
     assert.equal(
       roundTripMarkdown(fixture.body).markdown,
@@ -330,6 +359,13 @@ test("collaboration body fixtures round-trip byte-for-byte", () => {
 });
 
 test("collaboration frontmatter fixtures preserve supported values", () => {
+  assert.deepEqual(FRONTMATTER_FIXTURES.map((fixture) => fixture.type).sort(), [
+    "author",
+    "campaign",
+    "page",
+    "post",
+  ]);
+
   for (const fixture of FRONTMATTER_FIXTURES) {
     const cloned = cloneFrontmatter(fixture.frontmatter);
     assert.notEqual(cloned, fixture.frontmatter);

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
@@ -17,6 +17,7 @@ import {
   createTipTapEditorCursorSelection,
   insertUploadedMediaFiles,
   MediaImagePickerView,
+  resolveTipTapEditorCursorPresenceSelection,
   resolveTipTapRemoteCursorPositions,
   resolveMediaUploadFileEvent,
   TipTapEditor,
@@ -80,6 +81,28 @@ test("createTipTapEditorCursorSelection preserves collapsed and ranged selection
     anchor: 12,
     head: 3,
   });
+});
+
+test("resolveTipTapEditorCursorPresenceSelection hides cursors when the editor is blurred", () => {
+  const selection = { anchor: 5, head: 12 };
+
+  assert.deepEqual(
+    resolveTipTapEditorCursorPresenceSelection({
+      focused: true,
+      selection,
+    }),
+    {
+      anchor: 5,
+      head: 12,
+    },
+  );
+  assert.equal(
+    resolveTipTapEditorCursorPresenceSelection({
+      focused: false,
+      selection,
+    }),
+    null,
+  );
 });
 
 test("TipTapEditor renders an enabled image picker and hidden media upload input for writable media targets", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
@@ -13,10 +13,14 @@ import {
 } from "./tiptap-editor-utils.js";
 import { extractMarkdownFromEditor } from "../../../markdown-pipeline.js";
 import {
+  attachTipTapRemoteCursorPositionSync,
+  createTipTapEditorCursorSelection,
   insertUploadedMediaFiles,
   MediaImagePickerView,
+  resolveTipTapRemoteCursorPositions,
   resolveMediaUploadFileEvent,
   TipTapEditor,
+  TipTapRemoteCursorLayer,
 } from "./tiptap-editor.js";
 import { createDocumentEditor } from "../../../document-editor.js";
 
@@ -67,6 +71,17 @@ test("createTipTapEditorDependencies keeps editor lifetime independent of onChan
   );
 });
 
+test("createTipTapEditorCursorSelection preserves collapsed and ranged selections", () => {
+  assert.deepEqual(createTipTapEditorCursorSelection({ anchor: 5, head: 5 }), {
+    anchor: 5,
+    head: 5,
+  });
+  assert.deepEqual(createTipTapEditorCursorSelection({ anchor: 12, head: 3 }), {
+    anchor: 12,
+    head: 3,
+  });
+});
+
 test("TipTapEditor renders an enabled image picker and hidden media upload input for writable media targets", () => {
   const markup = renderToStaticMarkup(
     createElement(TipTapEditor, {
@@ -107,6 +122,160 @@ test("TipTapEditor disables the image toolbar control when media upload is unava
     markup,
     /<button(?=[^>]*aria-label="Upload media unavailable in this target\.")(?=[^>]*\sdisabled(?:=""|\s|>))[^>]*>/,
   );
+});
+
+test("TipTapRemoteCursorLayer renders compact labels with server-provided identity", () => {
+  const markup = renderToStaticMarkup(
+    createElement(TipTapRemoteCursorLayer, {
+      cursors: [
+        {
+          sessionId: "session-ada",
+          label: "Ada Lovelace",
+          color: "#2563eb",
+          cursor: { anchor: 2, head: 7 },
+          top: 24,
+          left: 48,
+        },
+      ],
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-remote-cursor="session-ada"/);
+  assert.match(markup, /Ada Lovelace/);
+  assert.match(markup, /#2563eb/);
+});
+
+test("resolveTipTapRemoteCursorPositions resolves cursor heads relative to the editor wrapper", () => {
+  const positions = resolveTipTapRemoteCursorPositions({
+    editor: {
+      view: {
+        coordsAtPos(position: number) {
+          if (position === 7) {
+            return {
+              top: 140,
+              right: 91,
+              bottom: 158,
+              left: 90,
+            };
+          }
+
+          throw new Error("stale position");
+        },
+      },
+    },
+    wrapper: {
+      getBoundingClientRect: () => ({
+        top: 120,
+        right: 320,
+        bottom: 520,
+        left: 64,
+        width: 256,
+        height: 400,
+      }),
+    },
+    remoteCursors: [
+      {
+        sessionId: "session-ada",
+        label: "Ada Lovelace",
+        color: "#2563eb",
+        cursor: { anchor: 2, head: 7 },
+      },
+      {
+        sessionId: "session-grace",
+        label: "Grace Hopper",
+        color: "#16a34a",
+        cursor: { anchor: 3, head: 99 },
+      },
+    ],
+  });
+
+  assert.deepEqual(positions, [
+    {
+      sessionId: "session-ada",
+      label: "Ada Lovelace",
+      color: "#2563eb",
+      cursor: { anchor: 2, head: 7 },
+      top: 20,
+      left: 26,
+    },
+  ]);
+});
+
+test("attachTipTapRemoteCursorPositionSync updates on scroll resize editor events and cleanup", () => {
+  const scrollListeners = new Set<() => void>();
+  const resizeListeners = new Set<() => void>();
+  const editorListeners = new Map<string, Set<() => void>>();
+  const editor = {
+    on: (eventName: string, listener: () => void) => {
+      const listeners = editorListeners.get(eventName) ?? new Set<() => void>();
+      listeners.add(listener);
+      editorListeners.set(eventName, listeners);
+    },
+    off: (eventName: string, listener: () => void) => {
+      editorListeners.get(eventName)?.delete(listener);
+    },
+  };
+  const scrollContainer = {
+    addEventListener: (
+      eventName: string,
+      listener: () => void,
+      options?: AddEventListenerOptions,
+    ) => {
+      assert.equal(eventName, "scroll");
+      assert.deepEqual(options, { passive: true });
+      scrollListeners.add(listener);
+    },
+    removeEventListener: (eventName: string, listener: () => void) => {
+      assert.equal(eventName, "scroll");
+      scrollListeners.delete(listener);
+    },
+  };
+  const viewport = {
+    addEventListener: (eventName: string, listener: () => void) => {
+      assert.equal(eventName, "resize");
+      resizeListeners.add(listener);
+    },
+    removeEventListener: (eventName: string, listener: () => void) => {
+      assert.equal(eventName, "resize");
+      resizeListeners.delete(listener);
+    },
+  };
+  let updateCount = 0;
+
+  const cleanup = attachTipTapRemoteCursorPositionSync({
+    editor,
+    scrollContainer,
+    viewport,
+    updateRemoteCursorPositions: () => {
+      updateCount += 1;
+    },
+  });
+
+  assert.equal(updateCount, 1);
+  assert.equal(scrollListeners.size, 1);
+  assert.equal(resizeListeners.size, 1);
+  assert.equal(editorListeners.get("update")?.size, 1);
+  assert.equal(editorListeners.get("selectionUpdate")?.size, 1);
+
+  scrollListeners.forEach((listener) => listener());
+  resizeListeners.forEach((listener) => listener());
+  editorListeners.get("update")?.forEach((listener) => listener());
+  editorListeners.get("selectionUpdate")?.forEach((listener) => listener());
+
+  assert.equal(updateCount, 5);
+
+  cleanup();
+  assert.equal(scrollListeners.size, 0);
+  assert.equal(resizeListeners.size, 0);
+  assert.equal(editorListeners.get("update")?.size, 0);
+  assert.equal(editorListeners.get("selectionUpdate")?.size, 0);
+
+  scrollListeners.forEach((listener) => listener());
+  resizeListeners.forEach((listener) => listener());
+  editorListeners.get("update")?.forEach((listener) => listener());
+  editorListeners.get("selectionUpdate")?.forEach((listener) => listener());
+
+  assert.equal(updateCount, 5);
 });
 
 test("MediaImagePickerView renders a library-first single-select image flow", () => {

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor-lifecycle.test.ts
@@ -135,12 +135,19 @@ test("TipTapRemoteCursorLayer renders compact labels with server-provided identi
           cursor: { anchor: 2, head: 7 },
           top: 24,
           left: 48,
+          selection: {
+            top: 24,
+            left: 24,
+            width: 24,
+            height: 16,
+          },
         },
       ],
     }),
   );
 
   assert.match(markup, /data-mdcms-remote-cursor="session-ada"/);
+  assert.match(markup, /data-mdcms-remote-selection="session-ada"/);
   assert.match(markup, /Ada Lovelace/);
   assert.match(markup, /#2563eb/);
 });
@@ -150,6 +157,15 @@ test("resolveTipTapRemoteCursorPositions resolves cursor heads relative to the e
     editor: {
       view: {
         coordsAtPos(position: number) {
+          if (position === 2) {
+            return {
+              top: 140,
+              right: 71,
+              bottom: 158,
+              left: 70,
+            };
+          }
+
           if (position === 7) {
             return {
               top: 140,
@@ -197,6 +213,12 @@ test("resolveTipTapRemoteCursorPositions resolves cursor heads relative to the e
       cursor: { anchor: 2, head: 7 },
       top: 20,
       left: 26,
+      selection: {
+        top: 20,
+        left: 6,
+        width: 21,
+        height: 18,
+      },
     },
   ]);
 });

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -30,6 +30,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { Extension } from "@tiptap/core";
 import {
   isRuntimeErrorLike,
   type MediaAsset,
@@ -45,6 +46,8 @@ import {
 import { Fragment, Slice } from "@tiptap/pm/model";
 import type { SelectionBookmark } from "@tiptap/pm/state";
 import type { Mappable } from "@tiptap/pm/transform";
+import { ySyncPlugin } from "y-prosemirror";
+import type * as Y from "yjs";
 
 import {
   Bold,
@@ -276,6 +279,17 @@ export type TipTapEditorRemoteCursorPosition = TipTapEditorRemoteCursor & {
 const EMPTY_REMOTE_CURSORS: TipTapEditorRemoteCursor[] = [];
 const EMPTY_REMOTE_CURSOR_POSITIONS: TipTapEditorRemoteCursorPosition[] = [];
 
+function createCollaborationExtension(body: Y.XmlFragment) {
+  return Extension.create({
+    name: "mdcmsCollaboration",
+    priority: 1000,
+
+    addProseMirrorPlugins() {
+      return [ySyncPlugin(body)];
+    },
+  });
+}
+
 export function createTipTapEditorCursorSelection(selection: {
   anchor: number;
   head: number;
@@ -310,6 +324,9 @@ interface TipTapEditorProps {
   context?: StudioMountContext;
   readOnly?: boolean;
   forbidden?: boolean;
+  collaboration?: {
+    body: Y.XmlFragment;
+  };
   mediaUpload?: TipTapEditorMediaUploadState;
   mediaLibrary?: TipTapEditorMediaLibraryState;
   onActiveMdxComponentChange?: (
@@ -1258,6 +1275,7 @@ function useTipTapEditorElement({
   context,
   readOnly = false,
   forbidden = false,
+  collaboration,
   mediaUpload,
   mediaLibrary,
   onActiveMdxComponentChange,
@@ -1281,6 +1299,11 @@ function useTipTapEditorElement({
     [catalogComponents],
   );
   const isEditorReadOnly = readOnly || forbidden;
+  const collaborationExtension = useMemo(
+    () =>
+      collaboration ? createCollaborationExtension(collaboration.body) : null,
+    [collaboration?.body],
+  );
   const mediaUploadUnavailableMessage =
     mediaUpload?.unavailableMessage?.trim() || MEDIA_UPLOAD_UNAVAILABLE_MESSAGE;
   const mediaLibraryUnavailableMessage =
@@ -1676,8 +1699,8 @@ function useTipTapEditorElement({
   );
   const editor = useEditor(
     {
-      content: initialEditorContent,
-      contentType: "json",
+      content: collaboration ? undefined : initialEditorContent,
+      contentType: collaboration ? undefined : "json",
       editable: !isEditorReadOnly,
       immediatelyRender: false,
       // Leaving `shouldRerenderOnTransaction` at its default (`false`) is
@@ -1686,29 +1709,32 @@ function useTipTapEditorElement({
       // lag behind during fast typing (especially Shift+Enter spam). The
       // toolbar stays reactive via `useEditorState` below, which subscribes
       // only to the handful of mark/node-active flags it actually reads.
-      extensions: createEditorExtensions({
-        codeBlock: CodeBlockWithNodeView,
-        image: StudioImageExtension.extend({
-          addNodeView() {
-            return ReactNodeViewRenderer(TipTapImageNodeView);
-          },
+      extensions: [
+        ...createEditorExtensions({
+          codeBlock: CodeBlockWithNodeView,
+          image: StudioImageExtension.extend({
+            addNodeView() {
+              return ReactNodeViewRenderer(TipTapImageNodeView);
+            },
+          }),
+          mdxRawJsx: MdxRawJsxExtension.extend({
+            addNodeView() {
+              return ReactNodeViewRenderer(MdxRawJsxNodeView);
+            },
+          }),
+          mdxComponent: MdxComponentExtension.extend({
+            addNodeView() {
+              return ReactNodeViewRenderer(TipTapMdxComponentNodeView);
+            },
+          }),
+          mdxIntrinsicElement: MdxIntrinsicElementExtension.extend({
+            addNodeView() {
+              return ReactNodeViewRenderer(MdxIntrinsicElementNodeView);
+            },
+          }),
         }),
-        mdxRawJsx: MdxRawJsxExtension.extend({
-          addNodeView() {
-            return ReactNodeViewRenderer(MdxRawJsxNodeView);
-          },
-        }),
-        mdxComponent: MdxComponentExtension.extend({
-          addNodeView() {
-            return ReactNodeViewRenderer(TipTapMdxComponentNodeView);
-          },
-        }),
-        mdxIntrinsicElement: MdxIntrinsicElementExtension.extend({
-          addNodeView() {
-            return ReactNodeViewRenderer(MdxIntrinsicElementNodeView);
-          },
-        }),
-      }),
+        ...(collaborationExtension ? [collaborationExtension] : []),
+      ],
       editorProps: {
         attributes: {
           // Padding lives on `.ProseMirror` itself rather than the outer
@@ -1818,12 +1844,15 @@ function useTipTapEditorElement({
         emitMarkdownNow(editor);
       },
     },
-    createTipTapEditorDependencies({
-      placeholder,
-      hostBridge: context?.hostBridge,
-      readOnly,
-      forbidden,
-    }),
+    [
+      ...createTipTapEditorDependencies({
+        placeholder,
+        hostBridge: context?.hostBridge,
+        readOnly,
+        forbidden,
+      }),
+      collaboration?.body ?? null,
+    ],
   );
   activeEditorRef.current = editor;
   isEditorReadOnlyRef.current = isEditorReadOnly;

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -272,9 +272,17 @@ export type TipTapEditorRemoteCursor = {
   cursor: TipTapEditorCursorSelection;
 };
 
+export type TipTapEditorRemoteSelectionPosition = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
 export type TipTapEditorRemoteCursorPosition = TipTapEditorRemoteCursor & {
   top: number;
   left: number;
+  selection?: TipTapEditorRemoteSelectionPosition;
 };
 
 const EMPTY_REMOTE_CURSORS: TipTapEditorRemoteCursor[] = [];
@@ -581,11 +589,28 @@ export function resolveTipTapRemoteCursorPositions({
 
   for (const remoteCursor of remoteCursors) {
     try {
+      const anchorRect = editor.view.coordsAtPos(remoteCursor.cursor.anchor);
       const cursorRect = editor.view.coordsAtPos(remoteCursor.cursor.head);
+      const selection =
+        remoteCursor.cursor.anchor === remoteCursor.cursor.head
+          ? undefined
+          : {
+              top: Math.min(anchorRect.top, cursorRect.top) - wrapperRect.top,
+              left:
+                Math.min(anchorRect.left, cursorRect.left) - wrapperRect.left,
+              width:
+                Math.max(anchorRect.right, cursorRect.right) -
+                Math.min(anchorRect.left, cursorRect.left),
+              height:
+                Math.max(anchorRect.bottom, cursorRect.bottom) -
+                Math.min(anchorRect.top, cursorRect.top),
+            };
+
       positions.push({
         ...remoteCursor,
         top: cursorRect.top - wrapperRect.top,
         left: cursorRect.left - wrapperRect.left,
+        ...(selection ? { selection } : {}),
       });
     } catch {
       // Remote cursor snapshots can briefly outlive the local document
@@ -655,27 +680,42 @@ export function TipTapRemoteCursorLayer({
   return (
     <div className="pointer-events-none absolute inset-0 z-20">
       {cursors.map((cursor) => (
-        <div
-          key={cursor.sessionId}
-          data-mdcms-remote-cursor={cursor.sessionId}
-          aria-label={`${cursor.label} cursor`}
-          className="absolute flex items-start gap-1"
-          style={{
-            top: cursor.top,
-            left: cursor.left,
-          }}
-        >
-          <span
-            className="mt-0.5 h-4 w-px rounded-full"
-            style={{ backgroundColor: cursor.color }}
-          />
-          <span
-            className="max-w-40 truncate rounded-sm px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm"
-            style={{ backgroundColor: cursor.color }}
+        <ReactFragment key={cursor.sessionId}>
+          {cursor.selection ? (
+            <div
+              data-mdcms-remote-selection={cursor.sessionId}
+              aria-hidden="true"
+              className="absolute rounded-sm opacity-20"
+              style={{
+                top: cursor.selection.top,
+                left: cursor.selection.left,
+                width: cursor.selection.width,
+                height: cursor.selection.height,
+                backgroundColor: cursor.color,
+              }}
+            />
+          ) : null}
+          <div
+            data-mdcms-remote-cursor={cursor.sessionId}
+            aria-label={`${cursor.label} cursor`}
+            className="absolute flex items-start gap-1"
+            style={{
+              top: cursor.top,
+              left: cursor.left,
+            }}
           >
-            {cursor.label}
-          </span>
-        </div>
+            <span
+              className="mt-0.5 h-4 w-px rounded-full"
+              style={{ backgroundColor: cursor.color }}
+            />
+            <span
+              className="max-w-40 truncate rounded-sm px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm"
+              style={{ backgroundColor: cursor.color }}
+            >
+              {cursor.label}
+            </span>
+          </div>
+        </ReactFragment>
       ))}
     </div>
   );

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -154,6 +154,7 @@ import { Separator } from "../ui/separator.js";
 import { cn } from "../../lib/utils.js";
 
 export interface TipTapEditorHandle {
+  getContent: () => string | null;
   setContent: (markdown: string) => void;
   /**
    * Returns the markdown serialization of the document slice between
@@ -2128,6 +2129,13 @@ function useTipTapEditorElement({
   useImperativeHandle(
     ref,
     () => ({
+      getContent() {
+        if (!editor || editor.isDestroyed) {
+          return null;
+        }
+
+        return extractMarkdownFromEditor(editor);
+      },
       setContent(markdown: string) {
         if (!editor || editor.isDestroyed) {
           return;

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -309,6 +309,16 @@ export function createTipTapEditorCursorSelection(selection: {
   };
 }
 
+export function resolveTipTapEditorCursorPresenceSelection({
+  focused,
+  selection,
+}: {
+  focused: boolean;
+  selection: { anchor: number; head: number };
+}): TipTapEditorCursorSelection | null {
+  return focused ? createTipTapEditorCursorSelection(selection) : null;
+}
+
 export type TipTapEditorMediaUploadState = {
   canUpload: boolean;
   isUploading: boolean;
@@ -348,7 +358,9 @@ interface TipTapEditorProps {
    * transforms.
    */
   onSelectionTextChange?: (selection: TipTapEditorSelectionInfo | null) => void;
-  onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
+  onCursorSelectionChange?: (
+    selection: TipTapEditorCursorSelection | null,
+  ) => void;
   remoteCursors?: TipTapEditorRemoteCursor[];
   /**
    * Renders ABOVE the editable surface inside the scrollable canvas area —
@@ -1873,12 +1885,29 @@ function useTipTapEditorElement({
       },
       onSelectionUpdate({ editor }) {
         onCursorSelectionChange?.(
-          createTipTapEditorCursorSelection(editor.state.selection),
+          resolveTipTapEditorCursorPresenceSelection({
+            focused: true,
+            selection: editor.state.selection,
+          }),
         );
         syncSlashTrigger(editor);
         scheduleAuxSelectionUpdate(editor);
       },
+      onFocus({ editor }) {
+        onCursorSelectionChange?.(
+          resolveTipTapEditorCursorPresenceSelection({
+            focused: true,
+            selection: editor.state.selection,
+          }),
+        );
+      },
       onBlur({ editor }) {
+        onCursorSelectionChange?.(
+          resolveTipTapEditorCursorPresenceSelection({
+            focused: false,
+            selection: editor.state.selection,
+          }),
+        );
         // Blur is typically the user switching away to save or navigate —
         // flush any pending debounced markdown emission now so the host app
         // sees the latest content immediately.

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -1887,7 +1887,7 @@ function useTipTapEditorElement({
       onSelectionUpdate({ editor }) {
         onCursorSelectionChange?.(
           resolveTipTapEditorCursorPresenceSelection({
-            focused: true,
+            focused: editor.isFocused,
             selection: editor.state.selection,
           }),
         );

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -156,6 +156,7 @@ import { cn } from "../../lib/utils.js";
 export interface TipTapEditorHandle {
   getContent: () => string | null;
   setContent: (markdown: string) => void;
+  applyAssistantContent: (markdown: string) => void;
   /**
    * Returns the markdown serialization of the document slice between
    * `from` and `to`, plus the mode the caller should use when
@@ -2236,6 +2237,32 @@ function useTipTapEditorElement({
 
         // Refresh derived UI state that onUpdate would normally handle,
         // since we suppressed the update event above.
+        publishSelectedMdxComponent(editor);
+        syncSlashTrigger(editor);
+      },
+      applyAssistantContent(markdown: string) {
+        if (!editor || editor.isDestroyed) {
+          return;
+        }
+
+        const currentMarkdown = extractMarkdownFromEditor(editor);
+
+        if (currentMarkdown === markdown) {
+          lastEmittedMarkdownRef.current = currentMarkdown;
+          return;
+        }
+
+        if (markdownEmitTimerRef.current !== null) {
+          clearTimeout(markdownEmitTimerRef.current);
+          markdownEmitTimerRef.current = null;
+        }
+
+        mediaUploadInsertionTargetsRef.current.clear();
+        editor.commands.setContent(parseMarkdownToDocument(markdown), {
+          contentType: "json",
+          emitUpdate: true,
+        });
+        handleEditorUpdate(editor);
         publishSelectedMdxComponent(editor);
         syncSlashTrigger(editor);
       },

--- a/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/editor/tiptap-editor.tsx
@@ -17,6 +17,7 @@ import {
   type ChangeEvent as ReactChangeEvent,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -255,6 +256,36 @@ export type TipTapEditorSelectionInfo = {
   anchorRect: TipTapEditorAnchorRect;
 };
 
+export type TipTapEditorCursorSelection = {
+  anchor: number;
+  head: number;
+};
+
+export type TipTapEditorRemoteCursor = {
+  sessionId: string;
+  label: string;
+  color: string;
+  cursor: TipTapEditorCursorSelection;
+};
+
+export type TipTapEditorRemoteCursorPosition = TipTapEditorRemoteCursor & {
+  top: number;
+  left: number;
+};
+
+const EMPTY_REMOTE_CURSORS: TipTapEditorRemoteCursor[] = [];
+const EMPTY_REMOTE_CURSOR_POSITIONS: TipTapEditorRemoteCursorPosition[] = [];
+
+export function createTipTapEditorCursorSelection(selection: {
+  anchor: number;
+  head: number;
+}): TipTapEditorCursorSelection {
+  return {
+    anchor: selection.anchor,
+    head: selection.head,
+  };
+}
+
 export type TipTapEditorMediaUploadState = {
   canUpload: boolean;
   isUploading: boolean;
@@ -291,6 +322,8 @@ interface TipTapEditorProps {
    * transforms.
    */
   onSelectionTextChange?: (selection: TipTapEditorSelectionInfo | null) => void;
+  onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
+  remoteCursors?: TipTapEditorRemoteCursor[];
   /**
    * Renders ABOVE the editable surface inside the scrollable canvas area —
    * for the document path chip, frontmatter mono row, and any
@@ -493,6 +526,142 @@ type ToolbarButtonProps = {
 };
 
 type TipTapEditorInstance = NonNullable<ReturnType<typeof useEditor>>;
+
+type TipTapRemoteCursorPositionResolverEditor = {
+  view: {
+    coordsAtPos: (position: number) => {
+      top: number;
+      left: number;
+      right: number;
+      bottom: number;
+    };
+  };
+};
+
+type TipTapRemoteCursorPositionResolverWrapper = {
+  getBoundingClientRect: () => {
+    top: number;
+    left: number;
+  };
+};
+
+export function resolveTipTapRemoteCursorPositions({
+  editor,
+  wrapper,
+  remoteCursors,
+}: {
+  editor?: TipTapRemoteCursorPositionResolverEditor | null;
+  wrapper?: TipTapRemoteCursorPositionResolverWrapper | null;
+  remoteCursors: readonly TipTapEditorRemoteCursor[];
+}): TipTapEditorRemoteCursorPosition[] {
+  if (!editor || !wrapper || remoteCursors.length === 0) {
+    return [];
+  }
+
+  const wrapperRect = wrapper.getBoundingClientRect();
+  const positions: TipTapEditorRemoteCursorPosition[] = [];
+
+  for (const remoteCursor of remoteCursors) {
+    try {
+      const cursorRect = editor.view.coordsAtPos(remoteCursor.cursor.head);
+      positions.push({
+        ...remoteCursor,
+        top: cursorRect.top - wrapperRect.top,
+        left: cursorRect.left - wrapperRect.left,
+      });
+    } catch {
+      // Remote cursor snapshots can briefly outlive the local document
+      // position they reference. The next presence snapshot/render can
+      // place it again once positions line up.
+    }
+  }
+
+  return positions;
+}
+
+type TipTapRemoteCursorPositionSyncEditor = {
+  on: (eventName: "update" | "selectionUpdate", listener: () => void) => void;
+  off: (eventName: "update" | "selectionUpdate", listener: () => void) => void;
+};
+
+type TipTapRemoteCursorPositionScrollTarget = {
+  addEventListener: (
+    eventName: "scroll",
+    listener: () => void,
+    options?: AddEventListenerOptions,
+  ) => void;
+  removeEventListener: (eventName: "scroll", listener: () => void) => void;
+};
+
+type TipTapRemoteCursorPositionViewport = {
+  addEventListener: (eventName: "resize", listener: () => void) => void;
+  removeEventListener: (eventName: "resize", listener: () => void) => void;
+};
+
+export function attachTipTapRemoteCursorPositionSync({
+  editor,
+  scrollContainer,
+  viewport,
+  updateRemoteCursorPositions,
+}: {
+  editor: TipTapRemoteCursorPositionSyncEditor;
+  scrollContainer: TipTapRemoteCursorPositionScrollTarget | null;
+  viewport: TipTapRemoteCursorPositionViewport;
+  updateRemoteCursorPositions: () => void;
+}): () => void {
+  updateRemoteCursorPositions();
+  scrollContainer?.addEventListener("scroll", updateRemoteCursorPositions, {
+    passive: true,
+  });
+  viewport.addEventListener("resize", updateRemoteCursorPositions);
+  editor.on("update", updateRemoteCursorPositions);
+  editor.on("selectionUpdate", updateRemoteCursorPositions);
+
+  return () => {
+    scrollContainer?.removeEventListener("scroll", updateRemoteCursorPositions);
+    viewport.removeEventListener("resize", updateRemoteCursorPositions);
+    editor.off("update", updateRemoteCursorPositions);
+    editor.off("selectionUpdate", updateRemoteCursorPositions);
+  };
+}
+
+export function TipTapRemoteCursorLayer({
+  cursors,
+}: {
+  cursors: readonly TipTapEditorRemoteCursorPosition[];
+}) {
+  if (cursors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20">
+      {cursors.map((cursor) => (
+        <div
+          key={cursor.sessionId}
+          data-mdcms-remote-cursor={cursor.sessionId}
+          aria-label={`${cursor.label} cursor`}
+          className="absolute flex items-start gap-1"
+          style={{
+            top: cursor.top,
+            left: cursor.left,
+          }}
+        >
+          <span
+            className="mt-0.5 h-4 w-px rounded-full"
+            style={{ backgroundColor: cursor.color }}
+          />
+          <span
+            className="max-w-40 truncate rounded-sm px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm"
+            style={{ backgroundColor: cursor.color }}
+          >
+            {cursor.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 type MediaUploadInsertEditor = {
   commands: Pick<
@@ -1093,6 +1262,8 @@ function useTipTapEditorElement({
   mediaLibrary,
   onActiveMdxComponentChange,
   onSelectionTextChange,
+  onCursorSelectionChange,
+  remoteCursors = EMPTY_REMOTE_CURSORS,
   canvasHeader,
 }: TipTapEditorProps & { initialEditorContent: ParsedEditorContent }) {
   const toolbar = createEditorToolbarLayout();
@@ -1160,7 +1331,11 @@ function useTipTapEditorElement({
   // explicitly so we can pin `user-select: none` on the editor and run an
   // auto-scroll loop while the canvas pane is the scrollable ancestor.
   const [isMdxDragging, setIsMdxDragging] = useState(false);
+  const [remoteCursorPositions, setRemoteCursorPositions] = useState<
+    TipTapEditorRemoteCursorPosition[]
+  >(EMPTY_REMOTE_CURSOR_POSITIONS);
   const editorWrapperRef = useRef<HTMLDivElement | null>(null);
+  const editorScrollContainerRef = useRef<HTMLDivElement | null>(null);
   const mediaUploadInputRef = useRef<HTMLInputElement | null>(null);
   const mediaUploadInFlightRef = useRef(false);
   const mediaUploadInsertionTargetsRef = useRef<
@@ -1630,6 +1805,9 @@ function useTipTapEditorElement({
         scheduleMarkdownEmission(editor);
       },
       onSelectionUpdate({ editor }) {
+        onCursorSelectionChange?.(
+          createTipTapEditorCursorSelection(editor.state.selection),
+        );
         syncSlashTrigger(editor);
         scheduleAuxSelectionUpdate(editor);
       },
@@ -2106,6 +2284,32 @@ function useTipTapEditorElement({
     readOnly,
     syncSlashTrigger,
   ]);
+
+  useLayoutEffect(() => {
+    const wrapper = editorWrapperRef.current;
+    if (!editor || !wrapper || remoteCursors.length === 0) {
+      setRemoteCursorPositions(EMPTY_REMOTE_CURSOR_POSITIONS);
+      return;
+    }
+
+    const updateRemoteCursorPositions = () => {
+      setRemoteCursorPositions(
+        resolveTipTapRemoteCursorPositions({
+          editor,
+          wrapper,
+          remoteCursors,
+        }),
+      );
+    };
+    const scrollContainer = editorScrollContainerRef.current;
+
+    return attachTipTapRemoteCursorPositionSync({
+      editor,
+      scrollContainer,
+      viewport: window,
+      updateRemoteCursorPositions,
+    });
+  }, [editor, remoteCursors]);
 
   // Drag lifecycle for MDX component handles. Listening at the wrapper
   // catches dragstart only when it originates from a `[data-drag-handle]`
@@ -2833,7 +3037,6 @@ function useTipTapEditorElement({
   const mediaUploadStatusText = mediaUploadProgress
     ? `Uploading media ${mediaUploadProgress.completedFiles} of ${mediaUploadProgress.totalFiles}`
     : "Uploading media...";
-
   return (
     <div
       ref={editorWrapperRef}
@@ -3182,6 +3385,7 @@ function useTipTapEditorElement({
             />
           ) : null}
           <div
+            ref={editorScrollContainerRef}
             className="min-w-0 flex-1 overflow-y-auto"
             onDragOver={handleVisualDragOver}
             onDrop={handleCanvasDrop}
@@ -3239,6 +3443,7 @@ function useTipTapEditorElement({
           </div>
         </div>
       </div>
+      <TipTapRemoteCursorLayer cursors={remoteCursorPositions} />
 
       {context ? (
         <VisualCompositionInsertionDialog

--- a/packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.test.tsx
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PresenceIndicators } from "./presence-indicators.js";
+
+const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
+
+function presenceUser(
+  overrides: Partial<CollaborationPresenceUser>,
+): CollaborationPresenceUser {
+  return {
+    userId: "user-1",
+    sessionId: "session-1",
+    label: "Ada",
+    color: "#2563eb",
+    documentId: DOCUMENT_ID,
+    mode: "view",
+    updatedAt: "2026-06-14T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("PresenceIndicators renders compact mode-marked avatars with accessible labels", () => {
+  const markup = renderToStaticMarkup(
+    createElement(PresenceIndicators, {
+      users: [
+        presenceUser({
+          sessionId: "session-ada",
+          label: "Ada Lovelace",
+          mode: "edit",
+          color: "#2563eb",
+        }),
+        presenceUser({
+          sessionId: "session-grace",
+          label: "Grace Hopper",
+          mode: "view",
+          color: "#16a34a",
+        }),
+      ],
+    }),
+  );
+
+  assert.match(markup, /data-mdcms-presence-indicators="true"/);
+  assert.match(markup, /data-mdcms-presence-mode="edit"/);
+  assert.match(markup, /data-mdcms-presence-mode="view"/);
+  assert.match(markup, /role="img"/);
+  assert.match(markup, /Ada Lovelace editing/);
+  assert.match(markup, /Grace Hopper viewing/);
+  assert.match(markup, /AL/);
+  assert.match(markup, /GH/);
+});
+
+test("PresenceIndicators renders nothing without users", () => {
+  const markup = renderToStaticMarkup(
+    createElement(PresenceIndicators, { users: [] }),
+  );
+
+  assert.equal(markup, "");
+});

--- a/packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/presence/presence-indicators.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { CollaborationPresenceUser } from "@mdcms/shared";
+
+import { cn } from "../../lib/utils.js";
+import { Avatar, AvatarFallback } from "../ui/avatar.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip.js";
+
+export type PresenceIndicatorsProps = {
+  users: CollaborationPresenceUser[];
+  maxVisible?: number;
+  className?: string;
+};
+
+function getPresenceInitials(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+  const initials =
+    parts.length >= 2
+      ? `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`
+      : (parts[0] ?? label).slice(0, 2);
+
+  return initials.toUpperCase() || "?";
+}
+
+function getPresenceLabel(user: CollaborationPresenceUser): string {
+  return `${user.label} ${user.mode === "edit" ? "editing" : "viewing"}`;
+}
+
+export function PresenceIndicators({
+  users,
+  maxVisible = 3,
+  className,
+}: PresenceIndicatorsProps) {
+  if (users.length === 0) {
+    return null;
+  }
+
+  const visibleUsers = users.slice(0, maxVisible);
+  const hiddenCount = Math.max(0, users.length - visibleUsers.length);
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div
+        data-mdcms-presence-indicators="true"
+        className={cn("flex h-5 items-center -space-x-1.5", className)}
+      >
+        {visibleUsers.map((user) => {
+          const label = getPresenceLabel(user);
+
+          return (
+            <Tooltip key={user.sessionId}>
+              <TooltipTrigger asChild>
+                <span
+                  role="img"
+                  aria-label={label}
+                  title={label}
+                  data-mdcms-presence-mode={user.mode}
+                  data-mdcms-presence-session={user.sessionId}
+                  className="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-card bg-card ring-1 ring-background"
+                >
+                  <Avatar className="size-5">
+                    <AvatarFallback
+                      className="text-[8px] font-bold text-white"
+                      style={{ backgroundColor: user.color }}
+                    >
+                      {getPresenceInitials(user.label)}
+                    </AvatarFallback>
+                  </Avatar>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{label}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <span
+            aria-label={`${hiddenCount} more collaborator${hiddenCount === 1 ? "" : "s"}`}
+            className="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-card bg-background-subtle font-mono text-[8px] font-bold text-foreground-muted ring-1 ring-background"
+          >
+            +{hiddenCount}
+          </span>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  CollaborationPresenceCursor,
+  CollaborationPresenceMode,
+  CollaborationPresenceSnapshot,
+  CollaborationPresenceUpdate,
+} from "@mdcms/shared";
+
+import {
+  createPresenceConnectionKey,
+  createPresenceWebSocketUrl,
+  PRESENCE_HEARTBEAT_INTERVAL_MS,
+  parsePresenceSnapshot,
+} from "../lib/collaboration-presence.js";
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
+import { useStudioSession } from "../app/admin/session-context.js";
+
+export type CollaborationPresenceConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "closed"
+  | "error";
+
+export type UseCollaborationPresenceInput = {
+  documentId?: string | null;
+  mode: CollaborationPresenceMode;
+  cursor?: CollaborationPresenceCursor | null;
+};
+
+export type UseCollaborationPresenceResult = {
+  status: CollaborationPresenceConnectionStatus;
+  snapshot: CollaborationPresenceSnapshot | null;
+  currentSessionId: string | null;
+};
+
+export function useCollaborationPresence({
+  documentId,
+  mode,
+  cursor,
+}: UseCollaborationPresenceInput): UseCollaborationPresenceResult {
+  const mountInfo = useStudioMountInfo();
+  const sessionState = useStudioSession();
+  const socketRef = useRef<WebSocket | null>(null);
+  const updateMessageRef = useRef<string>("");
+  const [status, setStatus] =
+    useState<CollaborationPresenceConnectionStatus>("idle");
+  const [snapshot, setSnapshot] =
+    useState<CollaborationPresenceSnapshot | null>(null);
+
+  const currentSessionId =
+    sessionState.status === "authenticated" ? sessionState.session.id : null;
+  const project = mountInfo.project;
+  const environment = mountInfo.environment;
+  const serverUrl = mountInfo.apiBaseUrl;
+  const canConnect =
+    mountInfo.auth.mode === "cookie" &&
+    sessionState.status === "authenticated" &&
+    Boolean(project) &&
+    Boolean(environment) &&
+    serverUrl.length > 0;
+
+  const webSocketUrl = useMemo(() => {
+    if (!canConnect || !project || !environment) {
+      return null;
+    }
+
+    return createPresenceWebSocketUrl({
+      serverUrl,
+      project,
+      environment,
+    });
+  }, [canConnect, environment, project, serverUrl]);
+  const connectionKey = useMemo(() => {
+    if (!webSocketUrl || !currentSessionId) {
+      return null;
+    }
+
+    return createPresenceConnectionKey({
+      webSocketUrl,
+      currentSessionId,
+    });
+  }, [currentSessionId, webSocketUrl]);
+
+  const updateMessage = useMemo(() => {
+    const update: CollaborationPresenceUpdate = {
+      type: "presence.update",
+      mode,
+    };
+
+    if (documentId !== undefined) {
+      update.documentId = documentId;
+    }
+
+    if (cursor !== undefined) {
+      update.cursor = cursor;
+    }
+
+    return JSON.stringify(update);
+  }, [cursor === null, cursor?.anchor, cursor?.head, documentId, mode]);
+
+  useEffect(() => {
+    updateMessageRef.current = updateMessage;
+
+    const socket = socketRef.current;
+    if (
+      !socket ||
+      typeof WebSocket === "undefined" ||
+      socket.readyState !== WebSocket.OPEN
+    ) {
+      return;
+    }
+
+    socket.send(updateMessage);
+  }, [updateMessage]);
+
+  useEffect(() => {
+    if (!connectionKey || !webSocketUrl || typeof WebSocket === "undefined") {
+      setSnapshot(null);
+      setStatus("idle");
+      return;
+    }
+
+    let disposed = false;
+    const socket = new WebSocket(webSocketUrl);
+    let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+    socketRef.current = socket;
+    setSnapshot(null);
+    setStatus("connecting");
+
+    const sendPresenceUpdate = () => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(updateMessageRef.current);
+      }
+    };
+
+    const clearHeartbeat = () => {
+      if (heartbeatInterval !== undefined) {
+        clearInterval(heartbeatInterval);
+        heartbeatInterval = undefined;
+      }
+    };
+
+    socket.addEventListener("open", () => {
+      if (disposed) {
+        return;
+      }
+
+      setStatus("open");
+      sendPresenceUpdate();
+      heartbeatInterval = setInterval(
+        sendPresenceUpdate,
+        PRESENCE_HEARTBEAT_INTERVAL_MS,
+      );
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (disposed) {
+        return;
+      }
+
+      const nextSnapshot = parsePresenceSnapshot(event.data);
+      if (nextSnapshot) {
+        setSnapshot(nextSnapshot);
+      }
+    });
+
+    socket.addEventListener("error", () => {
+      if (disposed) {
+        return;
+      }
+
+      setStatus("error");
+    });
+
+    socket.addEventListener("close", () => {
+      if (disposed) {
+        return;
+      }
+
+      clearHeartbeat();
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+      setStatus("closed");
+    });
+
+    return () => {
+      disposed = true;
+      clearHeartbeat();
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+      socket.close();
+    };
+  }, [connectionKey, webSocketUrl]);
+
+  return {
+    currentSessionId,
+    snapshot,
+    status,
+  };
+}

--- a/packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-collaboration-presence.ts
@@ -14,12 +14,17 @@ import {
   PRESENCE_HEARTBEAT_INTERVAL_MS,
   parsePresenceSnapshot,
 } from "../lib/collaboration-presence.js";
+import {
+  getCollaborationReconnectDelayMs,
+  isCollaborationCloseRetryable,
+} from "../lib/collaboration-reconnect.js";
 import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
 import { useStudioSession } from "../app/admin/session-context.js";
 
 export type CollaborationPresenceConnectionStatus =
   | "idle"
   | "connecting"
+  | "reconnecting"
   | "open"
   | "closed"
   | "error";
@@ -124,13 +129,19 @@ export function useCollaborationPresence({
     }
 
     let disposed = false;
-    const socket = new WebSocket(webSocketUrl);
+    let reconnectAttempt = 0;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
     let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-    socketRef.current = socket;
     setSnapshot(null);
-    setStatus("connecting");
 
-    const sendPresenceUpdate = () => {
+    const clearReconnect = () => {
+      if (reconnectTimeout !== undefined) {
+        clearTimeout(reconnectTimeout);
+        reconnectTimeout = undefined;
+      }
+    };
+
+    const sendPresenceUpdate = (socket: WebSocket) => {
       if (socket.readyState === WebSocket.OPEN) {
         socket.send(updateMessageRef.current);
       }
@@ -143,57 +154,99 @@ export function useCollaborationPresence({
       }
     };
 
-    socket.addEventListener("open", () => {
+    const scheduleReconnect = () => {
       if (disposed) {
         return;
       }
 
-      setStatus("open");
-      sendPresenceUpdate();
-      heartbeatInterval = setInterval(
-        sendPresenceUpdate,
-        PRESENCE_HEARTBEAT_INTERVAL_MS,
-      );
-    });
+      const delayMs = getCollaborationReconnectDelayMs(reconnectAttempt);
+      reconnectAttempt += 1;
+      setSnapshot(null);
+      setStatus("reconnecting");
+      reconnectTimeout = setTimeout(() => {
+        reconnectTimeout = undefined;
+        connect();
+      }, delayMs);
+    };
 
-    socket.addEventListener("message", (event) => {
+    const connect = () => {
       if (disposed) {
         return;
       }
 
-      const nextSnapshot = parsePresenceSnapshot(event.data);
-      if (nextSnapshot) {
-        setSnapshot(nextSnapshot);
-      }
-    });
+      const socket = new WebSocket(webSocketUrl);
+      socketRef.current = socket;
+      setStatus(reconnectAttempt === 0 ? "connecting" : "reconnecting");
 
-    socket.addEventListener("error", () => {
-      if (disposed) {
-        return;
-      }
+      socket.addEventListener("open", () => {
+        if (disposed) {
+          return;
+        }
 
-      setStatus("error");
-    });
+        reconnectAttempt = 0;
+        setStatus("open");
+        sendPresenceUpdate(socket);
+        heartbeatInterval = setInterval(
+          () => sendPresenceUpdate(socket),
+          PRESENCE_HEARTBEAT_INTERVAL_MS,
+        );
+      });
 
-    socket.addEventListener("close", () => {
-      if (disposed) {
-        return;
-      }
+      socket.addEventListener("message", (event) => {
+        if (disposed) {
+          return;
+        }
 
-      clearHeartbeat();
-      if (socketRef.current === socket) {
-        socketRef.current = null;
-      }
-      setStatus("closed");
-    });
+        const nextSnapshot = parsePresenceSnapshot(event.data);
+        if (nextSnapshot) {
+          setSnapshot(nextSnapshot);
+        }
+      });
+
+      socket.addEventListener("error", () => {
+        if (disposed) {
+          return;
+        }
+
+        setStatus("reconnecting");
+        if (
+          socket.readyState === WebSocket.OPEN ||
+          socket.readyState === WebSocket.CONNECTING
+        ) {
+          socket.close();
+        }
+      });
+
+      socket.addEventListener("close", (event) => {
+        if (disposed) {
+          return;
+        }
+
+        clearHeartbeat();
+        if (socketRef.current === socket) {
+          socketRef.current = null;
+        }
+
+        if (isCollaborationCloseRetryable({ code: event.code })) {
+          scheduleReconnect();
+        } else {
+          setSnapshot(null);
+          setStatus("error");
+        }
+      });
+    };
+
+    connect();
 
     return () => {
       disposed = true;
       clearHeartbeat();
-      if (socketRef.current === socket) {
+      clearReconnect();
+      const socket = socketRef.current;
+      if (socket) {
         socketRef.current = null;
+        socket.close();
       }
-      socket.close();
     };
   }, [connectionKey, webSocketUrl]);
 

--- a/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
@@ -221,7 +221,6 @@ export function useDocumentCollaboration({
         return;
       }
 
-      setStatus("open");
       socket.send(
         encodeCollaborationAuthMessage(connectionConfig.documentName),
       );
@@ -266,6 +265,10 @@ export function useDocumentCollaboration({
           transactionOrigin: SOCKET_UPDATE_ORIGIN,
           send: sendIfOpen,
         });
+
+        if (result.type === "sync") {
+          setStatus("open");
+        }
 
         if (result.type === "permission-denied" || result.type === "close") {
           setStatus("error");

--- a/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
@@ -19,10 +19,15 @@ import {
   parseCollaborationFlushResult,
   type CollaborationFlushResult,
 } from "../lib/collaboration-document.js";
+import {
+  getCollaborationReconnectDelayMs,
+  isCollaborationCloseRetryable,
+} from "../lib/collaboration-reconnect.js";
 
 export type DocumentCollaborationConnectionStatus =
   | "idle"
   | "connecting"
+  | "reconnecting"
   | "open"
   | "closed"
   | "error";
@@ -193,13 +198,13 @@ export function useDocumentCollaboration({
     }
 
     let disposed = false;
-    const socket = new WebSocket(connectionConfig.webSocketUrl);
-    socket.binaryType = "arraybuffer";
-    socketRef.current = socket;
-    setStatus("connecting");
+    let fatalClose = false;
+    let reconnectAttempt = 0;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
 
     const sendIfOpen = (data: Uint8Array | string) => {
-      if (!disposed && socket.readyState === WebSocket.OPEN) {
+      const socket = socketRef.current;
+      if (!disposed && socket?.readyState === WebSocket.OPEN) {
         socket.send(data);
       }
     };
@@ -216,107 +221,168 @@ export function useDocumentCollaboration({
 
     documentState.document.on("update", onLocalUpdate);
 
-    socket.onopen = () => {
+    const clearReconnect = () => {
+      if (reconnectTimeout !== undefined) {
+        clearTimeout(reconnectTimeout);
+        reconnectTimeout = undefined;
+      }
+    };
+
+    let connect: () => void;
+    const scheduleReconnect = () => {
       if (disposed) {
         return;
       }
 
-      socket.send(
-        encodeCollaborationAuthMessage(connectionConfig.documentName),
-      );
-      socket.send(
-        encodeCollaborationSyncStep1Message(
-          connectionConfig.documentName,
-          documentState.document,
-        ),
-      );
+      const delayMs = getCollaborationReconnectDelayMs(reconnectAttempt);
+      reconnectAttempt += 1;
+      setStatus("reconnecting");
+      reconnectTimeout = setTimeout(() => {
+        reconnectTimeout = undefined;
+        connect();
+      }, delayMs);
     };
 
-    socket.onmessage = (event) => {
-      void (async () => {
-        const data = await readWebSocketMessageData(event.data);
+    connect = () => {
+      if (disposed) {
+        return;
+      }
 
-        if (disposed || data === null) {
+      const socket = new WebSocket(connectionConfig.webSocketUrl);
+      socket.binaryType = "arraybuffer";
+      socketRef.current = socket;
+      setStatus(reconnectAttempt === 0 ? "connecting" : "reconnecting");
+
+      socket.onopen = () => {
+        if (disposed) {
           return;
         }
 
-        if (typeof data === "string") {
-          const flushResult = parseCollaborationFlushResult(data);
+        reconnectAttempt = 0;
+        socket.send(
+          encodeCollaborationAuthMessage(connectionConfig.documentName),
+        );
+        socket.send(
+          encodeCollaborationSyncStep1Message(
+            connectionConfig.documentName,
+            documentState.document,
+          ),
+        );
+      };
 
-          if (flushResult) {
-            const pending = pendingFlushesRef.current.get(
-              flushResult.requestId,
-            );
+      socket.onmessage = (event) => {
+        void (async () => {
+          const data = await readWebSocketMessageData(event.data);
 
-            if (pending) {
-              clearTimeout(pending.timeout);
-              pendingFlushesRef.current.delete(flushResult.requestId);
-              pending.resolve(flushResult);
-            }
+          if (disposed || data === null) {
+            return;
           }
 
+          if (typeof data === "string") {
+            const flushResult = parseCollaborationFlushResult(data);
+
+            if (flushResult) {
+              const pending = pendingFlushesRef.current.get(
+                flushResult.requestId,
+              );
+
+              if (pending) {
+                clearTimeout(pending.timeout);
+                pendingFlushesRef.current.delete(flushResult.requestId);
+                pending.resolve(flushResult);
+              }
+            }
+
+            return;
+          }
+
+          const result = handleCollaborationSyncMessage({
+            documentName: connectionConfig.documentName,
+            document: documentState.document,
+            data,
+            transactionOrigin: SOCKET_UPDATE_ORIGIN,
+            send: sendIfOpen,
+          });
+
+          if (result.type === "sync") {
+            setStatus("open");
+          }
+
+          if (result.type === "permission-denied" || result.type === "close") {
+            fatalClose = true;
+            setStatus("error");
+            rejectPendingFlushes(
+              pendingFlushesRef.current,
+              new Error("Document collaboration socket failed."),
+            );
+            if (
+              socket.readyState === WebSocket.OPEN ||
+              socket.readyState === WebSocket.CONNECTING
+            ) {
+              socket.close();
+            }
+          }
+        })();
+      };
+
+      socket.onclose = (event) => {
+        if (disposed) {
           return;
         }
 
-        const result = handleCollaborationSyncMessage({
-          documentName: connectionConfig.documentName,
-          document: documentState.document,
-          data,
-          transactionOrigin: SOCKET_UPDATE_ORIGIN,
-          send: sendIfOpen,
-        });
-
-        if (result.type === "sync") {
-          setStatus("open");
+        if (socketRef.current === socket) {
+          socketRef.current = null;
         }
 
-        if (result.type === "permission-denied" || result.type === "close") {
+        rejectPendingFlushes(
+          pendingFlushesRef.current,
+          new Error("Document collaboration socket closed."),
+        );
+
+        const shouldReconnect =
+          !fatalClose && isCollaborationCloseRetryable({ code: event.code });
+        if (shouldReconnect) {
+          scheduleReconnect();
+        } else {
           setStatus("error");
         }
-      })();
+      };
+
+      socket.onerror = () => {
+        if (disposed) {
+          return;
+        }
+
+        setStatus("reconnecting");
+        rejectPendingFlushes(
+          pendingFlushesRef.current,
+          new Error("Document collaboration socket failed."),
+        );
+        if (
+          socket.readyState === WebSocket.OPEN ||
+          socket.readyState === WebSocket.CONNECTING
+        ) {
+          socket.close();
+        }
+      };
     };
 
-    socket.onclose = () => {
-      if (disposed) {
-        return;
-      }
-
-      setStatus("closed");
-      rejectPendingFlushes(
-        pendingFlushesRef.current,
-        new Error("Document collaboration socket closed."),
-      );
-    };
-
-    socket.onerror = () => {
-      if (disposed) {
-        return;
-      }
-
-      setStatus("error");
-      rejectPendingFlushes(
-        pendingFlushesRef.current,
-        new Error("Document collaboration socket failed."),
-      );
-    };
+    connect();
 
     return () => {
       disposed = true;
+      fatalClose = true;
+      clearReconnect();
       documentState.document.off("update", onLocalUpdate);
       rejectPendingFlushes(
         pendingFlushesRef.current,
         new Error("Document collaboration disconnected."),
       );
 
-      if (
-        socket.readyState === WebSocket.OPEN ||
-        socket.readyState === WebSocket.CONNECTING
-      ) {
-        socket.close();
-      }
-
-      if (socketRef.current === socket) {
+      const socket = socketRef.current;
+      if (socket) {
         socketRef.current = null;
+        socket.close();
       }
     };
   }, [connectionConfig, documentState]);

--- a/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
@@ -1,0 +1,361 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as Y from "yjs";
+
+import { useStudioMountInfo } from "../app/admin/mount-info-context.js";
+import { useStudioSession } from "../app/admin/session-context.js";
+import {
+  COLLABORATION_DOCUMENT_FIELD_NAME,
+  COLLABORATION_FRONTMATTER_FIELD_NAME,
+  createCollaborationDocumentConnectionKey,
+  createCollaborationDocumentName,
+  createCollaborationFlushRequest,
+  createDocumentCollaborationWebSocketUrl,
+  encodeCollaborationAuthMessage,
+  encodeCollaborationSyncStep1Message,
+  encodeCollaborationUpdateMessage,
+  handleCollaborationSyncMessage,
+  parseCollaborationFlushResult,
+  type CollaborationFlushResult,
+} from "../lib/collaboration-document.js";
+
+export type DocumentCollaborationConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "closed"
+  | "error";
+
+export type UseDocumentCollaborationInput = {
+  enabled: boolean;
+  documentId?: string | null;
+};
+
+export type UseDocumentCollaborationResult = {
+  enabled: boolean;
+  status: DocumentCollaborationConnectionStatus;
+  documentName: string | null;
+  document: Y.Doc | null;
+  body: Y.XmlFragment | null;
+  frontmatter: Y.Map<unknown> | null;
+  flush: () => Promise<CollaborationFlushResult>;
+};
+
+type CollaborationDocumentState = {
+  connectionKey: string;
+  documentName: string;
+  document: Y.Doc;
+  body: Y.XmlFragment;
+  frontmatter: Y.Map<unknown>;
+};
+
+type PendingFlush = {
+  resolve: (result: CollaborationFlushResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+const SOCKET_UPDATE_ORIGIN = { source: "mdcms-document-socket" };
+const COLLABORATION_FLUSH_TIMEOUT_MS = 10_000;
+
+function createFlushRequestId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `flush-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function rejectPendingFlushes(
+  pendingFlushes: Map<string, PendingFlush>,
+  error: Error,
+): void {
+  for (const pending of pendingFlushes.values()) {
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+  }
+
+  pendingFlushes.clear();
+}
+
+async function readWebSocketMessageData(
+  data: MessageEvent["data"],
+): Promise<string | Uint8Array | null> {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  if (typeof Blob !== "undefined" && data instanceof Blob) {
+    return new Uint8Array(await data.arrayBuffer());
+  }
+
+  return null;
+}
+
+export function useDocumentCollaboration({
+  enabled,
+  documentId,
+}: UseDocumentCollaborationInput): UseDocumentCollaborationResult {
+  const mountInfo = useStudioMountInfo();
+  const sessionState = useStudioSession();
+  const socketRef = useRef<WebSocket | null>(null);
+  const pendingFlushesRef = useRef(new Map<string, PendingFlush>());
+  const [status, setStatus] =
+    useState<DocumentCollaborationConnectionStatus>("idle");
+
+  const project = mountInfo.project;
+  const environment = mountInfo.environment;
+  const serverUrl = mountInfo.apiBaseUrl;
+  const canConnect =
+    enabled &&
+    mountInfo.auth.mode === "cookie" &&
+    sessionState.status === "authenticated" &&
+    Boolean(project) &&
+    Boolean(environment) &&
+    Boolean(documentId) &&
+    serverUrl.length > 0;
+
+  const connectionConfig = useMemo(() => {
+    if (!canConnect || !project || !environment || !documentId) {
+      return null;
+    }
+
+    const webSocketUrl = createDocumentCollaborationWebSocketUrl({
+      serverUrl,
+      project,
+      environment,
+      documentId,
+    });
+    const documentName = createCollaborationDocumentName({
+      project,
+      environment,
+      documentId,
+    });
+
+    return {
+      webSocketUrl,
+      documentName,
+      connectionKey: createCollaborationDocumentConnectionKey({
+        webSocketUrl,
+        documentName,
+      }),
+    };
+  }, [canConnect, documentId, environment, project, serverUrl]);
+
+  const documentState = useMemo<CollaborationDocumentState | null>(() => {
+    if (!connectionConfig) {
+      return null;
+    }
+
+    const document = new Y.Doc();
+
+    return {
+      connectionKey: connectionConfig.connectionKey,
+      documentName: connectionConfig.documentName,
+      document,
+      body: document.getXmlFragment(COLLABORATION_DOCUMENT_FIELD_NAME),
+      frontmatter: document.getMap(COLLABORATION_FRONTMATTER_FIELD_NAME),
+    };
+  }, [connectionConfig]);
+
+  useEffect(
+    () => () => {
+      documentState?.document.destroy();
+    },
+    [documentState],
+  );
+
+  useEffect(() => {
+    if (
+      !connectionConfig ||
+      !documentState ||
+      typeof WebSocket === "undefined"
+    ) {
+      rejectPendingFlushes(
+        pendingFlushesRef.current,
+        new Error("Document collaboration is not connected."),
+      );
+      socketRef.current = null;
+      setStatus("idle");
+      return;
+    }
+
+    let disposed = false;
+    const socket = new WebSocket(connectionConfig.webSocketUrl);
+    socket.binaryType = "arraybuffer";
+    socketRef.current = socket;
+    setStatus("connecting");
+
+    const sendIfOpen = (data: Uint8Array | string) => {
+      if (!disposed && socket.readyState === WebSocket.OPEN) {
+        socket.send(data);
+      }
+    };
+
+    const onLocalUpdate = (update: Uint8Array, origin: unknown) => {
+      if (origin === SOCKET_UPDATE_ORIGIN) {
+        return;
+      }
+
+      sendIfOpen(
+        encodeCollaborationUpdateMessage(connectionConfig.documentName, update),
+      );
+    };
+
+    documentState.document.on("update", onLocalUpdate);
+
+    socket.onopen = () => {
+      if (disposed) {
+        return;
+      }
+
+      setStatus("open");
+      socket.send(
+        encodeCollaborationAuthMessage(connectionConfig.documentName),
+      );
+      socket.send(
+        encodeCollaborationSyncStep1Message(
+          connectionConfig.documentName,
+          documentState.document,
+        ),
+      );
+    };
+
+    socket.onmessage = (event) => {
+      void (async () => {
+        const data = await readWebSocketMessageData(event.data);
+
+        if (disposed || data === null) {
+          return;
+        }
+
+        if (typeof data === "string") {
+          const flushResult = parseCollaborationFlushResult(data);
+
+          if (flushResult) {
+            const pending = pendingFlushesRef.current.get(
+              flushResult.requestId,
+            );
+
+            if (pending) {
+              clearTimeout(pending.timeout);
+              pendingFlushesRef.current.delete(flushResult.requestId);
+              pending.resolve(flushResult);
+            }
+          }
+
+          return;
+        }
+
+        const result = handleCollaborationSyncMessage({
+          documentName: connectionConfig.documentName,
+          document: documentState.document,
+          data,
+          transactionOrigin: SOCKET_UPDATE_ORIGIN,
+          send: sendIfOpen,
+        });
+
+        if (result.type === "permission-denied" || result.type === "close") {
+          setStatus("error");
+        }
+      })();
+    };
+
+    socket.onclose = () => {
+      if (disposed) {
+        return;
+      }
+
+      setStatus("closed");
+      rejectPendingFlushes(
+        pendingFlushesRef.current,
+        new Error("Document collaboration socket closed."),
+      );
+    };
+
+    socket.onerror = () => {
+      if (disposed) {
+        return;
+      }
+
+      setStatus("error");
+      rejectPendingFlushes(
+        pendingFlushesRef.current,
+        new Error("Document collaboration socket failed."),
+      );
+    };
+
+    return () => {
+      disposed = true;
+      documentState.document.off("update", onLocalUpdate);
+      rejectPendingFlushes(
+        pendingFlushesRef.current,
+        new Error("Document collaboration disconnected."),
+      );
+
+      if (
+        socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING
+      ) {
+        socket.close();
+      }
+
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+    };
+  }, [connectionConfig, documentState]);
+
+  const flush = useCallback(() => {
+    const socket = socketRef.current;
+
+    if (
+      !socket ||
+      typeof WebSocket === "undefined" ||
+      socket.readyState !== WebSocket.OPEN
+    ) {
+      return Promise.reject(
+        new Error("Document collaboration is not connected."),
+      );
+    }
+
+    const requestId = createFlushRequestId();
+
+    return new Promise<CollaborationFlushResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingFlushesRef.current.delete(requestId);
+        reject(new Error("Timed out waiting for collaboration flush."));
+      }, COLLABORATION_FLUSH_TIMEOUT_MS);
+
+      pendingFlushesRef.current.set(requestId, {
+        resolve,
+        reject,
+        timeout,
+      });
+
+      socket.send(createCollaborationFlushRequest(requestId));
+    });
+  }, []);
+
+  return {
+    enabled: Boolean(connectionConfig && documentState),
+    status,
+    documentName: documentState?.documentName ?? null,
+    document: documentState?.document ?? null,
+    body: documentState?.body ?? null,
+    frontmatter: documentState?.frontmatter ?? null,
+    flush,
+  };
+}

--- a/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
+++ b/packages/studio/src/lib/runtime-ui/hooks/use-document-collaboration.ts
@@ -272,48 +272,72 @@ export function useDocumentCollaboration({
 
       socket.onmessage = (event) => {
         void (async () => {
-          const data = await readWebSocketMessageData(event.data);
+          try {
+            const data = await readWebSocketMessageData(event.data);
 
-          if (disposed || data === null) {
-            return;
-          }
-
-          if (typeof data === "string") {
-            const flushResult = parseCollaborationFlushResult(data);
-
-            if (flushResult) {
-              const pending = pendingFlushesRef.current.get(
-                flushResult.requestId,
-              );
-
-              if (pending) {
-                clearTimeout(pending.timeout);
-                pendingFlushesRef.current.delete(flushResult.requestId);
-                pending.resolve(flushResult);
-              }
+            if (disposed || data === null) {
+              return;
             }
 
-            return;
-          }
+            if (typeof data === "string") {
+              const flushResult = parseCollaborationFlushResult(data);
 
-          const result = handleCollaborationSyncMessage({
-            documentName: connectionConfig.documentName,
-            document: documentState.document,
-            data,
-            transactionOrigin: SOCKET_UPDATE_ORIGIN,
-            send: sendIfOpen,
-          });
+              if (flushResult) {
+                const pending = pendingFlushesRef.current.get(
+                  flushResult.requestId,
+                );
 
-          if (result.type === "sync") {
-            setStatus("open");
-          }
+                if (pending) {
+                  clearTimeout(pending.timeout);
+                  pendingFlushesRef.current.delete(flushResult.requestId);
+                  pending.resolve(flushResult);
+                }
+              }
 
-          if (result.type === "permission-denied" || result.type === "close") {
+              return;
+            }
+
+            const result = handleCollaborationSyncMessage({
+              documentName: connectionConfig.documentName,
+              document: documentState.document,
+              data,
+              transactionOrigin: SOCKET_UPDATE_ORIGIN,
+              send: sendIfOpen,
+            });
+
+            if (result.type === "sync") {
+              setStatus("open");
+            }
+
+            if (
+              result.type === "permission-denied" ||
+              result.type === "close"
+            ) {
+              fatalClose = true;
+              setStatus("error");
+              rejectPendingFlushes(
+                pendingFlushesRef.current,
+                new Error("Document collaboration socket failed."),
+              );
+              if (
+                socket.readyState === WebSocket.OPEN ||
+                socket.readyState === WebSocket.CONNECTING
+              ) {
+                socket.close();
+              }
+            }
+          } catch (error) {
+            if (disposed) {
+              return;
+            }
+
             fatalClose = true;
             setStatus("error");
             rejectPendingFlushes(
               pendingFlushesRef.current,
-              new Error("Document collaboration socket failed."),
+              error instanceof Error
+                ? error
+                : new Error("Document collaboration socket failed."),
             );
             if (
               socket.readyState === WebSocket.OPEN ||

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-document.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-document.test.ts
@@ -55,6 +55,15 @@ test("createCollaborationDocumentName and connection key are stable per routed d
     }),
     `ws://localhost:4000/api/v1/collaboration\u0000${DOCUMENT_NAME}`,
   );
+
+  assert.equal(
+    createCollaborationDocumentName({
+      project: "marketing:site",
+      environment: "preview/draft",
+      documentId: DOCUMENT_ID,
+    }),
+    `marketing%3Asite:preview%2Fdraft:${DOCUMENT_ID}`,
+  );
 });
 
 test("encodeCollaborationAuthMessage matches Hocuspocus token auth framing", () => {

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-document.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-document.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import * as decoding from "lib0/decoding.js";
+import * as encoding from "lib0/encoding.js";
+import * as syncProtocol from "y-protocols/sync.js";
+import * as Y from "yjs";
+
+import {
+  COLLABORATION_DOCUMENT_FIELD_NAME,
+  createCollaborationDocumentConnectionKey,
+  createCollaborationDocumentName,
+  createDocumentCollaborationWebSocketUrl,
+  encodeCollaborationAuthMessage,
+  encodeCollaborationSyncStep1Message,
+  handleCollaborationSyncMessage,
+} from "./collaboration-document.js";
+
+const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
+const DOCUMENT_NAME = "marketing:draft:11111111-1111-4111-8111-111111111111";
+
+test("createDocumentCollaborationWebSocketUrl targets the SPEC-007 document room endpoint", () => {
+  assert.equal(
+    createDocumentCollaborationWebSocketUrl({
+      serverUrl: "http://localhost:4000",
+      project: "marketing",
+      environment: "draft",
+      documentId: DOCUMENT_ID,
+    }),
+    `ws://localhost:4000/api/v1/collaboration?project=marketing&environment=draft&documentId=${DOCUMENT_ID}`,
+  );
+
+  assert.equal(
+    createDocumentCollaborationWebSocketUrl({
+      serverUrl: "https://cms.example.com/api",
+      project: "marketing site",
+      environment: "preview/draft",
+      documentId: DOCUMENT_ID,
+    }),
+    `wss://cms.example.com/api/api/v1/collaboration?project=marketing+site&environment=preview%2Fdraft&documentId=${DOCUMENT_ID}`,
+  );
+});
+
+test("createCollaborationDocumentName and connection key are stable per routed document room", () => {
+  const documentName = createCollaborationDocumentName({
+    project: "marketing",
+    environment: "draft",
+    documentId: DOCUMENT_ID,
+  });
+
+  assert.equal(documentName, DOCUMENT_NAME);
+  assert.equal(
+    createCollaborationDocumentConnectionKey({
+      webSocketUrl: "ws://localhost:4000/api/v1/collaboration",
+      documentName,
+    }),
+    `ws://localhost:4000/api/v1/collaboration\u0000${DOCUMENT_NAME}`,
+  );
+});
+
+test("encodeCollaborationAuthMessage matches Hocuspocus token auth framing", () => {
+  const message = encodeCollaborationAuthMessage(DOCUMENT_NAME);
+  const decoder = decoding.createDecoder(message);
+
+  assert.equal(decoding.readVarString(decoder), DOCUMENT_NAME);
+  assert.equal(decoding.readVarUint(decoder), 2);
+  assert.equal(decoding.readVarUint(decoder), 0);
+  assert.equal(decoding.readVarString(decoder), "");
+});
+
+test("handleCollaborationSyncMessage applies incoming sync and sends required replies", () => {
+  const localDoc = new Y.Doc();
+  const remoteDoc = new Y.Doc();
+  const remoteText = remoteDoc.getXmlFragment(
+    COLLABORATION_DOCUMENT_FIELD_NAME,
+  );
+  remoteText.insert(0, [new Y.XmlText("Shared body")]);
+
+  const incoming = encoding.createEncoder();
+  encoding.writeVarString(incoming, DOCUMENT_NAME);
+  encoding.writeVarUint(incoming, 0);
+  syncProtocol.writeSyncStep1(incoming, remoteDoc);
+
+  const replies: Uint8Array[] = [];
+  const result = handleCollaborationSyncMessage({
+    documentName: DOCUMENT_NAME,
+    document: localDoc,
+    data: encoding.toUint8Array(incoming),
+    send: (reply) => replies.push(reply),
+  });
+
+  assert.equal(result.type, "sync");
+  assert.equal(replies.length, 1);
+
+  const localSyncStep1 = encodeCollaborationSyncStep1Message(
+    DOCUMENT_NAME,
+    localDoc,
+  );
+  const decodedLocalStep = decoding.createDecoder(localSyncStep1);
+  assert.equal(decoding.readVarString(decodedLocalStep), DOCUMENT_NAME);
+  assert.equal(decoding.readVarUint(decodedLocalStep), 0);
+});

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
@@ -2,6 +2,7 @@ import * as decoding from "lib0/decoding.js";
 import * as encoding from "lib0/encoding.js";
 import * as syncProtocol from "y-protocols/sync.js";
 import type * as Y from "yjs";
+import { z } from "zod";
 
 import { resolveStudioRelativeUrl } from "../../url-resolution.js";
 
@@ -59,6 +60,22 @@ export type CollaborationFlushResult =
       code: string;
       message: string;
     };
+
+const CollaborationFlushResultSchema = z.discriminatedUnion("status", [
+  z.object({
+    type: z.literal("mdcms.collaboration.flush.result"),
+    requestId: z.string(),
+    status: z.enum(["saved", "unchanged"]),
+    draftRevision: z.number(),
+  }),
+  z.object({
+    type: z.literal("mdcms.collaboration.flush.result"),
+    requestId: z.string(),
+    status: z.literal("error"),
+    code: z.string(),
+    message: z.string(),
+  }),
+]);
 
 function encodeCollaborationDocumentNameSegment(segment: string): string {
   return encodeURIComponent(segment);
@@ -250,32 +267,6 @@ export function parseCollaborationFlushResult(
     return null;
   }
 
-  if (
-    typeof payload !== "object" ||
-    payload === null ||
-    (payload as { type?: unknown }).type !==
-      "mdcms.collaboration.flush.result" ||
-    typeof (payload as { requestId?: unknown }).requestId !== "string"
-  ) {
-    return null;
-  }
-
-  const status = (payload as { status?: unknown }).status;
-
-  if (
-    (status === "saved" || status === "unchanged") &&
-    typeof (payload as { draftRevision?: unknown }).draftRevision === "number"
-  ) {
-    return payload as CollaborationFlushResult;
-  }
-
-  if (
-    status === "error" &&
-    typeof (payload as { code?: unknown }).code === "string" &&
-    typeof (payload as { message?: unknown }).message === "string"
-  ) {
-    return payload as CollaborationFlushResult;
-  }
-
-  return null;
+  const result = CollaborationFlushResultSchema.safeParse(payload);
+  return result.success ? result.data : null;
 }

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
@@ -1,0 +1,273 @@
+import * as decoding from "lib0/decoding.js";
+import * as encoding from "lib0/encoding.js";
+import * as syncProtocol from "y-protocols/sync.js";
+import type * as Y from "yjs";
+
+import { resolveStudioRelativeUrl } from "../../url-resolution.js";
+
+export const COLLABORATION_DOCUMENT_FIELD_NAME = "default";
+export const COLLABORATION_FRONTMATTER_FIELD_NAME = "frontmatter";
+
+const HOCUSPOCUS_MESSAGE_SYNC = 0;
+const HOCUSPOCUS_MESSAGE_AUTH = 2;
+const HOCUSPOCUS_MESSAGE_SYNC_REPLY = 4;
+const HOCUSPOCUS_MESSAGE_CLOSE = 7;
+const HOCUSPOCUS_MESSAGE_SYNC_STATUS = 8;
+
+const HOCUSPOCUS_AUTH_TOKEN = 0;
+const HOCUSPOCUS_AUTH_PERMISSION_DENIED = 1;
+const HOCUSPOCUS_AUTH_AUTHENTICATED = 2;
+
+export type CreateDocumentCollaborationWebSocketUrlInput = {
+  serverUrl: string;
+  project: string;
+  environment: string;
+  documentId: string;
+};
+
+export type CreateCollaborationDocumentConnectionKeyInput = {
+  webSocketUrl: string;
+  documentName: string;
+};
+
+export type CreateCollaborationDocumentNameInput = {
+  project: string;
+  environment: string;
+  documentId: string;
+};
+
+export type CollaborationSyncMessageResult =
+  | { type: "sync" }
+  | { type: "authenticated"; readonly: boolean }
+  | { type: "permission-denied"; reason: string }
+  | { type: "token-requested" }
+  | { type: "sync-status" }
+  | { type: "close"; reason: string }
+  | { type: "ignored" };
+
+export type CollaborationFlushResult =
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "saved" | "unchanged";
+      draftRevision: number;
+    }
+  | {
+      type: "mdcms.collaboration.flush.result";
+      requestId: string;
+      status: "error";
+      code: string;
+      message: string;
+    };
+
+export function createCollaborationDocumentName({
+  project,
+  environment,
+  documentId,
+}: CreateCollaborationDocumentNameInput): string {
+  return `${project}:${environment}:${documentId}`;
+}
+
+export function createCollaborationDocumentConnectionKey({
+  webSocketUrl,
+  documentName,
+}: CreateCollaborationDocumentConnectionKeyInput): string {
+  return `${webSocketUrl}\u0000${documentName}`;
+}
+
+export function createDocumentCollaborationWebSocketUrl({
+  serverUrl,
+  project,
+  environment,
+  documentId,
+}: CreateDocumentCollaborationWebSocketUrlInput): string {
+  const url = resolveStudioRelativeUrl("/api/v1/collaboration", serverUrl);
+
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else {
+    url.protocol = "ws:";
+  }
+
+  url.searchParams.set("project", project);
+  url.searchParams.set("environment", environment);
+  url.searchParams.set("documentId", documentId);
+
+  return url.href;
+}
+
+function createHocuspocusMessageEncoder(
+  documentName: string,
+  messageType: number,
+): encoding.Encoder {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarString(encoder, documentName);
+  encoding.writeVarUint(encoder, messageType);
+  return encoder;
+}
+
+export function encodeCollaborationAuthMessage(
+  documentName: string,
+): Uint8Array {
+  const encoder = createHocuspocusMessageEncoder(
+    documentName,
+    HOCUSPOCUS_MESSAGE_AUTH,
+  );
+  encoding.writeVarUint(encoder, HOCUSPOCUS_AUTH_TOKEN);
+  encoding.writeVarString(encoder, "");
+  return encoding.toUint8Array(encoder);
+}
+
+export function encodeCollaborationSyncStep1Message(
+  documentName: string,
+  document: Y.Doc,
+): Uint8Array {
+  const encoder = createHocuspocusMessageEncoder(
+    documentName,
+    HOCUSPOCUS_MESSAGE_SYNC,
+  );
+  syncProtocol.writeSyncStep1(encoder, document);
+  return encoding.toUint8Array(encoder);
+}
+
+export function encodeCollaborationUpdateMessage(
+  documentName: string,
+  update: Uint8Array,
+): Uint8Array {
+  const encoder = createHocuspocusMessageEncoder(
+    documentName,
+    HOCUSPOCUS_MESSAGE_SYNC,
+  );
+  syncProtocol.writeUpdate(encoder, update);
+  return encoding.toUint8Array(encoder);
+}
+
+export function handleCollaborationSyncMessage({
+  documentName,
+  document,
+  data,
+  send,
+  transactionOrigin = null,
+}: {
+  documentName: string;
+  document: Y.Doc;
+  data: Uint8Array;
+  send: (data: Uint8Array) => void;
+  transactionOrigin?: unknown;
+}): CollaborationSyncMessageResult {
+  const decoder = decoding.createDecoder(data);
+  const messageDocumentName = decoding.readVarString(decoder);
+
+  if (messageDocumentName !== documentName) {
+    return { type: "ignored" };
+  }
+
+  const messageType = decoding.readVarUint(decoder);
+
+  if (
+    messageType === HOCUSPOCUS_MESSAGE_SYNC ||
+    messageType === HOCUSPOCUS_MESSAGE_SYNC_REPLY
+  ) {
+    const replyEncoder = createHocuspocusMessageEncoder(
+      documentName,
+      HOCUSPOCUS_MESSAGE_SYNC,
+    );
+    const replyStartLength = encoding.length(replyEncoder);
+    syncProtocol.readSyncMessage(
+      decoder,
+      replyEncoder,
+      document,
+      transactionOrigin,
+    );
+
+    if (encoding.length(replyEncoder) > replyStartLength) {
+      send(encoding.toUint8Array(replyEncoder));
+    }
+
+    return { type: "sync" };
+  }
+
+  if (messageType === HOCUSPOCUS_MESSAGE_AUTH) {
+    const authType = decoding.readVarUint(decoder);
+
+    if (authType === HOCUSPOCUS_AUTH_AUTHENTICATED) {
+      return {
+        type: "authenticated",
+        readonly: decoding.readVarString(decoder) === "readonly",
+      };
+    }
+
+    if (authType === HOCUSPOCUS_AUTH_PERMISSION_DENIED) {
+      return {
+        type: "permission-denied",
+        reason: decoding.readVarString(decoder),
+      };
+    }
+
+    if (authType === HOCUSPOCUS_AUTH_TOKEN) {
+      return { type: "token-requested" };
+    }
+  }
+
+  if (messageType === HOCUSPOCUS_MESSAGE_CLOSE) {
+    return { type: "close", reason: decoding.readVarString(decoder) };
+  }
+
+  if (messageType === HOCUSPOCUS_MESSAGE_SYNC_STATUS) {
+    return { type: "sync-status" };
+  }
+
+  return { type: "ignored" };
+}
+
+export function createCollaborationFlushRequest(requestId: string): string {
+  return JSON.stringify({
+    type: "mdcms.collaboration.flush",
+    requestId,
+  });
+}
+
+export function parseCollaborationFlushResult(
+  raw: unknown,
+): CollaborationFlushResult | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    (payload as { type?: unknown }).type !==
+      "mdcms.collaboration.flush.result" ||
+    typeof (payload as { requestId?: unknown }).requestId !== "string"
+  ) {
+    return null;
+  }
+
+  const status = (payload as { status?: unknown }).status;
+
+  if (
+    (status === "saved" || status === "unchanged") &&
+    typeof (payload as { draftRevision?: unknown }).draftRevision === "number"
+  ) {
+    return payload as CollaborationFlushResult;
+  }
+
+  if (
+    status === "error" &&
+    typeof (payload as { code?: unknown }).code === "string" &&
+    typeof (payload as { message?: unknown }).message === "string"
+  ) {
+    return payload as CollaborationFlushResult;
+  }
+
+  return null;
+}

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-document.ts
@@ -60,12 +60,20 @@ export type CollaborationFlushResult =
       message: string;
     };
 
+function encodeCollaborationDocumentNameSegment(segment: string): string {
+  return encodeURIComponent(segment);
+}
+
 export function createCollaborationDocumentName({
   project,
   environment,
   documentId,
 }: CreateCollaborationDocumentNameInput): string {
-  return `${project}:${environment}:${documentId}`;
+  return [
+    encodeCollaborationDocumentNameSegment(project),
+    encodeCollaborationDocumentNameSegment(environment),
+    encodeCollaborationDocumentNameSegment(documentId),
+  ].join(":");
 }
 
 export function createCollaborationDocumentConnectionKey({

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-presence.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-presence.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+
+import { test } from "bun:test";
+import type { CollaborationPresenceUser } from "@mdcms/shared";
+
+import {
+  createPresenceConnectionKey,
+  createPresenceWebSocketUrl,
+  groupPresenceByDocument,
+  PRESENCE_HEARTBEAT_INTERVAL_MS,
+  parsePresenceSnapshot,
+} from "./collaboration-presence.js";
+
+const DOCUMENT_A = "11111111-1111-4111-8111-111111111111";
+const DOCUMENT_B = "22222222-2222-4222-8222-222222222222";
+const DOCUMENT_HIDDEN = "33333333-3333-4333-8333-333333333333";
+const SERVER_PRESENCE_TTL_MS = 30_000;
+
+function presenceUser(
+  overrides: Partial<CollaborationPresenceUser>,
+): CollaborationPresenceUser {
+  return {
+    userId: "user-1",
+    sessionId: "session-1",
+    label: "Ada",
+    color: "#2563eb",
+    documentId: DOCUMENT_A,
+    mode: "view",
+    updatedAt: "2026-06-14T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("createPresenceWebSocketUrl converts http server URLs to the presence ws endpoint", () => {
+  assert.equal(
+    createPresenceWebSocketUrl({
+      serverUrl: "http://localhost:4000",
+      project: "marketing",
+      environment: "draft",
+    }),
+    "ws://localhost:4000/api/v1/collaboration/presence?project=marketing&environment=draft",
+  );
+});
+
+test("createPresenceWebSocketUrl preserves server path prefixes when converting https URLs", () => {
+  assert.equal(
+    createPresenceWebSocketUrl({
+      serverUrl: "https://cms.example.com/api",
+      project: "marketing site",
+      environment: "preview/draft",
+    }),
+    "wss://cms.example.com/api/api/v1/collaboration/presence?project=marketing+site&environment=preview%2Fdraft",
+  );
+});
+
+test("PRESENCE_HEARTBEAT_INTERVAL_MS refreshes presence before the server TTL", () => {
+  assert.equal(PRESENCE_HEARTBEAT_INTERVAL_MS, 20_000);
+  assert.ok(PRESENCE_HEARTBEAT_INTERVAL_MS < SERVER_PRESENCE_TTL_MS);
+});
+
+test("createPresenceConnectionKey changes when the authenticated session changes", () => {
+  const webSocketUrl =
+    "ws://localhost:4000/api/v1/collaboration/presence?project=marketing&environment=draft";
+
+  assert.notEqual(
+    createPresenceConnectionKey({
+      webSocketUrl,
+      currentSessionId: "session-1",
+    }),
+    createPresenceConnectionKey({
+      webSocketUrl,
+      currentSessionId: "session-2",
+    }),
+  );
+});
+
+test("parsePresenceSnapshot returns a parsed snapshot and rejects unknown shapes", () => {
+  const parsed = parsePresenceSnapshot(
+    JSON.stringify({
+      type: "presence.snapshot",
+      project: "marketing",
+      environment: "draft",
+      users: [
+        presenceUser({
+          sessionId: "session-ada",
+          label: "Ada",
+          mode: "edit",
+          cursor: { anchor: 2, head: 7 },
+        }),
+      ],
+    }),
+  );
+
+  assert.equal(parsed?.users[0]?.label, "Ada");
+  assert.equal(parsePresenceSnapshot('{"type":"presence.unknown"}'), null);
+  assert.equal(parsePresenceSnapshot({ type: "presence.snapshot" }), null);
+  assert.equal(parsePresenceSnapshot("not json"), null);
+});
+
+test("groupPresenceByDocument filters current and hidden users then sorts edit users first", () => {
+  const grouped = groupPresenceByDocument(
+    [
+      presenceUser({
+        sessionId: "current-session",
+        label: "Current",
+        documentId: DOCUMENT_A,
+        mode: "edit",
+      }),
+      presenceUser({
+        sessionId: "session-grace",
+        label: "Grace",
+        documentId: DOCUMENT_A,
+        mode: "view",
+      }),
+      presenceUser({
+        sessionId: "session-zed",
+        label: "Zed",
+        documentId: DOCUMENT_A,
+        mode: "edit",
+      }),
+      presenceUser({
+        sessionId: "session-ada",
+        label: "Ada",
+        documentId: DOCUMENT_A,
+        mode: "edit",
+      }),
+      presenceUser({
+        sessionId: "session-hidden",
+        label: "Hidden",
+        documentId: DOCUMENT_HIDDEN,
+        mode: "edit",
+      }),
+      presenceUser({
+        sessionId: "session-target",
+        label: "Target",
+        documentId: null,
+        mode: "view",
+      }),
+      presenceUser({
+        sessionId: "session-ben",
+        label: "Ben",
+        documentId: DOCUMENT_B,
+        mode: "view",
+      }),
+    ],
+    {
+      visibleDocumentIds: [DOCUMENT_A, DOCUMENT_B],
+      currentSessionId: "current-session",
+    },
+  );
+
+  assert.deepEqual(Array.from(grouped.keys()), [DOCUMENT_A, DOCUMENT_B]);
+  assert.deepEqual(
+    grouped.get(DOCUMENT_A)?.map((user) => `${user.label}:${user.mode}`),
+    ["Ada:edit", "Zed:edit", "Grace:view"],
+  );
+  assert.deepEqual(
+    grouped.get(DOCUMENT_B)?.map((user) => `${user.label}:${user.mode}`),
+    ["Ben:view"],
+  );
+});

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-presence.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-presence.ts
@@ -1,0 +1,124 @@
+import {
+  CollaborationPresenceSnapshotSchema,
+  type CollaborationPresenceSnapshot,
+  type CollaborationPresenceUser,
+} from "@mdcms/shared";
+
+import { resolveStudioRelativeUrl } from "../../url-resolution.js";
+
+export type CreatePresenceWebSocketUrlInput = {
+  serverUrl: string;
+  project: string;
+  environment: string;
+};
+
+export type CreatePresenceConnectionKeyInput = {
+  webSocketUrl: string;
+  currentSessionId: string;
+};
+
+export type GroupPresenceByDocumentOptions = {
+  visibleDocumentIds: Iterable<string>;
+  currentSessionId?: string | null;
+};
+
+export const PRESENCE_HEARTBEAT_INTERVAL_MS = 20_000;
+
+export function createPresenceConnectionKey({
+  webSocketUrl,
+  currentSessionId,
+}: CreatePresenceConnectionKeyInput): string {
+  return `${webSocketUrl}\u0000${currentSessionId}`;
+}
+
+export function createPresenceWebSocketUrl({
+  serverUrl,
+  project,
+  environment,
+}: CreatePresenceWebSocketUrlInput): string {
+  const url = resolveStudioRelativeUrl(
+    "/api/v1/collaboration/presence",
+    serverUrl,
+  );
+
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else {
+    url.protocol = "ws:";
+  }
+
+  url.searchParams.set("project", project);
+  url.searchParams.set("environment", environment);
+
+  return url.href;
+}
+
+function parsePresencePayload(raw: unknown): unknown {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  return raw;
+}
+
+export function parsePresenceSnapshot(
+  raw: unknown,
+): CollaborationPresenceSnapshot | null {
+  const parsed = CollaborationPresenceSnapshotSchema.safeParse(
+    parsePresencePayload(raw),
+  );
+
+  return parsed.success ? parsed.data : null;
+}
+
+function comparePresenceUsers(
+  left: CollaborationPresenceUser,
+  right: CollaborationPresenceUser,
+): number {
+  if (left.mode !== right.mode) {
+    return left.mode === "edit" ? -1 : 1;
+  }
+
+  const labelComparison = left.label.localeCompare(right.label);
+  if (labelComparison !== 0) {
+    return labelComparison;
+  }
+
+  return left.sessionId.localeCompare(right.sessionId);
+}
+
+export function groupPresenceByDocument(
+  users: CollaborationPresenceUser[],
+  { visibleDocumentIds, currentSessionId }: GroupPresenceByDocumentOptions,
+): Map<string, CollaborationPresenceUser[]> {
+  const visible = new Set(visibleDocumentIds);
+  const grouped = new Map<string, CollaborationPresenceUser[]>();
+
+  for (const user of users) {
+    if (!user.documentId) {
+      continue;
+    }
+
+    if (!visible.has(user.documentId)) {
+      continue;
+    }
+
+    if (currentSessionId && user.sessionId === currentSessionId) {
+      continue;
+    }
+
+    const group = grouped.get(user.documentId) ?? [];
+    group.push(user);
+    grouped.set(user.documentId, group);
+  }
+
+  for (const group of grouped.values()) {
+    group.sort(comparePresenceUsers);
+  }
+
+  return grouped;
+}

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-reconnect.test.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-reconnect.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import {
+  getCollaborationReconnectDelayMs,
+  isCollaborationCloseRetryable,
+} from "./collaboration-reconnect.js";
+
+test("collaboration reconnect delays retry immediately then back off with a cap", () => {
+  assert.equal(getCollaborationReconnectDelayMs(0), 0);
+  assert.equal(getCollaborationReconnectDelayMs(1), 1000);
+  assert.equal(getCollaborationReconnectDelayMs(2), 2000);
+  assert.equal(getCollaborationReconnectDelayMs(3), 4000);
+  assert.equal(getCollaborationReconnectDelayMs(4), 10_000);
+  assert.equal(getCollaborationReconnectDelayMs(99), 10_000);
+});
+
+test("collaboration reconnect retries transient closes but not authorization failures", () => {
+  assert.equal(isCollaborationCloseRetryable({ code: 1001 }), true);
+  assert.equal(isCollaborationCloseRetryable({ code: 1006 }), true);
+  assert.equal(isCollaborationCloseRetryable({ code: 1011 }), true);
+  assert.equal(isCollaborationCloseRetryable({ code: 4401 }), false);
+  assert.equal(isCollaborationCloseRetryable({ code: 4403 }), false);
+});

--- a/packages/studio/src/lib/runtime-ui/lib/collaboration-reconnect.ts
+++ b/packages/studio/src/lib/runtime-ui/lib/collaboration-reconnect.ts
@@ -1,0 +1,21 @@
+const COLLABORATION_RECONNECT_DELAYS_MS = [0, 1000, 2000, 4000, 10_000];
+const FATAL_COLLABORATION_CLOSE_CODES = new Set([4401, 4403]);
+
+export function getCollaborationReconnectDelayMs(attempt: number): number {
+  const index = Math.max(0, Math.floor(attempt));
+
+  return (
+    COLLABORATION_RECONNECT_DELAYS_MS[index] ??
+    COLLABORATION_RECONNECT_DELAYS_MS[
+      COLLABORATION_RECONNECT_DELAYS_MS.length - 1
+    ]!
+  );
+}
+
+export function isCollaborationCloseRetryable({
+  code,
+}: {
+  code?: number;
+}): boolean {
+  return !FATAL_COLLABORATION_CLOSE_CODES.has(code ?? 0);
+}

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -494,7 +494,7 @@ test("createContentDocumentPresenceInput reports edit only for writable latest d
   );
 });
 
-test("resolveContentDocumentEditorPresence filters current and off-document sessions", () => {
+test("resolveContentDocumentEditorPresence keeps current user chips and filters current cursor overlays", () => {
   const snapshot = createPresenceSnapshot([
     createPresenceUser(),
     createPresenceUser({
@@ -528,7 +528,12 @@ test("resolveContentDocumentEditorPresence filters current and off-document sess
 
   assert.deepEqual(
     presence.users.map((user) => user.sessionId),
-    ["session-ada", "session-no-cursor", "session-view-cursor"],
+    [
+      "session-ada",
+      "session-current",
+      "session-no-cursor",
+      "session-view-cursor",
+    ],
   );
   assert.deepEqual(presence.remoteCursors, [
     {
@@ -548,7 +553,12 @@ test("resolveContentDocumentEditorPresence filters current and off-document sess
 
   assert.deepEqual(
     readOnlyPresence.users.map((user) => user.sessionId),
-    ["session-ada", "session-no-cursor", "session-view-cursor"],
+    [
+      "session-ada",
+      "session-current",
+      "session-no-cursor",
+      "session-view-cursor",
+    ],
   );
   assert.deepEqual(readOnlyPresence.remoteCursors, []);
 });

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -673,6 +673,20 @@ test("ContentDocumentPageView disables publish while a collaboration room is act
   assert.match(markup, /disabled=""/);
 });
 
+test("ContentDocumentPageView renders document collaboration reconnect status", () => {
+  const document = new Y.Doc();
+  const body = document.getXmlFragment("default");
+  const markup = renderPageMarkup(createReadyState(), {
+    documentCollaboration: { status: "reconnecting", body },
+  });
+
+  assert.match(
+    markup,
+    /data-mdcms-document-collaboration-status="reconnecting"/,
+  );
+  assert.match(markup, /Reconnecting to the collaboration room/);
+});
+
 test("ContentDocumentPageView renders document route loading and failure states", () => {
   const loadingMarkup = renderPageMarkup(
     createContentDocumentPageState({

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mdcms/shared";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import * as Y from "yjs";
 
 import type { StudioDocumentShell } from "../../document-shell.js";
 import { StudioNavigationProvider } from "../navigation.js";
@@ -24,6 +25,8 @@ import {
   getLivePreviewViewportFrame,
   isLivePreviewReadyMessage,
   readContentDocumentPreviewModeSearchParam,
+  resolveCollaborationDraftSaveSnapshot,
+  resolveContentDocumentEditorCollaboration,
   resolveContentDocumentEditorPresence,
   resolveLivePreviewDocument,
   runLivePreviewRefresh,
@@ -563,6 +566,85 @@ test("resolveContentDocumentEditorPresence keeps current user chips and filters 
   assert.deepEqual(readOnlyPresence.remoteCursors, []);
 });
 
+test("resolveContentDocumentEditorPresence adds the current user chip before the presence snapshot echoes it", () => {
+  const snapshot = createPresenceSnapshot([
+    createPresenceUser({
+      sessionId: "session-ada",
+      label: "Ada Lovelace",
+    }),
+  ]);
+
+  const presence = resolveContentDocumentEditorPresence({
+    snapshot,
+    documentId: "11111111-1111-4111-8111-111111111111",
+    currentSessionId: null,
+    currentUser: createPresenceUser({
+      sessionId: "session-current",
+      label: "Current User",
+    }),
+  });
+
+  assert.deepEqual(
+    presence.users.map((user) => user.sessionId),
+    ["session-ada", "session-current"],
+  );
+  assert.deepEqual(presence.remoteCursors, [
+    {
+      sessionId: "session-ada",
+      label: "Ada Lovelace",
+      color: "#2563eb",
+      cursor: { anchor: 2, head: 7 },
+    },
+  ]);
+});
+
+test("resolveContentDocumentEditorCollaboration waits for room sync before binding the Yjs editor body", () => {
+  const document = new Y.Doc();
+  const body = document.getXmlFragment("default");
+
+  const connecting = resolveContentDocumentEditorCollaboration({
+    documentCollaboration: { status: "connecting", body },
+  });
+  assert.equal(connecting.editorCollaboration, undefined);
+  assert.equal(connecting.readOnlyBlockedByCollaboration, true);
+  assert.equal(connecting.publishBlockedByActiveCollaboration, true);
+
+  const open = resolveContentDocumentEditorCollaboration({
+    documentCollaboration: { status: "open", body },
+  });
+  assert.equal(open.editorCollaboration?.body, body);
+  assert.equal(open.readOnlyBlockedByCollaboration, false);
+  assert.equal(open.publishBlockedByActiveCollaboration, true);
+});
+
+test("resolveCollaborationDraftSaveSnapshot reads the live editor body after collaboration flush", () => {
+  const frontmatter = { title: "Launch Notes" };
+
+  assert.deepEqual(
+    resolveCollaborationDraftSaveSnapshot({
+      editor: { getContent: () => "Live collaborative body" },
+      fallbackBody: "Stale draft body",
+      frontmatter,
+    }),
+    {
+      body: "Live collaborative body",
+      frontmatter,
+    },
+  );
+
+  assert.deepEqual(
+    resolveCollaborationDraftSaveSnapshot({
+      editor: { getContent: () => null },
+      fallbackBody: "Fallback draft body",
+      frontmatter,
+    }),
+    {
+      body: "Fallback draft body",
+      frontmatter,
+    },
+  );
+});
+
 test("ContentDocumentPageView renders editor collaborator indicators", () => {
   const markup = renderPageMarkup(createReadyState(), {
     editorPresenceUsers: [
@@ -578,6 +660,17 @@ test("ContentDocumentPageView renders editor collaborator indicators", () => {
   assert.match(markup, /data-mdcms-editor-collaborators="true"/);
   assert.match(markup, /data-mdcms-presence-session="session-ada"/);
   assert.match(markup, /Ada Lovelace editing/);
+});
+
+test("ContentDocumentPageView disables publish while a collaboration room is active", () => {
+  const document = new Y.Doc();
+  const body = document.getXmlFragment("default");
+  const markup = renderPageMarkup(createReadyState(), {
+    documentCollaboration: { status: "open", body },
+  });
+
+  assert.match(markup, /data-mdcms-document-publish-disabled="true"/);
+  assert.match(markup, /disabled=""/);
 });
 
 test("ContentDocumentPageView renders document route loading and failure states", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.test.tsx
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 
 import { test } from "bun:test";
 import {
+  type CollaborationPresenceSnapshot,
+  type CollaborationPresenceUser,
   RuntimeError,
   type SchemaRegistryEntry,
   type StudioMountContext,
@@ -18,9 +20,11 @@ import {
   MDCMS_LIVE_PREVIEW_READY_MESSAGE,
   SidebarInfoTab,
   createLivePreviewIframeRoute,
+  createContentDocumentPresenceInput,
   getLivePreviewViewportFrame,
   isLivePreviewReadyMessage,
   readContentDocumentPreviewModeSearchParam,
+  resolveContentDocumentEditorPresence,
   resolveLivePreviewDocument,
   runLivePreviewRefresh,
   shouldPersistBeforeLivePreviewRefresh,
@@ -34,6 +38,7 @@ import {
   applySchemaStateToReadyState,
   createContentDocumentRouteRequestToken,
   createContentDocumentPageState,
+  createLoadingState,
   filterLocaleOptions,
   getPropertyDescriptors,
   loadContentDocumentPageState,
@@ -338,6 +343,33 @@ function createDocumentResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createPresenceUser(
+  overrides: Partial<CollaborationPresenceUser> = {},
+): CollaborationPresenceUser {
+  return {
+    userId: "user-ada",
+    sessionId: "session-ada",
+    label: "Ada Lovelace",
+    color: "#2563eb",
+    documentId: "11111111-1111-4111-8111-111111111111",
+    mode: "edit",
+    cursor: { anchor: 2, head: 7 },
+    updatedAt: "2026-06-14T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createPresenceSnapshot(
+  users: CollaborationPresenceUser[],
+): CollaborationPresenceSnapshot {
+  return {
+    type: "presence.snapshot",
+    project: "marketing-site",
+    environment: "staging",
+    users,
+  };
+}
+
 test("createContentDocumentPageState maps shell loading and error states into view states", () => {
   const loading = createContentDocumentPageState({
     shell: {
@@ -397,6 +429,145 @@ test("createContentDocumentPageState maps shell loading and error states into vi
   assert.equal(forbidden.status, "forbidden");
   assert.equal(notFound.status, "not-found");
   assert.equal(genericError.status, "error");
+});
+
+test("createContentDocumentPresenceInput reports edit only for writable latest drafts", () => {
+  const cursor = { anchor: 2, head: 7 };
+
+  assert.deepEqual(
+    createContentDocumentPresenceInput({
+      state: createReadyState(),
+      cursor,
+    }),
+    {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      mode: "edit",
+      cursor,
+    },
+  );
+
+  assert.deepEqual(
+    createContentDocumentPresenceInput({
+      state: createReadyState({ canWrite: false }),
+      cursor,
+    }),
+    {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      mode: "view",
+      cursor: null,
+    },
+  );
+
+  assert.deepEqual(
+    createContentDocumentPresenceInput({
+      state: createReadyState({
+        viewingVersion: {
+          version: 4,
+          body: "# Launch Notes v4",
+          status: "ready",
+        },
+      }),
+      cursor,
+    }),
+    {
+      documentId: "11111111-1111-4111-8111-111111111111",
+      mode: "view",
+      cursor: null,
+    },
+  );
+
+  assert.deepEqual(
+    createContentDocumentPresenceInput({
+      state: createLoadingState({
+        typeId: "BlogPost",
+        typeLabel: "Blog post",
+        documentId: "11111111-1111-4111-8111-111111111111",
+        route: createRouteContext(),
+      }),
+      cursor,
+    }),
+    {
+      documentId: null,
+      mode: "view",
+      cursor: null,
+    },
+  );
+});
+
+test("resolveContentDocumentEditorPresence filters current and off-document sessions", () => {
+  const snapshot = createPresenceSnapshot([
+    createPresenceUser(),
+    createPresenceUser({
+      sessionId: "session-current",
+      label: "Current User",
+    }),
+    createPresenceUser({
+      sessionId: "session-no-cursor",
+      label: "Grace Hopper",
+      cursor: undefined,
+      mode: "view",
+    }),
+    createPresenceUser({
+      sessionId: "session-view-cursor",
+      label: "Viewer Cursor",
+      mode: "view",
+      cursor: { anchor: 4, head: 9 },
+    }),
+    createPresenceUser({
+      sessionId: "session-other-doc",
+      label: "Katherine Johnson",
+      documentId: "22222222-2222-4222-8222-222222222222",
+    }),
+  ]);
+
+  const presence = resolveContentDocumentEditorPresence({
+    snapshot,
+    documentId: "11111111-1111-4111-8111-111111111111",
+    currentSessionId: "session-current",
+  });
+
+  assert.deepEqual(
+    presence.users.map((user) => user.sessionId),
+    ["session-ada", "session-no-cursor", "session-view-cursor"],
+  );
+  assert.deepEqual(presence.remoteCursors, [
+    {
+      sessionId: "session-ada",
+      label: "Ada Lovelace",
+      color: "#2563eb",
+      cursor: { anchor: 2, head: 7 },
+    },
+  ]);
+
+  const readOnlyPresence = resolveContentDocumentEditorPresence({
+    snapshot,
+    documentId: "11111111-1111-4111-8111-111111111111",
+    currentSessionId: "session-current",
+    includeRemoteCursors: false,
+  });
+
+  assert.deepEqual(
+    readOnlyPresence.users.map((user) => user.sessionId),
+    ["session-ada", "session-no-cursor", "session-view-cursor"],
+  );
+  assert.deepEqual(readOnlyPresence.remoteCursors, []);
+});
+
+test("ContentDocumentPageView renders editor collaborator indicators", () => {
+  const markup = renderPageMarkup(createReadyState(), {
+    editorPresenceUsers: [
+      createPresenceUser({
+        sessionId: "session-ada",
+        label: "Ada Lovelace",
+        color: "#2563eb",
+        mode: "edit",
+      }),
+    ],
+  });
+
+  assert.match(markup, /data-mdcms-editor-collaborators="true"/);
+  assert.match(markup, /data-mdcms-presence-session="session-ada"/);
+  assert.match(markup, /Ada Lovelace editing/);
 });
 
 test("ContentDocumentPageView renders document route loading and failure states", () => {

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -12,6 +12,10 @@ import {
 
 import {
   appendMdcmsPreviewTokenToUrl,
+  type CollaborationPresenceCursor,
+  type CollaborationPresenceMode,
+  type CollaborationPresenceSnapshot,
+  type CollaborationPresenceUser,
   isRuntimeErrorLike,
   type MdcmsPreviewDocument,
   RuntimeError,
@@ -35,11 +39,14 @@ import {
 import { MediaFieldControl } from "../components/editor/media-field-picker.js";
 import {
   TipTapEditor,
+  type TipTapEditorCursorSelection,
   type TipTapEditorHandle,
   type TipTapEditorMediaLibraryState,
   type TipTapEditorMediaUploadState,
+  type TipTapEditorRemoteCursor,
   type TipTapEditorSelectionInfo,
 } from "../components/editor/tiptap-editor.js";
+import { PresenceIndicators } from "../components/presence/presence-indicators.js";
 import { InlineAiBubble } from "../components/editor/inline-ai-bubble.js";
 import {
   createStudioAiRouteApi,
@@ -94,6 +101,8 @@ import {
   createStudioMediaLibraryApi,
   type StudioMediaLibraryApi,
 } from "../lib/media-library-api.js";
+import { groupPresenceByDocument } from "../lib/collaboration-presence.js";
+import { useCollaborationPresence } from "../hooks/use-collaboration-presence.js";
 import {
   Select,
   SelectContent,
@@ -217,6 +226,70 @@ function replaceBrowserContentDocumentPreviewMode(
   );
 }
 
+export function createContentDocumentPresenceInput({
+  state,
+  cursor,
+}: {
+  state: ContentDocumentPageState;
+  cursor: CollaborationPresenceCursor | null;
+}): {
+  documentId: string | null;
+  mode: CollaborationPresenceMode;
+  cursor: CollaborationPresenceCursor | null;
+} {
+  const isEditingLatestDraft =
+    state.status === "ready" && state.canWrite && !state.viewingVersion;
+
+  return {
+    documentId: state.status === "ready" ? state.documentId : null,
+    mode: isEditingLatestDraft ? "edit" : "view",
+    cursor: isEditingLatestDraft ? cursor : null,
+  };
+}
+
+export function resolveContentDocumentEditorPresence({
+  snapshot,
+  documentId,
+  currentSessionId,
+  includeRemoteCursors = true,
+}: {
+  snapshot: CollaborationPresenceSnapshot | null;
+  documentId: string | null;
+  currentSessionId?: string | null;
+  includeRemoteCursors?: boolean;
+}): {
+  users: CollaborationPresenceUser[];
+  remoteCursors: TipTapEditorRemoteCursor[];
+} {
+  if (!snapshot || !documentId) {
+    return { users: [], remoteCursors: [] };
+  }
+
+  const users =
+    groupPresenceByDocument(snapshot.users, {
+      visibleDocumentIds: [documentId],
+      currentSessionId,
+    }).get(documentId) ?? [];
+
+  return {
+    users,
+    remoteCursors: includeRemoteCursors
+      ? users.flatMap((user) =>
+          user.mode === "edit" && user.cursor
+            ? [
+                {
+                  sessionId: user.sessionId,
+                  label: user.label,
+                  color: user.color,
+                  cursor: user.cursor,
+                },
+              ]
+            : [],
+        )
+      : [],
+  };
+}
+
 function useLatestCallback<Args extends unknown[], Return>(
   callback: (...args: Args) => Return,
 ): (...args: Args) => Return {
@@ -336,6 +409,9 @@ type ContentDocumentPageViewProps = {
   mediaLibrary?: TipTapEditorMediaLibraryState;
   fileFieldMediaUploadApi?: StudioMediaUploadApi | null;
   fileFieldMediaLibraryApi?: Pick<StudioMediaLibraryApi, "get" | "list"> | null;
+  editorPresenceUsers?: CollaborationPresenceUser[];
+  remoteCursors?: TipTapEditorRemoteCursor[];
+  onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
   aiSelection?: TipTapEditorSelectionInfo | null;
   onAiSelectionChange?: (selection: TipTapEditorSelectionInfo | null) => void;
   aiApi?: StudioAiRouteApi;
@@ -1883,6 +1959,9 @@ function useContentDocumentPageViewElement({
   mediaLibrary,
   fileFieldMediaUploadApi,
   fileFieldMediaLibraryApi,
+  editorPresenceUsers = [],
+  remoteCursors = [],
+  onCursorSelectionChange,
   aiSelection,
   onAiSelectionChange,
   aiApi,
@@ -2065,6 +2144,18 @@ function useContentDocumentPageViewElement({
                   mode={activePreviewMode}
                   onModeChange={setPreviewMode}
                 />
+              ) : null}
+
+              {state.status === "ready" && editorPresenceUsers.length > 0 ? (
+                <div
+                  data-mdcms-editor-collaborators="true"
+                  className="flex h-8 items-center"
+                >
+                  <PresenceIndicators
+                    users={editorPresenceUsers}
+                    maxVisible={4}
+                  />
+                </div>
               ) : null}
 
               {state.status === "ready" &&
@@ -2258,6 +2349,8 @@ function useContentDocumentPageViewElement({
                         onChange={onDraftChange}
                         onActiveMdxComponentChange={onActiveMdxComponentChange}
                         onSelectionTextChange={onAiSelectionChange}
+                        onCursorSelectionChange={onCursorSelectionChange}
+                        remoteCursors={remoteCursors}
                         readOnly={!state.canWrite || !!state.viewingVersion}
                         forbidden={false}
                         mediaUpload={editorMediaUpload}
@@ -2642,6 +2735,8 @@ function useContentDocumentPageController({
     useState<MdxPropsPanelSelection | null>(null);
   const [aiSelection, setAiSelection] =
     useState<TipTapEditorSelectionInfo | null>(null);
+  const [cursorSelection, setCursorSelection] =
+    useState<TipTapEditorCursorSelection | null>(null);
   const [mediaUploadState, setMediaUploadState] =
     useState<MediaUploadControllerState>({ status: "idle" });
   const mediaUploadStateRef = useRef(mediaUploadState);
@@ -2702,6 +2797,29 @@ function useContentDocumentPageController({
   }, [activeContext, route]);
   const stateRef = useRef(state);
   const loadRequestIdRef = useRef(0);
+  const presenceInput = createContentDocumentPresenceInput({
+    state,
+    cursor: cursorSelection,
+  });
+  const collaborationPresence = useCollaborationPresence(presenceInput);
+  const editorPresence = useMemo(
+    () =>
+      resolveContentDocumentEditorPresence({
+        snapshot: collaborationPresence.snapshot,
+        documentId: presenceInput.documentId,
+        currentSessionId: collaborationPresence.currentSessionId,
+        includeRemoteCursors: presenceInput.mode === "edit",
+      }),
+    [
+      collaborationPresence.currentSessionId,
+      collaborationPresence.snapshot,
+      presenceInput.documentId,
+      presenceInput.mode,
+    ],
+  );
+  useEffect(() => {
+    setCursorSelection(null);
+  }, [documentId, presenceInput.mode]);
   const canBrowseMediaLibrary =
     state.status === "ready" &&
     state.canWrite &&
@@ -3953,6 +4071,9 @@ function useContentDocumentPageController({
     mediaLibrary,
     fileFieldMediaUploadApi: mediaUploadApi,
     fileFieldMediaLibraryApi: mediaLibraryApi,
+    editorPresenceUsers: editorPresence.users,
+    remoteCursors: editorPresence.remoteCursors,
+    onCursorSelectionChange: setCursorSelection,
     editorRef,
     onViewVersion: (version) => {
       void handleViewVersion(version);

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -546,7 +546,11 @@ type ContentDocumentPageViewProps = {
   sidebarOpen?: boolean;
   activeMdxComponent?: MdxPropsPanelSelection | null;
   onDraftChange?: (body: string) => void;
-  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
+  onFrontmatterFieldChange?: (
+    fieldName: string,
+    value: unknown,
+    options?: { syncCollaboration?: boolean },
+  ) => void;
   onActiveMdxComponentChange?: (
     selection: MdxPropsPanelSelection | null,
   ) => void;
@@ -1016,7 +1020,11 @@ export function SidebarInfoTab(props: {
 
 function SidebarPropertiesTab(props: {
   state: ContentDocumentPageReadyState;
-  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
+  onFrontmatterFieldChange?: (
+    fieldName: string,
+    value: unknown,
+    options?: { syncCollaboration?: boolean },
+  ) => void;
   fileFieldMediaUploadApi?: StudioMediaUploadApi | null;
   fileFieldMediaLibraryApi?: Pick<StudioMediaLibraryApi, "get" | "list"> | null;
 }) {
@@ -1405,7 +1413,11 @@ function ContentDocumentPageSidebar(props: {
   state: ContentDocumentPageReadyState;
   context?: StudioMountContext;
   activeMdxComponent?: MdxPropsPanelSelection | null;
-  onFrontmatterFieldChange?: (fieldName: string, value: unknown) => void;
+  onFrontmatterFieldChange?: (
+    fieldName: string,
+    value: unknown,
+    options?: { syncCollaboration?: boolean },
+  ) => void;
   fileFieldMediaUploadApi?: StudioMediaUploadApi | null;
   fileFieldMediaLibraryApi?: Pick<StudioMediaLibraryApi, "get" | "list"> | null;
   onViewVersion?: (version: number) => void;
@@ -2277,7 +2289,9 @@ function useContentDocumentPageViewElement({
         if (
           !areJsonValuesEqual(currentFrontmatter[key], draft.frontmatter[key])
         ) {
-          onFrontmatterFieldChange?.(key, draft.frontmatter[key]);
+          onFrontmatterFieldChange?.(key, draft.frontmatter[key], {
+            syncCollaboration: false,
+          });
         }
       }
     },
@@ -4413,8 +4427,9 @@ function useContentDocumentPageController({
           : current,
       );
     },
-    onFrontmatterFieldChange: (fieldName, value) => {
+    onFrontmatterFieldChange: (fieldName, value, options) => {
       if (
+        options?.syncCollaboration !== false &&
         documentCollaboration.enabled &&
         documentCollaboration.status === "open" &&
         documentCollaboration.frontmatter

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -332,6 +332,24 @@ export function resolveContentDocumentEditorCollaboration({
   };
 }
 
+function getDocumentCollaborationStatusMessage(
+  status: DocumentCollaborationConnectionStatus,
+): string | null {
+  switch (status) {
+    case "connecting":
+      return "Connecting to the collaboration room. Editing is paused until the live session is ready.";
+    case "reconnecting":
+      return "Reconnecting to the collaboration room. Editing is paused until the live session is ready.";
+    case "closed":
+      return "The collaboration room disconnected. Editing is paused while Studio reconnects.";
+    case "error":
+      return "The collaboration room connection failed. Reload the page if editing does not recover.";
+    case "idle":
+    case "open":
+      return null;
+  }
+}
+
 export function resolveCollaborationDraftSaveSnapshot({
   editor,
   fallbackBody,
@@ -2153,6 +2171,9 @@ function useContentDocumentPageViewElement({
   const editorCollaboration = resolveContentDocumentEditorCollaboration({
     documentCollaboration,
   });
+  const documentCollaborationStatusMessage = documentCollaboration
+    ? getDocumentCollaborationStatusMessage(documentCollaboration.status)
+    : null;
   const canPublish =
     state.status === "ready" &&
     state.canWrite &&
@@ -2495,6 +2516,18 @@ function useContentDocumentPageViewElement({
                                     onSchemaSync,
                                   })
                                 : null}
+
+                            {documentCollaboration &&
+                            documentCollaborationStatusMessage ? (
+                              <div
+                                data-mdcms-document-collaboration-status={
+                                  documentCollaboration.status
+                                }
+                                className="rounded-md border border-warning/40 bg-warning-subtle px-4 py-3 text-sm text-foreground"
+                              >
+                                {documentCollaborationStatusMessage}
+                              </div>
+                            ) : null}
 
                             {state.mutationError ? (
                               <div

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -523,7 +523,9 @@ type ContentDocumentPageViewProps = {
     status: DocumentCollaborationConnectionStatus;
     body: Y.XmlFragment;
   };
-  onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
+  onCursorSelectionChange?: (
+    selection: TipTapEditorCursorSelection | null,
+  ) => void;
   aiSelection?: TipTapEditorSelectionInfo | null;
   onAiSelectionChange?: (selection: TipTapEditorSelectionInfo | null) => void;
   aiApi?: StudioAiRouteApi;

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -52,6 +52,7 @@ import { InlineAiBubble } from "../components/editor/inline-ai-bubble.js";
 import {
   createStudioAiRouteApi,
   type StudioAiRouteApi,
+  type StudioAiProposal,
 } from "../../ai-route-api.js";
 import { BreadcrumbTrail } from "../components/layout/page-header.js";
 import { AssistantLauncher } from "../components/assistant/assistant-launcher.js";
@@ -62,6 +63,11 @@ import {
   useAssistant,
   type AssistantActiveDocument,
 } from "../components/assistant/assistant-context.js";
+import {
+  applyAssistantCollaborationProposalDraft,
+  isAssistantCollaborationProposalApplicable,
+  type AssistantCollaborationPriorDraft,
+} from "../components/assistant/assistant-collaboration-apply.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import {
@@ -350,6 +356,38 @@ function getDocumentCollaborationStatusMessage(
   }
 }
 
+function resolveEditorHandle(
+  ref: React.Ref<TipTapEditorHandle> | undefined,
+): TipTapEditorHandle | null {
+  return ref && typeof ref === "object" && "current" in ref
+    ? ref.current
+    : null;
+}
+
+function replaceCollaborationFrontmatter(
+  map: Y.Map<unknown> | null | undefined,
+  frontmatter: Record<string, unknown>,
+): void {
+  if (!map) {
+    return;
+  }
+
+  const nextKeys = new Set(Object.keys(frontmatter));
+  for (const key of Array.from(map.keys())) {
+    if (!nextKeys.has(key)) {
+      map.delete(key);
+    }
+  }
+
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (value === undefined) {
+      map.delete(key);
+    } else {
+      map.set(key, value);
+    }
+  }
+}
+
 export function resolveCollaborationDraftSaveSnapshot({
   editor,
   fallbackBody,
@@ -540,6 +578,7 @@ type ContentDocumentPageViewProps = {
   documentCollaboration?: {
     status: DocumentCollaborationConnectionStatus;
     body: Y.XmlFragment;
+    frontmatter?: Y.Map<unknown> | null;
   };
   onCursorSelectionChange?: (
     selection: TipTapEditorCursorSelection | null,
@@ -2213,6 +2252,101 @@ function useContentDocumentPageViewElement({
     return () => document.removeEventListener("keydown", onKey);
   }, [canSaveNow, triggerSaveShortcut]);
 
+  const applyCollaborationDraft = useLatestCallback(
+    (draft: {
+      body: string;
+      frontmatter: Record<string, unknown>;
+      applyBodyToEditor: boolean;
+    }) => {
+      if (draft.applyBodyToEditor) {
+        resolveEditorHandle(editorRef)?.applyAssistantContent(draft.body);
+      }
+
+      replaceCollaborationFrontmatter(
+        documentCollaboration?.frontmatter,
+        draft.frontmatter,
+      );
+
+      onDraftChange?.(draft.body);
+      const currentFrontmatter =
+        state.status === "ready" ? state.draftFrontmatter : {};
+      for (const key of new Set([
+        ...Object.keys(currentFrontmatter),
+        ...Object.keys(draft.frontmatter),
+      ])) {
+        if (
+          !areJsonValuesEqual(currentFrontmatter[key], draft.frontmatter[key])
+        ) {
+          onFrontmatterFieldChange?.(key, draft.frontmatter[key]);
+        }
+      }
+    },
+  );
+
+  const applyCollaborationProposal = useLatestCallback(
+    async ({ proposal }: { proposal: StudioAiProposal }) => {
+      if (
+        state.status !== "ready" ||
+        documentCollaboration?.status !== "open"
+      ) {
+        return null;
+      }
+
+      const editor = resolveEditorHandle(editorRef);
+      const body = editor?.getContent() ?? state.draftBody;
+      if (
+        !isAssistantCollaborationProposalApplicable({
+          proposal,
+          documentId: state.documentId,
+        })
+      ) {
+        return null;
+      }
+
+      const result = applyAssistantCollaborationProposalDraft({
+        proposal,
+        documentId: state.documentId,
+        body,
+        frontmatter: state.draftFrontmatter,
+      });
+
+      applyCollaborationDraft({
+        body: result.body,
+        frontmatter: result.frontmatter,
+        applyBodyToEditor: result.body !== body,
+      });
+
+      return result;
+    },
+  );
+
+  const undoCollaborationProposal = useLatestCallback(
+    async ({
+      priorDraft,
+    }: {
+      proposal: StudioAiProposal;
+      priorDraft: AssistantCollaborationPriorDraft;
+    }) => {
+      if (
+        state.status !== "ready" ||
+        documentCollaboration?.status !== "open"
+      ) {
+        throw new RuntimeError({
+          code: "AI_UNDO_UNAVAILABLE",
+          message:
+            "Undo is only available while the active collaboration room is connected.",
+          statusCode: 409,
+        });
+      }
+
+      applyCollaborationDraft({
+        body: priorDraft.body,
+        frontmatter: priorDraft.frontmatter,
+        applyBodyToEditor: true,
+      });
+    },
+  );
+
   // Publish the active document to the assistant rail so the chat surface
   // can attach the right document context + resolve the schema hash on
   // accept. The live editor selection is included so document chat can
@@ -2236,6 +2370,12 @@ function useContentDocumentPageViewElement({
         schemaHash,
         project: assistantReadyState.route.project,
         environment: assistantReadyState.route.initialEnvironment,
+        ...(documentCollaboration?.status === "open"
+          ? {
+              applyCollaborationProposal,
+              undoCollaborationProposal,
+            }
+          : {}),
         ...(aiSelection
           ? {
               selection: {
@@ -2245,7 +2385,13 @@ function useContentDocumentPageViewElement({
             }
           : {}),
       };
-    }, [assistantReadyState, aiSelection]);
+    }, [
+      assistantReadyState,
+      aiSelection,
+      applyCollaborationProposal,
+      documentCollaboration?.status,
+      undoCollaborationProposal,
+    ]);
 
   return (
     <AssistantActiveDocumentProvider value={assistantActiveDocument}>
@@ -4358,6 +4504,7 @@ function useContentDocumentPageController({
         ? {
             status: documentCollaboration.status,
             body: documentCollaboration.body,
+            frontmatter: documentCollaboration.frontmatter,
           }
         : undefined,
     onCursorSelectionChange: setCursorSelection,

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -256,30 +256,40 @@ export function resolveContentDocumentEditorPresence({
   snapshot,
   documentId,
   currentSessionId,
+  currentUser,
   includeRemoteCursors = true,
 }: {
   snapshot: CollaborationPresenceSnapshot | null;
   documentId: string | null;
   currentSessionId?: string | null;
+  currentUser?: CollaborationPresenceUser | null;
   includeRemoteCursors?: boolean;
 }): {
   users: CollaborationPresenceUser[];
   remoteCursors: TipTapEditorRemoteCursor[];
 } {
-  if (!snapshot || !documentId) {
+  if (!documentId) {
     return { users: [], remoteCursors: [] };
   }
 
-  const users =
-    groupPresenceByDocument(snapshot.users, {
-      visibleDocumentIds: [documentId],
-    }).get(documentId) ?? [];
+  const users = snapshot
+    ? (groupPresenceByDocument(snapshot.users, {
+        visibleDocumentIds: [documentId],
+      }).get(documentId) ?? [])
+    : [];
+  const visibleUsers =
+    currentUser &&
+    currentUser.documentId === documentId &&
+    !users.some((user) => user.sessionId === currentUser.sessionId)
+      ? [...users, currentUser]
+      : users;
 
   return {
-    users,
+    users: visibleUsers,
     remoteCursors: includeRemoteCursors
-      ? users.flatMap((user) =>
+      ? visibleUsers.flatMap((user) =>
           user.sessionId !== currentSessionId &&
+          user.sessionId !== currentUser?.sessionId &&
           user.mode === "edit" &&
           user.cursor
             ? [
@@ -293,6 +303,98 @@ export function resolveContentDocumentEditorPresence({
             : [],
         )
       : [],
+  };
+}
+
+type ContentDocumentEditorCollaborationInput = {
+  status: DocumentCollaborationConnectionStatus;
+  body: Y.XmlFragment;
+};
+
+export function resolveContentDocumentEditorCollaboration({
+  documentCollaboration,
+}: {
+  documentCollaboration?: ContentDocumentEditorCollaborationInput;
+}): {
+  editorCollaboration?: { body: Y.XmlFragment };
+  readOnlyBlockedByCollaboration: boolean;
+  publishBlockedByActiveCollaboration: boolean;
+} {
+  return {
+    editorCollaboration:
+      documentCollaboration?.status === "open"
+        ? { body: documentCollaboration.body }
+        : undefined,
+    readOnlyBlockedByCollaboration:
+      documentCollaboration !== undefined &&
+      documentCollaboration.status !== "open",
+    publishBlockedByActiveCollaboration: documentCollaboration !== undefined,
+  };
+}
+
+export function resolveCollaborationDraftSaveSnapshot({
+  editor,
+  fallbackBody,
+  frontmatter,
+}: {
+  editor: Pick<TipTapEditorHandle, "getContent"> | null | undefined;
+  fallbackBody: string;
+  frontmatter: Record<string, unknown>;
+}): {
+  body: string;
+  frontmatter: Record<string, unknown>;
+} {
+  return {
+    body: editor?.getContent() ?? fallbackBody,
+    frontmatter,
+  };
+}
+
+function deriveLocalPresenceLabel(input: {
+  email: string;
+  userId: string;
+}): string {
+  const [localPart] = input.email.split("@", 1);
+  const label = localPart?.trim();
+
+  return label && label.length > 0 ? label : input.userId;
+}
+
+function deriveLocalPresenceColor(userId: string): string {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < userId.length; index += 1) {
+    hash ^= userId.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return `#${(hash >>> 0).toString(16).padStart(8, "0").slice(0, 6)}`;
+}
+
+function createCurrentEditorPresenceUser({
+  session,
+  documentId,
+  mode,
+  cursor,
+}: {
+  session: { id: string; userId: string; email: string } | null;
+  documentId: string | null;
+  mode: CollaborationPresenceMode;
+  cursor: CollaborationPresenceCursor | null;
+}): CollaborationPresenceUser | null {
+  if (!session || !documentId) {
+    return null;
+  }
+
+  return {
+    userId: session.userId,
+    sessionId: session.id,
+    label: deriveLocalPresenceLabel(session),
+    color: deriveLocalPresenceColor(session.userId),
+    documentId,
+    mode,
+    ...(cursor ? { cursor } : {}),
+    updatedAt: new Date().toISOString(),
   };
 }
 
@@ -2046,12 +2148,16 @@ function useContentDocumentPageViewElement({
         ? "enabled"
         : "blocked"
       : "idle";
+  const editorCollaboration = resolveContentDocumentEditorCollaboration({
+    documentCollaboration,
+  });
   const canPublish =
     state.status === "ready" &&
     state.canWrite &&
     state.saveState === "saved" &&
     state.document.hasUnpublishedChanges &&
-    state.publishState !== "publishing";
+    state.publishState !== "publishing" &&
+    !editorCollaboration.publishBlockedByActiveCollaboration;
 
   const canSaveNow =
     state.status === "ready" &&
@@ -2250,6 +2356,9 @@ function useContentDocumentPageViewElement({
                   size="sm"
                   disabled={!canPublish}
                   onClick={() => onPublishDialogOpenChange?.(true)}
+                  data-mdcms-document-publish-disabled={
+                    !canPublish ? "true" : undefined
+                  }
                   data-mdcms-document-unpublished-changes={
                     state.document.hasUnpublishedChanges ? "true" : undefined
                   }
@@ -2365,14 +2474,9 @@ function useContentDocumentPageViewElement({
                         readOnly={
                           !state.canWrite ||
                           !!state.viewingVersion ||
-                          (documentCollaboration !== undefined &&
-                            documentCollaboration.status !== "open")
+                          editorCollaboration.readOnlyBlockedByCollaboration
                         }
-                        collaboration={
-                          documentCollaboration
-                            ? { body: documentCollaboration.body }
-                            : undefined
-                        }
+                        collaboration={editorCollaboration.editorCollaboration}
                         forbidden={false}
                         mediaUpload={editorMediaUpload}
                         mediaLibrary={editorMediaLibrary}
@@ -2828,17 +2932,39 @@ function useContentDocumentPageController({
       state.status === "ready" && state.canWrite && !state.viewingVersion,
     documentId: state.status === "ready" ? state.documentId : null,
   });
+  const currentEditorPresenceUser = useMemo(
+    () =>
+      createCurrentEditorPresenceUser({
+        session:
+          session.status === "authenticated" &&
+          collaborationPresence.status === "open"
+            ? session.session
+            : null,
+        documentId: presenceInput.documentId,
+        mode: presenceInput.mode,
+        cursor: presenceInput.cursor,
+      }),
+    [
+      collaborationPresence.status,
+      presenceInput.cursor,
+      presenceInput.documentId,
+      presenceInput.mode,
+      session,
+    ],
+  );
   const editorPresence = useMemo(
     () =>
       resolveContentDocumentEditorPresence({
         snapshot: collaborationPresence.snapshot,
         documentId: presenceInput.documentId,
         currentSessionId: collaborationPresence.currentSessionId,
+        currentUser: currentEditorPresenceUser,
         includeRemoteCursors: presenceInput.mode === "edit",
       }),
     [
       collaborationPresence.currentSessionId,
       collaborationPresence.snapshot,
+      currentEditorPresenceUser,
       presenceInput.documentId,
       presenceInput.mode,
     ],
@@ -3178,7 +3304,8 @@ function useContentDocumentPageController({
       !api ||
       !requestRoute ||
       currentState.status !== "ready" ||
-      !currentState.canWrite
+      !currentState.canWrite ||
+      documentCollaboration.enabled
     ) {
       return;
     }
@@ -3406,6 +3533,12 @@ function useContentDocumentPageController({
           return false;
         }
 
+        const persistedSnapshot = resolveCollaborationDraftSaveSnapshot({
+          editor: editorRef.current,
+          fallbackBody: requestBody,
+          frontmatter: requestFrontmatter,
+        });
+
         setState((current) =>
           current.status === "ready" &&
           matchesContentDocumentRouteRequestToken(requestToken, current)
@@ -3413,8 +3546,8 @@ function useContentDocumentPageController({
                 state: current,
                 requestBody,
                 requestFrontmatter,
-                persistedBody: requestBody,
-                persistedFrontmatter: requestFrontmatter,
+                persistedBody: persistedSnapshot.body,
+                persistedFrontmatter: persistedSnapshot.frontmatter,
                 updatedAt: currentState.document.updatedAt,
                 draftRevision: result.draftRevision,
               })

--- a/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
+++ b/packages/studio/src/lib/runtime-ui/pages/content-document-page.tsx
@@ -23,6 +23,7 @@ import {
   type StudioDocumentRouteMountContext,
   type StudioMountContext,
 } from "@mdcms/shared";
+import type * as Y from "yjs";
 
 import type { StudioDocumentRouteApi } from "../../document-route-api.js";
 import type { StudioSchemaState } from "../../schema-state.js";
@@ -103,6 +104,10 @@ import {
 } from "../lib/media-library-api.js";
 import { groupPresenceByDocument } from "../lib/collaboration-presence.js";
 import { useCollaborationPresence } from "../hooks/use-collaboration-presence.js";
+import {
+  useDocumentCollaboration,
+  type DocumentCollaborationConnectionStatus,
+} from "../hooks/use-document-collaboration.js";
 import {
   Select,
   SelectContent,
@@ -268,14 +273,15 @@ export function resolveContentDocumentEditorPresence({
   const users =
     groupPresenceByDocument(snapshot.users, {
       visibleDocumentIds: [documentId],
-      currentSessionId,
     }).get(documentId) ?? [];
 
   return {
     users,
     remoteCursors: includeRemoteCursors
       ? users.flatMap((user) =>
-          user.mode === "edit" && user.cursor
+          user.sessionId !== currentSessionId &&
+          user.mode === "edit" &&
+          user.cursor
             ? [
                 {
                   sessionId: user.sessionId,
@@ -411,6 +417,10 @@ type ContentDocumentPageViewProps = {
   fileFieldMediaLibraryApi?: Pick<StudioMediaLibraryApi, "get" | "list"> | null;
   editorPresenceUsers?: CollaborationPresenceUser[];
   remoteCursors?: TipTapEditorRemoteCursor[];
+  documentCollaboration?: {
+    status: DocumentCollaborationConnectionStatus;
+    body: Y.XmlFragment;
+  };
   onCursorSelectionChange?: (selection: TipTapEditorCursorSelection) => void;
   aiSelection?: TipTapEditorSelectionInfo | null;
   onAiSelectionChange?: (selection: TipTapEditorSelectionInfo | null) => void;
@@ -1961,6 +1971,7 @@ function useContentDocumentPageViewElement({
   fileFieldMediaLibraryApi,
   editorPresenceUsers = [],
   remoteCursors = [],
+  documentCollaboration,
   onCursorSelectionChange,
   aiSelection,
   onAiSelectionChange,
@@ -2351,7 +2362,17 @@ function useContentDocumentPageViewElement({
                         onSelectionTextChange={onAiSelectionChange}
                         onCursorSelectionChange={onCursorSelectionChange}
                         remoteCursors={remoteCursors}
-                        readOnly={!state.canWrite || !!state.viewingVersion}
+                        readOnly={
+                          !state.canWrite ||
+                          !!state.viewingVersion ||
+                          (documentCollaboration !== undefined &&
+                            documentCollaboration.status !== "open")
+                        }
+                        collaboration={
+                          documentCollaboration
+                            ? { body: documentCollaboration.body }
+                            : undefined
+                        }
                         forbidden={false}
                         mediaUpload={editorMediaUpload}
                         mediaLibrary={editorMediaLibrary}
@@ -2802,6 +2823,11 @@ function useContentDocumentPageController({
     cursor: cursorSelection,
   });
   const collaborationPresence = useCollaborationPresence(presenceInput);
+  const documentCollaboration = useDocumentCollaboration({
+    enabled:
+      state.status === "ready" && state.canWrite && !state.viewingVersion,
+    documentId: state.status === "ready" ? state.documentId : null,
+  });
   const editorPresence = useMemo(
     () =>
       resolveContentDocumentEditorPresence({
@@ -3312,13 +3338,8 @@ function useContentDocumentPageController({
     const currentState = stateRef.current;
     const requestContext = activeContext;
     const requestRoute = route;
-    const api = createRouteApi({
-      context: requestContext,
-      route: requestRoute,
-    });
 
     if (
-      !api ||
       // Fail closed when the embedded host cannot derive the local schema hash
       // required by guarded draft-write routes.
       !requestRoute ||
@@ -3353,6 +3374,80 @@ function useContentDocumentPageController({
       documentId: currentState.documentId,
       route: requestRoute,
     });
+
+    if (documentCollaboration.enabled) {
+      if (documentCollaboration.status !== "open") {
+        return false;
+      }
+
+      setState((current) =>
+        current.status === "ready"
+          ? reduceContentDocumentPageReadyState(current, {
+              type: "saveStarted",
+            })
+          : current,
+      );
+
+      try {
+        const result = await documentCollaboration.flush();
+
+        if (result.status === "error") {
+          setState((current) =>
+            current.status === "ready" &&
+            matchesContentDocumentRouteRequestToken(requestToken, current)
+              ? applyFailedDraftSaveToReadyState({
+                  state: current,
+                  requestBody,
+                  requestFrontmatter,
+                  message: result.message,
+                })
+              : current,
+          );
+          return false;
+        }
+
+        setState((current) =>
+          current.status === "ready" &&
+          matchesContentDocumentRouteRequestToken(requestToken, current)
+            ? applySuccessfulDraftSaveToReadyState({
+                state: current,
+                requestBody,
+                requestFrontmatter,
+                persistedBody: requestBody,
+                persistedFrontmatter: requestFrontmatter,
+                updatedAt: currentState.document.updatedAt,
+                draftRevision: result.draftRevision,
+              })
+            : current,
+        );
+        return true;
+      } catch (error) {
+        setState((current) =>
+          current.status === "ready" &&
+          matchesContentDocumentRouteRequestToken(requestToken, current)
+            ? applyFailedDraftSaveToReadyState({
+                state: current,
+                requestBody,
+                requestFrontmatter,
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "Collaboration save failed.",
+              })
+            : current,
+        );
+        return false;
+      }
+    }
+
+    const api = createRouteApi({
+      context: requestContext,
+      route: requestRoute,
+    });
+
+    if (!api) {
+      return false;
+    }
 
     setState((current) =>
       current.status === "ready"
@@ -3952,7 +4047,12 @@ function useContentDocumentPageController({
     return () => {
       clearTimeout(timeout);
     };
-  }, [saveDraft, state]);
+  }, [
+    documentCollaboration.enabled,
+    documentCollaboration.status,
+    saveDraft,
+    state,
+  ]);
 
   useEffect(() => {
     if (
@@ -4000,6 +4100,18 @@ function useContentDocumentPageController({
       );
     },
     onFrontmatterFieldChange: (fieldName, value) => {
+      if (
+        documentCollaboration.enabled &&
+        documentCollaboration.status === "open" &&
+        documentCollaboration.frontmatter
+      ) {
+        if (value === undefined) {
+          documentCollaboration.frontmatter.delete(fieldName);
+        } else {
+          documentCollaboration.frontmatter.set(fieldName, value);
+        }
+      }
+
       setState((current) =>
         current.status === "ready"
           ? reduceContentDocumentPageReadyState(current, {
@@ -4073,6 +4185,13 @@ function useContentDocumentPageController({
     fileFieldMediaLibraryApi: mediaLibraryApi,
     editorPresenceUsers: editorPresence.users,
     remoteCursors: editorPresence.remoteCursors,
+    documentCollaboration:
+      documentCollaboration.enabled && documentCollaboration.body
+        ? {
+            status: documentCollaboration.status,
+            body: documentCollaboration.body,
+          }
+        : undefined,
     onCursorSelectionChange: setCursorSelection,
     editorRef,
     onViewVersion: (version) => {


### PR DESCRIPTION
## Summary

- Implements the CMS-155 collaboration epic across server, Studio, docs, and tests.
- Wires active document collaboration rooms, Yjs-backed editor binding, presence chips/cursors, reconnect behavior, collaboration autosave/final save, and inactive cache invalidation.
- Fixes follow-up regressions found in local dev: display names in presence, remote cursor visibility on blur, AI provider env handling, and assistant proposal application while collaboration is active.
- Adds spec updates for collaboration runtime behavior, Studio collaboration UX, and AI proposal handling inside active collaboration rooms.

## Validation

- `bun test --cwd packages/studio ./src/lib/runtime-ui/components/assistant/assistant-collaboration-apply.test.ts ./src/lib/runtime-ui/components/assistant/assistant-context.test.ts ./src/lib/runtime-ui/pages/content-document-page.test.tsx`
- `bun run check`
- `bun run format:check`
- `bun run changeset:check`
- `git diff --check`
- Dev compose stack restarted and `http://127.0.0.1:4000/healthz` returned OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added real-time collaboration presence (view/edit) with an updated presence stream and per-document indicators.
  * Enabled frontmatter-aware collaborative editing with server-owned autosave and recovery behavior.
  * Added remote cursor/selection rendering and collaboration-aware editor save/publish behavior.
  * Implemented best-effort invalidation of inactive collaboration cache after successful content mutations.
  * Updated AI-assisted proposals to apply/undo through active collaboration rooms when applicable.

* **Bug Fixes**
  * Improved handling of blank provider base URL settings and more reliable local Postgres probing in tests.

* **Documentation**
  * Refreshed collaboration and presence specs to match the updated behavior and contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->