### PR TITLE
[codex] Fix Studio assistant history and starter prompts

### DIFF
--- a/docs/specs/SPEC-014-ai-assisted-studio-editing.md
+++ b/docs/specs/SPEC-014-ai-assisted-studio-editing.md
@@ -120,6 +120,11 @@ The assistant surface presents:
 - A thread list with conversation persistence across navigation.
 - A composer that auto-attaches the active document and any current editor
   selection as removable context chips.
+- Empty-thread starter prompts that match the assistant's currently available
+  context and model-callable tools. Starter prompts must not imply access to
+  version history, edit history, recently changed documents, repository source,
+  analytics, or other history/recency data unless that data is explicitly
+  available to the chat turn.
 - While a chat turn is pending, the composer remains editable so the user can
   draft the next message. Studio must block sending that draft until the
   pending turn completes or is stopped; the pending affordance remains Stop,
@@ -173,6 +178,11 @@ auto-collapses that earlier run into a summary row that names the number of
 tool calls or progress updates and can be expanded to inspect the individual
 status rows. The current trailing progress run remains expanded while the
 pending turn is still active.
+
+When the streaming turn completes, Studio commits the same ordered text and
+progress blocks into the assistant conversation history. Completed progress
+runs remain collapsed, expandable history rows and must not disappear when the
+stream placeholder is replaced by the final assistant message.
 
 Rejecting a proposal does not silently discard the model's turn. Reject opens
 an inline feedback textarea on the card; the user types what should change and

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.test.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.test.ts
@@ -5,6 +5,7 @@ import {
   buildAssistantChatRequestContext,
   buildAssistantMessageContextSnapshot,
   buildAssistantProposalDocumentPathMap,
+  commitAssistantStreamMessage,
   relTime,
   resolveAssistantProposalDisplayPath,
   studioProposalFromWire,
@@ -15,6 +16,7 @@ import type {
   AssistantActiveDocument,
   AssistantThread,
 } from "./assistant-context.js";
+import type { AssistantMessage } from "./assistant-types.js";
 
 test("relTime formats relative timestamps against an explicit now", () => {
   const now = "2026-05-07T10:00:00Z";
@@ -145,6 +147,50 @@ test("buildAssistantMessageContextSnapshot records attached document labels for 
       { path: "posts/releases/related.md", source: "attached" },
     ],
   );
+});
+
+test("commitAssistantStreamMessage preserves streamed progress history on the final turn", () => {
+  const placeholder = {
+    id: "placeholder",
+    role: "assistant",
+    at: "2026-05-07T10:00:00Z",
+    text: "Checking",
+    progress: [
+      {
+        phase: "tool-call",
+        status: "started",
+        toolName: "get_component_reference",
+        message: "Read component reference tool started",
+      },
+    ],
+    streamBlocks: [
+      { kind: "text", text: "Checking" },
+      {
+        kind: "progress",
+        events: [
+          {
+            phase: "tool-call",
+            status: "started",
+            toolName: "get_component_reference",
+            message: "Read component reference tool started",
+          },
+        ],
+      },
+    ],
+  } satisfies AssistantMessage;
+  const finalMessage = {
+    id: "server-message",
+    role: "assistant",
+    at: "2026-05-07T10:00:03Z",
+    text: "Done.",
+  } satisfies AssistantMessage;
+
+  const committed = commitAssistantStreamMessage(placeholder, finalMessage);
+
+  assert.equal(committed.id, "server-message");
+  assert.equal(committed.text, "Done.");
+  assert.deepEqual(committed.progress, placeholder.progress);
+  assert.deepEqual(committed.streamBlocks, placeholder.streamBlocks);
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-context.ts
@@ -103,6 +103,19 @@ function appendProgressStreamBlock(
   return [...current, { kind: "progress", events: [progress] }];
 }
 
+export function commitAssistantStreamMessage(
+  placeholder: AssistantMessage,
+  finalMessage: AssistantMessage,
+): AssistantMessage {
+  const streamBlocks = finalMessage.streamBlocks ?? placeholder.streamBlocks;
+  const progress = finalMessage.progress ?? placeholder.progress;
+  return {
+    ...finalMessage,
+    ...(streamBlocks && streamBlocks.length > 0 ? { streamBlocks } : {}),
+    ...(progress && progress.length > 0 ? { progress } : {}),
+  };
+}
+
 type AssistantAction =
   | { type: "open-rail" }
   | { type: "close" }
@@ -981,7 +994,9 @@ function reducer(
               docCount: Math.max(thread.docCount, docCount),
               updatedAt: action.finalMessage.at,
               messages: thread.messages.map((m) =>
-                m.id === action.placeholderId ? action.finalMessage : m,
+                m.id === action.placeholderId
+                  ? commitAssistantStreamMessage(m, action.finalMessage)
+                  : m,
               ),
             };
           }),

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel-layout.test.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel-layout.test.tsx
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { AssistantProvider } from "./assistant-context.js";
+import { EmptyStarter } from "./empty-starter.js";
 import { AssistantBubble, AssistantPanel } from "./assistant-panel.js";
 import {
   AssistantRail,
@@ -131,6 +132,74 @@ test("assistant pending progress renders between streamed text blocks and collap
   assert.ok(collapsedIndex > firstTextIndex);
   assert.ok(secondTextIndex > collapsedIndex);
   assert.ok(trailingProgressIndex > secondTextIndex);
+});
+
+test("assistant completed progress remains visible in conversation history", () => {
+  const message = {
+    id: "msg-complete",
+    role: "assistant",
+    text: "I checked the component reference and drafted the edit.",
+    streamBlocks: [
+      {
+        kind: "text",
+        text: "I checked the component reference.",
+      },
+      {
+        kind: "progress",
+        events: [
+          {
+            phase: "tool-call",
+            status: "started",
+            toolName: "component_reference",
+            message: "Read component reference tool started",
+          },
+        ],
+      },
+      {
+        kind: "text",
+        text: "Drafted the edit.",
+      },
+    ],
+    at: "2026-05-22T12:00:00.000Z",
+  } satisfies AssistantMessage;
+
+  const markup = renderToStaticMarkup(
+    <AssistantBubble
+      message={message}
+      proposalsById={{}}
+      documentPathById={new Map()}
+      isStreamingPlaceholder={false}
+      onAccept={() => undefined}
+      onReject={() => undefined}
+    />,
+  );
+
+  assert.match(markup, /data-mdcms-assistant-progress-collapsed/);
+  assert.match(markup, /1 tool call appended/);
+  assert.match(markup, /Read component reference tool started/);
+});
+
+test("assistant starter prompts only advertise currently supported context", () => {
+  const markup = renderToStaticMarkup(
+    <EmptyStarter
+      thread={{
+        id: "thread-empty",
+        title: "New conversation",
+        updatedAt: "2026-05-22T12:00:00.000Z",
+        preview: "",
+        contextDocs: [],
+        messages: [],
+        docCount: 0,
+      }}
+      activeDocument={null}
+      hasDraft={false}
+      onPick={() => undefined}
+    />,
+  );
+
+  assert.doesNotMatch(markup, /recent product changes/i);
+  assert.doesNotMatch(markup, /recently edited drafts/i);
+  assert.doesNotMatch(markup, /document history/i);
 });
 
 test("assistant rail exposes a resize handle and default width", () => {

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-panel.tsx
@@ -573,9 +573,11 @@ function hasVisibleStreamContent(block: AssistantStreamBlock): boolean {
 function AssistantStreamBlocks({
   blocks,
   hasProposalContent,
+  isStreamingPlaceholder,
 }: {
   blocks: AssistantStreamBlock[];
   hasProposalContent: boolean;
+  isStreamingPlaceholder: boolean;
 }) {
   const visibleBlocks = blocks.filter(hasVisibleStreamContent);
   return (
@@ -601,7 +603,7 @@ function AssistantStreamBlocks({
           <AssistantProgressTimeline
             key={`progress-${idx}`}
             events={block.events}
-            collapsed={hasLaterContent}
+            collapsed={hasLaterContent || !isStreamingPlaceholder}
           />
         );
       })}
@@ -644,14 +646,10 @@ export function AssistantBubble({
   onUndo?: (proposalId: string) => Promise<void>;
 }) {
   const proposalIds = message.proposals ?? [];
-  const streamBlocks =
-    isStreamingPlaceholder && message.streamBlocks?.length
-      ? message.streamBlocks
-      : [];
+  const streamBlocks = message.streamBlocks?.length ? message.streamBlocks : [];
   const hasStreamBlocks = streamBlocks.some(hasVisibleStreamContent);
   const text = hasStreamBlocks ? undefined : message.text?.trim();
-  const progressEvents =
-    isStreamingPlaceholder && !hasStreamBlocks ? (message.progress ?? []) : [];
+  const progressEvents = !hasStreamBlocks ? (message.progress ?? []) : [];
   if (
     proposalIds.length === 0 &&
     !text &&
@@ -678,6 +676,7 @@ export function AssistantBubble({
           <AssistantStreamBlocks
             blocks={streamBlocks}
             hasProposalContent={proposalIds.length > 0}
+            isStreamingPlaceholder={isStreamingPlaceholder}
           />
         ) : text ? (
           <div className="max-w-[92%] py-0.5">
@@ -693,8 +692,11 @@ export function AssistantBubble({
             <span className="size-1.5 animate-pulse rounded-full bg-primary [animation-delay:0.2s]" />
           </div>
         ) : null}
-        {isStreamingPlaceholder && progressEvents.length > 0 ? (
-          <AssistantProgressTimeline events={progressEvents} />
+        {progressEvents.length > 0 ? (
+          <AssistantProgressTimeline
+            events={progressEvents}
+            collapsed={!isStreamingPlaceholder}
+          />
         ) : null}
         {!isMultiTurn &&
           proposals.map((proposal) => (

--- a/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/assistant-types.ts
@@ -236,9 +236,10 @@ export type AssistantMessage = {
   context?: AssistantMessageContextSnapshot;
   progress?: AssistantProgressEvent[];
   /**
-   * Pending-stream-only render blocks. They preserve the order in
+   * Stream render blocks. They preserve the order in
    * which text deltas and progress events arrived so the assistant can
-   * show tool activity between prose blocks while a turn is streaming.
+   * show tool activity between prose blocks while a turn is streaming
+   * and keep those rows available after the turn is committed.
    */
   streamBlocks?: AssistantStreamBlock[];
   proposals?: string[];

--- a/packages/studio/src/lib/runtime-ui/components/assistant/empty-starter.tsx
+++ b/packages/studio/src/lib/runtime-ui/components/assistant/empty-starter.tsx
@@ -54,9 +54,9 @@ const EXAMPLE_SETS: Record<ExampleSet, Example[]> = {
         "Generate a 150–160 character SEO meta description summarising this document.",
     },
     {
-      label: "Summarize for changelog",
+      label: "Summarize this draft",
       prompt:
-        "Summarise the key changes in this document as a short changelog entry.",
+        "Summarise the current document and call out any unclear sections.",
     },
   ],
   global: [
@@ -72,12 +72,12 @@ const EXAMPLE_SETS: Record<ExampleSet, Example[]> = {
     {
       label: "Suggest blog topics",
       prompt:
-        "Suggest five blog topics for this week tied to recent product changes.",
+        "Suggest five evergreen blog topics for content editors using MDCMS.",
     },
     {
-      label: "Review my latest drafts",
+      label: "Outline a guide",
       prompt:
-        "Find my five most recently edited drafts and summarise what each needs to ship.",
+        "Draft an outline for a guide that explains MDCMS projects and environments.",
     },
   ],
 };


### PR DESCRIPTION
## Summary

- Preserve streamed assistant text/progress blocks when the pending placeholder is replaced by the final assistant message, so tool/progress rows remain visible in conversation history.
- Render completed assistant progress rows as collapsed, expandable history entries.
- Replace starter prompts that implied unavailable history/recency access with prompts grounded in the current document or general MDCMS writing help.
- Update the AI-assisted Studio editing spec and tests for the expected behavior.

## Validation

- bun run format:check
- bun run check
- bun test --cwd packages/studio ./src/lib/runtime-ui/components/assistant/assistant-panel-layout.test.tsx ./src/lib/runtime-ui/components/assistant/assistant-context.test.ts
- bun run changeset:check
- bun nx run studio:test --output-style=static
- bun nx run server:test --output-style=static outside sandbox
- bun nx run cli:test --output-style=static outside sandbox
- bun run ci:required outside sandbox reached the Studio embed smoke step after passing quality/typecheck/unit, then failed because another worktree already had 127.0.0.1:4173 occupied by a stale Next.js server.
- Equivalent Studio embed smoke assertions passed on 127.0.0.1:4174 for /admin, /admin/content/posts, /, and /demo/content.

## Notes

No changeset was created because the changed Studio paths are covered by the package runtime-only changeset gate.