### PR TITLE
fix(packages): exclude tests from bundles

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,19 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.mjs",
+    "dist/**/*.mjs.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.woff2",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "!dist/**/__tests__/**",
+    "!dist/**/__mocks__/**"
   ],
   "repository": {
     "type": "git",

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -7,7 +7,19 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.mjs",
+    "dist/**/*.mjs.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.woff2",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "!dist/**/__tests__/**",
+    "!dist/**/__mocks__/**"
   ],
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,7 +7,19 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.mjs",
+    "dist/**/*.mjs.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.woff2",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "!dist/**/__tests__/**",
+    "!dist/**/__mocks__/**"
   ],
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,19 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.mjs",
+    "dist/**/*.mjs.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.woff2",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "!dist/**/__tests__/**",
+    "!dist/**/__mocks__/**"
   ],
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -7,7 +7,19 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.mjs",
+    "dist/**/*.mjs.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.woff2",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "!dist/**/__tests__/**",
+    "!dist/**/__mocks__/**"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Narrow published package file lists for CLI, shared, SDK, Studio, and editor-core
- Exclude compiled test/spec files and test-only directories from npm tarballs

## Verification
- bun run build
- npm pack --dry-run --ignore-scripts --json for all five published packages, checked for test/spec files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined package publication configurations across multiple modules to explicitly specify production artifacts (scripts, type definitions, stylesheets) while excluding test-related files from distribution for cleaner package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->